### PR TITLE
[JAXRS-CXF] Improve handling of additional properties in JavaCXFClien…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFClientCodegen.java
@@ -88,33 +88,30 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(USE_GENERIC_RESPONSE, "Use generic response"));
     }
 
-
     @Override
     public void processOpts() {
         super.processOpts();
 
         if (additionalProperties.containsKey(USE_BEANVALIDATION)) {
-            boolean useBeanValidationProp = convertPropertyToBooleanAndWriteBack(USE_BEANVALIDATION);
-            this.setUseBeanValidation(useBeanValidationProp);
+            this.setUseBeanValidation(convertPropertyToBooleanAndWriteBack(USE_BEANVALIDATION));
         }
 
         if (additionalProperties.containsKey(USE_GENERIC_RESPONSE)) {
-            this.setUseGenericResponse(convertPropertyToBoolean(USE_GENERIC_RESPONSE));
+            this.setUseGenericResponse(convertPropertyToBooleanAndWriteBack(USE_GENERIC_RESPONSE));
         }
 
-        if (useGenericResponse) {
-            writePropertyBack(USE_GENERIC_RESPONSE, useGenericResponse);
+        if (additionalProperties.containsKey(USE_GZIP_FEATURE_FOR_TESTS)) {
+            this.setUseGzipFeatureForTests(convertPropertyToBooleanAndWriteBack(USE_GZIP_FEATURE_FOR_TESTS));
         }
 
-        this.setUseGzipFeatureForTests(convertPropertyToBooleanAndWriteBack(USE_GZIP_FEATURE_FOR_TESTS));
-        this.setUseLoggingFeatureForTests(convertPropertyToBooleanAndWriteBack(USE_LOGGING_FEATURE_FOR_TESTS));
-
+        if (additionalProperties.containsKey(USE_LOGGING_FEATURE_FOR_TESTS)) {
+            this.setUseLoggingFeatureForTests(convertPropertyToBooleanAndWriteBack(USE_LOGGING_FEATURE_FOR_TESTS));
+        }
 
         supportingFiles.clear(); // Don't need extra files provided by AbstractJAX-RS & Java Codegen
 
         supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml")
             .doNotOverwrite());
-
     }
 
     @Override
@@ -154,20 +151,40 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
         return "Generates a Java JAXRS Client based on Apache CXF framework.";
     }
 
+    @Override
     public void setUseBeanValidation(boolean useBeanValidation) {
         this.useBeanValidation = useBeanValidation;
     }
 
+    public boolean isUseBeanValidation() {
+        return useBeanValidation;
+    }
+
+    @Override
     public void setUseGzipFeatureForTests(boolean useGzipFeatureForTests) {
         this.useGzipFeatureForTests = useGzipFeatureForTests;
     }
 
+    public boolean isUseGzipFeatureForTests() {
+        return useGzipFeatureForTests;
+    }
+
+    @Override
     public void setUseLoggingFeatureForTests(boolean useLoggingFeatureForTests) {
         this.useLoggingFeatureForTests = useLoggingFeatureForTests;
     }
 
+    public boolean isUseLoggingFeatureForTests() {
+        return useLoggingFeatureForTests;
+    }
+
+    @Override
     public void setUseGenericResponse(boolean useGenericResponse) {
         this.useGenericResponse = useGenericResponse;
+    }
+
+    public boolean isUseGenericResponse() {
+        return useGenericResponse;
     }
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaCXFClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaCXFClientCodegenTest.java
@@ -27,6 +27,10 @@ import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenResponse;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.JavaCXFClientCodegen;
+import org.openapitools.codegen.languages.features.BeanValidationFeatures;
+import org.openapitools.codegen.languages.features.GzipTestFeatures;
+import org.openapitools.codegen.languages.features.LoggingTestFeatures;
+import org.openapitools.codegen.languages.features.UseGenericResponseFeatures;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -118,4 +122,61 @@ public class JavaCXFClientCodegenTest {
         Assert.assertEquals(codegen.getInvokerPackage(), "org.openapitools.client.xyz.invoker");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "org.openapitools.client.xyz.invoker");
     }
