### PR TITLE
Expose Handlebars infiniteLoops setting

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/HandlebarsEngineAdapter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/HandlebarsEngineAdapter.java
@@ -45,6 +45,7 @@ public class HandlebarsEngineAdapter extends AbstractTemplatingEngineAdapter {
 
     // We use this as a simple lookup for valid file name extensions. This adapter will inspect .mustache (built-in) and infer the relevant handlebars filename
     private final String[] canCompileFromExtensions = new String[]{".handlebars",".hbs",".mustache"};
+    private boolean infiniteLoops = false;
 
     /**
      * Provides an identifier used to load the adapter. This could be a name, uuid, or any other string.
@@ -82,6 +83,7 @@ public class HandlebarsEngineAdapter extends AbstractTemplatingEngineAdapter {
         StringHelpers.register(handlebars);
         handlebars.registerHelpers(ConditionalHelpers.class);
         handlebars.registerHelpers(org.openapitools.codegen.templating.handlebars.StringHelpers.class);
+        handlebars.setInfiniteLoops(infiniteLoops);
         Template tmpl = handlebars.compile(templateFile);
         return tmpl.apply(context);
     }
@@ -120,6 +122,17 @@ public class HandlebarsEngineAdapter extends AbstractTemplatingEngineAdapter {
     public boolean handlesFile(String filename) {
         // disallow any extension-only files like ".hbs" or ".mustache", and only consider a file compilable if it's handlebars or mustache (from which we later infer the handlebars filename)
         return Arrays.stream(canCompileFromExtensions).anyMatch(suffix -> !suffix.equalsIgnoreCase(filename) && filename.endsWith(suffix));
+    }
+
+    /**
+     * Enable/disable infiniteLoops setting for the Handlebars engine. Enabling this allows for recursive partial inclusion.
+     *
+     * @param infiniteLoops Whether to enable (true) or disable (false)
+     * @return this object
+     */
+    public HandlebarsEngineAdapter infiniteLoops(boolean infiniteLoops) {
+        this.infiniteLoops = infiniteLoops;
+        return this;
     }
 }
 


### PR DESCRIPTION
This exposes a setting value for Handlebars' `infiniteLoops` setting value, which allows for recursive partials usage. I implemented this using the builder patter to be able to easily do something like this in a Codegen class:

```
  private TemplatingEngineAdapter templatingEngine = new HandlebarsEngineAdapter().infiniteLoops(true);
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
