### PR TITLE
[JS] (#7910) Fixing undefined error caused by no `this` instances

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
@@ -306,16 +306,16 @@
     }
     switch (collectionFormat) {
       case 'csv':
-        return param.map(this.paramToString).join(',');
+        return param.map(this.paramToString, this).join(',');
       case 'ssv':
-        return param.map(this.paramToString).join(' ');
+        return param.map(this.paramToString, this).join(' ');
       case 'tsv':
-        return param.map(this.paramToString).join('\t');
+        return param.map(this.paramToString, this).join('\t');
       case 'pipes':
-        return param.map(this.paramToString).join('|');
+        return param.map(this.paramToString, this).join('|');
       case 'multi':
         // return the array directly as SuperAgent will handle it as expected
-        return param.map(this.paramToString);
+        return param.map(this.paramToString, this);
       default:
         throw new Error('Unknown collection format: ' + collectionFormat);
     }

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -272,16 +272,16 @@ class ApiClient {
         }
         switch (collectionFormat) {
             case 'csv':
-                return param.map(this.paramToString).join(',');
+                return param.map(this.paramToString, this).join(',');
             case 'ssv':
-                return param.map(this.paramToString).join(' ');
+                return param.map(this.paramToString, this).join(' ');
             case 'tsv':
-                return param.map(this.paramToString).join('\t');
+                return param.map(this.paramToString, this).join('\t');
             case 'pipes':
-                return param.map(this.paramToString).join('|');
+                return param.map(this.paramToString, this).join('|');
             case 'multi':
                 //return the array directly as SuperAgent will handle it as expected
-                return param.map(this.paramToString);
+                return param.map(this.paramToString, this);
             default:
                 throw new Error('Unknown collection format: ' + collectionFormat);
         }

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -270,16 +270,16 @@ class ApiClient {
         }
         switch (collectionFormat) {
             case 'csv':
-                return param.map(this.paramToString).join(',');
+                return param.map(this.paramToString, this).join(',');
             case 'ssv':
-                return param.map(this.paramToString).join(' ');
+                return param.map(this.paramToString, this).join(' ');
             case 'tsv':
-                return param.map(this.paramToString).join('\t');
+                return param.map(this.paramToString, this).join('\t');
             case 'pipes':
-                return param.map(this.paramToString).join('|');
+                return param.map(this.paramToString, this).join('|');
             case 'multi':
                 //return the array directly as SuperAgent will handle it as expected
-                return param.map(this.paramToString);
+                return param.map(this.paramToString, this);
             default:
                 throw new Error('Unknown collection format: ' + collectionFormat);
         }

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -270,16 +270,16 @@ class ApiClient {
         }
         switch (collectionFormat) {
             case 'csv':
-                return param.map(this.paramToString).join(',');
+                return param.map(this.paramToString, this).join(',');
             case 'ssv':
-                return param.map(this.paramToString).join(' ');
+                return param.map(this.paramToString, this).join(' ');
             case 'tsv':
-                return param.map(this.paramToString).join('\t');
+                return param.map(this.paramToString, this).join('\t');
             case 'pipes':
-                return param.map(this.paramToString).join('|');
+                return param.map(this.paramToString, this).join('|');
             case 'multi':
                 //return the array directly as SuperAgent will handle it as expected
-                return param.map(this.paramToString);
+                return param.map(this.paramToString, this);
             default:
                 throw new Error('Unknown collection format: ' + collectionFormat);
         }


### PR DESCRIPTION
PR for issue: [7910](https://github.com/OpenAPITools/openapi-generator/issues/7910)

This change modifies the mustache files to generate 

```
switch (collectionFormat) {
      case 'csv':
        return param.map(this.paramToString, this).join(',');
      case 'ssv':
        return param.map(this.paramToString, this).join(' ');
      case 'tsv':
        return param.map(this.paramToString, this).join('\t');
      case 'pipes':
        return param.map(this.paramToString, this).join('|');
      case 'multi':
        // return the array directly as SuperAgent will handle it as expected
        return param.map(this.paramToString, this);
      default:
        throw new Error('Unknown collection format: ' + collectionFormat);
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
CC: @CodeNinjai @frol @cliffano @wing328 