### PR TITLE
[rust-server] Update templating docs to correct the name of x-response-id

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -916,9 +916,9 @@ x-content-type: application/json
 
 ### Rust-server
 
-#### x-responseId
+#### x-response-id
 
-Each response may specify a unique `x-responseId`. `rust-server` will use this to name the corresponding enum variant in the code. e.g.
+Each response may specify a unique `x-response-id`. `rust-server` will use this to name the corresponding enum variant in the code. e.g.
 
 ```yaml
 paths:
@@ -927,7 +927,7 @@ paths:
       responses:
         200:
           description: OK
-          x-responseId: Pong
+          x-response-id: Pong
 ```
 
 ### MySQL Schema


### PR DESCRIPTION
I spotted a way to control the enum variants in rust-server for the responses in the docs, tried it out and discovered it doesn't work. Further digging found that the property was simply mislabelled in the docs and works as expected when using the correct property name.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
