### PR TITLE
Fix abstract method withLeniency(java.lang.Boolean) in com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase issue.

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/CustomInstantDeserializer.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/CustomInstantDeserializer.mustache
@@ -137,6 +137,14 @@ public class CustomInstantDeserializer<T extends Temporal>
     } : adjust;
   }
 
+  protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, Boolean leniency) {
+    super(base,base._isLenient);
+    parsedToValue = base.parsedToValue;
+    fromMilliseconds = base.fromMilliseconds;
+    fromNanoseconds = base.fromNanoseconds;
+    adjust = base.adjust;
+  }
+
   @SuppressWarnings("unchecked")
   protected CustomInstantDeserializer(CustomInstantDeserializer<T> base, DateTimeFormatter f) {
     super((Class<T>) base.handledType(), f);
@@ -147,11 +155,16 @@ public class CustomInstantDeserializer<T extends Temporal>
   }
 
   @Override
-  protected JsonDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
-    if (dtf == _formatter) {
-      return this;
-    }
-    return new CustomInstantDeserializer<T>(this, dtf);
+  protected CustomInstantDeserializer<T> withDateFormat(DateTimeFormatter dtf) {
+      if (dtf == _formatter) {
+         return this;
+      }
+      return new CustomInstantDeserializer<T>(this, dtf);
+  }
+
+  @Override
+  protected CustomInstantDeserializer<T> withLeniency(Boolean aBoolean) {
+       return new CustomInstantDeserializer<T>(this,aBoolean);
   }
 
   @Override
@@ -229,4 +242,5 @@ public class CustomInstantDeserializer<T extends Temporal>
       this.zoneId = zoneId;
     }
   }
+
 }


### PR DESCRIPTION
Fixes #5444

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

When generating apis from the code, I was getting this issue :

[ERROR] /home/rsousa/Code/personalmanager/api/target/generated-sources/openapi/src/main/java/ca/renardnumerique/personalmanager/invoker/CustomInstantDeserializer.java:[31,8] ca.renardnumerique.personalmanager.invoker.CustomInstantDeserializer is not abstract and does not override abstract method withLeniency(java.lang.Boolean) in com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase
[ERROR] /home/rsousa/Code/personalmanager/api/target/generated-sources/openapi/src/main/java/ca/renardnumerique/personalmanager/invoker/CustomInstantDeserializer.java:[150,33] withDateFormat(org.threeten.bp.format.DateTimeFormatter) in ca.renardnumerique.personalmanager.invoker.CustomInstantDeserializer cannot override withDateFormat(org.threeten.bp.format.DateTimeFormatter) in com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase
  return type com.fasterxml.jackson.databind.JsonDeserializer<T> is not compatible with com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase<T>
[ERROR] /home/rsousa/Code/personalmanager/api/target/generated-sources/openapi/src/main/java/ca/renardnumerique/personalmanager/invoker/CustomInstantDeserializer.java:[149,3] method does not override or implement a method from a supertype
[INFO] 3 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.595 s
[INFO] Finished at: 2020-11-10T13:50:37-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project api: Compilation failure: Compilation failure: 
[ERROR] /home/rsousa/Code/personalmanager/api/target/generated-sources/openapi/src/main/java/ca/renardnumerique/personalmanager/invoker/CustomInstantDeserializer.java:[31,8] ca.renardnumerique.personalmanager.invoker.CustomInstantDeserializer is not abstract and does not override abstract method withLeniency(java.lang.Boolean) in com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase
[ERROR] /home/rsousa/Code/personalmanager/api/target/generated-sources/openapi/src/main/java/ca/renardnumerique/personalmanager/invoker/CustomInstantDeserializer.java:[150,33] withDateFormat(org.threeten.bp.format.DateTimeFormatter) in ca.renardnumerique.personalmanager.invoker.CustomInstantDeserializer cannot override withDateFormat(org.threeten.bp.format.DateTimeFormatter) in com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase
[ERROR]   return type com.fasterxml.jackson.databind.JsonDeserializer<T> is not compatible with com.fasterxml.jackson.datatype.threetenbp.deser.ThreeTenDateTimeDeserializerBase<T>
[ERROR] /home/rsousa/Code/personalmanager/api/target/generated-sources/openapi/src/main/java/ca/renardnumerique/personalmanager/invoker/CustomInstantDeserializer.java:[149,3] method does not override or implement a method from a supertype
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

I modified the Mustache template in order to fix that.
