### PR TITLE
[c#][netcore] Skip readonly properties in serialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
@@ -38,7 +38,7 @@
         {{#isReadOnly}}
 
         /// <summary>
-        /// Return false as {{name}} should not be serialized given that it's read only.
+        /// Returns false as {{name}} should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerialize{{name}}()
@@ -131,7 +131,7 @@
 
         {{#isReadOnly}}
         /// <summary>
-        /// Return false as {{name}} should not be serialized given that it's read only.
+        /// Returns false as {{name}} should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerialize{{name}}()

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
@@ -35,6 +35,17 @@
         {{/description}}
         [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = true{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/vendorExtensions.x-emit-default-value}})]
         public {{#complexType}}{{{complexType}}}{{/complexType}}{{^complexType}}{{{datatypeWithEnum}}}{{/complexType}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}} {{name}} { get; set; }
+        {{#isReadOnly}}
+
+        /// <summary>
+        /// Return false as {{name}} should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerialize{{name}}()
+        {
+            return false;
+        }
+        {{/isReadOnly}}
         {{/isEnum}}
         {{/vars}}
     {{#hasRequired}}
@@ -118,6 +129,17 @@
         {{/isDate}}
         public {{{dataType}}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }
 
+        {{#isReadOnly}}
+        /// <summary>
+        /// Return false as {{name}} should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerialize{{name}}()
+        {
+            return false;
+        }
+
+        {{/isReadOnly}}
         {{/isEnum}}
         {{/isInherited}}
         {{/vars}}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         public string Bar { get; private set; }
 
         /// <summary>
-        /// Return false as Bar should not be serialized given that it's read only.
+        /// Returns false as Bar should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerializeBar()
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         public string Foo { get; private set; }
 
         /// <summary>
-        /// Return false as Foo should not be serialized given that it's read only.
+        /// Returns false as Foo should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerializeFoo()

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -48,10 +48,28 @@ namespace Org.OpenAPITools.Model
         public string Bar { get; private set; }
 
         /// <summary>
+        /// Return false as Bar should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeBar()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Gets or Sets Foo
         /// </summary>
         [DataMember(Name = "foo", EmitDefaultValue = false)]
         public string Foo { get; private set; }
+
+        /// <summary>
+        /// Return false as Foo should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeFoo()
+        {
+            return false;
+        }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Name.cs
@@ -65,6 +65,15 @@ namespace Org.OpenAPITools.Model
         public int SnakeCase { get; private set; }
 
         /// <summary>
+        /// Return false as SnakeCase should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeSnakeCase()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Gets or Sets Property
         /// </summary>
         [DataMember(Name = "property", EmitDefaultValue = false)]
@@ -75,6 +84,15 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "123Number", EmitDefaultValue = false)]
         public int _123Number { get; private set; }
+
+        /// <summary>
+        /// Return false as _123Number should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerialize_123Number()
+        {
+            return false;
+        }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         public int SnakeCase { get; private set; }
 
         /// <summary>
-        /// Return false as SnakeCase should not be serialized given that it's read only.
+        /// Returns false as SnakeCase should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerializeSnakeCase()
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         public int _123Number { get; private set; }
 
         /// <summary>
-        /// Return false as _123Number should not be serialized given that it's read only.
+        /// Returns false as _123Number should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerialize_123Number()

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -49,6 +49,15 @@ namespace Org.OpenAPITools.Model
         public string Bar { get; private set; }
 
         /// <summary>
+        /// Return false as Bar should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeBar()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Gets or Sets Baz
         /// </summary>
         [DataMember(Name = "baz", EmitDefaultValue = false)]

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         public string Bar { get; private set; }
 
         /// <summary>
-        /// Return false as Bar should not be serialized given that it's read only.
+        /// Returns false as Bar should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerializeBar()

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Test
         /// Test GetServerUrl
         /// </summary>
         [Fact]
-        public void testOneOfSchemaAdditionalProperties()
+        public void TestOneOfSchemaAdditionalProperties()
         {
             // TODO
         }
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Test
         /// Test GetServerUrl
         /// </summary>
         [Fact]
-        public void testOneOfSchemaWithDiscriminator()
+        public void TestOneOfSchemaWithDiscriminator()
         {
             // Mammal can be one of whale, pig and zebra.
             // pig has sub-classes.
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Test
             Mammal m = Mammal.FromJson(str);
             Assert.NotNull(m);
             Assert.IsType<Whale>(m.ActualInstance);
-            
+
             String str2 = "{ \"className\": \"zebra\", \"type\": \"plains\" }";
             Mammal m2 = Mammal.FromJson(str2);
             Assert.NotNull(m2);
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Test
         /// Test Fruit
         /// </summary>
         [Fact]
-        public void testFruit()
+        public void TestFruit()
         {
             Apple a = new Apple();
             a.Origin = "Japan";
@@ -94,6 +94,17 @@ namespace Org.OpenAPITools.Test
 
             // test custom serializer
             Assert.Equal("{\"lengthCm\":98.0}", JsonConvert.SerializeObject(f5));
+        }
+
+        /// <summary>
+        /// ReadOnly property tests
+        /// </summary>
+        [Fact]
+        public void ReadOnlyFruit()
+        {
+            ReadOnlyFirst r = JsonConvert.DeserializeObject<ReadOnlyFirst>("{\"baz\":\"from json gaz\",\"bar\":\"from json bar\"}");
+            Assert.Equal("from json bar", r.Bar);
+            Assert.Equal("{\"baz\":\"from json gaz\"}", JsonConvert.SerializeObject(r));
         }
     }
 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         public string Bar { get; private set; }
 
         /// <summary>
-        /// Return false as Bar should not be serialized given that it's read only.
+        /// Returns false as Bar should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerializeBar()
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         public string Foo { get; private set; }
 
         /// <summary>
-        /// Return false as Foo should not be serialized given that it's read only.
+        /// Returns false as Foo should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerializeFoo()

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -48,10 +48,28 @@ namespace Org.OpenAPITools.Model
         public string Bar { get; private set; }
 
         /// <summary>
+        /// Return false as Bar should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeBar()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Gets or Sets Foo
         /// </summary>
         [DataMember(Name = "foo", EmitDefaultValue = false)]
         public string Foo { get; private set; }
+
+        /// <summary>
+        /// Return false as Foo should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeFoo()
+        {
+            return false;
+        }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Name.cs
@@ -65,6 +65,15 @@ namespace Org.OpenAPITools.Model
         public int SnakeCase { get; private set; }
 
         /// <summary>
+        /// Return false as SnakeCase should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeSnakeCase()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Gets or Sets Property
         /// </summary>
         [DataMember(Name = "property", EmitDefaultValue = false)]
@@ -75,6 +84,15 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "123Number", EmitDefaultValue = false)]
         public int _123Number { get; private set; }
+
+        /// <summary>
+        /// Return false as _123Number should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerialize_123Number()
+        {
+            return false;
+        }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Name.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         public int SnakeCase { get; private set; }
 
         /// <summary>
-        /// Return false as SnakeCase should not be serialized given that it's read only.
+        /// Returns false as SnakeCase should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerializeSnakeCase()
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         public int _123Number { get; private set; }
 
         /// <summary>
-        /// Return false as _123Number should not be serialized given that it's read only.
+        /// Returns false as _123Number should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerialize_123Number()

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -49,6 +49,15 @@ namespace Org.OpenAPITools.Model
         public string Bar { get; private set; }
 
         /// <summary>
+        /// Return false as Bar should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeBar()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Gets or Sets Baz
         /// </summary>
         [DataMember(Name = "baz", EmitDefaultValue = false)]

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         public string Bar { get; private set; }
 
         /// <summary>
-        /// Return false as Bar should not be serialized given that it's read only.
+        /// Returns false as Bar should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerializeBar()

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -47,10 +47,28 @@ namespace Org.OpenAPITools.Model
         public string Bar { get; private set; }
 
         /// <summary>
+        /// Return false as Bar should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeBar()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Gets or Sets Foo
         /// </summary>
         [DataMember(Name = "foo", EmitDefaultValue = false)]
         public string Foo { get; private set; }
+
+        /// <summary>
+        /// Return false as Foo should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeFoo()
+        {
+            return false;
+        }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         public string Bar { get; private set; }
 
         /// <summary>
-        /// Return false as Bar should not be serialized given that it's read only.
+        /// Returns false as Bar should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerializeBar()
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         public string Foo { get; private set; }
 
         /// <summary>
-        /// Return false as Foo should not be serialized given that it's read only.
+        /// Returns false as Foo should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerializeFoo()

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Name.cs
@@ -61,6 +61,15 @@ namespace Org.OpenAPITools.Model
         public int SnakeCase { get; private set; }
 
         /// <summary>
+        /// Return false as SnakeCase should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeSnakeCase()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Gets or Sets Property
         /// </summary>
         [DataMember(Name = "property", EmitDefaultValue = false)]
@@ -71,6 +80,15 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "123Number", EmitDefaultValue = false)]
         public int _123Number { get; private set; }
+
+        /// <summary>
+        /// Return false as _123Number should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerialize_123Number()
+        {
+            return false;
+        }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Name.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         public int SnakeCase { get; private set; }
 
         /// <summary>
-        /// Return false as SnakeCase should not be serialized given that it's read only.
+        /// Returns false as SnakeCase should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerializeSnakeCase()
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         public int _123Number { get; private set; }
 
         /// <summary>
-        /// Return false as _123Number should not be serialized given that it's read only.
+        /// Returns false as _123Number should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerialize_123Number()

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -48,6 +48,15 @@ namespace Org.OpenAPITools.Model
         public string Bar { get; private set; }
 
         /// <summary>
+        /// Return false as Bar should not be serialized given that it's read only.
+        /// </summary>
+        /// <returns>false (boolean)</returns>
+        public bool ShouldSerializeBar()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Gets or Sets Baz
         /// </summary>
         [DataMember(Name = "baz", EmitDefaultValue = false)]

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         public string Bar { get; private set; }
 
         /// <summary>
-        /// Return false as Bar should not be serialized given that it's read only.
+        /// Returns false as Bar should not be serialized given that it's read-only.
         /// </summary>
         /// <returns>false (boolean)</returns>
         public bool ShouldSerializeBar()


### PR DESCRIPTION
- Skip readonly properties in serialization

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)


