### PR TITLE
[python] check output content-type only if preload_content is set

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -200,8 +200,6 @@ class ApiClient(object):
             e.body = e.body.decode('utf-8') if six.PY3 else e.body
             raise e
 
-        content_type = response_data.getheader('content-type')
-
         self.last_response = response_data
 
         return_data = response_data
@@ -218,6 +216,7 @@ class ApiClient(object):
 
         if six.PY3 and response_type not in ["file", "bytes"]:
             match = None
+            content_type = response_data.getheader('content-type')
             if content_type is not None:
                 match = re.search(r"charset=([a-zA-Z\-\d]+)[\s\;]?", content_type)
             encoding = match.group(1) if match else "utf-8"

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -191,8 +191,6 @@ class ApiClient(object):
             e.body = e.body.decode('utf-8') if six.PY3 else e.body
             raise e
 
-        content_type = response_data.getheader('content-type')
-
         self.last_response = response_data
 
         return_data = response_data
@@ -204,6 +202,7 @@ class ApiClient(object):
 
         if six.PY3 and response_type not in ["file", "bytes"]:
             match = None
+            content_type = response_data.getheader('content-type')
             if content_type is not None:
                 match = re.search(r"charset=([a-zA-Z\-\d]+)[\s\;]?", content_type)
             encoding = match.group(1) if match else "utf-8"

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -192,8 +192,6 @@ class ApiClient(object):
             e.body = e.body.decode('utf-8') if six.PY3 else e.body
             raise e
 
-        content_type = response_data.getheader('content-type')
-
         self.last_response = response_data
 
         return_data = response_data
@@ -205,6 +203,7 @@ class ApiClient(object):
 
         if six.PY3 and response_type not in ["file", "bytes"]:
             match = None
+            content_type = response_data.getheader('content-type')
             if content_type is not None:
                 match = re.search(r"charset=([a-zA-Z\-\d]+)[\s\;]?", content_type)
             encoding = match.group(1) if match else "utf-8"

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -190,8 +190,6 @@ class ApiClient(object):
             e.body = e.body.decode('utf-8') if six.PY3 else e.body
             raise e
 
-        content_type = response_data.getheader('content-type')
-
         self.last_response = response_data
 
         return_data = response_data
@@ -203,6 +201,7 @@ class ApiClient(object):
 
         if six.PY3 and response_type not in ["file", "bytes"]:
             match = None
+            content_type = response_data.getheader('content-type')
             if content_type is not None:
                 match = re.search(r"charset=([a-zA-Z\-\d]+)[\s\;]?", content_type)
             encoding = match.group(1) if match else "utf-8"

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -190,8 +190,6 @@ class ApiClient(object):
             e.body = e.body.decode('utf-8') if six.PY3 else e.body
             raise e
 
-        content_type = response_data.getheader('content-type')
-
         self.last_response = response_data
 
         return_data = response_data
@@ -203,6 +201,7 @@ class ApiClient(object):
 
         if six.PY3 and response_type not in ["file", "bytes"]:
             match = None
+            content_type = response_data.getheader('content-type')
             if content_type is not None:
                 match = re.search(r"charset=([a-zA-Z\-\d]+)[\s\;]?", content_type)
             encoding = match.group(1) if match else "utf-8"


### PR DESCRIPTION
In the Python client generator we have code to detect output encoding (https://github.com/OpenAPITools/openapi-generator/pull/5679). This code checks received headers but it doesn't work if preloading content is disabled. In such situation raw response is returned (from native client library like aiohttp) and method getheader() doesn't exist. In this PR I rearrange code a little bit to work in such cases.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC: @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @arun-nalla (2019/11) @spacether (2019/11)