### PR TITLE
[JS] (#7913) Adding support for multi file upload.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -5771,7 +5771,6 @@ public class DefaultCodegen implements CodegenConfig {
                 CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
                 // key => property name
                 // value => property schema
-                String collectionFormat = null;
                 Schema s = entry.getValue();
                 // array of schema
                 if (ModelUtils.isArraySchema(s)) {
@@ -5795,6 +5794,7 @@ public class DefaultCodegen implements CodegenConfig {
                     }
                     //TODO fix collectformat for form parameters
                     //collectionFormat = getCollectionFormat(s);
+                    String collectionFormat = getCollectionFormat(codegenParameter);
                     // default to csv:
                     codegenParameter.collectionFormat = StringUtils.isEmpty(collectionFormat) ? "csv" : collectionFormat;
 
@@ -6668,5 +6668,16 @@ public class DefaultCodegen implements CodegenConfig {
      */
     protected static boolean isJsonVendorMimeType(String mime) {
         return mime != null && JSON_VENDOR_MIME_PATTERN.matcher(mime).matches();
+    }
+
+    /**
+     * Returns null by default but can be overwritten to return a valid collectionFormat
+     * for the {@link CodegenParameter}.
+     *
+     * @param codegenParameter parameter
+     * @return string for a collectionFormat.
+     */
+    protected String getCollectionFormat(CodegenParameter codegenParameter) {
+        return null;
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
@@ -1220,4 +1220,16 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
             }
         }
     }
+
+    @Override
+    protected String getCollectionFormat(CodegenParameter codegenParameter) {
+        // This method will return `passthrough` when the parameter data format is binary and an array.
+        // `passthrough` is not part of the OAS spec. However, this will act like a flag that we should
+        // not do any processing on the collection type (i.e. convert to tsv, csv, etc..). This is
+        // critical to support multi file uploads correctly.
+        if (codegenParameter.isArray && Objects.equals(codegenParameter.dataFormat, "binary")) {
+            return "passthrough";
+        }
+        return super.getCollectionFormat(codegenParameter);
+    }
 }

--- a/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
@@ -316,6 +316,8 @@
       case 'multi':
         // return the array directly as SuperAgent will handle it as expected
         return param.map(this.paramToString, this);
+      case 'passthrough':
+        return param;
       default:
         throw new Error('Unknown collection format: ' + collectionFormat);
     }
