### PR TITLE
[python] Add option to return None instead of raising exception when accessing unset attribute

### DIFF
--- a/docs/generators/python-experimental.md
+++ b/docs/generators/python-experimental.md
@@ -14,6 +14,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |packageUrl|python package URL.| |null|
 |packageVersion|python package version.| |1.0.0|
 |projectName|python project name in setup.py (e.g. petstore-api).| |null|
+|pythonAttrNoneIfUnset|when accessing unset attribute, return `None` instead of raising `ApiAttributeError`| |false|
 |recursionLimit|Set the recursion limit. If not set, use the system default value.| |null|
 |useNose|use the nose test framework| |false|
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -67,6 +67,9 @@ public class CodegenConstants {
     public static final String PYTHON_PACKAGE_NAME = "pythonPackageName";
     public static final String PYTHON_PACKAGE_NAME_DESC = "package name for generated python code";
 
+    public static final String PYTHON_ATTR_NONE_IF_UNSET = "pythonAttrNoneIfUnset";
+    public static final String PYTHON_ATTR_NONE_IF_UNSET_DESC = "when accessing unset attribute, return `None` instead of raising `ApiAttributeError`";
+
     public static final String WITH_GO_CODEGEN_COMMENT = "withGoCodegenComment";
     public static final String WITH_GO_CODEGEN_COMMENT_DESC = "whether to include Go codegen comment to disable Go Lint and collapse by default in GitHub PRs and diffs";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientExperimentalCodegen.java
@@ -122,6 +122,9 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
         // optional params/props with **kwargs in python
         cliOptions.remove(4);
 
+        cliOptions.add(new CliOption(CodegenConstants.PYTHON_ATTR_NONE_IF_UNSET, CodegenConstants.PYTHON_ATTR_NONE_IF_UNSET_DESC)
+                .defaultValue(Boolean.FALSE.toString()));
+
         generatorMetadata = GeneratorMetadata.newBuilder(generatorMetadata)
                 .stability(Stability.EXPERIMENTAL)
                 .build();
@@ -209,6 +212,12 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
         // default this to true so the python ModelSimple models will be generated
         ModelUtils.setGenerateAliasAsModel(true);
         LOGGER.info(CodegenConstants.GENERATE_ALIAS_AS_MODEL + " is hard coded to true in this generator. Alias models will only be generated if they contain validations or enums");
+
+        Boolean attrNoneIfUnset = false;
+        if (additionalProperties.containsKey(CodegenConstants.PYTHON_ATTR_NONE_IF_UNSET)) {
+            attrNoneIfUnset = Boolean.valueOf(additionalProperties.get(CodegenConstants.PYTHON_ATTR_NONE_IF_UNSET).toString());
+        }
+        additionalProperties.put("attrNoneIfUnset", attrNoneIfUnset);
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_composed.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_composed.mustache
@@ -85,3 +85,6 @@
                     return True
 
         return False
+
+    __setattr__ = __setitem__
+    __getattr__ = {{#attrNoneIfUnset}}get{{/attrNoneIfUnset}}{{^attrNoneIfUnset}}__getitem__{{/attrNoneIfUnset}}

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_composed.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_composed.mustache
@@ -1,5 +1,5 @@
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
         if name in self.required_properties:
             self.__dict__[name] = value
             return
@@ -29,7 +29,7 @@
     __unset_attribute_value__ = object()
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
+        """returns the value of an attribute or some default value if the attribute was not set"""
         if name in self.required_properties:
             return self.__dict__[name]
 
@@ -61,8 +61,9 @@
             )
 
     def __getitem__(self, name):
-        value = self.get(name, self.__unset_attribute_value__)
-        if value is self.__unset_attribute_value__:
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
+        value = self.get(name, self.__dict__['__unset_attribute_value__'])
+        if value is self.__dict__['__unset_attribute_value__']:
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),
@@ -71,7 +72,7 @@
         return value
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
 
         if name in self.required_properties:
             return name in self.__dict__
@@ -85,6 +86,3 @@
                     return True
 
         return False
-
-    __setattr__ = __setitem__
-    __getattr__ = {{#attrNoneIfUnset}}get{{/attrNoneIfUnset}}{{^attrNoneIfUnset}}__getitem__{{/attrNoneIfUnset}}

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_composed.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_composed.mustache
@@ -62,8 +62,8 @@
 
     def __getitem__(self, name):
         """get the value of an attribute using square-bracket notation: `instance[attr]`"""
-        value = self.get(name, self.__dict__['__unset_attribute_value__'])
-        if value is self.__dict__['__unset_attribute_value__']:
+        value = self.get(name, self.__unset_attribute_value__)
+        if value is self.__unset_attribute_value__:
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_composed.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_composed.mustache
@@ -55,11 +55,15 @@
                         values.append(v)
         len_values = len(values)
         if len_values == 0:
+{{#attrNoneIfUnset}}
+            return None
+{{/attrNoneIfUnset}}{{^attrNoneIfUnset}}
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),
                 path_to_item
             )
+{{/attrNoneIfUnset}}
         elif len_values == 1:
             return values[0]
         elif len_values > 1:

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_composed.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_composed.mustache
@@ -1,4 +1,4 @@
-    def __setattr__(self, name, value):
+    def __setitem__(self, name, value):
         """this allows us to set a value with instance.field_name = val"""
         if name in self.required_properties:
             self.__dict__[name] = value
@@ -20,17 +20,15 @@
                     )
             return None
 
-        path_to_item = []
-        if self._path_to_item:
-            path_to_item.extend(self._path_to_item)
-        path_to_item.append(name)
         raise ApiAttributeError(
             "{0} has no attribute '{1}'".format(
                 type(self).__name__, name),
-            path_to_item
+            [e for e in [self._path_to_item, name] if e]
         )
 
-    def __getattr__(self, name):
+    __unset_attribute_value__ = object()
+
+    def get(self, name, default=None):
         """this allows us to get a value with val = instance.field_name"""
         if name in self.required_properties:
             return self.__dict__[name]
@@ -38,10 +36,6 @@
         # get the attribute from the correct instance
         model_instances = self._var_name_to_model_instances.get(
             name, self._additional_properties_model_instances)
-        path_to_item = []
-        if self._path_to_item:
-            path_to_item.extend(self._path_to_item)
-        path_to_item.append(name)
         values = []
         # A composed model stores child (oneof/anyOf/allOf) models under
         # self._var_name_to_model_instances. A named property can exist in
@@ -55,15 +49,7 @@
                         values.append(v)
         len_values = len(values)
         if len_values == 0:
-{{#attrNoneIfUnset}}
-            return None
-{{/attrNoneIfUnset}}{{^attrNoneIfUnset}}
-            raise ApiAttributeError(
-                "{0} has no attribute '{1}'".format(
-                    type(self).__name__, name),
-                path_to_item
-            )
-{{/attrNoneIfUnset}}
+            return default
         elif len_values == 1:
             return values[0]
         elif len_values > 1:
@@ -71,8 +57,18 @@
                 "Values stored for property {0} in {1} differ when looking "
                 "at self and self's composed instances. All values must be "
                 "the same".format(name, type(self).__name__),
-                path_to_item
+                [e for e in [self._path_to_item, name] if e]
             )
+
+    def __getitem__(self, name):
+        value = self.get(name, self.__unset_attribute_value__)
+        if value is self.__unset_attribute_value__:
+            raise ApiAttributeError(
+                "{0} has no attribute '{1}'".format(
+                    type(self).__name__, name),
+                    [e for e in [self._path_to_item, name] if e]
+            )
+        return value
 
     def __contains__(self, name):
         """this allows us to use `in` operator: `'attr' in instance`"""

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_normal.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_normal.mustache
@@ -1,6 +1,6 @@
     def __setitem__(self, name, value):
         """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             self.__dict__[name] = value
             return
 
@@ -8,7 +8,7 @@
 
     def get(self, name, default=None):
         """returns the value of an attribute or some default value if the attribute was not set"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
@@ -26,7 +26,7 @@
 
     def __contains__(self, name):
         """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_normal.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_normal.mustache
@@ -1,20 +1,20 @@
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
-        if name in self.required_properties:
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
+        if name in self.__dict__['required_properties']:
             self.__dict__[name] = value
             return
 
         self.set_attribute(name, value)
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
-        if name in self.required_properties:
+        """returns the value of an attribute or some default value if the attribute was not set"""
+        if name in self.__dict__['required_properties']:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
 
     def __getitem__(self, name):
-        """this allows us to get a value with val = instance.field_name"""
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
         if name in self:
             return self.get(name)
 
@@ -25,11 +25,8 @@
         )
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
-        if name in self.required_properties:
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
+        if name in self.__dict__['required_properties']:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
-
-    __setattr__ = __setitem__
-    __getattr__ = {{#attrNoneIfUnset}}get{{/attrNoneIfUnset}}{{^attrNoneIfUnset}}__getitem__{{/attrNoneIfUnset}}

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_normal.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_normal.mustache
@@ -30,3 +30,6 @@
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
+
+    __setattr__ = __setitem__
+    __getattr__ = {{#attrNoneIfUnset}}get{{/attrNoneIfUnset}}{{^attrNoneIfUnset}}__getitem__{{/attrNoneIfUnset}}

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_normal.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_normal.mustache
@@ -1,4 +1,4 @@
-    def __setattr__(self, name, value):
+    def __setitem__(self, name, value):
         """this allows us to set a value with instance.field_name = val"""
         if name in self.required_properties:
             self.__dict__[name] = value
@@ -6,26 +6,23 @@
 
         self.set_attribute(name, value)
 
-    def __getattr__(self, name):
+    def get(self, name, default=None):
         """this allows us to get a value with val = instance.field_name"""
         if name in self.required_properties:
             return self.__dict__[name]
-{{#attrNoneIfUnset}}
-        return self.__dict__['_data_store'].get(name)
-{{/attrNoneIfUnset}}{{^attrNoneIfUnset}}
-        if name in self.__dict__['_data_store']:
-            return self.__dict__['_data_store'][name]
 
-        path_to_item = []
-        if self._path_to_item:
-            path_to_item.extend(self._path_to_item)
-        path_to_item.append(name)
+        return self.__dict__['_data_store'].get(name, default)
+
+    def __getitem__(self, name):
+        """this allows us to get a value with val = instance.field_name"""
+        if name in self:
+            return self.get(name)
+
         raise ApiAttributeError(
             "{0} has no attribute '{1}'".format(
                 type(self).__name__, name),
-            [name]
+            [e for e in [self._path_to_item, name] if e]
         )
-{{/attrNoneIfUnset}}
 
     def __contains__(self, name):
         """this allows us to use `in` operator: `'attr' in instance`"""

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_normal.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_setattr_getattr_normal.mustache
@@ -10,7 +10,9 @@
         """this allows us to get a value with val = instance.field_name"""
         if name in self.required_properties:
             return self.__dict__[name]
-
+{{#attrNoneIfUnset}}
+        return self.__dict__['_data_store'].get(name)
+{{/attrNoneIfUnset}}{{^attrNoneIfUnset}}
         if name in self.__dict__['_data_store']:
             return self.__dict__['_data_store'][name]
 
@@ -23,6 +25,7 @@
                 type(self).__name__, name),
             [name]
         )
+{{/attrNoneIfUnset}}
 
     def __contains__(self, name):
         """this allows us to use `in` operator: `'attr' in instance`"""

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_shared.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_shared.mustache
@@ -5,6 +5,3 @@
     def __ne__(self, other):
         """Returns true if both objects are not equal"""
         return not self == other
-
-    __setattr__ = __setitem__
-    __getattr__ = {{#attrNoneIfUnset}}get{{/attrNoneIfUnset}}{{^attrNoneIfUnset}}__getitem__{{/attrNoneIfUnset}}

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_shared.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_shared.mustache
@@ -5,3 +5,11 @@
     def __ne__(self, other):
         """Returns true if both objects are not equal"""
         return not self == other
+
+    def __setattr__(self, attr, value):
+        """set the value of an attribute using dot notation: `instance.attr = val`"""
+        self[attr] = value
+
+    def __getattr__(self, attr):
+        """get the value of an attribute using dot notation: `instance.attr`"""
+        return self.{{#attrNoneIfUnset}}get{{/attrNoneIfUnset}}{{^attrNoneIfUnset}}__getitem__{{/attrNoneIfUnset}}(attr)

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_shared.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_templates/methods_shared.mustache
@@ -1,11 +1,3 @@
-    def __setitem__(self, name, value):
-        """this allows us to set values with instance[field_name] = val"""
-        self.__setattr__(name, value)
-
-    def __getitem__(self, name):
-        """this allows us to get a value with val = instance[field_name]"""
-        return self.__getattr__(name)
-
     def __repr__(self):
         """For `print` and `pprint`"""
         return self.to_str()
@@ -13,3 +5,6 @@
     def __ne__(self, other):
         """Returns true if both objects are not equal"""
         return not self == other
+
+    __setattr__ = __setitem__
+    __getattr__ = {{#attrNoneIfUnset}}get{{/attrNoneIfUnset}}{{^attrNoneIfUnset}}__getitem__{{/attrNoneIfUnset}}

--- a/samples/client/petstore/python-experimental/petstore_api/model_utils.py
+++ b/samples/client/petstore/python-experimental/petstore_api/model_utils.py
@@ -489,6 +489,7 @@ class ModelComposed(OpenApiModel):
                         values.append(v)
         len_values = len(values)
         if len_values == 0:
+
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),

--- a/samples/client/petstore/python-experimental/petstore_api/model_utils.py
+++ b/samples/client/petstore/python-experimental/petstore_api/model_utils.py
@@ -292,7 +292,7 @@ class ModelSimple(OpenApiModel):
 
     def __setitem__(self, name, value):
         """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             self.__dict__[name] = value
             return
 
@@ -300,7 +300,7 @@ class ModelSimple(OpenApiModel):
 
     def get(self, name, default=None):
         """returns the value of an attribute or some default value if the attribute was not set"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
@@ -318,7 +318,7 @@ class ModelSimple(OpenApiModel):
 
     def __contains__(self, name):
         """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
@@ -347,7 +347,7 @@ class ModelNormal(OpenApiModel):
 
     def __setitem__(self, name, value):
         """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             self.__dict__[name] = value
             return
 
@@ -355,7 +355,7 @@ class ModelNormal(OpenApiModel):
 
     def get(self, name, default=None):
         """returns the value of an attribute or some default value if the attribute was not set"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
@@ -373,7 +373,7 @@ class ModelNormal(OpenApiModel):
 
     def __contains__(self, name):
         """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
@@ -494,8 +494,8 @@ class ModelComposed(OpenApiModel):
 
     def __getitem__(self, name):
         """get the value of an attribute using square-bracket notation: `instance[attr]`"""
-        value = self.get(name, self.__dict__['__unset_attribute_value__'])
-        if value is self.__dict__['__unset_attribute_value__']:
+        value = self.get(name, self.__unset_attribute_value__)
+        if value is self.__unset_attribute_value__:
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),

--- a/samples/client/petstore/python-experimental/petstore_api/model_utils.py
+++ b/samples/client/petstore/python-experimental/petstore_api/model_utils.py
@@ -164,8 +164,13 @@ class OpenApiModel(object):
         """Returns true if both objects are not equal"""
         return not self == other
 
-    __setattr__ = __setitem__
-    __getattr__ = __getitem__
+    def __setattr__(self, attr, value):
+        """set the value of an attribute using dot notation: `instance.attr = val`"""
+        self[attr] = value
+
+    def __getattr__(self, attr):
+        """get the value of an attribute using dot notation: `instance.attr`"""
+        return self.__getitem__(attr)
 
     def __new__(cls, *args, **kwargs):
         # this function uses the discriminator to
@@ -286,22 +291,22 @@ class ModelSimple(OpenApiModel):
     swagger/openapi"""
 
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
-        if name in self.required_properties:
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
+        if name in self.__dict__['required_properties']:
             self.__dict__[name] = value
             return
 
         self.set_attribute(name, value)
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
-        if name in self.required_properties:
+        """returns the value of an attribute or some default value if the attribute was not set"""
+        if name in self.__dict__['required_properties']:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
 
     def __getitem__(self, name):
-        """this allows us to get a value with val = instance.field_name"""
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
         if name in self:
             return self.get(name)
 
@@ -312,12 +317,11 @@ class ModelSimple(OpenApiModel):
         )
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
-        if name in self.required_properties:
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
+        if name in self.__dict__['required_properties']:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
-
 
     def to_str(self):
         """Returns the string representation of the model"""
@@ -342,22 +346,22 @@ class ModelNormal(OpenApiModel):
     swagger/openapi"""
 
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
-        if name in self.required_properties:
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
+        if name in self.__dict__['required_properties']:
             self.__dict__[name] = value
             return
 
         self.set_attribute(name, value)
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
-        if name in self.required_properties:
+        """returns the value of an attribute or some default value if the attribute was not set"""
+        if name in self.__dict__['required_properties']:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
 
     def __getitem__(self, name):
-        """this allows us to get a value with val = instance.field_name"""
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
         if name in self:
             return self.get(name)
 
@@ -368,12 +372,11 @@ class ModelNormal(OpenApiModel):
         )
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
-        if name in self.required_properties:
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
+        if name in self.__dict__['required_properties']:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
-
 
     def to_dict(self):
         """Returns the model properties as a dict"""
@@ -428,7 +431,7 @@ class ModelComposed(OpenApiModel):
     """
 
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
         if name in self.required_properties:
             self.__dict__[name] = value
             return
@@ -458,7 +461,7 @@ class ModelComposed(OpenApiModel):
     __unset_attribute_value__ = object()
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
+        """returns the value of an attribute or some default value if the attribute was not set"""
         if name in self.required_properties:
             return self.__dict__[name]
 
@@ -490,8 +493,9 @@ class ModelComposed(OpenApiModel):
             )
 
     def __getitem__(self, name):
-        value = self.get(name, self.__unset_attribute_value__)
-        if value is self.__unset_attribute_value__:
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
+        value = self.get(name, self.__dict__['__unset_attribute_value__'])
+        if value is self.__dict__['__unset_attribute_value__']:
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),
@@ -500,7 +504,7 @@ class ModelComposed(OpenApiModel):
         return value
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
 
         if name in self.required_properties:
             return name in self.__dict__
