### PR TITLE
Allow metadata file generation to be disabled using additionalProperties.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -294,4 +294,8 @@ public interface CodegenConfig {
     void setRemoveEnumValuePrefix(boolean removeEnumValuePrefix);
 
     Schema unaliasSchema(Schema schema, Map<String, String> usedImportMappings);
+
+    boolean getGenerateMetadataFiles();
+
+    void setGenerateMetadataFiles(boolean generateMetadata);
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -381,4 +381,8 @@ public class CodegenConstants {
 
     public static final String USE_ONEOF_DISCRIMINATOR_LOOKUP = "useOneOfDiscriminatorLookup";
     public static final String USE_ONEOF_DISCRIMINATOR_LOOKUP_DESC = "Use the discriminator's mapping in oneOf to speed up the model lookup. IMPORTANT: Validation (e.g. one and onlye one match in oneOf's schemas) will be skipped.";
+
+    public static final String GENERATE_METADATA_FILES = "generateMetadataFiles";
+    public static final String GENERATE_METADATA_FILES_DESC = "Generate metadata files used by OpenAPI Generator. " +
+        "This includes .openapi-generator-ignore and any files within .openapi-generator";
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -243,6 +243,11 @@ public class DefaultCodegen implements CodegenConfig {
     // See CodegenConstants.java for more details.
     protected boolean disallowAdditionalPropertiesIfNotPresent = true;
 
+    // Boolean value indicating whether or not to generate OpenAPI Generator metadata files.
+    // These files include .openapi-generator/VERSION, .openapi-generator-ignore,
+    // or other metadata files used by OpenAPI Generator.
+    protected boolean generateMetadataFiles = true;
+
     // make openapi available to all methods
     protected OpenAPI openAPI;
 
@@ -345,6 +350,12 @@ public class DefaultCodegen implements CodegenConfig {
         if (additionalProperties.containsKey(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT)) {
             this.setDisallowAdditionalPropertiesIfNotPresent(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.GENERATE_METADATA_FILES)) {
+            this.setGenerateMetadataFiles(Boolean.valueOf(additionalProperties
+                    .get(CodegenConstants.GENERATE_METADATA_FILES).toString()
+            ));
         }
     }
 
@@ -6478,6 +6489,28 @@ public class DefaultCodegen implements CodegenConfig {
     @Override
     public void setRemoveEnumValuePrefix(final boolean removeEnumValuePrefix) {
         this.removeEnumValuePrefix = removeEnumValuePrefix;
+    }
+
+    /**
+     * Get the boolean value indicating whether to generate OpenAPI Generator metadata files.
+     *
+     * These files include .openapi-generator/VERSION, .openapi-generator-ignore,
+     * or other metadata files used by OpenAPI Generator.
+     */
+    @Override
+    public boolean getGenerateMetadataFiles() {
+        return this.generateMetadataFiles;
+    }
+
+    /**
+     * Set the boolean value indicating whether to generate OpenAPI Generator metadata files.
+     *
+     * These files include .openapi-generator/VERSION, .openapi-generator-ignore,
+     * or other metadata files used by OpenAPI Generator.
+     */
+    @Override
+    public void setGenerateMetadataFiles(final boolean generateMetadataFiles) {
+        this.generateMetadataFiles = generateMetadataFiles;
     }
 
     //// Following methods are related to the "useOneOfInterfaces" feature

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -84,7 +84,6 @@ public class DefaultGenerator implements Generator {
     private Boolean generateApiDocumentation = null;
     private Boolean generateModelTests = null;
     private Boolean generateModelDocumentation = null;
-    private Boolean generateMetadata = true;
     private String basePath;
     private String basePathWithoutHost;
     private String contextPath;
@@ -167,10 +166,13 @@ public class DefaultGenerator implements Generator {
      * or other metadata files used by OpenAPI Generator.
      *
      * @param generateMetadata true: enable outputs, false: disable outputs
+     * @deprecated use {@link CodegenConfig#setGenerateMetadataFiles(boolean)} instead
+     * @throws NullPointerException if the config is not already instantiated
      */
     @SuppressWarnings("WeakerAccess")
+    @Deprecated
     public void setGenerateMetadata(Boolean generateMetadata) {
-        this.generateMetadata = generateMetadata;
+        this.config.setGenerateMetadataFiles(generateMetadata);
     }
 
     /**
@@ -223,9 +225,6 @@ public class DefaultGenerator implements Generator {
         generateModelDocumentation = GlobalSettings.getProperty(CodegenConstants.MODEL_DOCS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.MODEL_DOCS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.MODEL_DOCS, true);
         generateApiTests = GlobalSettings.getProperty(CodegenConstants.API_TESTS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.API_TESTS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.API_TESTS, true);
         generateApiDocumentation = GlobalSettings.getProperty(CodegenConstants.API_DOCS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.API_DOCS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.API_DOCS, true);
-
-        // allows disabling the default generation of OpenAPI Generator metadata files.
-        generateMetadata = config.additionalProperties().containsKey(CodegenConstants.GENERATE_METADATA_FILES) ? Boolean.valueOf(config.additionalProperties().get(CodegenConstants.GENERATE_METADATA_FILES).toString()) : getGeneratorPropertyDefaultSwitch(CodegenConstants.GENERATE_METADATA_FILES, true);
 
         // Additional properties added for tests to exclude references in project related files
         config.additionalProperties().put(CodegenConstants.GENERATE_API_TESTS, generateApiTests);
@@ -739,7 +738,7 @@ public class DefaultGenerator implements Generator {
         final String openapiGeneratorIgnore = ".openapi-generator-ignore";
         String ignoreFileNameTarget = config.outputFolder() + File.separator + openapiGeneratorIgnore;
         File ignoreFile = new File(ignoreFileNameTarget);
-        if (generateMetadata) {
+        if (config.getGenerateMetadataFiles()) {
             try {
                 boolean shouldGenerate = !ignoreFile.exists();
                 if (shouldGenerate && supportingFilesToGenerate != null && !supportingFilesToGenerate.isEmpty()) {
@@ -1417,7 +1416,7 @@ public class DefaultGenerator implements Generator {
      */
     private void generateVersionMetadata(List<File> files) {
         String versionMetadata = config.outputFolder() + File.separator + METADATA_DIR + File.separator + "VERSION";
-        if (generateMetadata) {
+        if (config.getGenerateMetadataFiles()) {
             File versionMetadataFile = new File(versionMetadata);
             try {
                 File written = this.templateProcessor.writeToFile(versionMetadata, ImplementationVersion.read().getBytes(StandardCharsets.UTF_8));
@@ -1448,7 +1447,7 @@ public class DefaultGenerator implements Generator {
      * @param files The list tracking generated files
      */
     private void generateFilesMetadata(List<File> files) {
-        if (generateMetadata) {
+        if (config.getGenerateMetadataFiles()) {
             try {
                 StringBuilder sb = new StringBuilder();
                 Path outDir = absPath(new File(this.config.getOutputDir()));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -224,6 +224,9 @@ public class DefaultGenerator implements Generator {
         generateApiTests = GlobalSettings.getProperty(CodegenConstants.API_TESTS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.API_TESTS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.API_TESTS, true);
         generateApiDocumentation = GlobalSettings.getProperty(CodegenConstants.API_DOCS) != null ? Boolean.valueOf(GlobalSettings.getProperty(CodegenConstants.API_DOCS)) : getGeneratorPropertyDefaultSwitch(CodegenConstants.API_DOCS, true);
 
+        // allows disabling the default generation of OpenAPI Generator metadata files.
+        generateMetadata = config.additionalProperties().containsKey(CodegenConstants.GENERATE_METADATA_FILES) ? Boolean.valueOf(config.additionalProperties().get(CodegenConstants.GENERATE_METADATA_FILES).toString()) : getGeneratorPropertyDefaultSwitch(CodegenConstants.GENERATE_METADATA_FILES, true);
+
         // Additional properties added for tests to exclude references in project related files
         config.additionalProperties().put(CodegenConstants.GENERATE_API_TESTS, generateApiTests);
         config.additionalProperties().put(CodegenConstants.GENERATE_MODEL_TESTS, generateModelTests);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/AbstractIntegrationTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/AbstractIntegrationTest.java
@@ -44,7 +44,6 @@ public abstract class AbstractIntegrationTest {
     @Test(enabled = false)
     public void generatesCorrectDirectoryStructure() throws IOException {
         DefaultGenerator codeGen = new DefaultGenerator();
-        codeGen.setGenerateMetadata(generateMetadata);
         for (Map.Entry<String, String> propertyOverride : globalPropertyOverrides.entrySet()) {
             codeGen.setGeneratorPropertyDefault(propertyOverride.getKey(), propertyOverride.getValue());
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -636,5 +636,37 @@ public class DefaultGeneratorTest {
             templates.toFile().delete();
         }
     }
+
+    @Test
+    public void dryRunWithGenerateMetadataOff() throws IOException {
+        Path target = Files.createTempDirectory("test");
+        File output = target.toFile();
+        try {
+            final CodegenConfigurator configurator = new CodegenConfigurator()
+                    .setGeneratorName("java")
+                    .setInputSpec("src/test/resources/3_0/pingSomeObj.yaml")
+                    .addAdditionalProperty(CodegenConstants.GENERATE_METADATA_FILES, "false")
+                    .setOutputDir(target.toAbsolutePath().toString());
+
+            final ClientOptInput clientOptInput = configurator.toClientOptInput();
+            DefaultGenerator generator = new DefaultGenerator(true);
+
+            List<File> files = generator.opts(clientOptInput).generate();
+
+            // Assert that metadata files are no longer created.
+            TestUtils.ensureDoesNotContainsFile(files, output, ".openapi-generator-ignore");
+            TestUtils.ensureDoesNotContainsFile(files, output, ".openapi-generator/VERSION");
+
+            // Sanity check that other files are still created.
+            TestUtils.ensureContainsFile(files, output, "src/main/java/org/openapitools/client/api/PingApi.java");
+            TestUtils.ensureContainsFile(files, output, "src/main/java/org/openapitools/client/model/SomeObj.java");
+            TestUtils.ensureContainsFile(files, output, "pom.xml");
+            TestUtils.ensureContainsFile(files, output, ".travis.yml");
+            TestUtils.ensureContainsFile(files, output, ".gitignore");
+            TestUtils.ensureContainsFile(files, output, "git_push.sh");
+        } finally {
+            output.delete();
+        }
+    }
 }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocGeneratorTest.java
@@ -49,7 +49,6 @@ public class AsciidocGeneratorTest {
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
         DefaultGenerator generator = new DefaultGenerator();
-        generator.setGenerateMetadata(false);
         List<File> generatedFiles = generator.opts(clientOptInput).generate();
         TestUtils.ensureContainsFile(generatedFiles, output, "index.adoc");
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/haskellservant/HaskellServantCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/haskellservant/HaskellServantCodegenTest.java
@@ -58,7 +58,6 @@ public class HaskellServantCodegenTest {
 
         // when
         DefaultGenerator generator = new DefaultGenerator();
-        generator.setGenerateMetadata(false);
         generator.opts(input).generate();
 
         // then

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -553,7 +553,6 @@ public class JavaClientCodegenTest {
         generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
         // tests if NPE will crash generation when path in yaml arent provided
         generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
-        generator.setGenerateMetadata(false);
         List<File> files = generator.opts(clientOptInput).generate();
 
         Assert.assertEquals(files.size(), 1);
@@ -647,7 +646,6 @@ public class JavaClientCodegenTest {
         generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
         generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
         generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
-        generator.setGenerateMetadata(false);
         List<File> files = generator.opts(clientOptInput).generate();
         files.forEach(File::deleteOnExit);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
@@ -358,8 +358,6 @@ public class ScalaAkkaClientCodegenTest {
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
         DefaultGenerator generator = new DefaultGenerator();
 
-        generator.setGenerateMetadata(false);
-
         generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
         generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
         generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
@@ -400,8 +398,6 @@ public class ScalaAkkaClientCodegenTest {
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
         DefaultGenerator generator = new DefaultGenerator();
-
-        generator.setGenerateMetadata(false);
 
         generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
         generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");


### PR DESCRIPTION
When `generateMetadataFiles = false` is passed in `additionalParameters`, do not generate `.openapi-generator-ignore` or `.openapi-generator/{FILE,VERSION}`.

* Moves the boolean for this into `CodegenConfig` so that custom implementations can set this now.
* Removes the mutable variable from `DefaultGenerator` and instead relies on the functions in the `CodegenConfig` interface. Looking for input on this point.
* Adds a `CodegenConstant` for `generateMetadataFiles` and hooks it into `DefaultCodegen#processOpts()`
* Adds a unit test for suppressing metadata file generation.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
