### PR TITLE
Set generateAliasAsModel to false in tests

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -2400,6 +2400,12 @@ public class DefaultCodegenTest {
         CodegenProperty mapWithAddPropsFalse;
         CodegenProperty mapWithAddPropsSchema;
 
+        // make sure isGenerateAliasAsModel is false
+        boolean isGenerateAliasAsModel = ModelUtils.isGenerateAliasAsModel();
+        if (isGenerateAliasAsModel) {
+            GlobalSettings.setProperty("generateAliasAsModel", "false");
+        }
+
         modelName = "ObjectModelWithRefAddPropsInProps";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         cm = codegen.fromModel(modelName, sc);
@@ -2423,6 +2429,10 @@ public class DefaultCodegenTest {
         assertEquals(mapWithAddPropsFalse.getAdditionalProperties(), null);
         mapWithAddPropsSchema = cm.getVars().get(3);
         assertEquals(mapWithAddPropsSchema.getAdditionalProperties(), stringCp);
+
+        if (isGenerateAliasAsModel) { // restore the setting
+            GlobalSettings.setProperty("generateAliasAsModel", "true");
+        }
     }
 
     @Test
@@ -2443,6 +2453,12 @@ public class DefaultCodegenTest {
         CodegenParameter mapWithAddPropsFalse;
         CodegenParameter mapWithAddPropsSchema;
 
+        // make sure isGenerateAliasAsModel is false
+        boolean isGenerateAliasAsModel = ModelUtils.isGenerateAliasAsModel();
+        if (isGenerateAliasAsModel) {
+            GlobalSettings.setProperty("generateAliasAsModel", "false");
+        }
+
         path = "/ref_additional_properties/";
         operation = openAPI.getPaths().get(path).getPost();
         co = codegen.fromOperation(path, "POST", operation, null);
@@ -2466,6 +2482,10 @@ public class DefaultCodegenTest {
         assertEquals(mapWithAddPropsFalse.getAdditionalProperties(), null);
         mapWithAddPropsSchema = co.queryParams.get(3);
         assertEquals(mapWithAddPropsSchema.getAdditionalProperties(), stringCp);
+
+        if (isGenerateAliasAsModel) { // restore the setting
+            GlobalSettings.setProperty("generateAliasAsModel", "true");
+        }
     }
 
     @Test
@@ -2486,6 +2506,12 @@ public class DefaultCodegenTest {
         CodegenResponse mapWithAddPropsFalse;
         CodegenResponse mapWithAddPropsSchema;
 
+        // make sure isGenerateAliasAsModel is false
+        boolean isGenerateAliasAsModel = ModelUtils.isGenerateAliasAsModel();
+        if (isGenerateAliasAsModel) {
+            GlobalSettings.setProperty("generateAliasAsModel", "false");
+        }
+
         path = "/ref_additional_properties/";
         operation = openAPI.getPaths().get(path).getPost();
         co = codegen.fromOperation(path, "POST", operation, null);
@@ -2509,6 +2535,10 @@ public class DefaultCodegenTest {
         assertEquals(mapWithAddPropsFalse.getAdditionalProperties(), null);
         mapWithAddPropsSchema = co.responses.get(3);
         assertEquals(mapWithAddPropsSchema.getAdditionalProperties(), stringCp);
+
+        if (isGenerateAliasAsModel) { // restore the setting
+            GlobalSettings.setProperty("generateAliasAsModel", "true");
+        }
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -35,6 +35,7 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.parser.core.models.ParseOptions;
 
 import org.openapitools.codegen.config.CodegenConfigurator;
+import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.templating.mustache.CamelCaseLambda;
 import org.openapitools.codegen.templating.mustache.IndentedLambda;
 import org.openapitools.codegen.templating.mustache.LowercaseLambda;


### PR DESCRIPTION
- Set generateAliasAsModel to false in tests to fix github action's failure

cc @OpenAPITools/generator-core-team 


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