@@ -489,11 +491,16 @@
       var _formParams = this.normalizeParams(formParams);
       for (var key in _formParams) {
         if (_formParams.hasOwnProperty(key)) {
-          if (this.isFileParam(_formParams[key])) {
+          let _formParamsValue = _formParams[key];
+          if (this.isFileParam(_formParamsValue)) {
             // file field
-            request.attach(key, _formParams[key]);
+            request.attach(key, _formParamsValue);
+          } else if (Array.isArray(_formParamsValue) && _formParamsValue.length
+            && this.isFileParam(_formParamsValue[0])) {
+            // multiple files
+            _formParamsValue.forEach(file => request.attach(key, file));
           } else {
-            request.field(key, _formParams[key]);
+            request.field(key, _formParamsValue);
           }
         }
       }

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -282,6 +282,8 @@ class ApiClient {
             case 'multi':
                 //return the array directly as SuperAgent will handle it as expected
                 return param.map(this.paramToString, this);
+            case 'passthrough':
+                return param;
             default:
                 throw new Error('Unknown collection format: ' + collectionFormat);
         }
@@ -451,11 +453,16 @@ class ApiClient {
             var _formParams = this.normalizeParams(formParams);
             for (var key in _formParams) {
                 if (_formParams.hasOwnProperty(key)) {
-                    if (this.isFileParam(_formParams[key])) {
+                    let _formParamsValue = _formParams[key];
+                    if (this.isFileParam(_formParamsValue)) {
                         // file field
-                        request.attach(key, _formParams[key]);
+                        request.attach(key, _formParamsValue);
+                    } else if (Array.isArray(_formParamsValue) && _formParamsValue.length
+                        && this.isFileParam(_formParamsValue[0])) {
+                        // multiple files
+                        _formParamsValue.forEach(file => request.attach(key, file));
                     } else {
-                        request.field(key, _formParams[key]);
+                        request.field(key, _formParamsValue);
                     }
                 }
             }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/javascript/JavascriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/javascript/JavascriptClientCodegenTest.java
@@ -17,9 +17,13 @@
 
 package org.openapitools.codegen.javascript;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.RequestBody;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.JavascriptClientCodegen;
 import org.testng.Assert;
@@ -111,6 +115,20 @@ public class JavascriptClientCodegenTest {
 
         Assert.assertEquals(coText.responses.size(), 1);
 
+    }
+
+    @Test(description = "test multiple file upload collection is correct")
+    public void testMultipleFileUpload() throws Exception {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/form-multipart-binary-array.yaml");
+        final JavascriptClientCodegen codegen = new JavascriptClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final String requestPath = "/multipart-array";
+        Operation textOperation = openAPI.getPaths().get(requestPath).getPost();
+        CodegenOperation operation = codegen.fromOperation(requestPath, "post", textOperation, null);
+        CodegenParameter codegenParameter = operation.allParams.get(0);
+
+        Assert.assertEquals(codegenParameter.collectionFormat, "passthrough");
     }
 
 }

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -280,6 +280,8 @@ class ApiClient {
             case 'multi':
                 //return the array directly as SuperAgent will handle it as expected
                 return param.map(this.paramToString, this);
+            case 'passthrough':
+                return param;
             default:
                 throw new Error('Unknown collection format: ' + collectionFormat);
         }
@@ -439,11 +441,16 @@ class ApiClient {
             var _formParams = this.normalizeParams(formParams);
             for (var key in _formParams) {
                 if (_formParams.hasOwnProperty(key)) {
-                    if (this.isFileParam(_formParams[key])) {
+                    let _formParamsValue = _formParams[key];
+                    if (this.isFileParam(_formParamsValue)) {
                         // file field
-                        request.attach(key, _formParams[key]);
+                        request.attach(key, _formParamsValue);
+                    } else if (Array.isArray(_formParamsValue) && _formParamsValue.length
+                        && this.isFileParam(_formParamsValue[0])) {
+                        // multiple files
+                        _formParamsValue.forEach(file => request.attach(key, file));
                     } else {
-                        request.field(key, _formParams[key]);
+                        request.field(key, _formParamsValue);
                     }
                 }
             }

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -280,6 +280,8 @@ class ApiClient {
             case 'multi':
                 //return the array directly as SuperAgent will handle it as expected
                 return param.map(this.paramToString, this);
+            case 'passthrough':
+                return param;
             default:
                 throw new Error('Unknown collection format: ' + collectionFormat);
         }
@@ -431,11 +433,16 @@ class ApiClient {
             var _formParams = this.normalizeParams(formParams);
             for (var key in _formParams) {
                 if (_formParams.hasOwnProperty(key)) {
-                    if (this.isFileParam(_formParams[key])) {
+                    let _formParamsValue = _formParams[key];
+                    if (this.isFileParam(_formParamsValue)) {
                         // file field
-                        request.attach(key, _formParams[key]);
+                        request.attach(key, _formParamsValue);
+                    } else if (Array.isArray(_formParamsValue) && _formParamsValue.length
+                        && this.isFileParam(_formParamsValue[0])) {
+                        // multiple files
+                        _formParamsValue.forEach(file => request.attach(key, file));
                     } else {
-                        request.field(key, _formParams[key]);
+                        request.field(key, _formParamsValue);
                     }
                 }
             }


### PR DESCRIPTION
To fix https://github.com/OpenAPITools/openapi-generator/issues/7913

Adding support for multi file upload. Also adding the option for individual CodeGens to specify a collectionFormat for CodegenParameters

* updated samples as well

See the issue for details on the implementation.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC: @CodeNinjai @frol @cliffano @wing328