### PR TITLE
Feature suppoert  dart  sample code in html2 generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/htmlDocs2/index.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/index.mustache
@@ -234,6 +234,7 @@
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-{{baseName}}-{{nickname}}-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-java">Java</a></li>
+                          <li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-{{baseName}}-{{nickname}}-0-objc">Obj-C</a></li>
@@ -256,6 +257,10 @@
                           </div>
                           <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-java">
                             <pre class="prettyprint"><code class="language-java">{{>sample_java}}</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">{{>sample_dart}}</code></pre>
                           </div>
 
                           <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-android">

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/sample_dart.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/sample_dart.mustache
@@ -1,0 +1,15 @@
+import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+{{#allParams}}
+final {{{dataType}}} {{{paramName}}} = new {{{dataType}}}(); // {{{dataType}}} | {{{unescapedDescription}}}
+{{/allParams}}
+
+try {
+    final result = await api_instance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/allParams}});
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->{{{operationId}}}: $e\n');
+}
+

--- a/samples/documentation/html2/index.html
+++ b/samples/documentation/html2/index.html
@@ -1167,6 +1167,7 @@ ul.nav-tabs {
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-Pet-addPet-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-Pet-addPet-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-addPet-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-Pet-addPet-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-Pet-addPet-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-Pet-addPet-0-objc">Obj-C</a></li>
@@ -1217,6 +1218,23 @@ public class PetApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Pet-addPet-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final Pet pet = new Pet(); // Pet | 
+
+try {
+    final result = await api_instance.addPet(pet);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->addPet: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -1593,6 +1611,7 @@ $(document).ready(function() {
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-Pet-deletePet-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-Pet-deletePet-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-deletePet-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-Pet-deletePet-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-Pet-deletePet-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-Pet-deletePet-0-objc">Obj-C</a></li>
@@ -1641,6 +1660,24 @@ public class PetApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Pet-deletePet-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final Long petId = new Long(); // Long | Pet id to delete
+final String apiKey = new String(); // String | 
+
+try {
+    final result = await api_instance.deletePet(petId, apiKey);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->deletePet: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -1954,6 +1991,7 @@ Pet id to delete
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-Pet-findPetsByStatus-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-Pet-findPetsByStatus-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-findPetsByStatus-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-Pet-findPetsByStatus-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-Pet-findPetsByStatus-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-Pet-findPetsByStatus-0-objc">Obj-C</a></li>
@@ -2003,6 +2041,23 @@ public class PetApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Pet-findPetsByStatus-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final array[String] status = new array[String](); // array[String] | Status values that need to be considered for filter
+
+try {
+    final result = await api_instance.findPetsByStatus(status);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->findPetsByStatus: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -2358,6 +2413,7 @@ Status values that need to be considered for filter
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-Pet-findPetsByTags-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-Pet-findPetsByTags-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-findPetsByTags-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-Pet-findPetsByTags-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-Pet-findPetsByTags-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-Pet-findPetsByTags-0-objc">Obj-C</a></li>
@@ -2407,6 +2463,23 @@ public class PetApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Pet-findPetsByTags-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final array[String] tags = new array[String](); // array[String] | Tags to filter by
+
+try {
+    final result = await api_instance.findPetsByTags(tags);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->findPetsByTags: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -2762,6 +2835,7 @@ Tags to filter by
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-Pet-getPetById-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-Pet-getPetById-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-getPetById-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-Pet-getPetById-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-Pet-getPetById-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-Pet-getPetById-0-objc">Obj-C</a></li>
@@ -2813,6 +2887,23 @@ public class PetApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Pet-getPetById-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final Long petId = new Long(); // Long | ID of pet to return
+
+try {
+    final result = await api_instance.getPetById(petId);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->getPetById: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -3194,6 +3285,7 @@ ID of pet to return
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-Pet-updatePet-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-Pet-updatePet-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-updatePet-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-Pet-updatePet-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-Pet-updatePet-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-Pet-updatePet-0-objc">Obj-C</a></li>
@@ -3244,6 +3336,23 @@ public class PetApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Pet-updatePet-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final Pet pet = new Pet(); // Pet | 
+
+try {
+    final result = await api_instance.updatePet(pet);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->updatePet: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -3664,6 +3773,7 @@ $(document).ready(function() {
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-Pet-updatePetWithForm-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-Pet-updatePetWithForm-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-updatePetWithForm-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-Pet-updatePetWithForm-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-Pet-updatePetWithForm-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-Pet-updatePetWithForm-0-objc">Obj-C</a></li>
@@ -3714,6 +3824,25 @@ public class PetApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Pet-updatePetWithForm-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final Long petId = new Long(); // Long | ID of pet that needs to be updated
+final String name = new String(); // String | Updated name of the pet
+final String status = new String(); // String | Updated status of the pet
+
+try {
+    final result = await api_instance.updatePetWithForm(petId, name, status);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->updatePetWithForm: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -4059,6 +4188,7 @@ Updated status of the pet
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-Pet-uploadFile-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-Pet-uploadFile-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Pet-uploadFile-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-Pet-uploadFile-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-Pet-uploadFile-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-Pet-uploadFile-0-objc">Obj-C</a></li>
@@ -4111,6 +4241,25 @@ public class PetApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Pet-uploadFile-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final Long petId = new Long(); // Long | ID of pet to update
+final String additionalMetadata = new String(); // String | Additional data to pass to server
+final File file = new File(); // File | file to upload
+
+try {
+    final result = await api_instance.uploadFile(petId, additionalMetadata, file);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->uploadFile: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -4514,6 +4663,7 @@ file to upload
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-Store-deleteOrder-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-Store-deleteOrder-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Store-deleteOrder-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-Store-deleteOrder-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-Store-deleteOrder-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-Store-deleteOrder-0-objc">Obj-C</a></li>
@@ -4555,6 +4705,23 @@ public class StoreApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Store-deleteOrder-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final String orderId = new String(); // String | ID of the order that needs to be deleted
+
+try {
+    final result = await api_instance.deleteOrder(orderId);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->deleteOrder: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -4822,6 +4989,7 @@ ID of the order that needs to be deleted
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-Store-getInventory-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-Store-getInventory-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Store-getInventory-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-Store-getInventory-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-Store-getInventory-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-Store-getInventory-0-objc">Obj-C</a></li>
@@ -4872,6 +5040,22 @@ public class StoreApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Store-getInventory-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+
+try {
+    final result = await api_instance.getInventory();
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->getInventory: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -5166,6 +5350,7 @@ pub fn main() {
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-Store-getOrderById-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-Store-getOrderById-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Store-getOrderById-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-Store-getOrderById-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-Store-getOrderById-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-Store-getOrderById-0-objc">Obj-C</a></li>
@@ -5209,6 +5394,23 @@ public class StoreApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Store-getOrderById-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final Long orderId = new Long(); // Long | ID of pet that needs to be fetched
+
+try {
+    final result = await api_instance.getOrderById(orderId);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->getOrderById: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -5558,6 +5760,7 @@ ID of pet that needs to be fetched
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-Store-placeOrder-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-Store-placeOrder-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Store-placeOrder-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-Store-placeOrder-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-Store-placeOrder-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-Store-placeOrder-0-objc">Obj-C</a></li>
@@ -5602,6 +5805,23 @@ public class StoreApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Store-placeOrder-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final Order order = new Order(); // Order | 
+
+try {
+    final result = await api_instance.placeOrder(order);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->placeOrder: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -5946,6 +6166,7 @@ $(document).ready(function() {
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-User-createUser-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-User-createUser-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-createUser-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-User-createUser-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-User-createUser-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-User-createUser-0-objc">Obj-C</a></li>
@@ -5996,6 +6217,23 @@ public class UserApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-User-createUser-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final User user = new User(); // User | 
+
+try {
+    final result = await api_instance.createUser(user);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->createUser: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -6290,6 +6528,7 @@ $(document).ready(function() {
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-User-createUsersWithArrayInput-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-User-createUsersWithArrayInput-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-createUsersWithArrayInput-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-User-createUsersWithArrayInput-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-User-createUsersWithArrayInput-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-User-createUsersWithArrayInput-0-objc">Obj-C</a></li>
@@ -6340,6 +6579,23 @@ public class UserApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-User-createUsersWithArrayInput-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final array[User] user = new array[User](); // array[User] | 
+
+try {
+    final result = await api_instance.createUsersWithArrayInput(user);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->createUsersWithArrayInput: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -6637,6 +6893,7 @@ $(document).ready(function() {
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-User-createUsersWithListInput-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-User-createUsersWithListInput-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-createUsersWithListInput-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-User-createUsersWithListInput-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-User-createUsersWithListInput-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-User-createUsersWithListInput-0-objc">Obj-C</a></li>
@@ -6687,6 +6944,23 @@ public class UserApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-User-createUsersWithListInput-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final array[User] user = new array[User](); // array[User] | 
+
+try {
+    final result = await api_instance.createUsersWithListInput(user);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->createUsersWithListInput: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -6984,6 +7258,7 @@ $(document).ready(function() {
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-User-deleteUser-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-User-deleteUser-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-deleteUser-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-User-deleteUser-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-User-deleteUser-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-User-deleteUser-0-objc">Obj-C</a></li>
@@ -7033,6 +7308,23 @@ public class UserApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-User-deleteUser-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final String username = new String(); // String | The name that needs to be deleted
+
+try {
+    final result = await api_instance.deleteUser(username);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->deleteUser: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -7332,6 +7624,7 @@ The name that needs to be deleted
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-User-getUserByName-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-User-getUserByName-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-getUserByName-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-User-getUserByName-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-User-getUserByName-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-User-getUserByName-0-objc">Obj-C</a></li>
@@ -7375,6 +7668,23 @@ public class UserApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-User-getUserByName-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final String username = new String(); // String | The name that needs to be fetched. Use user1 for testing.
+
+try {
+    final result = await api_instance.getUserByName(username);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->getUserByName: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -7721,6 +8031,7 @@ The name that needs to be fetched. Use user1 for testing.
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-User-loginUser-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-User-loginUser-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-loginUser-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-User-loginUser-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-User-loginUser-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-User-loginUser-0-objc">Obj-C</a></li>
@@ -7765,6 +8076,24 @@ public class UserApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-User-loginUser-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final String username = new String(); // String | The user name for login
+final String password = new String(); // String | The password for login in clear text
+
+try {
+    final result = await api_instance.loginUser(username, password);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->loginUser: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -8181,6 +8510,7 @@ The password for login in clear text
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-User-logoutUser-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-User-logoutUser-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-logoutUser-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-User-logoutUser-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-User-logoutUser-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-User-logoutUser-0-objc">Obj-C</a></li>
@@ -8229,6 +8559,22 @@ public class UserApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-User-logoutUser-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+
+try {
+    final result = await api_instance.logoutUser();
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->logoutUser: $e\n');
+}
+
 </code></pre>
                           </div>
 
@@ -8467,6 +8813,7 @@ pub fn main() {
                         <ul class="nav nav-tabs nav-tabs-examples">
                           <li class="active"><a href="#examples-User-updateUser-0-curl">Curl</a></li>
                           <li class=""><a href="#examples-User-updateUser-0-java">Java</a></li>
+                          <li class=""><a href="#examples-User-updateUser-0-dart">Dart</a></li>
                           <li class=""><a href="#examples-User-updateUser-0-android">Android</a></li>
                           <!--<li class=""><a href="#examples-User-updateUser-0-groovy">Groovy</a></li>-->
                           <li class=""><a href="#examples-User-updateUser-0-objc">Obj-C</a></li>
@@ -8518,6 +8865,24 @@ public class UserApiExample {
         }
     }
 }
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-User-updateUser-0-dart">
+                            <pre class="prettyprint"><code class="language-dart">import 'package:openapi/api.dart';
+
+final api_instance = DefaultApi();
+
+final String username = new String(); // String | name that need to be deleted
+final User user = new User(); // User | 
+
+try {
+    final result = await api_instance.updateUser(username, user);
+    print(result);
+} catch (e) {
+    print('Exception when calling DefaultApi->updateUser: $e\n');
+}
+
 </code></pre>
                           </div>
 


### PR DESCRIPTION
Add dart code sample while generating documentation using `html2` generator 

For eg: `java  -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -i ./samples/yaml/pet.yml -g html2` will now generate html file which includes dart code samples

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
