### PR TITLE
Allows install typescript client via npm from Git

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/package.mustache
@@ -14,7 +14,7 @@
   "typings": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "dependencies": {
     {{#frameworks}}

--- a/samples/openapi3/client/petstore/typescript/builds/default/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/default/package.json
@@ -14,7 +14,7 @@
   "typings": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "dependencies": {
     "node-fetch": "^2.6.0",

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/package.json
@@ -14,7 +14,7 @@
   "typings": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "dependencies": {
     "node-fetch": "^2.6.0",

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/package.json
@@ -14,7 +14,7 @@
   "typings": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@types/jquery": "^3.3.29",

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/package.json
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/package.json
@@ -14,7 +14,7 @@
   "typings": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "dependencies": {
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
'prepublishOnly' is run before the package is published. 'prepack' is run before the package is published and after local installation eg. via Git.


### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
