### PR TITLE
[DART2] A couple of bug fixes

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api.mustache
@@ -79,9 +79,19 @@ class {{{classname}}} {
     }
       {{/required}}
     {{/queryParams}}
-    {{#headerParams}}
-    headerParams['{{{baseName}}}'] = {{{paramName}}};
-    {{/headerParams}}
+    {{#hasHeaderParams}}
+
+      {{#headerParams}}
+        {{#required}}
+    headerParams['{{{baseName}}}'] = parameterToString({{{paramName}}});
+        {{/required}}
+        {{^required}}
+    if ({{{paramName}}} != null) {
+      headerParams['{{{baseName}}}'] = parameterToString({{{paramName}}});
+    }
+        {{/required}}
+      {{/headerParams}}
+    {{/hasHeaderParams}}
 
     final contentTypes = <String>[{{#consumes}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/consumes}}];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;

--- a/modules/openapi-generator/src/main/resources/dart2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api.mustache
@@ -69,16 +69,18 @@ class {{{classname}}} {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
+    {{#hasQueryParams}}
 
-    {{#queryParams}}
-      {{^required}}
+      {{#queryParams}}
+        {{^required}}
     if ({{{paramName}}} != null) {
-      {{/required}}
+          {{/required}}
       queryParams.addAll(_convertParametersForCollectionFormat('{{{collectionFormat}}}', '{{{baseName}}}', {{{paramName}}}));
-      {{^required}}
+          {{^required}}
     }
-      {{/required}}
-    {{/queryParams}}
+        {{/required}}
+      {{/queryParams}}
+    {{/hasQueryParams}}
     {{#hasHeaderParams}}
 
       {{#headerParams}}

--- a/modules/openapi-generator/src/main/resources/dart2/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/class.mustache
@@ -77,8 +77,8 @@ class {{{classname}}} {
     return json;
   }
 
-  /// Returns a new [{{{classname}}}] instance and optionally import its values from
-  /// [json] if it's non-null.
+  /// Returns a new [{{{classname}}}] instance and imports its values from
+  /// [json] if it's non-null, null if [json] is null.
   static {{{classname}}} fromJson(Map<String, dynamic> json) => json == null
     ? null
     : {{{classname}}}(

--- a/modules/openapi-generator/src/main/resources/dart2/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/class.mustache
@@ -6,118 +6,6 @@ class {{{classname}}} {
   {{/vars}}
   });
 
-  /// Returns a new [{{{classname}}}] instance and optionally import its values from
-  /// [json] if it's non-null.
-  {{{classname}}}.fromJson(Map<String, dynamic> json) {
-    if (json != null) {
-  {{#vars}}
-  {{#isDateTime}}
-      {{{name}}} = json['{{{baseName}}}'] == null
-        ? null
-    {{#pattern}}
-        : _dateEpochMarker == '{{{pattern}}}'
-          ? DateTime.fromMillisecondsSinceEpoch(json['{{{baseName}}}'] as int, isUtc: true)
-          : DateTime.parse(json['{{{baseName}}}']);
-	{{/pattern}}
-    {{^pattern}}
-        : DateTime.parse(json['{{{baseName}}}']);
-	{{/pattern}}
-  {{/isDateTime}}
-  {{#isDate}}
-      {{{name}}} = json['{{{baseName}}}'] == null
-        ? null
-    {{#pattern}}
-        : _dateEpochMarker == '{{{pattern}}}'
-          ? DateTime.fromMillisecondsSinceEpoch(json['{{{baseName}}}'] as int, isUtc: true)
-          : DateTime.parse(json['{{{baseName}}}']);
-	{{/pattern}}
-    {{^pattern}}
-        : DateTime.parse(json['{{{baseName}}}']);
-	{{/pattern}}
-  {{/isDate}}
-  {{^isDateTime}}
-  {{^isDate}}
-    {{#complexType}}
-      {{#isArray}}
-        {{#items.isArray}}
-      {{{name}}} = json['{{{baseName}}}'] == null
-        ? null
-        : (json['{{{baseName}}}'] as List).map(
-      {{#items.complexType}}
-            {{items.complexType}}.listFromJson(json['{{{baseName}}}'])
-      {{/items.complexType}}
-      {{^items.complexType}}
-            (e) => e == null ? null : (e as List).cast<{{items.items.dataType}}>()
-      {{/items.complexType}}
-          ).toList(growable: false);
-        {{/items.isArray}}
-        {{^items.isArray}}
-      {{{name}}} = {{{complexType}}}.listFromJson(json['{{{baseName}}}']);
-        {{/items.isArray}}
-      {{/isArray}}
-      {{^isArray}}
-        {{#isMap}}
-          {{#items.isArray}}
-      {{{name}}} = json['{{{baseName}}}'] == null
-        ? null
-            {{#items.complexType}}
-        : {{items.complexType}}.mapListFromJson(json['{{{baseName}}}']);
-            {{/items.complexType}}
-            {{^items.complexType}}
-        : (json['{{{baseName}}}'] as Map).cast<String, List>();
-	        {{/items.complexType}}
-          {{/items.isArray}}
-          {{^items.isArray}}
-      {{{name}}} = json['{{{baseName}}}'] == null
-        ? null
-        : {{{complexType}}}.mapFromJson(json['{{{baseName}}}']);
-          {{/items.isArray}}
-        {{/isMap}}
-        {{^isMap}}
-      {{{name}}} = {{{complexType}}}.fromJson(json['{{{baseName}}}']);
-        {{/isMap}}
-      {{/isArray}}
-    {{/complexType}}
-    {{^complexType}}
-      {{#isArray}}
-        {{#isEnum}}
-      {{{name}}} = {{{classname}}}{{{items.datatypeWithEnum}}}.listFromJson(json['{{{baseName}}}']);
-        {{/isEnum}}
-        {{^isEnum}}
-      {{{name}}} = json['{{{baseName}}}'] == null
-        ? null
-        : (json['{{{baseName}}}'] as List).cast<{{{items.datatype}}}>();
-        {{/isEnum}}
-      {{/isArray}}
-      {{^isArray}}
-        {{#isMap}}
-      {{{name}}} = json['{{{baseName}}}'] == null ?
-        null :
-        (json['{{{baseName}}}'] as Map).cast<String, {{{items.datatype}}}>();
-        {{/isMap}}
-        {{^isMap}}
-          {{#isNumber}}
-      {{{name}}} = json['{{{baseName}}}'] == null ?
-        null :
-        json['{{{baseName}}}'].toDouble();
-          {{/isNumber}}
-          {{^isNumber}}
-    {{^isEnum}}
-      {{{name}}} = json['{{{baseName}}}'];
-    {{/isEnum}}
-    {{#isEnum}}
-      {{{name}}} = {{{classname}}}{{{enumName}}}.fromJson(json['{{{baseName}}}']);
-    {{/isEnum}}
-          {{/isNumber}}
-        {{/isMap}}
-      {{/isArray}}
-    {{/complexType}}
-  {{/isDate}}
-  {{/isDateTime}}
-  {{/vars}}
-    }
-  }
-
   {{#vars}}
   {{#description}}/// {{{description}}}{{/description}}
   {{^isEnum}}
@@ -149,7 +37,7 @@ class {{{classname}}} {
   @override
   int get hashCode =>
   {{#vars}}
-    {{#isNullable}}({{{name}}}?.hashCode ?? 0){{/isNullable}}{{^isNullable}}{{{name}}}.hashCode{{/isNullable}}{{^-last}} +{{/-last}}{{#-last}};{{/-last}}
+    ({{{name}}} == null ? 0 : {{{name}}}.hashCode){{^-last}} +{{/-last}}{{#-last}};{{/-last}}
   {{/vars}}
 
   @override
@@ -157,37 +45,149 @@ class {{{classname}}} {
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
-{{#vars}}
+  {{#vars}}
     if ({{{name}}} != null) {
-  {{#isDateTime}}
-    {{#pattern}}
+    {{#isDateTime}}
+      {{#pattern}}
       json['{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
         ? {{{name}}}.millisecondsSinceEpoch
         : {{{name}}}.toUtc().toIso8601String();
-    {{/pattern}}
-    {{^pattern}}
+      {{/pattern}}
+      {{^pattern}}
       json['{{{baseName}}}'] = {{{name}}}.toUtc().toIso8601String();
-    {{/pattern}}
-  {{/isDateTime}}
-  {{#isDate}}
-    {{#pattern}}
+      {{/pattern}}
+    {{/isDateTime}}
+    {{#isDate}}
+      {{#pattern}}
       json['{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
         ? {{{name}}}.millisecondsSinceEpoch
         : _dateFormatter.format({{{name}}}.toUtc());
-    {{/pattern}}
-    {{^pattern}}
+      {{/pattern}}
+      {{^pattern}}
       json['{{{baseName}}}'] = _dateFormatter.format({{{name}}}.toUtc());
-    {{/pattern}}
-  {{/isDate}}
-  {{^isDateTime}}
-    {{^isDate}}
-      json['{{{baseName}}}'] = {{{name}}};
+      {{/pattern}}
     {{/isDate}}
-  {{/isDateTime}}
+    {{^isDateTime}}
+      {{^isDate}}
+      json['{{{baseName}}}'] = {{{name}}};
+      {{/isDate}}
+    {{/isDateTime}}
     }
-{{/vars}}
+  {{/vars}}
     return json;
   }
+
+  /// Returns a new [{{{classname}}}] instance and optionally import its values from
+  /// [json] if it's non-null.
+  static {{{classname}}} fromJson(Map<String, dynamic> json) => json == null
+    ? null
+    : {{{classname}}}(
+  {{#vars}}
+  {{#isDateTime}}
+        {{{name}}}: json['{{{baseName}}}'] == null
+          ? null
+    {{#pattern}}
+          : _dateEpochMarker == '{{{pattern}}}'
+            ? DateTime.fromMillisecondsSinceEpoch(json['{{{baseName}}}'] as int, isUtc: true)
+            : DateTime.parse(json['{{{baseName}}}']),
+	{{/pattern}}
+    {{^pattern}}
+          : DateTime.parse(json['{{{baseName}}}']),
+	{{/pattern}}
+  {{/isDateTime}}
+  {{#isDate}}
+        {{{name}}}: json['{{{baseName}}}'] == null
+          ? null
+    {{#pattern}}
+          : _dateEpochMarker == '{{{pattern}}}'
+            ? DateTime.fromMillisecondsSinceEpoch(json['{{{baseName}}}'] as int, isUtc: true)
+            : DateTime.parse(json['{{{baseName}}}']),
+	{{/pattern}}
+    {{^pattern}}
+          : DateTime.parse(json['{{{baseName}}}']),
+	{{/pattern}}
+  {{/isDate}}
+  {{^isDateTime}}
+  {{^isDate}}
+    {{#complexType}}
+      {{#isArray}}
+        {{#items.isArray}}
+        {{{name}}}: json['{{{baseName}}}'] == null
+          ? null
+          : (json['{{{baseName}}}'] as List).map(
+      {{#items.complexType}}
+              {{items.complexType}}.listFromJson(json['{{{baseName}}}'])
+      {{/items.complexType}}
+      {{^items.complexType}}
+              (e) => e == null ? null : (e as List).cast<{{items.items.dataType}}>()
+      {{/items.complexType}}
+            ).toList(growable: false),
+        {{/items.isArray}}
+        {{^items.isArray}}
+        {{{name}}}: {{{complexType}}}.listFromJson(json['{{{baseName}}}']),
+        {{/items.isArray}}
+      {{/isArray}}
+      {{^isArray}}
+        {{#isMap}}
+          {{#items.isArray}}
+        {{{name}}}: json['{{{baseName}}}'] == null
+          ? null
+              {{#items.complexType}}
+          : {{items.complexType}}.mapListFromJson(json['{{{baseName}}}']),
+              {{/items.complexType}}
+              {{^items.complexType}}
+          : (json['{{{baseName}}}'] as Map).cast<String, List>(),
+  	          {{/items.complexType}}
+          {{/items.isArray}}
+          {{^items.isArray}}
+        {{{name}}}: json['{{{baseName}}}'] == null
+          ? null
+          : {{{complexType}}}.mapFromJson(json['{{{baseName}}}']),
+          {{/items.isArray}}
+        {{/isMap}}
+        {{^isMap}}
+        {{{name}}}: {{{complexType}}}.fromJson(json['{{{baseName}}}']),
+        {{/isMap}}
+      {{/isArray}}
+    {{/complexType}}
+    {{^complexType}}
+      {{#isArray}}
+        {{#isEnum}}
+        {{{name}}}: {{{classname}}}{{{items.datatypeWithEnum}}}.listFromJson(json['{{{baseName}}}']),
+        {{/isEnum}}
+        {{^isEnum}}
+        {{{name}}}: json['{{{baseName}}}'] == null
+          ? null
+          : (json['{{{baseName}}}'] as List).cast<{{{items.datatype}}}>(),
+        {{/isEnum}}
+      {{/isArray}}
+      {{^isArray}}
+        {{#isMap}}
+        {{{name}}}: json['{{{baseName}}}'] == null ?
+          null :
+          (json['{{{baseName}}}'] as Map).cast<String, {{{items.datatype}}}>(),
+        {{/isMap}}
+        {{^isMap}}
+          {{#isNumber}}
+        {{{name}}}: json['{{{baseName}}}'] == null ?
+          null :
+          json['{{{baseName}}}'].toDouble(),
+          {{/isNumber}}
+          {{^isNumber}}
+    {{^isEnum}}
+        {{{name}}}: json['{{{baseName}}}'],
+    {{/isEnum}}
+    {{#isEnum}}
+        {{{name}}}: {{{classname}}}{{{enumName}}}.fromJson(json['{{{baseName}}}']),
+    {{/isEnum}}
+          {{/isNumber}}
+        {{/isMap}}
+      {{/isArray}}
+    {{/complexType}}
+  {{/isDate}}
+  {{/isDateTime}}
+  {{/vars}}
+    );
 
   static List<{{{classname}}}> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
     json == null || json.isEmpty

--- a/modules/openapi-generator/src/main/resources/dart2/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/enum.mustache
@@ -39,7 +39,7 @@ class {{{classname}}} {
   {{/allowableValues}}
   ];
 
-  static {{{classname}}} fromJson({{{dataType}}} value) =>
+  static {{{classname}}} fromJson(dynamic value) =>
     {{{classname}}}TypeTransformer().decode(value);
 
   static List<{{{classname}}}> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/modules/openapi-generator/src/main/resources/dart2/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/enum_inline.mustache
@@ -39,7 +39,7 @@ class {{{classname}}}{{{enumName}}} {
   {{/allowableValues}}
   ];
 
-  static {{{classname}}}{{{enumName}}} fromJson({{{dataType}}} value) =>
+  static {{{classname}}}{{{enumName}}} fromJson(dynamic value) =>
     {{{classname}}}{{{enumName}}}TypeTransformer().decode(value);
 
   static List<{{{classname}}}{{{enumName}}}> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
@@ -104,7 +104,10 @@ class PetApi {
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
-    headerParams['api_key'] = apiKey;
+
+    if (apiKey != null) {
+      headerParams['api_key'] = parameterToString(apiKey);
+    }
 
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
@@ -37,7 +37,6 @@ class PetApi {
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
-
     final contentTypes = <String>['application/json', 'application/xml'];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     final authNames = <String>['petstore_auth'];
@@ -103,7 +102,6 @@ class PetApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
-
 
     if (apiKey != null) {
       headerParams['api_key'] = parameterToString(apiKey);
@@ -333,7 +331,6 @@ class PetApi {
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
-
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     final authNames = <String>['api_key'];
@@ -406,7 +403,6 @@ class PetApi {
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
-
     final contentTypes = <String>['application/json', 'application/xml'];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     final authNames = <String>['petstore_auth'];
@@ -476,7 +472,6 @@ class PetApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
-
 
     final contentTypes = <String>['application/x-www-form-urlencoded'];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
@@ -567,7 +562,6 @@ class PetApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
-
 
     final contentTypes = <String>['multipart/form-data'];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
@@ -40,7 +40,6 @@ class StoreApi {
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
-
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     final authNames = <String>[];
@@ -97,7 +96,6 @@ class StoreApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
-
 
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
@@ -168,7 +166,6 @@ class StoreApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
-
 
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
@@ -241,7 +238,6 @@ class StoreApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
-
 
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
@@ -39,7 +39,6 @@ class UserApi {
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
-
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     final authNames = <String>[];
@@ -105,7 +104,6 @@ class UserApi {
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
-
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     final authNames = <String>[];
@@ -168,7 +166,6 @@ class UserApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
-
 
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
@@ -236,7 +233,6 @@ class UserApi {
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
-
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     final authNames = <String>[];
@@ -302,7 +298,6 @@ class UserApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
-
 
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
@@ -446,7 +441,6 @@ class UserApi {
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
-
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
     final authNames = <String>[];
@@ -513,7 +507,6 @@ class UserApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
-
 
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
@@ -55,8 +55,8 @@ class ApiResponse {
     return json;
   }
 
-  /// Returns a new [ApiResponse] instance and optionally import its values from
-  /// [json] if it's non-null.
+  /// Returns a new [ApiResponse] instance and imports its values from
+  /// [json] if it's non-null, null if [json] is null.
   static ApiResponse fromJson(Map<String, dynamic> json) => json == null
     ? null
     : ApiResponse(

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
@@ -17,16 +17,6 @@ class ApiResponse {
     this.message,
   });
 
-  /// Returns a new [ApiResponse] instance and optionally import its values from
-  /// [json] if it's non-null.
-  ApiResponse.fromJson(Map<String, dynamic> json) {
-    if (json != null) {
-      code = json['code'];
-      type = json['type'];
-      message = json['message'];
-    }
-  }
-
   
   int code;
 
@@ -44,9 +34,9 @@ class ApiResponse {
 
   @override
   int get hashCode =>
-    code.hashCode +
-    type.hashCode +
-    message.hashCode;
+    (code == null ? 0 : code.hashCode) +
+    (type == null ? 0 : type.hashCode) +
+    (message == null ? 0 : message.hashCode);
 
   @override
   String toString() => 'ApiResponse[code=$code, type=$type, message=$message]';
@@ -64,6 +54,16 @@ class ApiResponse {
     }
     return json;
   }
+
+  /// Returns a new [ApiResponse] instance and optionally import its values from
+  /// [json] if it's non-null.
+  static ApiResponse fromJson(Map<String, dynamic> json) => json == null
+    ? null
+    : ApiResponse(
+        code: json['code'],
+        type: json['type'],
+        message: json['message'],
+    );
 
   static List<ApiResponse> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
     json == null || json.isEmpty

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
@@ -46,8 +46,8 @@ class Category {
     return json;
   }
 
-  /// Returns a new [Category] instance and optionally import its values from
-  /// [json] if it's non-null.
+  /// Returns a new [Category] instance and imports its values from
+  /// [json] if it's non-null, null if [json] is null.
   static Category fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Category(

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
@@ -16,15 +16,6 @@ class Category {
     this.name,
   });
 
-  /// Returns a new [Category] instance and optionally import its values from
-  /// [json] if it's non-null.
-  Category.fromJson(Map<String, dynamic> json) {
-    if (json != null) {
-      id = json['id'];
-      name = json['name'];
-    }
-  }
-
   
   int id;
 
@@ -38,8 +29,8 @@ class Category {
 
   @override
   int get hashCode =>
-    id.hashCode +
-    name.hashCode;
+    (id == null ? 0 : id.hashCode) +
+    (name == null ? 0 : name.hashCode);
 
   @override
   String toString() => 'Category[id=$id, name=$name]';
@@ -54,6 +45,15 @@ class Category {
     }
     return json;
   }
+
+  /// Returns a new [Category] instance and optionally import its values from
+  /// [json] if it's non-null.
+  static Category fromJson(Map<String, dynamic> json) => json == null
+    ? null
+    : Category(
+        id: json['id'],
+        name: json['name'],
+    );
 
   static List<Category> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
     json == null || json.isEmpty

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -154,7 +154,7 @@ class OrderStatusEnum {
     delivered_,
   ];
 
-  static OrderStatusEnum fromJson(String value) =>
+  static OrderStatusEnum fromJson(dynamic value) =>
     OrderStatusEnumTypeTransformer().decode(value);
 
   static List<OrderStatusEnum> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -82,8 +82,8 @@ class Order {
     return json;
   }
 
-  /// Returns a new [Order] instance and optionally import its values from
-  /// [json] if it's non-null.
+  /// Returns a new [Order] instance and imports its values from
+  /// [json] if it's non-null, null if [json] is null.
   static Order fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Order(

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -20,21 +20,6 @@ class Order {
     this.complete = false,
   });
 
-  /// Returns a new [Order] instance and optionally import its values from
-  /// [json] if it's non-null.
-  Order.fromJson(Map<String, dynamic> json) {
-    if (json != null) {
-      id = json['id'];
-      petId = json['petId'];
-      quantity = json['quantity'];
-      shipDate = json['shipDate'] == null
-        ? null
-        : DateTime.parse(json['shipDate']);
-      status = OrderStatusEnum.fromJson(json['status']);
-      complete = json['complete'];
-    }
-  }
-
   
   int id;
 
@@ -64,12 +49,12 @@ class Order {
 
   @override
   int get hashCode =>
-    id.hashCode +
-    petId.hashCode +
-    quantity.hashCode +
-    shipDate.hashCode +
-    status.hashCode +
-    complete.hashCode;
+    (id == null ? 0 : id.hashCode) +
+    (petId == null ? 0 : petId.hashCode) +
+    (quantity == null ? 0 : quantity.hashCode) +
+    (shipDate == null ? 0 : shipDate.hashCode) +
+    (status == null ? 0 : status.hashCode) +
+    (complete == null ? 0 : complete.hashCode);
 
   @override
   String toString() => 'Order[id=$id, petId=$petId, quantity=$quantity, shipDate=$shipDate, status=$status, complete=$complete]';
@@ -96,6 +81,21 @@ class Order {
     }
     return json;
   }
+
+  /// Returns a new [Order] instance and optionally import its values from
+  /// [json] if it's non-null.
+  static Order fromJson(Map<String, dynamic> json) => json == null
+    ? null
+    : Order(
+        id: json['id'],
+        petId: json['petId'],
+        quantity: json['quantity'],
+        shipDate: json['shipDate'] == null
+          ? null
+          : DateTime.parse(json['shipDate']),
+        status: OrderStatusEnum.fromJson(json['status']),
+        complete: json['complete'],
+    );
 
   static List<Order> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
     json == null || json.isEmpty

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -82,8 +82,8 @@ class Pet {
     return json;
   }
 
-  /// Returns a new [Pet] instance and optionally import its values from
-  /// [json] if it's non-null.
+  /// Returns a new [Pet] instance and imports its values from
+  /// [json] if it's non-null, null if [json] is null.
   static Pet fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Pet(

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -154,7 +154,7 @@ class PetStatusEnum {
     sold_,
   ];
 
-  static PetStatusEnum fromJson(String value) =>
+  static PetStatusEnum fromJson(dynamic value) =>
     PetStatusEnumTypeTransformer().decode(value);
 
   static List<PetStatusEnum> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -20,21 +20,6 @@ class Pet {
     this.status,
   });
 
-  /// Returns a new [Pet] instance and optionally import its values from
-  /// [json] if it's non-null.
-  Pet.fromJson(Map<String, dynamic> json) {
-    if (json != null) {
-      id = json['id'];
-      category = Category.fromJson(json['category']);
-      name = json['name'];
-      photoUrls = json['photoUrls'] == null
-        ? null
-        : (json['photoUrls'] as List).cast<String>();
-      tags = Tag.listFromJson(json['tags']);
-      status = PetStatusEnum.fromJson(json['status']);
-    }
-  }
-
   
   int id;
 
@@ -64,12 +49,12 @@ class Pet {
 
   @override
   int get hashCode =>
-    id.hashCode +
-    category.hashCode +
-    name.hashCode +
-    photoUrls.hashCode +
-    tags.hashCode +
-    status.hashCode;
+    (id == null ? 0 : id.hashCode) +
+    (category == null ? 0 : category.hashCode) +
+    (name == null ? 0 : name.hashCode) +
+    (photoUrls == null ? 0 : photoUrls.hashCode) +
+    (tags == null ? 0 : tags.hashCode) +
+    (status == null ? 0 : status.hashCode);
 
   @override
   String toString() => 'Pet[id=$id, category=$category, name=$name, photoUrls=$photoUrls, tags=$tags, status=$status]';
@@ -96,6 +81,21 @@ class Pet {
     }
     return json;
   }
+
+  /// Returns a new [Pet] instance and optionally import its values from
+  /// [json] if it's non-null.
+  static Pet fromJson(Map<String, dynamic> json) => json == null
+    ? null
+    : Pet(
+        id: json['id'],
+        category: Category.fromJson(json['category']),
+        name: json['name'],
+        photoUrls: json['photoUrls'] == null
+          ? null
+          : (json['photoUrls'] as List).cast<String>(),
+        tags: Tag.listFromJson(json['tags']),
+        status: PetStatusEnum.fromJson(json['status']),
+    );
 
   static List<Pet> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
     json == null || json.isEmpty

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
@@ -16,15 +16,6 @@ class Tag {
     this.name,
   });
 
-  /// Returns a new [Tag] instance and optionally import its values from
-  /// [json] if it's non-null.
-  Tag.fromJson(Map<String, dynamic> json) {
-    if (json != null) {
-      id = json['id'];
-      name = json['name'];
-    }
-  }
-
   
   int id;
 
@@ -38,8 +29,8 @@ class Tag {
 
   @override
   int get hashCode =>
-    id.hashCode +
-    name.hashCode;
+    (id == null ? 0 : id.hashCode) +
+    (name == null ? 0 : name.hashCode);
 
   @override
   String toString() => 'Tag[id=$id, name=$name]';
@@ -54,6 +45,15 @@ class Tag {
     }
     return json;
   }
+
+  /// Returns a new [Tag] instance and optionally import its values from
+  /// [json] if it's non-null.
+  static Tag fromJson(Map<String, dynamic> json) => json == null
+    ? null
+    : Tag(
+        id: json['id'],
+        name: json['name'],
+    );
 
   static List<Tag> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
     json == null || json.isEmpty

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
@@ -46,8 +46,8 @@ class Tag {
     return json;
   }
 
-  /// Returns a new [Tag] instance and optionally import its values from
-  /// [json] if it's non-null.
+  /// Returns a new [Tag] instance and imports its values from
+  /// [json] if it's non-null, null if [json] is null.
   static Tag fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Tag(

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
@@ -100,8 +100,8 @@ class User {
     return json;
   }
 
-  /// Returns a new [User] instance and optionally import its values from
-  /// [json] if it's non-null.
+  /// Returns a new [User] instance and imports its values from
+  /// [json] if it's non-null, null if [json] is null.
   static User fromJson(Map<String, dynamic> json) => json == null
     ? null
     : User(

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
@@ -22,21 +22,6 @@ class User {
     this.userStatus,
   });
 
-  /// Returns a new [User] instance and optionally import its values from
-  /// [json] if it's non-null.
-  User.fromJson(Map<String, dynamic> json) {
-    if (json != null) {
-      id = json['id'];
-      username = json['username'];
-      firstName = json['firstName'];
-      lastName = json['lastName'];
-      email = json['email'];
-      password = json['password'];
-      phone = json['phone'];
-      userStatus = json['userStatus'];
-    }
-  }
-
   
   int id;
 
@@ -74,14 +59,14 @@ class User {
 
   @override
   int get hashCode =>
-    id.hashCode +
-    username.hashCode +
-    firstName.hashCode +
-    lastName.hashCode +
-    email.hashCode +
-    password.hashCode +
-    phone.hashCode +
-    userStatus.hashCode;
+    (id == null ? 0 : id.hashCode) +
+    (username == null ? 0 : username.hashCode) +
+    (firstName == null ? 0 : firstName.hashCode) +
+    (lastName == null ? 0 : lastName.hashCode) +
+    (email == null ? 0 : email.hashCode) +
+    (password == null ? 0 : password.hashCode) +
+    (phone == null ? 0 : phone.hashCode) +
+    (userStatus == null ? 0 : userStatus.hashCode);
 
   @override
   String toString() => 'User[id=$id, username=$username, firstName=$firstName, lastName=$lastName, email=$email, password=$password, phone=$phone, userStatus=$userStatus]';
@@ -114,6 +99,21 @@ class User {
     }
     return json;
   }
+
+  /// Returns a new [User] instance and optionally import its values from
+  /// [json] if it's non-null.
+  static User fromJson(Map<String, dynamic> json) => json == null
+    ? null
+    : User(
+        id: json['id'],
+        username: json['username'],
+        firstName: json['firstName'],
+        lastName: json['lastName'],
+        email: json['email'],
+        password: json['password'],
+        phone: json['phone'],
+        userStatus: json['userStatus'],
+    );
 
   static List<User> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
     json == null || json.isEmpty


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
The current implementation has a couple of problems and this pr addresses them:

1) Change `fromJson(value)` to accept a `dynamic value`.
2) Encode non-String header values using `parameterToString()` method.
3) Changed `fromJson()` to a static function, will not instantiate a new object when json == null.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09) @athornz (2019/12) @amondnet (2019/12) @wing328 @sbu-WBT @agilob