### PR TITLE
[php][bug] Fixes exceptions with API's with too high date-time nanosecond precision

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -306,7 +306,15 @@ class ObjectSerializer
             // be interpreted as a missing field/value. Let's handle
             // this graceful.
             if (!empty($data)) {
-                return new \DateTime($data);
+                try {
+                    return new \DateTime($data);
+                } catch (\Exception $exception) {
+                    // Some API's return a date-time with too high nanosecond
+                    // precision for php's DateTime to handle. This conversion
+                    // (string -> unix timestamp -> DateTime) is a workaround
+                    // for the problem.
+                    return (new \DateTime())->setTimestamp(strtotime($data));
+                }
             } else {
                 return null;
             }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -322,7 +322,7 @@ class ObjectSerializer
                     // Some API's return a date-time with too high nanosecond
                     // precision for php's DateTime to handle. This conversion
                     // (string -> unix timestamp -> DateTime) is a workaround
-                    // for this problem.
+                    // for the problem.
                     return (new \DateTime())->setTimestamp(strtotime($data));
                 }
             } else {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -316,7 +316,15 @@ class ObjectSerializer
             // be interpreted as a missing field/value. Let's handle
             // this graceful.
             if (!empty($data)) {
-                return new \DateTime($data);
+                try {
+                    return new \DateTime($data);
+                } catch (\Exception $exception) {
+                    // Some API's return a date-time with too high nanosecond
+                    // precision for php's DateTime to handle. This conversion
+                    // (string -> unix timestamp -> DateTime) is a workaround
+                    // for this problem.
+                    return (new \DateTime())->setTimestamp(strtotime($data));
+                }
             } else {
                 return null;
             }


### PR DESCRIPTION
Closes #7942

@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ackintosh, @ybelenko, @renepardon

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [Y] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