+
+    @Test
+    public void testUseBeanValidationAdditionalProperty() throws Exception {
+        final JavaCXFClientCodegen codegen = new JavaCXFClientCodegen();
+
+        codegen.processOpts();
+        Assert.assertNull(codegen.additionalProperties().get(BeanValidationFeatures.USE_BEANVALIDATION));
+        Assert.assertFalse(codegen.isUseBeanValidation());
+
+        codegen.additionalProperties().put(BeanValidationFeatures.USE_BEANVALIDATION, true);
+        codegen.processOpts();
+        Assert.assertEquals(codegen.additionalProperties().get(BeanValidationFeatures.USE_BEANVALIDATION), Boolean.TRUE);
+        Assert.assertTrue(codegen.isUseBeanValidation());
+    }
+
+    @Test
+    public void testUseGenericResponseAdditionalProperty() throws Exception {
+        final JavaCXFClientCodegen codegen = new JavaCXFClientCodegen();
+
+        codegen.processOpts();
+        Assert.assertNull(codegen.additionalProperties().get(UseGenericResponseFeatures.USE_GENERIC_RESPONSE));
+        Assert.assertFalse(codegen.isUseGenericResponse());
+
+        codegen.additionalProperties().put(UseGenericResponseFeatures.USE_GENERIC_RESPONSE, true);
+        codegen.processOpts();
+        Assert.assertEquals(codegen.additionalProperties().get(UseGenericResponseFeatures.USE_GENERIC_RESPONSE), Boolean.TRUE);
+        Assert.assertTrue(codegen.isUseGenericResponse());
+    }
+
+    @Test
+    public void testUseLoggingFeatureForTestsAdditionalProperty() throws Exception {
+        final JavaCXFClientCodegen codegen = new JavaCXFClientCodegen();
+
+        codegen.processOpts();
+        Assert.assertNull(codegen.additionalProperties().get(LoggingTestFeatures.USE_LOGGING_FEATURE_FOR_TESTS));
+        Assert.assertFalse(codegen.isUseLoggingFeatureForTests());
+
+        codegen.additionalProperties().put(LoggingTestFeatures.USE_LOGGING_FEATURE_FOR_TESTS, true);
+        codegen.processOpts();
+        Assert.assertEquals(codegen.additionalProperties().get(LoggingTestFeatures.USE_LOGGING_FEATURE_FOR_TESTS), Boolean.TRUE);
+        Assert.assertTrue(codegen.isUseLoggingFeatureForTests());
+    }
+
+    @Test
+    public void testUseGzipFeatureForTestsAdditionalProperty() throws Exception {
+        final JavaCXFClientCodegen codegen = new JavaCXFClientCodegen();
+
+        codegen.processOpts();
+        Assert.assertNull(codegen.additionalProperties().get(GzipTestFeatures.USE_GZIP_FEATURE_FOR_TESTS));
+        Assert.assertFalse(codegen.isUseLoggingFeatureForTests());
+
+        codegen.additionalProperties().put(GzipTestFeatures.USE_GZIP_FEATURE_FOR_TESTS, true);
+        codegen.processOpts();
+        Assert.assertEquals(codegen.additionalProperties().get(GzipTestFeatures.USE_GZIP_FEATURE_FOR_TESTS), Boolean.TRUE);
+        Assert.assertTrue(codegen.isUseGzipFeatureForTests());
+    }
+
 }


### PR DESCRIPTION
This PR improves the handling of additional properties of the `JavaCXFClientCodegen` and the corresponding tests.

Currently, when using the `jaxrs-cxf-client` generator without explicitly setting `useGzipFeatureForTests` and `useLoggingFeatureForTests` a warning is logged for each of these properties, saying: `The value (generator's option) must be either boolean or string. Default to false.` The behavior is fixed in this MR.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


cc: @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @bkabrda