@@ -514,7 +518,6 @@ class ModelComposed(OpenApiModel):
                     return True
 
         return False
-
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/model_utils.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/model_utils.py
@@ -489,6 +489,7 @@ class ModelComposed(OpenApiModel):
                         values.append(v)
         len_values = len(values)
         if len_values == 0:
+
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/model_utils.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/model_utils.py
@@ -292,7 +292,7 @@ class ModelSimple(OpenApiModel):
 
     def __setitem__(self, name, value):
         """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             self.__dict__[name] = value
             return
 
@@ -300,7 +300,7 @@ class ModelSimple(OpenApiModel):
 
     def get(self, name, default=None):
         """returns the value of an attribute or some default value if the attribute was not set"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
@@ -318,7 +318,7 @@ class ModelSimple(OpenApiModel):
 
     def __contains__(self, name):
         """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
@@ -347,7 +347,7 @@ class ModelNormal(OpenApiModel):
 
     def __setitem__(self, name, value):
         """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             self.__dict__[name] = value
             return
 
@@ -355,7 +355,7 @@ class ModelNormal(OpenApiModel):
 
     def get(self, name, default=None):
         """returns the value of an attribute or some default value if the attribute was not set"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
@@ -373,7 +373,7 @@ class ModelNormal(OpenApiModel):
 
     def __contains__(self, name):
         """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
