### PR TITLE
Replace '.' characters by '_' in enum type names since OCaml doesn't allow to use '.' in any kind of identifiers.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OCamlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OCamlClientCodegen.java
@@ -361,7 +361,7 @@ public class OCamlClientCodegen extends DefaultCodegen implements CodegenConfig 
     }
 
     private String sanitizeOCamlTypeName(String name) {
-        String typeName = name.replace("-", "_").replace(" ", "_").trim();
+        String typeName = name.replace("-", "_").replace(" ", "_").replace('.', '_').trim();
         int i = 0;
         char c;
         while (i < typeName.length() && (Character.isDigit(c = typeName.charAt(i)) || c == '_')) {


### PR DESCRIPTION
This PR replaces '.' characters by '_' ones in generated type names. More precisely this only affects types generated in the support/Enums.ml file.

It brings us one step closer to being able to generated compilable code for https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.yaml

Fixes #7757.