### PR TITLE
[haskell-http-client] have applyOptionalParemeter (-&-) append values in headers or querystrings instead of replacing values

### DIFF
--- a/modules/openapi-generator/src/main/resources/haskell-http-client/API.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/API.mustache
@@ -69,8 +69,8 @@ import qualified Prelude as P
 {{operationId}} {{^vendorExtensions.x-inline-content-type}}_ {{/vendorExtensions.x-inline-content-type}}{{^vendorExtensions.x-inline-accept}} _ {{/vendorExtensions.x-inline-accept}}{{#allParams}}{{#required}}{{#isBodyParam}}{{{paramName}}}{{/isBodyParam}}{{^isBodyParam}}({{#vendorExtensions.x-param-name-type}}{{{.}}}{{/vendorExtensions.x-param-name-type}}{{^vendorExtensions.x-param-name-type}}{{{dataType}}}{{/vendorExtensions.x-param-name-type}} {{{paramName}}}){{/isBodyParam}} {{/required}}{{/allParams}}=
   _mkRequest "{{httpMethod}}" {{{vendorExtensions.x-path}}}{{#authMethods}}
     `_hasAuthType` (P.Proxy :: P.Proxy {{name}}){{/authMethods}}{{#allParams}}{{#required}}{{#isHeaderParam}}
-    `setHeader` {{>_headerColl}} ("{{{baseName}}}", {{{paramName}}}){{/isHeaderParam}}{{#isQueryParam}}
-    `setQuery` {{>_queryColl}} ("{{{baseName}}}", Just {{{paramName}}}){{/isQueryParam}}{{#isFormParam}}{{#isFile}}
+    `addHeader` {{>_headerColl}} ("{{{baseName}}}", {{{paramName}}}){{/isHeaderParam}}{{#isQueryParam}}
+    `addQuery` {{>_queryColl}} ("{{{baseName}}}", Just {{{paramName}}}){{/isQueryParam}}{{#isFormParam}}{{#isFile}}
     `_addMultiFormPart` NH.partFileSource "{{{baseName}}}" {{{paramName}}}{{/isFile}}{{^isFile}}{{#isMultipart}}
     `_addMultiFormPart` NH.partLBS "{{{baseName}}}" (mimeRender' MimeMultipartFormData {{{paramName}}}){{/isMultipart}}{{^isMultipart}}
     `addForm` {{>_formColl}} ("{{{baseName}}}", {{{paramName}}}){{/isMultipart}}{{/isFile}}{{/isFormParam}}{{#isBodyParam}}
@@ -86,7 +86,7 @@ instance HasBodyParam {{{vendorExtensions.x-operation-type}}} {{#vendorExtension
 -- | /Optional Param/ "{{{baseName}}}" - {{{description}}}{{/description}}
 instance HasOptionalParam {{{vendorExtensions.x-operation-type}}} {{#vendorExtensions.x-param-name-type}}{{{.}}}{{/vendorExtensions.x-param-name-type}}{{^vendorExtensions.x-param-name-type}}{{{dataType}}}{{/vendorExtensions.x-param-name-type}} where
   applyOptionalParam req ({{#vendorExtensions.x-param-name-type}}{{{.}}}{{/vendorExtensions.x-param-name-type}}{{^vendorExtensions.x-param-name-type}}{{{dataType}}}{{/vendorExtensions.x-param-name-type}} xs) =
-    {{#isHeaderParam}}req `setHeader` {{>_headerColl}} ("{{{baseName}}}", xs){{/isHeaderParam}}{{#isQueryParam}}req `setQuery` {{>_queryColl}} ("{{{baseName}}}", Just xs){{/isQueryParam}}{{#isFormParam}}{{#isFile}}req `_addMultiFormPart` NH.partFileSource "{{{baseName}}}" xs{{/isFile}}{{^isFile}}{{#isMultipart}}req `_addMultiFormPart` NH.partLBS "{{{baseName}}}" (mimeRender' MimeMultipartFormData xs){{/isMultipart}}{{^isMultipart}}req `addForm` {{>_formColl}} ("{{{baseName}}}", xs){{/isMultipart}}{{/isFile}}{{/isFormParam}}{{/required}}{{/isBodyParam}}{{/allParams}}{{/vendorExtensions.x-has-optional-params}}{{#hasConsumes}}
+    {{#isHeaderParam}}req `addHeader` {{>_headerColl}} ("{{{baseName}}}", xs){{/isHeaderParam}}{{#isQueryParam}}req `addQuery` {{>_queryColl}} ("{{{baseName}}}", Just xs){{/isQueryParam}}{{#isFormParam}}{{#isFile}}req `_addMultiFormPart` NH.partFileSource "{{{baseName}}}" xs{{/isFile}}{{^isFile}}{{#isMultipart}}req `_addMultiFormPart` NH.partLBS "{{{baseName}}}" (mimeRender' MimeMultipartFormData xs){{/isMultipart}}{{^isMultipart}}req `addForm` {{>_formColl}} ("{{{baseName}}}", xs){{/isMultipart}}{{/isFile}}{{/isFormParam}}{{/required}}{{/isBodyParam}}{{/allParams}}{{/vendorExtensions.x-has-optional-params}}{{#hasConsumes}}
 
 {{#consumes}}-- | @{{{mediaType}}}@{{^x-mediaIsWildcard}}
 instance Consumes {{{vendorExtensions.x-operation-type}}} {{{x-mediaDataType}}}{{/x-mediaIsWildcard}}{{#x-mediaIsWildcard}}

--- a/modules/openapi-generator/src/main/resources/haskell-http-client/Core.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/Core.mustache
@@ -228,10 +228,19 @@ _mkRequest m u = {{requestType}} m u _mkParams []
 _mkParams :: Params
 _mkParams = Params [] [] ParamBodyNone
 
-setHeader :: {{requestType}} req contentType res accept -> [NH.Header] -> {{requestType}} req contentType res accept
+setHeader ::
+     {{requestType}} req contentType res accept
+  -> [NH.Header]
+  -> {{requestType}} req contentType res accept
 setHeader req header =
-  req `removeHeader` P.fmap P.fst header &
-  L.over (rParamsL . paramsHeadersL) (header P.++)
+  req `removeHeader` P.fmap P.fst header
+  & (`addHeader` header)
+
+addHeader ::
+     {{requestType}} req contentType res accept
+  -> [NH.Header]
+  -> {{requestType}} req contentType res accept
+addHeader req header = L.over (rParamsL . paramsHeadersL) (header P.++) req
 
 removeHeader :: {{requestType}} req contentType res accept -> [NH.HeaderName] -> {{requestType}} req contentType res accept
 removeHeader req header =
@@ -255,14 +264,24 @@ _setAcceptHeader req =
         Just m -> req `setHeader` [("accept", BC.pack $ P.show m)]
         Nothing -> req `removeHeader` ["accept"]
 
-setQuery :: {{requestType}} req contentType res accept -> [NH.QueryItem] -> {{requestType}} req contentType res accept
-setQuery req query = 
+setQuery ::
+     {{requestType}} req contentType res accept
+  -> [NH.QueryItem]
+  -> {{requestType}} req contentType res accept
+setQuery req query =
   req &
   L.over
     (rParamsL . paramsQueryL)
-    ((query P.++) . P.filter (\q -> cifst q `P.notElem` P.fmap cifst query))
+    (P.filter (\q -> cifst q `P.notElem` P.fmap cifst query)) &
+  (`addQuery` query)
   where
     cifst = CI.mk . P.fst
+
+addQuery ::
+     {{requestType}} req contentType res accept
+  -> [NH.QueryItem]
+  -> {{requestType}} req contentType res accept
+addQuery req query = req & L.over (rParamsL . paramsQueryL) (query P.++)
 
 addForm :: {{requestType}} req contentType res accept -> WH.Form -> {{requestType}} req contentType res accept
 addForm req newform = 

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/API/Fake.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/API/Fake.hs
@@ -234,7 +234,7 @@ testBodyWithQueryParams
 testBodyWithQueryParams body (Query query) =
   _mkRequest "PUT" ["/fake/body-with-query-params"]
     `setBodyParam` body
-    `setQuery` toQuery ("query", Just query)
+    `addQuery` toQuery ("query", Just query)
 
 data TestBodyWithQueryParams 
 instance HasBodyParam TestBodyWithQueryParams User 
@@ -385,32 +385,32 @@ instance HasOptionalParam TestEnumParameters EnumFormString where
 -- | /Optional Param/ "enum_header_string_array" - Header parameter enum test (string array)
 instance HasOptionalParam TestEnumParameters EnumHeaderStringArray where
   applyOptionalParam req (EnumHeaderStringArray xs) =
-    req `setHeader` toHeaderColl CommaSeparated ("enum_header_string_array", xs)
+    req `addHeader` toHeaderColl CommaSeparated ("enum_header_string_array", xs)
 
 -- | /Optional Param/ "enum_header_string" - Header parameter enum test (string)
 instance HasOptionalParam TestEnumParameters EnumHeaderString where
   applyOptionalParam req (EnumHeaderString xs) =
-    req `setHeader` toHeader ("enum_header_string", xs)
+    req `addHeader` toHeader ("enum_header_string", xs)
 
 -- | /Optional Param/ "enum_query_string_array" - Query parameter enum test (string array)
 instance HasOptionalParam TestEnumParameters EnumQueryStringArray where
   applyOptionalParam req (EnumQueryStringArray xs) =
-    req `setQuery` toQueryColl CommaSeparated ("enum_query_string_array", Just xs)
+    req `addQuery` toQueryColl CommaSeparated ("enum_query_string_array", Just xs)
 
 -- | /Optional Param/ "enum_query_string" - Query parameter enum test (string)
 instance HasOptionalParam TestEnumParameters EnumQueryString where
   applyOptionalParam req (EnumQueryString xs) =
-    req `setQuery` toQuery ("enum_query_string", Just xs)
+    req `addQuery` toQuery ("enum_query_string", Just xs)
 
 -- | /Optional Param/ "enum_query_integer" - Query parameter enum test (double)
 instance HasOptionalParam TestEnumParameters EnumQueryInteger where
   applyOptionalParam req (EnumQueryInteger xs) =
-    req `setQuery` toQuery ("enum_query_integer", Just xs)
+    req `addQuery` toQuery ("enum_query_integer", Just xs)
 
 -- | /Optional Param/ "enum_query_double" - Query parameter enum test (double)
 instance HasOptionalParam TestEnumParameters EnumQueryDouble where
   applyOptionalParam req (EnumQueryDouble xs) =
-    req `setQuery` toQuery ("enum_query_double", Just xs)
+    req `addQuery` toQuery ("enum_query_double", Just xs)
 
 -- | @application/x-www-form-urlencoded@
 instance Consumes TestEnumParameters MimeFormUrlEncoded
@@ -433,26 +433,26 @@ testGroupParameters
   -> OpenAPIPetstoreRequest TestGroupParameters MimeNoContent NoContent MimeNoContent
 testGroupParameters (RequiredStringGroup requiredStringGroup) (RequiredBooleanGroup requiredBooleanGroup) (RequiredInt64Group requiredInt64Group) =
   _mkRequest "DELETE" ["/fake"]
-    `setQuery` toQuery ("required_string_group", Just requiredStringGroup)
-    `setHeader` toHeader ("required_boolean_group", requiredBooleanGroup)
-    `setQuery` toQuery ("required_int64_group", Just requiredInt64Group)
+    `addQuery` toQuery ("required_string_group", Just requiredStringGroup)
+    `addHeader` toHeader ("required_boolean_group", requiredBooleanGroup)
+    `addQuery` toQuery ("required_int64_group", Just requiredInt64Group)
 
 data TestGroupParameters  
 
 -- | /Optional Param/ "string_group" - String in group parameters
 instance HasOptionalParam TestGroupParameters StringGroup where
   applyOptionalParam req (StringGroup xs) =
-    req `setQuery` toQuery ("string_group", Just xs)
+    req `addQuery` toQuery ("string_group", Just xs)
 
 -- | /Optional Param/ "boolean_group" - Boolean in group parameters
 instance HasOptionalParam TestGroupParameters BooleanGroup where
   applyOptionalParam req (BooleanGroup xs) =
-    req `setHeader` toHeader ("boolean_group", xs)
+    req `addHeader` toHeader ("boolean_group", xs)
 
 -- | /Optional Param/ "int64_group" - Integer in group parameters
 instance HasOptionalParam TestGroupParameters Int64Group where
   applyOptionalParam req (Int64Group xs) =
-    req `setQuery` toQuery ("int64_group", Just xs)
+    req `addQuery` toQuery ("int64_group", Just xs)
 instance Produces TestGroupParameters MimeNoContent
 
 
@@ -520,11 +520,11 @@ testQueryParameterCollectionFormat
   -> OpenAPIPetstoreRequest TestQueryParameterCollectionFormat MimeNoContent NoContent MimeNoContent
 testQueryParameterCollectionFormat (Pipe pipe) (Ioutil ioutil) (Http http) (Url url) (Context context) =
   _mkRequest "PUT" ["/fake/test-query-paramters"]
-    `setQuery` toQueryColl CommaSeparated ("pipe", Just pipe)
-    `setQuery` toQueryColl CommaSeparated ("ioutil", Just ioutil)
-    `setQuery` toQueryColl SpaceSeparated ("http", Just http)
-    `setQuery` toQueryColl CommaSeparated ("url", Just url)
-    `setQuery` toQueryColl MultiParamArray ("context", Just context)
+    `addQuery` toQueryColl CommaSeparated ("pipe", Just pipe)
+    `addQuery` toQueryColl CommaSeparated ("ioutil", Just ioutil)
+    `addQuery` toQueryColl SpaceSeparated ("http", Just http)
+    `addQuery` toQueryColl CommaSeparated ("url", Just url)
+    `addQuery` toQueryColl MultiParamArray ("context", Just context)
 
 data TestQueryParameterCollectionFormat  
 instance Produces TestQueryParameterCollectionFormat MimeNoContent

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/API/Pet.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/API/Pet.hs
@@ -106,7 +106,7 @@ deletePet (PetId petId) =
 data DeletePet  
 instance HasOptionalParam DeletePet ApiKey where
   applyOptionalParam req (ApiKey xs) =
-    req `setHeader` toHeader ("api_key", xs)
+    req `addHeader` toHeader ("api_key", xs)
 instance Produces DeletePet MimeNoContent
 
 
@@ -127,7 +127,7 @@ findPetsByStatus
 findPetsByStatus  _ (Status status) =
   _mkRequest "GET" ["/pet/findByStatus"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthOAuthPetstoreAuth)
-    `setQuery` toQueryColl CommaSeparated ("status", Just status)
+    `addQuery` toQueryColl CommaSeparated ("status", Just status)
 
 data FindPetsByStatus  
 -- | @application/xml@
@@ -153,7 +153,7 @@ findPetsByTags
 findPetsByTags  _ (Tags tags) =
   _mkRequest "GET" ["/pet/findByTags"]
     `_hasAuthType` (P.Proxy :: P.Proxy AuthOAuthPetstoreAuth)
-    `setQuery` toQueryColl CommaSeparated ("tags", Just tags)
+    `addQuery` toQueryColl CommaSeparated ("tags", Just tags)
 
 {-# DEPRECATED findPetsByTags "" #-}
 

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/API/User.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/API/User.hs
@@ -188,8 +188,8 @@ loginUser
   -> OpenAPIPetstoreRequest LoginUser MimeNoContent Text accept
 loginUser  _ (Username username) (Password password) =
   _mkRequest "GET" ["/user/login"]
-    `setQuery` toQuery ("username", Just username)
-    `setQuery` toQuery ("password", Just password)
+    `addQuery` toQuery ("username", Just username)
+    `addQuery` toQuery ("password", Just password)
 
 data LoginUser  
 -- | @application/xml@


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