@@ -494,8 +494,8 @@ class ModelComposed(OpenApiModel):
 
     def __getitem__(self, name):
         """get the value of an attribute using square-bracket notation: `instance[attr]`"""
-        value = self.get(name, self.__dict__['__unset_attribute_value__'])
-        if value is self.__dict__['__unset_attribute_value__']:
+        value = self.get(name, self.__unset_attribute_value__)
+        if value is self.__unset_attribute_value__:
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/model_utils.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python-experimental/x_auth_id_alias/model_utils.py
@@ -164,8 +164,13 @@ class OpenApiModel(object):
         """Returns true if both objects are not equal"""
         return not self == other
 
-    __setattr__ = __setitem__
-    __getattr__ = __getitem__
+    def __setattr__(self, attr, value):
+        """set the value of an attribute using dot notation: `instance.attr = val`"""
+        self[attr] = value
+
+    def __getattr__(self, attr):
+        """get the value of an attribute using dot notation: `instance.attr`"""
+        return self.__getitem__(attr)
 
     def __new__(cls, *args, **kwargs):
         # this function uses the discriminator to
@@ -286,22 +291,22 @@ class ModelSimple(OpenApiModel):
     swagger/openapi"""
 
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
-        if name in self.required_properties:
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
+        if name in self.__dict__['required_properties']:
             self.__dict__[name] = value
             return
 
         self.set_attribute(name, value)
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
-        if name in self.required_properties:
+        """returns the value of an attribute or some default value if the attribute was not set"""
+        if name in self.__dict__['required_properties']:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
 
     def __getitem__(self, name):
-        """this allows us to get a value with val = instance.field_name"""
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
         if name in self:
             return self.get(name)
 
@@ -312,12 +317,11 @@ class ModelSimple(OpenApiModel):
         )
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
-        if name in self.required_properties:
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
+        if name in self.__dict__['required_properties']:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
-
 
     def to_str(self):
         """Returns the string representation of the model"""
@@ -342,22 +346,22 @@ class ModelNormal(OpenApiModel):
     swagger/openapi"""
 
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
-        if name in self.required_properties:
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
+        if name in self.__dict__['required_properties']:
             self.__dict__[name] = value
             return
 
         self.set_attribute(name, value)
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
-        if name in self.required_properties:
+        """returns the value of an attribute or some default value if the attribute was not set"""
+        if name in self.__dict__['required_properties']:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
 
     def __getitem__(self, name):
