### PR TITLE
Do not use cached properties for additionalProperties

### DIFF
--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
@@ -33,6 +33,22 @@ export interface EnumArrays {
     arrayEnum?: Array<EnumArraysArrayEnumEnum>;
 }
 
+/**
+* @export
+* @enum {string}
+*/
+export enum EnumArraysJustSymbolEnum {
+    GreaterThanOrEqualTo = '>=',
+    Dollar = '$'
+}/**
+* @export
+* @enum {string}
+*/
+export enum EnumArraysArrayEnumEnum {
+    Fish = 'fish',
+    Crab = 'crab'
+}
+
 export function EnumArraysFromJSON(json: any): EnumArrays {
     return EnumArraysFromJSONTyped(json, false);
 }
@@ -60,23 +76,6 @@ export function EnumArraysToJSON(value?: EnumArrays | null): any {
         'just_symbol': value.justSymbol,
         'array_enum': value.arrayEnum,
     };
-}
-
-/**
-* @export
-* @enum {string}
-*/
-export enum EnumArraysJustSymbolEnum {
-    GreaterThanOrEqualTo = '>=',
-    Dollar = '$'
-}
-/**
-* @export
-* @enum {string}
-*/
-export enum EnumArraysArrayEnumEnum {
-    Fish = 'fish',
-    Crab = 'crab'
 }
 
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -88,6 +88,38 @@ export interface EnumTest {
     outerEnumIntegerDefaultValue?: OuterEnumIntegerDefaultValue;
 }
 
+/**
+* @export
+* @enum {string}
+*/
+export enum EnumTestEnumStringEnum {
+    Upper = 'UPPER',
+    Lower = 'lower',
+    Empty = ''
+}/**
+* @export
+* @enum {string}
+*/
+export enum EnumTestEnumStringRequiredEnum {
+    Upper = 'UPPER',
+    Lower = 'lower',
+    Empty = ''
+}/**
+* @export
+* @enum {string}
+*/
+export enum EnumTestEnumIntegerEnum {
+    NUMBER_1 = 1,
+    NUMBER_MINUS_1 = -1
+}/**
+* @export
+* @enum {string}
+*/
+export enum EnumTestEnumNumberEnum {
+    NUMBER_1_DOT_1 = 1.1,
+    NUMBER_MINUS_1_DOT_2 = -1.2
+}
+
 export function EnumTestFromJSON(json: any): EnumTest {
     return EnumTestFromJSONTyped(json, false);
 }
@@ -127,41 +159,6 @@ export function EnumTestToJSON(value?: EnumTest | null): any {
         'outerEnumDefaultValue': OuterEnumDefaultValueToJSON(value.outerEnumDefaultValue),
         'outerEnumIntegerDefaultValue': OuterEnumIntegerDefaultValueToJSON(value.outerEnumIntegerDefaultValue),
     };
-}
-
-/**
-* @export
-* @enum {string}
-*/
-export enum EnumTestEnumStringEnum {
-    Upper = 'UPPER',
-    Lower = 'lower',
-    Empty = ''
-}
-/**
-* @export
-* @enum {string}
-*/
-export enum EnumTestEnumStringRequiredEnum {
-    Upper = 'UPPER',
-    Lower = 'lower',
-    Empty = ''
-}
-/**
-* @export
-* @enum {string}
-*/
-export enum EnumTestEnumIntegerEnum {
-    NUMBER_1 = 1,
-    NUMBER_MINUS_1 = -1
-}
-/**
-* @export
-* @enum {string}
-*/
-export enum EnumTestEnumNumberEnum {
-    NUMBER_1_DOT_1 = 1.1,
-    NUMBER_MINUS_1_DOT_2 = -1.2
 }
 
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/InlineObject2.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/InlineObject2.ts
@@ -33,6 +33,23 @@ export interface InlineObject2 {
     enumFormString?: InlineObject2EnumFormStringEnum;
 }
 
+/**
+* @export
+* @enum {string}
+*/
+export enum InlineObject2EnumFormStringArrayEnum {
+    GreaterThan = '>',
+    Dollar = '$'
+}/**
+* @export
+* @enum {string}
+*/
+export enum InlineObject2EnumFormStringEnum {
+    Abc = '_abc',
+    Efg = '-efg',
+    Xyz = '(xyz)'
+}
+
 export function InlineObject2FromJSON(json: any): InlineObject2 {
     return InlineObject2FromJSONTyped(json, false);
 }
@@ -60,24 +77,6 @@ export function InlineObject2ToJSON(value?: InlineObject2 | null): any {
         'enum_form_string_array': value.enumFormStringArray,
         'enum_form_string': value.enumFormString,
     };
-}
-
-/**
-* @export
-* @enum {string}
-*/
-export enum InlineObject2EnumFormStringArrayEnum {
-    GreaterThan = '>',
-    Dollar = '$'
-}
-/**
-* @export
-* @enum {string}
-*/
-export enum InlineObject2EnumFormStringEnum {
-    Abc = '_abc',
-    Efg = '-efg',
-    Xyz = '(xyz)'
 }
 
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
@@ -45,6 +45,15 @@ export interface MapTest {
     indirectMap?: { [key: string]: boolean; };
 }
 
