### PR TITLE
[typescript-rxjs] Added support for servers

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
@@ -91,6 +91,7 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
         super.processOpts();
         supportingFiles.add(new SupportingFile("index.mustache", "", "index.ts"));
         supportingFiles.add(new SupportingFile("runtime.mustache", "", "runtime.ts"));
+        supportingFiles.add(new SupportingFile("servers.mustache", "", "servers.ts"));
         supportingFiles.add(new SupportingFile("apis.index.mustache", apiPackage().replace('.', File.separatorChar), "index.ts"));
         supportingFiles.add(new SupportingFile("models.index.mustache", modelPackage().replace('.', File.separatorChar), "index.ts"));
         supportingFiles.add(new SupportingFile("tsconfig.mustache", "", "tsconfig.json"));
@@ -344,6 +345,7 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
         this.reservedWords.add("Middleware");
         this.reservedWords.add("AjaxRequest");
         this.reservedWords.add("AjaxResponse");
+        this.reservedWords.add("servers");
     }
 
     class ExtendedCodegenOperation extends CodegenOperation {

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/index.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/index.mustache
@@ -1,3 +1,4 @@
 export * from './runtime';
+export * from './servers';
 export * from './apis';
 export * from './models';

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -3,8 +3,9 @@
 import { Observable, of{{#withProgressSubscriber}}, Subscriber{{/withProgressSubscriber}} } from 'rxjs';
 import { ajax, AjaxRequest, AjaxResponse } from 'rxjs/ajax';
 import { map, concatMap } from 'rxjs/operators';
+import { servers } from './servers';
 
-export const BASE_PATH = '{{{basePath}}}'.replace(/\/+$/, '');
+export const BASE_PATH = servers[0].getUrl();
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/servers.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/servers.mustache
@@ -1,0 +1,45 @@
+/**
+ *
+ * Represents the configuration of a server including its
+ * url template and variable configuration based on the url.
+ *
+ */
+export class ServerConfiguration<T extends { [key: string]: string }> {
+    public constructor(private url: string, private variableConfiguration: T, private description: string) {}
+
+    /**
+     * Sets the value of the variables of this server.
+     *
+     * @param variableConfiguration a partial variable configuration for the variables contained in the url
+     */
+    public setVariables(variableConfiguration: Partial<T>) {
+        Object.assign(this.variableConfiguration, variableConfiguration);
+    }
+
+	public getConfiguration(): T {
+		return this.variableConfiguration
+	}
+
+	public getDescription(): string {
+		return this.description
+	}
+
+	/**
+	 * Constructions the URL this server using the url with variables
+	 * replaced with their respective values
+	 */	
+	public getUrl(): string {
+		let replacedUrl = this.url;
+		for (const key in this.variableConfiguration) {
+			var re = new RegExp("{" + key + "}","g");
+			replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
+		}
+		return replacedUrl
+	}
+}
+
+{{#servers}}
+const server{{-index}} = new ServerConfiguration<{ {{#variables}} "{{name}}": {{#enumValues}}"{{.}}"{{^-last}} | {{/-last}}{{/enumValues}}{{^enumValues}}string{{/enumValues}}{{^-last}},{{/-last}} {{/variables}} }>("{{url}}", { {{#variables}} "{{name}}": "{{defaultValue}}" {{^-last}},{{/-last}}{{/variables}} }, "{{description}}")
+{{/servers}}
+
+export const servers = [{{#servers}}server{{-index}}{{^-last}}, {{/-last}}{{/servers}}];

--- a/samples/client/petstore/typescript-rxjs/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-rxjs/builds/default/.openapi-generator/FILES
@@ -12,4 +12,5 @@ models/Tag.ts
 models/User.ts
 models/index.ts
 runtime.ts
+servers.ts
 tsconfig.json

--- a/samples/client/petstore/typescript-rxjs/builds/default/index.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/index.ts
@@ -1,3 +1,4 @@
 export * from './runtime';
+export * from './servers';
 export * from './apis';
 export * from './models';

--- a/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
@@ -14,8 +14,9 @@
 import { Observable, of } from 'rxjs';
 import { ajax, AjaxRequest, AjaxResponse } from 'rxjs/ajax';
 import { map, concatMap } from 'rxjs/operators';
+import { servers } from './servers';
 
-export const BASE_PATH = 'http://petstore.swagger.io/v2'.replace(/\/+$/, '');
+export const BASE_PATH = servers[0].getUrl();
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path

--- a/samples/client/petstore/typescript-rxjs/builds/default/servers.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/servers.ts
@@ -1,0 +1,43 @@
+/**
+ *
+ * Represents the configuration of a server including its
+ * url template and variable configuration based on the url.
+ *
+ */
+export class ServerConfiguration<T extends { [key: string]: string }> {
+    public constructor(private url: string, private variableConfiguration: T, private description: string) {}
+
+    /**
+     * Sets the value of the variables of this server.
+     *
+     * @param variableConfiguration a partial variable configuration for the variables contained in the url
+     */
+    public setVariables(variableConfiguration: Partial<T>) {
+        Object.assign(this.variableConfiguration, variableConfiguration);
+    }
+
+	public getConfiguration(): T {
+		return this.variableConfiguration
+	}
+
+	public getDescription(): string {
+		return this.description
+	}
+
+	/**
+	 * Constructions the URL this server using the url with variables
+	 * replaced with their respective values
+	 */	
+	public getUrl(): string {
+		let replacedUrl = this.url;
+		for (const key in this.variableConfiguration) {
+			var re = new RegExp("{" + key + "}","g");
+			replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
+		}
+		return replacedUrl
+	}
+}
+
+const server1 = new ServerConfiguration<{  }>("http://petstore.swagger.io/v2", {  }, "")
+
+export const servers = [server1];

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/.openapi-generator/FILES
@@ -14,4 +14,5 @@ models/User.ts
 models/index.ts
 package.json
 runtime.ts
+servers.ts
 tsconfig.json

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/index.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/index.ts
@@ -1,3 +1,4 @@
 export * from './runtime';
+export * from './servers';
 export * from './apis';
 export * from './models';

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
@@ -14,8 +14,9 @@
 import { Observable, of } from 'rxjs';
 import { ajax, AjaxRequest, AjaxResponse } from 'rxjs/ajax';
 import { map, concatMap } from 'rxjs/operators';
+import { servers } from './servers';
 
-export const BASE_PATH = 'http://petstore.swagger.io/v2'.replace(/\/+$/, '');
+export const BASE_PATH = servers[0].getUrl();
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/servers.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/servers.ts
@@ -1,0 +1,43 @@
+/**
+ *
+ * Represents the configuration of a server including its
+ * url template and variable configuration based on the url.
+ *
+ */
+export class ServerConfiguration<T extends { [key: string]: string }> {
+    public constructor(private url: string, private variableConfiguration: T, private description: string) {}
+
+    /**
+     * Sets the value of the variables of this server.
+     *
+     * @param variableConfiguration a partial variable configuration for the variables contained in the url
+     */
+    public setVariables(variableConfiguration: Partial<T>) {
+        Object.assign(this.variableConfiguration, variableConfiguration);
+    }
+
+	public getConfiguration(): T {
+		return this.variableConfiguration
+	}
+
+	public getDescription(): string {
+		return this.description
+	}
+
+	/**
+	 * Constructions the URL this server using the url with variables
+	 * replaced with their respective values
+	 */	
+	public getUrl(): string {
+		let replacedUrl = this.url;
+		for (const key in this.variableConfiguration) {
+			var re = new RegExp("{" + key + "}","g");
+			replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
+		}
+		return replacedUrl
+	}
+}
+
+const server1 = new ServerConfiguration<{  }>("http://petstore.swagger.io/v2", {  }, "")
+
+export const servers = [server1];

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/.openapi-generator/FILES
@@ -14,4 +14,5 @@ models/User.ts
 models/index.ts
 package.json
 runtime.ts
+servers.ts
 tsconfig.json

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/index.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/index.ts
@@ -1,3 +1,4 @@
 export * from './runtime';
+export * from './servers';
 export * from './apis';
 export * from './models';

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
@@ -14,8 +14,9 @@
 import { Observable, of } from 'rxjs';
 import { ajax, AjaxRequest, AjaxResponse } from 'rxjs/ajax';
 import { map, concatMap } from 'rxjs/operators';
+import { servers } from './servers';
 
-export const BASE_PATH = 'http://petstore.swagger.io/v2'.replace(/\/+$/, '');
+export const BASE_PATH = servers[0].getUrl();
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/servers.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/servers.ts
@@ -1,0 +1,43 @@
+/**
+ *
+ * Represents the configuration of a server including its
+ * url template and variable configuration based on the url.
+ *
+ */
+export class ServerConfiguration<T extends { [key: string]: string }> {
+    public constructor(private url: string, private variableConfiguration: T, private description: string) {}
+
+    /**
+     * Sets the value of the variables of this server.
+     *
+     * @param variableConfiguration a partial variable configuration for the variables contained in the url
+     */
+    public setVariables(variableConfiguration: Partial<T>) {
+        Object.assign(this.variableConfiguration, variableConfiguration);
+    }
+
+	public getConfiguration(): T {
+		return this.variableConfiguration
+	}
+
+	public getDescription(): string {
+		return this.description
+	}
+
+	/**
+	 * Constructions the URL this server using the url with variables
+	 * replaced with their respective values
+	 */	
+	public getUrl(): string {
+		let replacedUrl = this.url;
+		for (const key in this.variableConfiguration) {
+			var re = new RegExp("{" + key + "}","g");
+			replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
+		}
+		return replacedUrl
+	}
+}
+
+const server1 = new ServerConfiguration<{  }>("http://petstore.swagger.io/v2", {  }, "")
+
+export const servers = [server1];

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/.openapi-generator/FILES
@@ -12,4 +12,5 @@ models/Tag.ts
 models/User.ts
 models/index.ts
 runtime.ts
+servers.ts
 tsconfig.json

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/index.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/index.ts
@@ -1,3 +1,4 @@
 export * from './runtime';
+export * from './servers';
 export * from './apis';
 export * from './models';

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/runtime.ts
@@ -14,8 +14,9 @@
 import { Observable, of, Subscriber } from 'rxjs';
 import { ajax, AjaxRequest, AjaxResponse } from 'rxjs/ajax';
 import { map, concatMap } from 'rxjs/operators';
+import { servers } from './servers';
 
-export const BASE_PATH = 'http://petstore.swagger.io/v2'.replace(/\/+$/, '');
+export const BASE_PATH = servers[0].getUrl();
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/servers.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/servers.ts
@@ -1,0 +1,43 @@
+/**
+ *
+ * Represents the configuration of a server including its
+ * url template and variable configuration based on the url.
+ *
+ */
+export class ServerConfiguration<T extends { [key: string]: string }> {
+    public constructor(private url: string, private variableConfiguration: T, private description: string) {}
+
+    /**
+     * Sets the value of the variables of this server.
+     *
+     * @param variableConfiguration a partial variable configuration for the variables contained in the url
+     */
+    public setVariables(variableConfiguration: Partial<T>) {
+        Object.assign(this.variableConfiguration, variableConfiguration);
+    }
+
+	public getConfiguration(): T {
+		return this.variableConfiguration
+	}
+
+	public getDescription(): string {
+		return this.description
+	}
+
+	/**
+	 * Constructions the URL this server using the url with variables
+	 * replaced with their respective values
+	 */	
+	public getUrl(): string {
+		let replacedUrl = this.url;
+		for (const key in this.variableConfiguration) {
+			var re = new RegExp("{" + key + "}","g");
+			replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
+		}
+		return replacedUrl
+	}
+}
+
+const server1 = new ServerConfiguration<{  }>("http://petstore.swagger.io/v2", {  }, "")
+
+export const servers = [server1];


### PR DESCRIPTION
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Description of the PR

- allows the typescript-rxjs client to retrieve all server URLs defined in the spec (based on #1361)
- based on the main typescript project

_(if somebody could tell me, if typescript-rxjs is still a good idea to use or if the main typescript generator would be a better option (as it seems to use rxjs as well), I would highly appreciate it)_

cc @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)