-        """this allows us to get a value with val = instance.field_name"""
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
         if name in self:
             return self.get(name)
 
@@ -368,12 +372,11 @@ class ModelNormal(OpenApiModel):
         )
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
-        if name in self.required_properties:
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
+        if name in self.__dict__['required_properties']:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
-
 
     def to_dict(self):
         """Returns the model properties as a dict"""
@@ -428,7 +431,7 @@ class ModelComposed(OpenApiModel):
     """
 
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
         if name in self.required_properties:
             self.__dict__[name] = value
             return
@@ -458,7 +461,7 @@ class ModelComposed(OpenApiModel):
     __unset_attribute_value__ = object()
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
+        """returns the value of an attribute or some default value if the attribute was not set"""
         if name in self.required_properties:
             return self.__dict__[name]
 
@@ -490,8 +493,9 @@ class ModelComposed(OpenApiModel):
             )
 
     def __getitem__(self, name):
-        value = self.get(name, self.__unset_attribute_value__)
-        if value is self.__unset_attribute_value__:
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
+        value = self.get(name, self.__dict__['__unset_attribute_value__'])
+        if value is self.__dict__['__unset_attribute_value__']:
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),
@@ -500,7 +504,7 @@ class ModelComposed(OpenApiModel):
         return value
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
 
         if name in self.required_properties:
             return name in self.__dict__
@@ -514,7 +518,6 @@ class ModelComposed(OpenApiModel):
                     return True
 
         return False
-
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/model_utils.py
+++ b/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/model_utils.py
@@ -489,6 +489,7 @@ class ModelComposed(OpenApiModel):
                         values.append(v)
         len_values = len(values)
         if len_values == 0:
+
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),

--- a/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/model_utils.py
+++ b/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/model_utils.py
@@ -292,7 +292,7 @@ class ModelSimple(OpenApiModel):
 
     def __setitem__(self, name, value):
         """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             self.__dict__[name] = value
             return
 
