### PR TITLE
feature(PHP): include the current value with enum failure

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -197,7 +197,8 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         $allowedValues = $this->{{getter}}AllowableValues();
         if (!is_null($this->container['{{name}}']) && !in_array($this->container['{{name}}'], $allowedValues, true)) {
             $invalidProperties[] = sprintf(
-                "invalid value for '{{name}}', must be one of '%s'",
+                "invalid value '%s' for '{{name}}', must be one of '%s'",
+                $this->container['{{name}}'],
                 implode("', '", $allowedValues)
             );
         }
@@ -290,7 +291,8 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         if ({{^required}}!is_null(${{name}}) && {{/required}}!in_array(${{{name}}}, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    "Invalid value for '{{name}}', must be one of '%s'",
+                    "Invalid value '%s' for '{{name}}', must be one of '%s'",
+                    ${{{name}}},
                     implode("', '", $allowedValues)
                 )
             );

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
@@ -233,7 +233,8 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
         $allowedValues = $this->getJustSymbolAllowableValues();
         if (!is_null($this->container['just_symbol']) && !in_array($this->container['just_symbol'], $allowedValues, true)) {
             $invalidProperties[] = sprintf(
-                "invalid value for 'just_symbol', must be one of '%s'",
+                "invalid value '%s' for 'just_symbol', must be one of '%s'",
+                $this->container['just_symbol'],
                 implode("', '", $allowedValues)
             );
         }
@@ -276,7 +277,8 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
         if (!is_null($just_symbol) && !in_array($just_symbol, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    "Invalid value for 'just_symbol', must be one of '%s'",
+                    "Invalid value '%s' for 'just_symbol', must be one of '%s'",
+                    $just_symbol,
                     implode("', '", $allowedValues)
                 )
             );

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -303,7 +303,8 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         $allowedValues = $this->getEnumStringAllowableValues();
         if (!is_null($this->container['enum_string']) && !in_array($this->container['enum_string'], $allowedValues, true)) {
             $invalidProperties[] = sprintf(
-                "invalid value for 'enum_string', must be one of '%s'",
+                "invalid value '%s' for 'enum_string', must be one of '%s'",
+                $this->container['enum_string'],
                 implode("', '", $allowedValues)
             );
         }
@@ -314,7 +315,8 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         $allowedValues = $this->getEnumStringRequiredAllowableValues();
         if (!is_null($this->container['enum_string_required']) && !in_array($this->container['enum_string_required'], $allowedValues, true)) {
             $invalidProperties[] = sprintf(
-                "invalid value for 'enum_string_required', must be one of '%s'",
+                "invalid value '%s' for 'enum_string_required', must be one of '%s'",
+                $this->container['enum_string_required'],
                 implode("', '", $allowedValues)
             );
         }
@@ -322,7 +324,8 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         $allowedValues = $this->getEnumIntegerAllowableValues();
         if (!is_null($this->container['enum_integer']) && !in_array($this->container['enum_integer'], $allowedValues, true)) {
             $invalidProperties[] = sprintf(
-                "invalid value for 'enum_integer', must be one of '%s'",
+                "invalid value '%s' for 'enum_integer', must be one of '%s'",
+                $this->container['enum_integer'],
                 implode("', '", $allowedValues)
             );
         }
@@ -330,7 +333,8 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         $allowedValues = $this->getEnumNumberAllowableValues();
         if (!is_null($this->container['enum_number']) && !in_array($this->container['enum_number'], $allowedValues, true)) {
             $invalidProperties[] = sprintf(
-                "invalid value for 'enum_number', must be one of '%s'",
+                "invalid value '%s' for 'enum_number', must be one of '%s'",
+                $this->container['enum_number'],
                 implode("', '", $allowedValues)
             );
         }
@@ -373,7 +377,8 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (!is_null($enum_string) && !in_array($enum_string, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    "Invalid value for 'enum_string', must be one of '%s'",
+                    "Invalid value '%s' for 'enum_string', must be one of '%s'",
+                    $enum_string,
                     implode("', '", $allowedValues)
                 )
             );
