### PR TITLE
Make the generated API controller code compile.

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
@@ -49,7 +49,7 @@ import java.util.concurrent.Callable;
 @RequestMapping("${openapi.<%title%>.base-path:<%>defaultBasePath%>}")
 <%={{ }}=%>
 {{#operations}}
-public class {{classname}}Controller implements {{classname}} {
+public {{^jdk8-default-interface}}abstract {{/jdk8-default-interface}}class {{classname}}Controller implements {{classname}} {
 {{#isDelegate}}
 
     private final {{classname}}Delegate delegate;


### PR DESCRIPTION
This change causes the generated API controller class to be declared 'abstract' if the (also generated) interface that it implements doesn't have any default methods, because the programmer set the Spring generator's "skipDefaultInterface" option.

Without this change, the generated code doesn't compile. With this change, it does.

Apart from the existing project tests, I tested that my POC Spring project that uses OpenAPI generator compiles when I use this branch of OpenAPI generator, which it previously doesn't.

I could have also added 'Base' to the end of the class name when it's abstract, as I discussed in the associated GitLab issue about this (#3894 ).
I didn't do this, that's a larger change, as the generated filename then needs to change too. In my opinion this would add unjustified additional complexity to OpenAPI Generator for something that's mostly just of cosmetic value. But if other people deem this additional change worthwhile, I'm happy to implement it.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