@@ -300,7 +300,7 @@ class ModelSimple(OpenApiModel):
 
     def get(self, name, default=None):
         """returns the value of an attribute or some default value if the attribute was not set"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
@@ -318,7 +318,7 @@ class ModelSimple(OpenApiModel):
 
     def __contains__(self, name):
         """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
@@ -347,7 +347,7 @@ class ModelNormal(OpenApiModel):
 
     def __setitem__(self, name, value):
         """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             self.__dict__[name] = value
             return
 
@@ -355,7 +355,7 @@ class ModelNormal(OpenApiModel):
 
     def get(self, name, default=None):
         """returns the value of an attribute or some default value if the attribute was not set"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
@@ -373,7 +373,7 @@ class ModelNormal(OpenApiModel):
 
     def __contains__(self, name):
         """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
@@ -494,8 +494,8 @@ class ModelComposed(OpenApiModel):
 
     def __getitem__(self, name):
         """get the value of an attribute using square-bracket notation: `instance[attr]`"""
-        value = self.get(name, self.__dict__['__unset_attribute_value__'])
-        if value is self.__dict__['__unset_attribute_value__']:
+        value = self.get(name, self.__unset_attribute_value__)
+        if value is self.__unset_attribute_value__:
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),

--- a/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/model_utils.py
+++ b/samples/openapi3/client/features/dynamic-servers/python-experimental/dynamic_servers/model_utils.py
@@ -164,8 +164,13 @@ class OpenApiModel(object):
         """Returns true if both objects are not equal"""
         return not self == other
 
-    __setattr__ = __setitem__
-    __getattr__ = __getitem__
+    def __setattr__(self, attr, value):
+        """set the value of an attribute using dot notation: `instance.attr = val`"""
+        self[attr] = value
+
+    def __getattr__(self, attr):
+        """get the value of an attribute using dot notation: `instance.attr`"""
+        return self.__getitem__(attr)
 
     def __new__(cls, *args, **kwargs):
         # this function uses the discriminator to
@@ -286,22 +291,22 @@ class ModelSimple(OpenApiModel):
     swagger/openapi"""
 
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
-        if name in self.required_properties:
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
+        if name in self.__dict__['required_properties']:
             self.__dict__[name] = value
             return
 
         self.set_attribute(name, value)
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
-        if name in self.required_properties:
+        """returns the value of an attribute or some default value if the attribute was not set"""
+        if name in self.__dict__['required_properties']:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
 
     def __getitem__(self, name):
