### PR TITLE
Fixes clone method of CodegenProperty

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -600,14 +600,10 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
                 cp.additionalProperties = this.additionalProperties.clone();
             }
             if (this.vars != null) {
-                for (CodegenProperty var: this.vars) {
-                    cp.vars.add(var.clone());
-                }
+                cp.vars = new ArrayList<>(this.vars);
             }
             if (this.requiredVars != null) {
-                for (CodegenProperty var: this.requiredVars) {
-                    cp.requiredVars.add(var.clone());
-                }
+                cp.requiredVars = new ArrayList<>(this.requiredVars);
             }
             if (this.mostInnerItems != null) {
                 cp.mostInnerItems = this.mostInnerItems.clone();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -594,19 +594,23 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
                 cp.allowableValues = new HashMap<String, Object>(this.allowableValues);
             }
             if (this.items != null) {
-                cp.items = this.items;
+                cp.items = this.items.clone();
             }
             if (this.additionalProperties != null) {
-                cp.additionalProperties = this.additionalProperties;
+                cp.additionalProperties = this.additionalProperties.clone();
             }
             if (this.vars != null) {
-                cp.vars = this.vars;
+                for (CodegenProperty var: this.vars) {
+                    cp.vars.add(var.clone());
+                }
             }
             if (this.requiredVars != null) {
-                cp.requiredVars = this.requiredVars;
+                for (CodegenProperty var: this.requiredVars) {
+                    cp.requiredVars.add(var.clone());
+                }
             }
             if (this.mostInnerItems != null) {
-                cp.mostInnerItems = this.mostInnerItems;
+                cp.mostInnerItems = this.mostInnerItems.clone();
             }
             if (this.vendorExtensions != null) {
                 cp.vendorExtensions = new HashMap<String, Object>(this.vendorExtensions);


### PR DESCRIPTION
The clone method for CodegenProperty was maintaining references to additionalProperties, items, vars, and requiredVars
This PR updated the method so those properties are cloned

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Core Team Members
@wing328 (2015/07) ❤️
@jimschubert (2016/05) ❤️
@cbornet (2016/05)
@ackintosh (2018/02) ❤️
@jmini (2018/04) ❤️
@etherealjoy (2019/06)
@spacether (2020/05)