### PR TITLE
[rust-server] Fix keyParamName not  used for query API token

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/context.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/context.mustache
@@ -148,7 +148,7 @@ impl<T, A, B, C, D, ReqBody> Service<Request<ReqBody>> for AddContext<T, A, B, C
         {{#isKeyInQuery}}
         {
             let key = form_urlencoded::parse(request.uri().query().unwrap_or_default().as_bytes())
-                .filter(|e| e.0 == "api_key_query")
+                .filter(|e| e.0 == "{{{keyParamName}}}")
                 .map(|e| e.1.clone().into_owned())
                 .nth(0);
             if let Some(key) = key {


### PR DESCRIPTION
Instead of using `keyParamName` of `CodegenSecurity`, a hard coded token name of "api_key_query" was used to parse API tokens in query strings.

This PR changes this string to the template value `{{{keyParamName}}}`.

Closes #7904

Technical committee: @frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05)

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