-        """this allows us to get a value with val = instance.field_name"""
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
         if name in self:
             return self.get(name)
 
@@ -312,12 +317,11 @@ class ModelSimple(OpenApiModel):
         )
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
-        if name in self.required_properties:
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
+        if name in self.__dict__['required_properties']:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
-
 
     def to_str(self):
         """Returns the string representation of the model"""
@@ -342,22 +346,22 @@ class ModelNormal(OpenApiModel):
     swagger/openapi"""
 
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
-        if name in self.required_properties:
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
+        if name in self.__dict__['required_properties']:
             self.__dict__[name] = value
             return
 
         self.set_attribute(name, value)
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
-        if name in self.required_properties:
+        """returns the value of an attribute or some default value if the attribute was not set"""
+        if name in self.__dict__['required_properties']:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
 
     def __getitem__(self, name):
-        """this allows us to get a value with val = instance.field_name"""
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
         if name in self:
             return self.get(name)
 
@@ -368,12 +372,11 @@ class ModelNormal(OpenApiModel):
         )
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
-        if name in self.required_properties:
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
+        if name in self.__dict__['required_properties']:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
-
 
     def to_dict(self):
         """Returns the model properties as a dict"""
@@ -428,7 +431,7 @@ class ModelComposed(OpenApiModel):
     """
 
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
         if name in self.required_properties:
             self.__dict__[name] = value
             return
@@ -458,7 +461,7 @@ class ModelComposed(OpenApiModel):
     __unset_attribute_value__ = object()
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
+        """returns the value of an attribute or some default value if the attribute was not set"""
         if name in self.required_properties:
             return self.__dict__[name]
 
@@ -490,8 +493,9 @@ class ModelComposed(OpenApiModel):
             )
 
     def __getitem__(self, name):
-        value = self.get(name, self.__unset_attribute_value__)
-        if value is self.__unset_attribute_value__:
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
+        value = self.get(name, self.__dict__['__unset_attribute_value__'])
+        if value is self.__dict__['__unset_attribute_value__']:
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),
@@ -500,7 +504,7 @@ class ModelComposed(OpenApiModel):
         return value
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
 
         if name in self.required_properties:
             return name in self.__dict__
@@ -514,7 +518,6 @@ class ModelComposed(OpenApiModel):
                     return True
 
         return False
-
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model_utils.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model_utils.py
@@ -156,14 +156,6 @@ class OpenApiModel(object):
             )
         self.__dict__['_data_store'][name] = value
 
-    def __setitem__(self, name, value):
-        """this allows us to set values with instance[field_name] = val"""
-        self.__setattr__(name, value)
-
-    def __getitem__(self, name):
-        """this allows us to get a value with val = instance[field_name]"""
-        return self.__getattr__(name)
-
     def __repr__(self):
         """For `print` and `pprint`"""
         return self.to_str()
@@ -171,6 +163,9 @@ class OpenApiModel(object):
     def __ne__(self, other):
         """Returns true if both objects are not equal"""
         return not self == other
+
+    __setattr__ = __setitem__
+    __getattr__ = __getitem__
 
     def __new__(cls, *args, **kwargs):
         # this function uses the discriminator to
@@ -290,7 +285,7 @@ class ModelSimple(OpenApiModel):
     """the parent class of models whose type != object in their
     swagger/openapi"""
 
-    def __setattr__(self, name, value):
+    def __setitem__(self, name, value):
         """this allows us to set a value with instance.field_name = val"""
         if name in self.required_properties:
             self.__dict__[name] = value
@@ -298,22 +293,22 @@ class ModelSimple(OpenApiModel):
 
         self.set_attribute(name, value)
 
-    def __getattr__(self, name):
+    def get(self, name, default=None):
         """this allows us to get a value with val = instance.field_name"""
         if name in self.required_properties:
             return self.__dict__[name]
 
-        if name in self.__dict__['_data_store']:
-            return self.__dict__['_data_store'][name]
+        return self.__dict__['_data_store'].get(name, default)
 
-        path_to_item = []
-        if self._path_to_item:
-            path_to_item.extend(self._path_to_item)
-        path_to_item.append(name)
+    def __getitem__(self, name):
+        """this allows us to get a value with val = instance.field_name"""
+        if name in self:
+            return self.get(name)
+
         raise ApiAttributeError(
             "{0} has no attribute '{1}'".format(
                 type(self).__name__, name),
-            [name]
+            [e for e in [self._path_to_item, name] if e]
         )
 
     def __contains__(self, name):
@@ -346,7 +341,7 @@ class ModelNormal(OpenApiModel):
     """the parent class of models whose type == object in their
     swagger/openapi"""
 
-    def __setattr__(self, name, value):
+    def __setitem__(self, name, value):
         """this allows us to set a value with instance.field_name = val"""
         if name in self.required_properties:
             self.__dict__[name] = value
@@ -354,22 +349,22 @@ class ModelNormal(OpenApiModel):
 
         self.set_attribute(name, value)
 