+/**
+* @export
+* @enum {string}
+*/
+export enum MapTestMapOfEnumStringEnum {
+    Upper = 'UPPER',
+    Lower = 'lower'
+}
+
 export function MapTestFromJSON(json: any): MapTest {
     return MapTestFromJSONTyped(json, false);
 }
@@ -76,15 +85,6 @@ export function MapTestToJSON(value?: MapTest | null): any {
         'direct_map': value.directMap,
         'indirect_map': value.indirectMap,
     };
-}
-
-/**
-* @export
-* @enum {string}
-*/
-export enum MapTestMapOfEnumStringEnum {
-    Upper = 'UPPER',
-    Lower = 'lower'
 }
 
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
@@ -57,6 +57,16 @@ export interface Order {
     complete?: boolean;
 }
 
+/**
+* @export
+* @enum {string}
+*/
+export enum OrderStatusEnum {
+    Placed = 'placed',
+    Approved = 'approved',
+    Delivered = 'delivered'
+}
+
 export function OrderFromJSON(json: any): Order {
     return OrderFromJSONTyped(json, false);
 }
@@ -92,16 +102,6 @@ export function OrderToJSON(value?: Order | null): any {
         'status': value.status,
         'complete': value.complete,
     };
-}
-
-/**
-* @export
-* @enum {string}
-*/
-export enum OrderStatusEnum {
-    Placed = 'placed',
-    Approved = 'approved',
-    Delivered = 'delivered'
 }
 
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -68,6 +68,16 @@ export interface Pet {
     status?: PetStatusEnum;
 }
 
+/**
+* @export
+* @enum {string}
+*/
+export enum PetStatusEnum {
+    Available = 'available',
+    Pending = 'pending',
+    Sold = 'sold'
+}
+
 export function PetFromJSON(json: any): Pet {
     return PetFromJSONTyped(json, false);
 }
@@ -103,16 +113,6 @@ export function PetToJSON(value?: Pet | null): any {
         'tags': value.tags === undefined ? undefined : ((value.tags as Array<any>).map(TagToJSON)),
         'status': value.status,
     };
-}
-
-/**
-* @export
-* @enum {string}
-*/
-export enum PetStatusEnum {
-    Available = 'available',
-    Pending = 'pending',
-    Sold = 'sold'
 }
 
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/InlineObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/InlineObject.ts
@@ -45,6 +45,24 @@ export interface InlineObject {
     nullableNumberEnum?: number | null;
 }
 
+/**
+* @export
+* @enum {string}
+*/
+export enum InlineObjectStringEnumEnum {
+    One = 'one',
+    Two = 'two',
+    Three = 'three'
+}/**
+* @export
+* @enum {string}
+*/
+export enum InlineObjectNumberEnumEnum {
+    NUMBER_1 = 1,
+    NUMBER_2 = 2,
+    NUMBER_3 = 3
+}
+
 export function InlineObjectFromJSON(json: any): InlineObject {
     return InlineObjectFromJSONTyped(json, false);
 }
@@ -76,25 +94,6 @@ export function InlineObjectToJSON(value?: InlineObject | null): any {
         'number-enum': value.numberEnum,
         'nullable-number-enum': value.nullableNumberEnum,
     };
-}
-
-/**
-* @export
-* @enum {string}
-*/
-export enum InlineObjectStringEnumEnum {
-    One = 'one',
-    Two = 'two',
-    Three = 'three'
-}
-/**
-* @export
-* @enum {string}
-*/
-export enum InlineObjectNumberEnumEnum {
-    NUMBER_1 = 1,
-    NUMBER_2 = 2,
-    NUMBER_3 = 3
 }
 
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/InlineResponse200.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/InlineResponse200.ts
@@ -45,6 +45,24 @@ export interface InlineResponse200 {
     nullableNumberEnum?: number | null;
 }
 
+/**
+* @export
+* @enum {string}
+*/
+export enum InlineResponse200StringEnumEnum {
+    One = 'one',
+    Two = 'two',
+    Three = 'three'
+}/**
+* @export
+* @enum {string}
+*/
+export enum InlineResponse200NumberEnumEnum {
+    NUMBER_1 = 1,
+    NUMBER_2 = 2,
+    NUMBER_3 = 3
+}
+
 export function InlineResponse200FromJSON(json: any): InlineResponse200 {
     return InlineResponse200FromJSONTyped(json, false);
 }
@@ -76,25 +94,6 @@ export function InlineResponse200ToJSON(value?: InlineResponse200 | null): any {
         'number-enum': value.numberEnum,
         'nullable-number-enum': value.nullableNumberEnum,
     };
-}
-
-/**
-* @export
-* @enum {string}
-*/
-export enum InlineResponse200StringEnumEnum {
-    One = 'one',
-    Two = 'two',
-    Three = 'three'
-}
-/**
-* @export
-* @enum {string}
-*/
-export enum InlineResponse200NumberEnumEnum {
-    NUMBER_1 = 1,
-    NUMBER_2 = 2,
-    NUMBER_3 = 3
 }
 
 


### PR DESCRIPTION
Do not use cached properties for additionalProperties
This should fix the bug where additionalProperties tests are intermittently failing

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Core Team Members
@wing328 (2015/07) ❤️
@jimschubert (2016/05) ❤️
@cbornet (2016/05)
@ackintosh (2018/02) ❤️
@jmini (2018/04) ❤️
@etherealjoy (2019/06)
@spacether (2020/05)