### PR TITLE
Fix NPE in CodegenIgnoreProcessor.java (fixes #3356)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/ignore/CodegenIgnoreProcessor.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/ignore/CodegenIgnoreProcessor.java
@@ -142,7 +142,7 @@ public class CodegenIgnoreProcessor {
     public boolean allowsFile(final File targetFile) {
         if(this.ignoreFile == null) return true;
 
-        File file = new File(this.ignoreFile.getParentFile().toURI().relativize(targetFile.toURI()).getPath());
+        File file = new File(this.ignoreFile.getAbsoluteFile().getParentFile().toURI().relativize(targetFile.toURI()).getPath());
         Boolean directoryExcluded = false;
         Boolean exclude = false;
         if(exclusionRules.size() == 0 && inclusionRules.size() == 0) {


### PR DESCRIPTION
There is a NullPointerException thrown when using an override ignore file with no parent.

This is not specific to a particular language; it impacts all generators.

See https://github.com/OpenAPITools/openapi-generator/issues/3356

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
