### PR TITLE
[C][Client]Fix coredump in multi-thread environment

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -7,7 +7,6 @@
 size_t writeDataCallback(void *buffer, size_t size, size_t nmemb, void *userp);
 
 apiClient_t *apiClient_create() {
-    curl_global_init(CURL_GLOBAL_ALL);
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
     apiClient->basePath = strdup("{{{basePath}}}");
     apiClient->sslConfig = NULL;
@@ -43,7 +42,6 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
 {{/authMethods}}
 {{/hasAuthMethods}}
 ) {
-    curl_global_init(CURL_GLOBAL_ALL);
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
     if(basePath){
         apiClient->basePath = strdup(basePath);
@@ -128,7 +126,6 @@ void apiClient_free(apiClient_t *apiClient) {
     {{/authMethods}}
     {{/hasAuthMethods}}
     free(apiClient);
-    curl_global_cleanup();
 }
 
 sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify) {
@@ -620,3 +617,10 @@ char *strReplace(char *orig, char *rep, char *with) {
     return result;
 }
 
+void apiClient_setupGlobalEnv() {
+    curl_global_init(CURL_GLOBAL_ALL);
+}
+
+void apiClient_unsetupGlobalEnv() {
+    curl_global_cleanup();
+}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
@@ -64,4 +64,16 @@ void sslConfig_free(sslConfig_t *sslConfig);
 
 char *strReplace(char *orig, char *rep, char *with);
 
+/*
+ * In single thread program, the function apiClient_setupGlobalEnv is not needed.
+ * But in multi-thread program, apiClient_setupGlobalEnv must be called before any worker thread is created
+ */
+void apiClient_setupGlobalEnv();
+
+/*
+ * This function apiClient_unsetupGlobalEnv must be called whether single or multiple program.
+ * In multi-thread program, it is must be called after all worker threads end.
+ */
+void apiClient_unsetupGlobalEnv();
+
 #endif // INCLUDE_API_CLIENT_H

--- a/samples/client/petstore/c/include/apiClient.h
+++ b/samples/client/petstore/c/include/apiClient.h
@@ -46,4 +46,16 @@ void sslConfig_free(sslConfig_t *sslConfig);
 
 char *strReplace(char *orig, char *rep, char *with);
 
+/*
+ * In single thread program, the function apiClient_setupGlobalEnv is not needed.
+ * But in multi-thread program, apiClient_setupGlobalEnv must be called before any worker thread is created
+ */
+void apiClient_setupGlobalEnv();
+
+/*
+ * This function apiClient_unsetupGlobalEnv must be called whether single or multiple program.
+ * In multi-thread program, it is must be called after all worker threads end.
+ */
+void apiClient_unsetupGlobalEnv();
+
 #endif // INCLUDE_API_CLIENT_H

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -7,7 +7,6 @@
 size_t writeDataCallback(void *buffer, size_t size, size_t nmemb, void *userp);
 
 apiClient_t *apiClient_create() {
-    curl_global_init(CURL_GLOBAL_ALL);
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
     apiClient->basePath = strdup("http://petstore.swagger.io/v2");
     apiClient->sslConfig = NULL;
@@ -25,7 +24,6 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
 , sslConfig_t *sslConfig
 , list_t *apiKeys_api_key
 ) {
-    curl_global_init(CURL_GLOBAL_ALL);
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
     if(basePath){
         apiClient->basePath = strdup(basePath);
@@ -82,7 +80,6 @@ void apiClient_free(apiClient_t *apiClient) {
         free(apiClient->accessToken);
     }
     free(apiClient);
-    curl_global_cleanup();
 }
 
 sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify) {
@@ -526,3 +523,10 @@ char *strReplace(char *orig, char *rep, char *with) {
     return result;
 }
 
+void apiClient_setupGlobalEnv() {
+    curl_global_init(CURL_GLOBAL_ALL);
+}
+
+void apiClient_unsetupGlobalEnv() {
+    curl_global_cleanup();
+}

--- a/samples/client/petstore/c/unit-tests/manual-PetAPI.c
+++ b/samples/client/petstore/c/unit-tests/manual-PetAPI.c
@@ -139,4 +139,6 @@ int main() {
 		fclose(file);
 	}
 	apiClient_free(apiClient3);
+
+	apiClient_unsetupGlobalEnv();
 }

--- a/samples/client/petstore/c/unit-tests/manual-StoreAPI.c
+++ b/samples/client/petstore/c/unit-tests/manual-StoreAPI.c
@@ -100,4 +100,6 @@ int main() {
 	}
 	list_free(elementToReturn);
 	apiClient_free(apiClient5);
+
+	apiClient_unsetupGlobalEnv();
 }

--- a/samples/client/petstore/c/unit-tests/manual-UserAPI.c
+++ b/samples/client/petstore/c/unit-tests/manual-UserAPI.c
@@ -120,4 +120,6 @@ int main() {
 
 	UserAPI_deleteUser(apiClient5, "example123");
 	apiClient_free(apiClient5);
+
+	apiClient_unsetupGlobalEnv();
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
@wing328 @zhemant @michelealbano

Described in libcurl official document https://curl.haxx.se/libcurl/c/libcurl.html, the functions ```curl_global_init``` and ```curl_global_cleanup``` cannot be called in multiple thread environment, or it will cause a coredump.

Following by the guide, this PR removes the 2 function calls from ```apiClient_create*``` and ```apiClient_free```,  and adds 2 new functions for user to call:
```c

/*
 * In single thread program, the function apiClient_setupGlobalEnv is not needed.
 * But in multi-thread program, apiClient_setupGlobalEnv must be called before any worker thread is created
 */
void apiClient_setupGlobalEnv()
{
    curl_global_init(CURL_GLOBAL_ALL);
}

/*
 * This function apiClient_unsetupGlobalEnv must be called whether single or multiple program.
 * In multi-thread program, it is must be called after all worker threads end.
 */
void apiClient_unsetupGlobalEnv()
{
    curl_global_cleanup();
}
```
Then user can create more than one api clients with multiple threads safely.

The difference compared with the original use case in single thread environment is:
User needs call the function ```apiClient_unsetupGlobalEnv``` at the end of program.



The detail discussion can be found at the issue: https://github.com/kubernetes-client/c/issues/34
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