-    def __getattr__(self, name):
+    def get(self, name, default=None):
         """this allows us to get a value with val = instance.field_name"""
         if name in self.required_properties:
             return self.__dict__[name]
 
-        if name in self.__dict__['_data_store']:
-            return self.__dict__['_data_store'][name]
+        return self.__dict__['_data_store'].get(name, default)
 
-        path_to_item = []
-        if self._path_to_item:
-            path_to_item.extend(self._path_to_item)
-        path_to_item.append(name)
+    def __getitem__(self, name):
+        """this allows us to get a value with val = instance.field_name"""
+        if name in self:
+            return self.get(name)
+
         raise ApiAttributeError(
             "{0} has no attribute '{1}'".format(
                 type(self).__name__, name),
-            [name]
+            [e for e in [self._path_to_item, name] if e]
         )
 
     def __contains__(self, name):
@@ -432,7 +427,7 @@ class ModelComposed(OpenApiModel):
     which contain the value that the key is referring to.
     """
 
-    def __setattr__(self, name, value):
+    def __setitem__(self, name, value):
         """this allows us to set a value with instance.field_name = val"""
         if name in self.required_properties:
             self.__dict__[name] = value
@@ -454,17 +449,15 @@ class ModelComposed(OpenApiModel):
                     )
             return None
 
-        path_to_item = []
-        if self._path_to_item:
-            path_to_item.extend(self._path_to_item)
-        path_to_item.append(name)
         raise ApiAttributeError(
             "{0} has no attribute '{1}'".format(
                 type(self).__name__, name),
-            path_to_item
+            [e for e in [self._path_to_item, name] if e]
         )
 
-    def __getattr__(self, name):
+    __unset_attribute_value__ = object()
+
+    def get(self, name, default=None):
         """this allows us to get a value with val = instance.field_name"""
         if name in self.required_properties:
             return self.__dict__[name]
@@ -472,10 +465,6 @@ class ModelComposed(OpenApiModel):
         # get the attribute from the correct instance
         model_instances = self._var_name_to_model_instances.get(
             name, self._additional_properties_model_instances)
-        path_to_item = []
-        if self._path_to_item:
-            path_to_item.extend(self._path_to_item)
-        path_to_item.append(name)
         values = []
         # A composed model stores child (oneof/anyOf/allOf) models under
         # self._var_name_to_model_instances. A named property can exist in
@@ -489,11 +478,7 @@ class ModelComposed(OpenApiModel):
                         values.append(v)
         len_values = len(values)
         if len_values == 0:
-            raise ApiAttributeError(
-                "{0} has no attribute '{1}'".format(
-                    type(self).__name__, name),
-                path_to_item
-            )
+            return default
         elif len_values == 1:
             return values[0]
         elif len_values > 1:
@@ -501,8 +486,18 @@ class ModelComposed(OpenApiModel):
                 "Values stored for property {0} in {1} differ when looking "
                 "at self and self's composed instances. All values must be "
                 "the same".format(name, type(self).__name__),
-                path_to_item
+                [e for e in [self._path_to_item, name] if e]
             )
+
+    def __getitem__(self, name):
+        value = self.get(name, self.__unset_attribute_value__)
+        if value is self.__unset_attribute_value__:
+            raise ApiAttributeError(
+                "{0} has no attribute '{1}'".format(
+                    type(self).__name__, name),
+                    [e for e in [self._path_to_item, name] if e]
+            )
+        return value
 
     def __contains__(self, name):
         """this allows us to use `in` operator: `'attr' in instance`"""

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model_utils.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model_utils.py
@@ -292,7 +292,7 @@ class ModelSimple(OpenApiModel):
 
     def __setitem__(self, name, value):
         """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             self.__dict__[name] = value
             return
 
@@ -300,7 +300,7 @@ class ModelSimple(OpenApiModel):
 
     def get(self, name, default=None):
         """returns the value of an attribute or some default value if the attribute was not set"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
@@ -318,7 +318,7 @@ class ModelSimple(OpenApiModel):
 
     def __contains__(self, name):
         """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
@@ -347,7 +347,7 @@ class ModelNormal(OpenApiModel):
 
     def __setitem__(self, name, value):
         """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             self.__dict__[name] = value
             return
 
@@ -355,7 +355,7 @@ class ModelNormal(OpenApiModel):
 
     def get(self, name, default=None):
         """returns the value of an attribute or some default value if the attribute was not set"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