@@ -406,7 +411,8 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (!in_array($enum_string_required, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    "Invalid value for 'enum_string_required', must be one of '%s'",
+                    "Invalid value '%s' for 'enum_string_required', must be one of '%s'",
+                    $enum_string_required,
                     implode("', '", $allowedValues)
                 )
             );
@@ -439,7 +445,8 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (!is_null($enum_integer) && !in_array($enum_integer, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    "Invalid value for 'enum_integer', must be one of '%s'",
+                    "Invalid value '%s' for 'enum_integer', must be one of '%s'",
+                    $enum_integer,
                     implode("', '", $allowedValues)
                 )
             );
@@ -472,7 +479,8 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
         if (!is_null($enum_number) && !in_array($enum_number, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    "Invalid value for 'enum_number', must be one of '%s'",
+                    "Invalid value '%s' for 'enum_number', must be one of '%s'",
+                    $enum_number,
                     implode("', '", $allowedValues)
                 )
             );

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject2.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject2.php
@@ -235,7 +235,8 @@ class InlineObject2 implements ModelInterface, ArrayAccess, \JsonSerializable
         $allowedValues = $this->getEnumFormStringAllowableValues();
         if (!is_null($this->container['enum_form_string']) && !in_array($this->container['enum_form_string'], $allowedValues, true)) {
             $invalidProperties[] = sprintf(
-                "invalid value for 'enum_form_string', must be one of '%s'",
+                "invalid value '%s' for 'enum_form_string', must be one of '%s'",
+                $this->container['enum_form_string'],
                 implode("', '", $allowedValues)
             );
         }
@@ -311,7 +312,8 @@ class InlineObject2 implements ModelInterface, ArrayAccess, \JsonSerializable
         if (!is_null($enum_form_string) && !in_array($enum_form_string, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    "Invalid value for 'enum_form_string', must be one of '%s'",
+                    "Invalid value '%s' for 'enum_form_string', must be one of '%s'",
+                    $enum_form_string,
                     implode("', '", $allowedValues)
                 )
             );

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
@@ -244,7 +244,8 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
         $allowedValues = $this->getStatusAllowableValues();
         if (!is_null($this->container['status']) && !in_array($this->container['status'], $allowedValues, true)) {
             $invalidProperties[] = sprintf(
-                "invalid value for 'status', must be one of '%s'",
+                "invalid value '%s' for 'status', must be one of '%s'",
+                $this->container['status'],
                 implode("', '", $allowedValues)
             );
         }
@@ -383,7 +384,8 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
         if (!is_null($status) && !in_array($status, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    "Invalid value for 'status', must be one of '%s'",
+                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    $status,
                     implode("', '", $allowedValues)
                 )
             );

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -250,7 +250,8 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
         $allowedValues = $this->getStatusAllowableValues();
         if (!is_null($this->container['status']) && !in_array($this->container['status'], $allowedValues, true)) {
             $invalidProperties[] = sprintf(
-                "invalid value for 'status', must be one of '%s'",
+                "invalid value '%s' for 'status', must be one of '%s'",
+                $this->container['status'],
                 implode("', '", $allowedValues)
             );
         }
@@ -413,7 +414,8 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
         if (!is_null($status) && !in_array($status, $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    "Invalid value for 'status', must be one of '%s'",
+                    "Invalid value '%s' for 'status', must be one of '%s'",
+                    $status,
                     implode("', '", $allowedValues)
                 )
             );

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/EnumTestTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/EnumTestTest.php
@@ -26,7 +26,7 @@ class EnumTestTest extends TestCase
         $this->assertFalse($enum->valid());
 
         $expected = [
-            "invalid value for 'enum_string', must be one of 'UPPER', 'lower', ''",
+            "invalid value '0' for 'enum_string', must be one of 'UPPER', 'lower', ''",
             "'enum_string_required' can't be null",
         ];
         $this->assertSame($expected, $enum->listInvalidProperties());


### PR DESCRIPTION
Purpose is simple: if the property is an enum and the value in the response doesn't match the enum, print the received value in the exception, allowing spec designers to easily fix the spec.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09) heart, @ybelenko (2018/07), @renepardon (2018/12)