### PR TITLE
[C#][netcore] Add test for AdditionalProperties in both child and parent

### DIFF
--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools.Test/Model/CatTests.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools.Test/Model/CatTests.cs
@@ -51,8 +51,9 @@ namespace Org.OpenAPITools.Test.Model
         [Fact]
         public void CatInstanceTest()
         {
-            // TODO uncomment below to test "IsType" Cat
-            //Assert.IsType<Cat>(instance);
+            // test to ensure both Cat and Animal (parent) can have "AdditionalProperties", which result in warnings
+            Cat c = JsonConvert.DeserializeObject<Cat>("{\"className\":\"cat\",\"bar\":\"from json bar\"}");
+            Assert.Equal("from json bar", c.AdditionalProperties["bar"]);
         }
 
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs
@@ -100,11 +100,22 @@ namespace Org.OpenAPITools.Test
         /// ReadOnly property tests
         /// </summary>
         [Fact]
-        public void ReadOnlyFruit()
+        public void TestReadOnlyFruit()
         {
             ReadOnlyFirst r = JsonConvert.DeserializeObject<ReadOnlyFirst>("{\"baz\":\"from json gaz\",\"bar\":\"from json bar\"}");
             Assert.Equal("from json bar", r.Bar);
             Assert.Equal("{\"baz\":\"from json gaz\"}", JsonConvert.SerializeObject(r));
+        }
+
+        /// <summary>
+        /// Cat property tests
+        /// </summary>
+        [Fact]
+        public void TestCat()
+        {
+            // test to ensure both Cat and Animal (parent) can have "AdditionalProperties", which result in warnings
+            Cat c = JsonConvert.DeserializeObject<Cat>("{\"className\":\"cat\",\"bar\":\"from json bar\"}");
+            Assert.Equal("from json bar", c.AdditionalProperties["bar"]);
         }
     }
 }


### PR DESCRIPTION
- Add test for AdditionalProperties in both child and parent

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)