@@ -373,7 +373,7 @@ class ModelNormal(OpenApiModel):
 
     def __contains__(self, name):
         """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
-        if name in self.__dict__['required_properties']:
+        if name in self.required_properties:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
@@ -494,8 +494,8 @@ class ModelComposed(OpenApiModel):
 
     def __getitem__(self, name):
         """get the value of an attribute using square-bracket notation: `instance[attr]`"""
-        value = self.get(name, self.__dict__['__unset_attribute_value__'])
-        if value is self.__dict__['__unset_attribute_value__']:
+        value = self.get(name, self.__unset_attribute_value__)
+        if value is self.__unset_attribute_value__:
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),

--- a/samples/openapi3/client/petstore/python-experimental/petstore_api/model_utils.py
+++ b/samples/openapi3/client/petstore/python-experimental/petstore_api/model_utils.py
@@ -164,8 +164,13 @@ class OpenApiModel(object):
         """Returns true if both objects are not equal"""
         return not self == other
 
-    __setattr__ = __setitem__
-    __getattr__ = __getitem__
+    def __setattr__(self, attr, value):
+        """set the value of an attribute using dot notation: `instance.attr = val`"""
+        self[attr] = value
+
+    def __getattr__(self, attr):
+        """get the value of an attribute using dot notation: `instance.attr`"""
+        return self.__getitem__(attr)
 
     def __new__(cls, *args, **kwargs):
         # this function uses the discriminator to
@@ -286,22 +291,22 @@ class ModelSimple(OpenApiModel):
     swagger/openapi"""
 
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
-        if name in self.required_properties:
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
+        if name in self.__dict__['required_properties']:
             self.__dict__[name] = value
             return
 
         self.set_attribute(name, value)
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
-        if name in self.required_properties:
+        """returns the value of an attribute or some default value if the attribute was not set"""
+        if name in self.__dict__['required_properties']:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
 
     def __getitem__(self, name):
-        """this allows us to get a value with val = instance.field_name"""
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
         if name in self:
             return self.get(name)
 
@@ -312,12 +317,11 @@ class ModelSimple(OpenApiModel):
         )
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
-        if name in self.required_properties:
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
+        if name in self.__dict__['required_properties']:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
-
 
     def to_str(self):
         """Returns the string representation of the model"""
@@ -342,22 +346,22 @@ class ModelNormal(OpenApiModel):
     swagger/openapi"""
 
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
-        if name in self.required_properties:
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
+        if name in self.__dict__['required_properties']:
             self.__dict__[name] = value
             return
 
         self.set_attribute(name, value)
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
-        if name in self.required_properties:
+        """returns the value of an attribute or some default value if the attribute was not set"""
+        if name in self.__dict__['required_properties']:
             return self.__dict__[name]
 
         return self.__dict__['_data_store'].get(name, default)
 
     def __getitem__(self, name):
-        """this allows us to get a value with val = instance.field_name"""
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
         if name in self:
             return self.get(name)
 
@@ -368,12 +372,11 @@ class ModelNormal(OpenApiModel):
         )
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
-        if name in self.required_properties:
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
+        if name in self.__dict__['required_properties']:
             return name in self.__dict__
 
         return name in self.__dict__['_data_store']
-
 
     def to_dict(self):
         """Returns the model properties as a dict"""
@@ -428,7 +431,7 @@ class ModelComposed(OpenApiModel):
     """
 
     def __setitem__(self, name, value):
-        """this allows us to set a value with instance.field_name = val"""
+        """set the value of an attribute using square-bracket notation: `instance[attr] = val`"""
         if name in self.required_properties:
             self.__dict__[name] = value
             return
@@ -458,7 +461,7 @@ class ModelComposed(OpenApiModel):
     __unset_attribute_value__ = object()
 
     def get(self, name, default=None):
-        """this allows us to get a value with val = instance.field_name"""
+        """returns the value of an attribute or some default value if the attribute was not set"""
         if name in self.required_properties:
             return self.__dict__[name]
 
@@ -490,8 +493,9 @@ class ModelComposed(OpenApiModel):
             )
 
     def __getitem__(self, name):
-        value = self.get(name, self.__unset_attribute_value__)
-        if value is self.__unset_attribute_value__:
+        """get the value of an attribute using square-bracket notation: `instance[attr]`"""
+        value = self.get(name, self.__dict__['__unset_attribute_value__'])
+        if value is self.__dict__['__unset_attribute_value__']:
             raise ApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),
@@ -500,7 +504,7 @@ class ModelComposed(OpenApiModel):
         return value
 
     def __contains__(self, name):
-        """this allows us to use `in` operator: `'attr' in instance`"""
+        """used by `in` operator to check if an attrbute value was set in an instance: `'attr' in instance`"""
 
         if name in self.required_properties:
             return name in self.__dict__
@@ -514,7 +518,6 @@ class ModelComposed(OpenApiModel):
                     return True
 
         return False
-
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python-experimental/tests_manual/test_fruit.py
+++ b/samples/openapi3/client/petstore/python-experimental/tests_manual/test_fruit.py
@@ -47,6 +47,7 @@ class TestFruit(unittest.TestCase):
         # check its properties
         self.assertEqual(fruit.length_cm, length_cm)
         self.assertEqual(fruit['length_cm'], length_cm)
+        self.assertEqual(fruit.get('length_cm'), length_cm)
         self.assertEqual(getattr(fruit, 'length_cm'), length_cm)
         self.assertEqual(fruit.color, color)
         self.assertEqual(fruit['color'], color)
@@ -85,6 +86,8 @@ class TestFruit(unittest.TestCase):
         # Per Python doc, if the named attribute does not exist,
         # default is returned if provided.
         self.assertEqual(getattr(fruit, 'cultivar', 'some value'), 'some value')
+        self.assertEqual(fruit.get('cultivar'), None)
+        self.assertEqual(fruit.get('cultivar', 'some value'), 'some value')
 
         # Per Python doc, if the named attribute does not exist,
         # default is returned if provided, otherwise AttributeError is raised.


### PR DESCRIPTION
See #7781

Add option to return None instead of raising exception when accessing unset attribute.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @spacether 