### PR TITLE
[asciidoc] convert markdown into asciidoc (#7765)

### DIFF
--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -433,6 +433,11 @@
             <artifactId>caffeine</artifactId>
             <version>2.8.1</version>
         </dependency>
+        <dependency>
+            <groupId>nl.jworks.markdown_to_asciidoc</groupId>
+            <artifactId>markdown_to_asciidoc</artifactId>
+            <version>1.1</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>
@@ -442,5 +447,10 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+	    <repository>
+	        <id>jcenter</id>
+	        <name>jcenter</name>
+	        <url>https://jcenter.bintray.com</url>
+	    </repository>
     </repositories>
 </project>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3803,6 +3803,7 @@ public class DefaultCodegen implements CodegenConfig {
                 }
                 bodyParam = fromRequestBody(requestBody, imports, bodyParameterName);
                 bodyParam.description = escapeText(requestBody.getDescription());
+                bodyParam.unescapedDescription = requestBody.getDescription();
                 postProcessParameter(bodyParam);
 
                 bodyParams.add(bodyParam);
@@ -5798,6 +5799,7 @@ public class DefaultCodegen implements CodegenConfig {
                     codegenParameter.isContainer = true;
                     codegenParameter.isArray = true;
                     codegenParameter.description = escapeText(s.getDescription());
+                    codegenParameter.unescapedDescription = s.getDescription();
                     codegenParameter.dataType = getTypeDeclaration(arraySchema);
                     if (codegenParameter.baseType != null && codegenParameter.enumName != null) {
                         codegenParameter.datatypeWithEnum = codegenParameter.dataType.replace(codegenParameter.baseType, codegenParameter.enumName);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AsciidocDocumentationCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AsciidocDocumentationCodegen.java
@@ -16,7 +16,7 @@
 
 package org.openapitools.codegen.languages;
 
-import org.openapitools.codegen.*;
+import static nl.jworks.markdown_to_asciidoc.Converter.convertMarkdownToAsciiDoc;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,15 +27,36 @@ import java.nio.file.Paths;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 
-import org.openapitools.codegen.meta.features.*;
+import org.openapitools.codegen.CliOption;
+import org.openapitools.codegen.CodegenConfig;
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenParameter;
+import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.CodegenResponse;
+import org.openapitools.codegen.CodegenType;
+import org.openapitools.codegen.DefaultCodegen;
+import org.openapitools.codegen.SupportingFile;
+import org.openapitools.codegen.meta.features.ClientModificationFeature;
+import org.openapitools.codegen.meta.features.DocumentationFeature;
+import org.openapitools.codegen.meta.features.GlobalFeature;
+import org.openapitools.codegen.meta.features.SchemaSupportFeature;
+import org.openapitools.codegen.meta.features.SecurityFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.samskivert.mustache.Escapers;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.servers.Server;
 
 /**
  * basic asciidoc markup generator.
@@ -350,12 +371,79 @@ public class AsciidocDocumentationCodegen extends DefaultCodegen implements Code
         processBooleanFlag(USE_TABLE_TITLES_FLAG, useTableTitles);
     }
 
+    @Override
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+
+        op.summary = concertLineByLine(operation.getSummary());
+        op.notes = concertLineByLine(op.unescapedNotes);
+
+        convertParamList(op.bodyParams);
+        convertParamList(op.pathParams);
+        convertParamList(op.queryParams);
+        convertParamList(op.headerParams);
+        convertParamList(op.formParams);
+
+        return op;
+    }
+
+    @Override
+    public CodegenResponse fromResponse(String responseCode, ApiResponse response) {
+        CodegenResponse r = super.fromResponse(responseCode, response);
+        r.message = concertLineByLine(response.getDescription());
+        return r;
+    }
+
+    @Override
+    public CodegenModel fromModel(String name, @SuppressWarnings("rawtypes") Schema schema) {
+        CodegenModel m = super.fromModel(name, schema);
+        if (m != null) {
+            m.description = concertLineByLine(m.unescapedDescription);
+        }
+        return m;
+    }
+
+    @Override
+    public CodegenProperty fromProperty(String name, @SuppressWarnings("rawtypes") Schema p) {
+        CodegenProperty cpc = super.fromProperty(name, p);
+        if(cpc != null) {
+            cpc.description = concertLineByLine(cpc.unescapedDescription);
+        }
+        return cpc;
+    }
+
+    private static String concertLineByLine(String content) {
+        if (content == null) {
+            return null;
+        }
+
+        return convertSpecialChars(convertMarkdownToAsciiDoc(content)).trim();
+    }
+
+    private static String convertSpecialChars(String content) {
+        return content.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">");
+    }
+
+    private void convertParamList(List<CodegenParameter> params) {
+        if (params == null) {
+            return;
+        }
+        for (CodegenParameter param : params) {
+            param.description = concertLineByLine(param.unescapedDescription);
+        }
+    }
+
     private void processBooleanFlag(String flag, boolean value) {
         if (additionalProperties.containsKey(flag)) {
             this.setHeaderAttributes(convertPropertyToBooleanAndWriteBack(flag));
         } else {
             additionalProperties.put(flag, value);
         }
+    }
+
+    @Override
+    public Mustache.Compiler processCompiler(Mustache.Compiler compiler) {
+        return compiler.withEscaper(Escapers.NONE);
     }
 
     @Override
@@ -366,6 +454,10 @@ public class AsciidocDocumentationCodegen extends DefaultCodegen implements Code
         if (this.includeSnippetMarkupLambda != null) {
             LOGGER.debug("snippets: " + ": " + this.includeSnippetMarkupLambda.resetCounter());
         }
+
+        String appDescription = (String) additionalProperties().get("unescapedAppDescription");
+        additionalProperties().put("appDescription", concertLineByLine(appDescription));
+
         super.processOpenAPI(openAPI);
     }
 

--- a/modules/openapi-generator/src/main/resources/asciidoc-documentation/model.mustache
+++ b/modules/openapi-generator/src/main/resources/asciidoc-documentation/model.mustache
@@ -7,7 +7,7 @@
 [#{{classname}}]
 === _{{classname}}_ {{title}}
 
-{{unescapedDescription}}
+{{description}}
 
 [.fields-{{classname}}]
 [cols="2,1,2,4,1"]

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocMarkdownConvertTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocMarkdownConvertTest.java
@@ -1,0 +1,127 @@
+package org.openapitools.codegen.asciidoc;
+
+import static org.testng.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/** checks if markdown is converted to asciidoc */
+public class AsciidocMarkdownConvertTest {
+    public String markupContent = null;
+    public String markupFileName = null;
+
+    @BeforeClass
+    public void beforeClassGenerateTestMarkup() throws Exception {
+        File outputTempDirectory = Files.createTempDirectory("test-asciidoc-markdown-generator.").toFile();
+
+        CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("asciidoc")
+                .setInputSpec("src/test/resources/3_0/asciidoc/api-docs-markdown.yaml")
+                .setOutputDir(outputTempDirectory.getAbsolutePath());
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+
+        for (File file : files) {
+            if (file.getName().equals("index.adoc")) {
+                this.markupFileName = file.getAbsoluteFile().toString();
+                this.markupContent = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+            }
+        }
+    }
+
+    @AfterClass
+    public void afterClassCleanUpTestMarkup() throws Exception {
+        if (this.markupFileName != null) {
+            Files.deleteIfExists(Paths.get(this.markupFileName));
+        }
+    }
+
+    /**
+     * Source:
+     * 
+     * <pre>
+     * this library can be used by:
+     *
+     * 1. someone who need it
+     * 2. everybody else
+     * </pre>
+     */
+    @Test
+    public void testMarkDownInInfoDescription() {
+        assertContent("this library can be used by:\n\n. someone who need it\n. everybody else", "info description");
+    }
+
+    /**
+     * Source:
+     * 
+     * <pre>
+     * *dummy* application info endpoint.
+     * </pre>
+     */
+    @Test
+    public void testMarkDownInPathSummary() {
+        assertContent("_dummy_ application info endpoint.", "path summary");
+    }
+
+    /**
+     * Source:
+     * 
+     * <pre>
+     * some *notes* with special ><& char
+     * </pre>
+     */
+    @Test
+    public void testMarkDownInPathDescription() {
+        assertContent("some _notes_ with special ><& chars", "path description");
+    }
+
+    /**
+     * Source:
+     * 
+     * <pre>
+     * the **default** response
+     * </pre>
+     */
+    @Test
+    public void testMarkDownInPathResponseDescription() {
+        assertContent("the *default* response", "path response description");
+    }
+
+    /**
+     * Source:
+     * 
+     * <pre>
+     * oh, ``you`` should care about it
+     * </pre>
+     */
+    @Test
+    public void testMarkDownInComponentsSchemasDescription() {
+        assertContent("oh, `you` should care about it", "component schema description");
+    }
+
+    /**
+     * Source:
+     * 
+     * <pre>
+     * should be *very* secure
+     * </pre>
+     */
+    @Test
+    public void testMarkDownInComponentSchemaPropertyDescription() {
+        assertContent("should be _very_ secure", "component schema property description");
+    }
+
+    private void assertContent(String expected, String field) {
+        assertTrue(markupContent.contains(expected), "expected " + field + " to be converted to be '" + expected + "'");
+    }
+}

--- a/modules/openapi-generator/src/test/resources/3_0/asciidoc/api-docs-markdown.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/asciidoc/api-docs-markdown.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.1
+info:
+  title: markdown rest api
+  description: |
+    this library can be used by:
+
+    1. someone who need it
+    2. everybody else
+  version: '0.1'
+servers:
+  - url: 'http://localhost'
+    description: Generated server url
+tags:
+  - name: admin
+    description: 'admin **api**, internal use'
+paths:
+  /rest/admin/info:
+    get:
+      tags:
+        - admin
+      summary: '*dummy* application info endpoint.'
+      description: some *notes* with special ><& chars
+      operationId: info
+      responses:
+        '200':
+          description: 'the **default** response'
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/AdminInfo"
+components:
+  schemas:
+    AdminInfo:
+      type: object
+      properties:
+        userName:
+          type: string
+        password:
+          type: string
+          description: 'should be *very* secure'
+      description: 'oh, ``you`` should care about it'
+  securitySchemes:
+    Authentication:
+      type: apiKey
+      description: |
+        auth with jwt bearer token in 'Authentication' header of proctected
+        requests.
+      name: Authentication
+      in: header


### PR DESCRIPTION
I enhanced the asciidoc generator to convert the embended markdown rich text also into asciidoc.
I added also a test to make sure all rich text fields are covered.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

close #7765 