### PR TITLE
Fix deserialization for null JSON payload in .NET framework 4.7

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelAnyOf.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelAnyOf.mustache
@@ -99,6 +99,11 @@
         public static {{classname}} FromJson(string jsonString)
         {
             {{classname}} new{{classname}} = null;
+
+            if (jsonString == null)
+            {
+                return new{{classname}};
+            }
             {{#anyOf}}
 
             try

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelOneOf.mustache
@@ -99,6 +99,11 @@
         public static {{classname}} FromJson(string jsonString)
         {
             {{classname}} new{{classname}} = null;
+
+            if (jsonString == null)
+            {
+                return new{{classname}};
+            }
             {{#useOneOfDiscriminatorLookup}}
             {{#discriminator}}
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Fruit.cs
@@ -137,6 +137,11 @@ namespace Org.OpenAPITools.Model
         public static Fruit FromJson(string jsonString)
         {
             Fruit newFruit = null;
+
+            if (jsonString == null)
+            {
+                return newFruit;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -146,6 +146,11 @@ namespace Org.OpenAPITools.Model
         public static FruitReq FromJson(string jsonString)
         {
             FruitReq newFruitReq = null;
+
+            if (jsonString == null)
+            {
+                return newFruitReq;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -137,6 +137,11 @@ namespace Org.OpenAPITools.Model
         {
             GmFruit newGmFruit = null;
 
+            if (jsonString == null)
+            {
+                return newGmFruit;
+            }
+
             try
             {
                 newGmFruit = new GmFruit(JsonConvert.DeserializeObject<Apple>(jsonString, GmFruit.SerializerSettings));

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Mammal.cs
@@ -165,6 +165,11 @@ namespace Org.OpenAPITools.Model
         {
             Mammal newMammal = null;
 
+            if (jsonString == null)
+            {
+                return newMammal;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["className"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -148,6 +148,11 @@ namespace Org.OpenAPITools.Model
         {
             NullableShape newNullableShape = null;
 
+            if (jsonString == null)
+            {
+                return newNullableShape;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["shapeType"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Pig.cs
@@ -139,6 +139,11 @@ namespace Org.OpenAPITools.Model
         {
             Pig newPig = null;
 
+            if (jsonString == null)
+            {
+                return newPig;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["className"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -139,6 +139,11 @@ namespace Org.OpenAPITools.Model
         {
             Quadrilateral newQuadrilateral = null;
 
+            if (jsonString == null)
+            {
+                return newQuadrilateral;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["quadrilateralType"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Shape.cs
@@ -139,6 +139,11 @@ namespace Org.OpenAPITools.Model
         {
             Shape newShape = null;
 
+            if (jsonString == null)
+            {
+                return newShape;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["shapeType"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -148,6 +148,11 @@ namespace Org.OpenAPITools.Model
         {
             ShapeOrNull newShapeOrNull = null;
 
+            if (jsonString == null)
+            {
+                return newShapeOrNull;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["shapeType"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Triangle.cs
@@ -165,6 +165,11 @@ namespace Org.OpenAPITools.Model
         {
             Triangle newTriangle = null;
 
+            if (jsonString == null)
+            {
+                return newTriangle;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["triangleType"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Fruit.cs
@@ -137,6 +137,11 @@ namespace Org.OpenAPITools.Model
         public static Fruit FromJson(string jsonString)
         {
             Fruit newFruit = null;
+
+            if (jsonString == null)
+            {
+                return newFruit;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -146,6 +146,11 @@ namespace Org.OpenAPITools.Model
         public static FruitReq FromJson(string jsonString)
         {
             FruitReq newFruitReq = null;
+
+            if (jsonString == null)
+            {
+                return newFruitReq;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -137,6 +137,11 @@ namespace Org.OpenAPITools.Model
         {
             GmFruit newGmFruit = null;
 
+            if (jsonString == null)
+            {
+                return newGmFruit;
+            }
+
             try
             {
                 newGmFruit = new GmFruit(JsonConvert.DeserializeObject<Apple>(jsonString, GmFruit.SerializerSettings));

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Mammal.cs
@@ -165,6 +165,11 @@ namespace Org.OpenAPITools.Model
         {
             Mammal newMammal = null;
 
+            if (jsonString == null)
+            {
+                return newMammal;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["className"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -148,6 +148,11 @@ namespace Org.OpenAPITools.Model
         {
             NullableShape newNullableShape = null;
 
+            if (jsonString == null)
+            {
+                return newNullableShape;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["shapeType"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pig.cs
@@ -139,6 +139,11 @@ namespace Org.OpenAPITools.Model
         {
             Pig newPig = null;
 
+            if (jsonString == null)
+            {
+                return newPig;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["className"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -139,6 +139,11 @@ namespace Org.OpenAPITools.Model
         {
             Quadrilateral newQuadrilateral = null;
 
+            if (jsonString == null)
+            {
+                return newQuadrilateral;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["quadrilateralType"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Shape.cs
@@ -139,6 +139,11 @@ namespace Org.OpenAPITools.Model
         {
             Shape newShape = null;
 
+            if (jsonString == null)
+            {
+                return newShape;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["shapeType"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -148,6 +148,11 @@ namespace Org.OpenAPITools.Model
         {
             ShapeOrNull newShapeOrNull = null;
 
+            if (jsonString == null)
+            {
+                return newShapeOrNull;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["shapeType"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Triangle.cs
@@ -165,6 +165,11 @@ namespace Org.OpenAPITools.Model
         {
             Triangle newTriangle = null;
 
+            if (jsonString == null)
+            {
+                return newTriangle;
+            }
+
             string discriminatorValue = JObject.Parse(jsonString)["triangleType"].ToString();
             switch (discriminatorValue)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -137,6 +137,11 @@ namespace Org.OpenAPITools.Model
         public static Fruit FromJson(string jsonString)
         {
             Fruit newFruit = null;
+
+            if (jsonString == null)
+            {
+                return newFruit;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -146,6 +146,11 @@ namespace Org.OpenAPITools.Model
         public static FruitReq FromJson(string jsonString)
         {
             FruitReq newFruitReq = null;
+
+            if (jsonString == null)
+            {
+                return newFruitReq;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -137,6 +137,11 @@ namespace Org.OpenAPITools.Model
         {
             GmFruit newGmFruit = null;
 
+            if (jsonString == null)
+            {
+                return newGmFruit;
+            }
+
             try
             {
                 newGmFruit = new GmFruit(JsonConvert.DeserializeObject<Apple>(jsonString, GmFruit.SerializerSettings));

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -164,6 +164,11 @@ namespace Org.OpenAPITools.Model
         public static Mammal FromJson(string jsonString)
         {
             Mammal newMammal = null;
+
+            if (jsonString == null)
+            {
+                return newMammal;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -147,6 +147,11 @@ namespace Org.OpenAPITools.Model
         public static NullableShape FromJson(string jsonString)
         {
             NullableShape newNullableShape = null;
+
+            if (jsonString == null)
+            {
+                return newNullableShape;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pig.cs
@@ -138,6 +138,11 @@ namespace Org.OpenAPITools.Model
         public static Pig FromJson(string jsonString)
         {
             Pig newPig = null;
+
+            if (jsonString == null)
+            {
+                return newPig;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -138,6 +138,11 @@ namespace Org.OpenAPITools.Model
         public static Quadrilateral FromJson(string jsonString)
         {
             Quadrilateral newQuadrilateral = null;
+
+            if (jsonString == null)
+            {
+                return newQuadrilateral;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Shape.cs
@@ -138,6 +138,11 @@ namespace Org.OpenAPITools.Model
         public static Shape FromJson(string jsonString)
         {
             Shape newShape = null;
+
+            if (jsonString == null)
+            {
+                return newShape;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -147,6 +147,11 @@ namespace Org.OpenAPITools.Model
         public static ShapeOrNull FromJson(string jsonString)
         {
             ShapeOrNull newShapeOrNull = null;
+
+            if (jsonString == null)
+            {
+                return newShapeOrNull;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -164,6 +164,11 @@ namespace Org.OpenAPITools.Model
         public static Triangle FromJson(string jsonString)
         {
             Triangle newTriangle = null;
+
+            if (jsonString == null)
+            {
+                return newTriangle;
+            }
             int match = 0;
             List<string> matchedTypes = new List<string>();
 


### PR DESCRIPTION
Fix deserialisation for null json payload in .NET framework 4.7 to avoid exceptions

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)



