### PR TITLE
Correct allOf with only one child schema (no discriminator)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1308,14 +1308,12 @@ public class ModelUtils {
             }
         }
 
-        // parent name only makes sense when there is a single obvious parent
-        if (refedWithoutDiscriminator.size() == 1) {
-            if (hasAmbiguousParents) {
-                LOGGER.warn("[deprecated] inheritance without use of 'discriminator.propertyName' is deprecated " +
-                                "and will be removed in a future release. Generating model for composed schema name: {}. Title: {}",
-                        composedSchema.getName(), composedSchema.getTitle());
-            }
-            return refedWithoutDiscriminator.get(0);
+        if (refedWithoutDiscriminator.size() == 1 && hasAmbiguousParents) {
+            // allOf with a single $ref (no discriminator)
+            // TODO to be removed in 5.x or 6.x release
+            LOGGER.info("[deprecated] inheritance without use of 'discriminator.propertyName' has been deprecated" +
+                    " in the 5.x release. Composed schema name: {}. Title: {}",
+                    composedSchema.getName(), composedSchema.getTitle());
         }
 
         return null;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1374,9 +1374,9 @@ public class DefaultCodegenTest {
         Schema schema = openAPI.getComponents().getSchemas().get("NewMessageEventCoreNoOwnProps");
         codegen.setOpenAPI(openAPI);
         CodegenModel model = codegen.fromModel("NewMessageEventCoreNoOwnProps", schema);
-        Assert.assertEquals(getNames(model.getVars()), Collections.emptyList());
-        Assert.assertEquals(model.parent, "MessageEventCore");
-        Assert.assertEquals(model.allParents, Collections.singletonList("MessageEventCore"));
+        Assert.assertEquals(getNames(model.getVars()), Arrays.asList("id","message"));
+        Assert.assertNull(model.parent);
+        Assert.assertNull(model.allParents);
     }
 
     class CodegenWithMultipleInheritance extends DefaultCodegen {
@@ -1386,7 +1386,6 @@ public class DefaultCodegenTest {
             supportsMultipleInheritance = true;
         }
     }
-
 
     @Test
     public void testAllOfParent() {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -975,10 +975,10 @@ public class JavaClientCodegenTest {
         validateJavaSourceFiles(files);
 
         TestUtils.assertFileContains(Paths.get(output + "/src/main/java/org/openapitools/client/model/RealCommand.java"),
-                "class RealCommand extends Command");
+                "class RealCommand {");
 
         TestUtils.assertFileContains(Paths.get(output + "/src/main/java/org/openapitools/client/model/Command.java"),
-                "class Command");
+                "class Command {");
 
         output.deleteOnExit();
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaInheritanceTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaInheritanceTest.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.models.media.Discriminator;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import java.util.Collections;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
@@ -57,8 +58,8 @@ public class JavaInheritanceTest {
 
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.parent, "Base");
-        Assert.assertEquals(cm.imports, Sets.newHashSet("Base"));
+        Assert.assertNull(cm.parent);
+        Assert.assertEquals(cm.imports, Collections.emptySet());
     }
 
     @Test(description = "convert a composed model with discriminator")


### PR DESCRIPTION
cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
