### PR TITLE
5.0.0 beta3 fix dart client enum name generation

### DIFF
--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -433,6 +433,11 @@
             <artifactId>caffeine</artifactId>
             <version>2.8.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.unbescape</groupId>
+            <artifactId>unbescape</artifactId>
+            <version>1.1.6.RELEASE</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
@@ -32,6 +32,9 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
+import org.unbescape.html.HtmlEscape;
+import org.unbescape.html.HtmlEscapeLevel;
+import org.unbescape.html.HtmlEscapeType;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -529,11 +532,25 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
         if (value.length() == 0) {
             return "empty";
         }
-        String var = value.replaceAll("\\W+", "_");
-        if ("number".equalsIgnoreCase(datatype) ||
-                "int".equalsIgnoreCase(datatype)) {
-            var = "Number" + var;
-        }
+        String var = value;
+        var = HtmlEscape.escapeHtml(
+            var,
+            HtmlEscapeType.HTML5_NAMED_REFERENCES_DEFAULT_TO_DECIMAL,
+            HtmlEscapeLevel.LEVEL_3_ALL_NON_ALPHANUMERIC);
+        // replace all escaped space characters with _ characters,
+        var = var.replaceAll("&#32;", "_");
+        // A string with a single _ character is a space, marked with 'space'
+        var = var.replaceAll("^_$", "space");
+        // remove & and ; characters from escaped HTML entities
+        var = var.replaceAll("[&;]", "_");
+        // Replace consecutive _ characters with a single _ character
+        var = var.replaceAll("_+", "_");
+        // replace all # with 'num' string
+        var = var.replaceAll("#", "num");
+        // remove _ character from the beginning and end of the string
+        var = var.replaceAll("^_|_$", "");
+        // strings beginning with a number should start with text
+        var = var.replaceAll("^(\\d+)", "Number$1");
         return escapeReservedWord(camelize(var, true));
     }
 


### PR DESCRIPTION
This pull request fixes the issue #7867. The problem, this pull request addresses, is that the generated Dart client code included enum parameter names that were automatically generated based on enum values (see line 528 in modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java in tag v5.0.0-beta3) The problematic method can be found here: https://github.com/OpenAPITools/openapi-generator/blob/2715f1371a1bd438159e4aa79bd8f1fe172b03d9/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java#L528

However, the corresponding java code of OpenAPI Generator, mentioned above, was not ready to handle cases, where the enum value was a special character, like a % character. In such cases, the enum parameter name was a single '_' character. This pull request fixes this by converting special characters to alphanumeric strings using HTML escaping. I have checked multiple Java packages that can handle HTML escaping, and the most versatile and the most configurable one, that included the most HTML entities was the unbescape java package. Even though it was modified last time in 2018, it has too many advantages just to ignore it.

I have checked if the code is working by running `mvnw clean install` in the root of the openapi-generator repository and then generating Dart client code using the generated openapi-generator-cli.jar file in the way mentioned in issue #7867.

The branch for this fix is checked out from tag v5.0.0-beta3, in line with [How can I submit a PR for a branch (e.g. 4.2.x)?](https://github.com/OpenAPITools/openapi-generator/wiki/FAQ#how-can-i-submit-a-pr-for-a-branch-eg-42x).

If I did not follow the pull request procedure appropriately, please forgive me, I am ready to improve if you give me directions.

Dart technical committee: @ircecho @swipesight @jaumard @amondnet 

A couple of other contributors to Dart, who might have some influence on this PR: @wing328 @agilob 

Closes #7867

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
