### PR TITLE
[maven] Run integration on master checks

### DIFF
--- a/.github/workflows/check-supported-versions.yaml
+++ b/.github/workflows/check-supported-versions.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Build on JDK ${{ matrix.java }} and ${{ matrix.os }}
+    name: 'Build: JDK ${{ matrix.java }} (${{ matrix.os }})'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -48,10 +48,6 @@ jobs:
         shell: bash
         run: mvn -nsu -B --quiet -Djacoco.skip=true -Dorg.slf4j.simpleLogger.defaultLogLevel=error --no-transfer-progress clean install --file pom.xml ${{ matrix.flags }}
 
-      - name: Test gradle
-        shell: bash
-        run: gradle -b modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle buildGoSdk --stacktrace
-
       - name: Upload Maven build artifact
         uses: actions/upload-artifact@v1
         if: matrix.java == '8' && matrix.os == 'ubuntu-latest'
@@ -59,8 +55,18 @@ jobs:
           name: artifact
           path: modules/openapi-generator-cli/target/openapi-generator-cli.jar
 
+      - name: Test Gradle plugin usage
+        shell: bash
+        run: gradle -b modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle buildGoSdk --stacktrace
+
+      - name: Test Maven plugin integration
+        shell: bash
+        run: |
+          cd modules/openapi-generator-maven-plugin
+          mvn verify -Pintegration
+
   verify:
-    name: Verifies integrity of the commit on ${{ matrix.os }}
+    name: Verify outputs on ${{ matrix.os }}
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
This adds the Maven integration tests to the Check Supported Java
Versions job which runs on master.

Maven on Windows was previously broken with templateDirectory. This was
fixed previously in a pull request, but the Maven plugin integration
testing did not work in our other CI vendors. This was tested and
verified in a private repo. The difference is likely due to vCPUs
available in GitHub Workflows differing from other free CI we use
elsewhere.

cc @OpenAPITools/generator-core-team 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
