### PR TITLE
Improve generated Java examples

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1012,6 +1012,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             example = "new File(\"" + escapeText(example) + "\")";
         } else if ("Date".equals(type)) {
             example = "new Date()";
+        } else if ("OffsetDateTime".equals(type)) {
+            example = "OffsetDateTime.now()";
         } else if (!languageSpecificPrimitives.contains(type)) {
             // type is a model class, e.g. User
             example = "new " + type + "()";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1014,6 +1014,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             example = "new Date()";
         } else if ("OffsetDateTime".equals(type)) {
             example = "OffsetDateTime.now()";
+        } else if (p.allowableValues != null && !p.allowableValues.isEmpty()) {
+            Map<String, Object> allowableValues = p.allowableValues;
+            List<Object> values = (List<Object>) allowableValues.get("values");
+            example = type + ".fromValue(\"" + String.valueOf(values.get(0)) + "\")";
         } else if (!languageSpecificPrimitives.contains(type)) {
             // type is a model class, e.g. User
             example = "new " + type + "()";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1139,6 +1139,18 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 itr.remove();
             }
         }
+
+        Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
+        List<CodegenOperation> operationList = (List<CodegenOperation>) operations.get("operation");
+        for (CodegenOperation op : operationList) {
+            Collection<String> operationImports = new TreeSet<String>();
+            for (CodegenParameter p : op.allParams) {
+                if (importMapping.containsKey(p.dataType)) {
+                    operationImports.add(importMapping.get(p.dataType));
+                }
+            }
+            op.vendorExtensions.put("x-java-import", operationImports);
+        }
         return objs;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1014,6 +1014,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             example = "new Date()";
         } else if ("OffsetDateTime".equals(type)) {
             example = "OffsetDateTime.now()";
+        } else if ("BigDecimal".equals(type)) {
+            example = "new BigDecimal(78)";
         } else if (p.allowableValues != null && !p.allowableValues.isEmpty()) {
             Map<String, Object> allowableValues = p.allowableValues;
             List<Object> values = (List<Object>) allowableValues.get("values");

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api_doc.mustache
@@ -28,6 +28,9 @@ Method | HTTP request | Description
 ### Example
 
 ```java
+{{#vendorExtensions.x-java-import}}
+import {{.}};
+{{/vendorExtensions.x-java-import}}
 // Import classes:
 import {{{invokerPackage}}}.ApiClient;
 import {{{invokerPackage}}}.ApiException;

--- a/samples/client/petstore/java/google-api-client/docs/FakeApi.md
+++ b/samples/client/petstore/java/google-api-client/docs/FakeApi.md
@@ -239,7 +239,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -568,7 +568,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/google-api-client/docs/FakeApi.md
+++ b/samples/client/petstore/java/google-api-client/docs/FakeApi.md
@@ -579,7 +579,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/jersey1/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey1/docs/FakeApi.md
@@ -239,7 +239,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -568,7 +568,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/jersey1/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey1/docs/FakeApi.md
@@ -579,7 +579,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -587,7 +587,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -240,7 +240,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -576,7 +576,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -226,6 +226,7 @@ Test serialization of outer number types
 ### Example
 
 ```java
+import java.math.BigDecimal;
 // Import classes:
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
@@ -552,6 +553,10 @@ Fake endpoint for testing various parameters
 ### Example
 
 ```java
+import java.io.File;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 // Import classes:
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;

--- a/samples/client/petstore/java/jersey2-java8/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/PetApi.md
@@ -520,6 +520,7 @@ uploads an image
 ### Example
 
 ```java
+import java.io.File;
 // Import classes:
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
@@ -592,6 +593,7 @@ uploads an image (required)
 ### Example
 
 ```java
+import java.io.File;
 // Import classes:
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;

--- a/samples/client/petstore/java/native-async/docs/FakeApi.md
+++ b/samples/client/petstore/java/native-async/docs/FakeApi.md
@@ -1215,7 +1215,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {
@@ -1314,7 +1314,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/native-async/docs/FakeApi.md
+++ b/samples/client/petstore/java/native-async/docs/FakeApi.md
@@ -487,7 +487,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             CompletableFuture<BigDecimal> result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result.get());
@@ -554,7 +554,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             CompletableFuture<ApiResponse<BigDecimal>> response = apiInstance.fakeOuterNumberSerializeWithHttpInfo(body);
             System.out.println("Status code: " + response.get().getStatusCode());
@@ -1204,7 +1204,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None
@@ -1303,7 +1303,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/native/docs/FakeApi.md
+++ b/samples/client/petstore/java/native/docs/FakeApi.md
@@ -1142,7 +1142,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {
@@ -1240,7 +1240,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/native/docs/FakeApi.md
+++ b/samples/client/petstore/java/native/docs/FakeApi.md
@@ -459,7 +459,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -525,7 +525,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             ApiResponse<BigDecimal> response = apiInstance.fakeOuterNumberSerializeWithHttpInfo(body);
             System.out.println("Status code: " + response.getStatusCode());
@@ -1131,7 +1131,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None
@@ -1229,7 +1229,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
@@ -553,7 +553,7 @@ public class Example {
     String string = "string_example"; // String | None
     File binary = new File("/path/to/file"); // File | None
     LocalDate date = new LocalDate(); // LocalDate | None
-    OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+    OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
     String password = "password_example"; // String | None
     String paramCallback = "paramCallback_example"; // String | None
     try {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
@@ -228,7 +228,7 @@ public class Example {
     defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
     FakeApi apiInstance = new FakeApi(defaultClient);
-    BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+    BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
     try {
       BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
       System.out.println(result);
@@ -542,7 +542,7 @@ public class Example {
     http_basic_test.setPassword("YOUR PASSWORD");
 
     FakeApi apiInstance = new FakeApi(defaultClient);
-    BigDecimal number = new BigDecimal(); // BigDecimal | None
+    BigDecimal number = new BigDecimal(78); // BigDecimal | None
     Double _double = 3.4D; // Double | None
     String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
     byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
@@ -553,7 +553,7 @@ public class Example {
     String string = "string_example"; // String | None
     File binary = new File("/path/to/file"); // File | None
     LocalDate date = new LocalDate(); // LocalDate | None
-    OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+    OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
     String password = "password_example"; // String | None
     String paramCallback = "paramCallback_example"; // String | None
     try {

--- a/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
@@ -228,7 +228,7 @@ public class Example {
     defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
     FakeApi apiInstance = new FakeApi(defaultClient);
-    BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+    BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
     try {
       BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
       System.out.println(result);
@@ -542,7 +542,7 @@ public class Example {
     http_basic_test.setPassword("YOUR PASSWORD");
 
     FakeApi apiInstance = new FakeApi(defaultClient);
-    BigDecimal number = new BigDecimal(); // BigDecimal | None
+    BigDecimal number = new BigDecimal(78); // BigDecimal | None
     Double _double = 3.4D; // Double | None
     String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
     byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/resteasy/docs/FakeApi.md
+++ b/samples/client/petstore/java/resteasy/docs/FakeApi.md
@@ -239,7 +239,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -568,7 +568,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/resteasy/docs/FakeApi.md
+++ b/samples/client/petstore/java/resteasy/docs/FakeApi.md
@@ -579,7 +579,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/resttemplate-withXml/docs/FakeApi.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/FakeApi.md
@@ -239,7 +239,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -568,7 +568,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/resttemplate-withXml/docs/FakeApi.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/FakeApi.md
@@ -579,7 +579,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/resttemplate/docs/FakeApi.md
+++ b/samples/client/petstore/java/resttemplate/docs/FakeApi.md
@@ -239,7 +239,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -568,7 +568,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/resttemplate/docs/FakeApi.md
+++ b/samples/client/petstore/java/resttemplate/docs/FakeApi.md
@@ -579,7 +579,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/retrofit2-play26/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/FakeApi.md
@@ -239,7 +239,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -568,7 +568,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/retrofit2-play26/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/FakeApi.md
@@ -579,7 +579,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/retrofit2/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/FakeApi.md
@@ -239,7 +239,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -568,7 +568,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/retrofit2/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/FakeApi.md
@@ -579,7 +579,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/retrofit2rx2/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/FakeApi.md
@@ -239,7 +239,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -568,7 +568,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/retrofit2rx2/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/FakeApi.md
@@ -579,7 +579,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/retrofit2rx3/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx3/docs/FakeApi.md
@@ -239,7 +239,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -568,7 +568,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/retrofit2rx3/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx3/docs/FakeApi.md
@@ -579,7 +579,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/vertx-no-nullable/docs/FakeApi.md
+++ b/samples/client/petstore/java/vertx-no-nullable/docs/FakeApi.md
@@ -239,7 +239,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -568,7 +568,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/vertx-no-nullable/docs/FakeApi.md
+++ b/samples/client/petstore/java/vertx-no-nullable/docs/FakeApi.md
@@ -579,7 +579,7 @@ public class Example {
         String string = "string_example"; // String | None
         AsyncFile binary = new AsyncFile(); // AsyncFile | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/vertx/docs/FakeApi.md
+++ b/samples/client/petstore/java/vertx/docs/FakeApi.md
@@ -239,7 +239,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -568,7 +568,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/vertx/docs/FakeApi.md
+++ b/samples/client/petstore/java/vertx/docs/FakeApi.md
@@ -579,7 +579,7 @@ public class Example {
         String string = "string_example"; // String | None
         AsyncFile binary = new AsyncFile(); // AsyncFile | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/client/petstore/java/webclient/docs/FakeApi.md
+++ b/samples/client/petstore/java/webclient/docs/FakeApi.md
@@ -239,7 +239,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -568,7 +568,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/client/petstore/java/webclient/docs/FakeApi.md
+++ b/samples/client/petstore/java/webclient/docs/FakeApi.md
@@ -579,7 +579,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -643,7 +643,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -236,7 +236,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -632,7 +632,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/openapi3/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -222,6 +222,7 @@ Test serialization of outer number types
 ### Example
 
 ```java
+import java.math.BigDecimal;
 // Import classes:
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
@@ -608,6 +609,10 @@ Fake endpoint for testing various parameters
 ### Example
 
 ```java
+import java.io.File;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 // Import classes:
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/docs/PetApi.md
@@ -521,6 +521,7 @@ uploads an image
 ### Example
 
 ```java
+import java.io.File;
 // Import classes:
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
@@ -593,6 +594,7 @@ uploads an image (required)
 ### Example
 
 ```java
+import java.io.File;
 // Import classes:
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;

--- a/samples/openapi3/client/petstore/java/native/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/java/native/docs/FakeApi.md
@@ -451,7 +451,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
             System.out.println(result);
@@ -517,7 +517,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        BigDecimal body = new BigDecimal(78); // BigDecimal | Input number as post body
         try {
             ApiResponse<BigDecimal> response = apiInstance.fakeOuterNumberSerializeWithHttpInfo(body);
             System.out.println("Status code: " + response.getStatusCode());
@@ -1245,7 +1245,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None
@@ -1343,7 +1343,7 @@ public class Example {
         http_basic_test.setPassword("YOUR PASSWORD");
 
         FakeApi apiInstance = new FakeApi(defaultClient);
-        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        BigDecimal number = new BigDecimal(78); // BigDecimal | None
         Double _double = 3.4D; // Double | None
         String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
         byte[] _byte = null; // byte[] | None

--- a/samples/openapi3/client/petstore/java/native/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/java/native/docs/FakeApi.md
@@ -1256,7 +1256,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {
@@ -1354,7 +1354,7 @@ public class Example {
         String string = "string_example"; // String | None
         File binary = new File("/path/to/file"); // File | None
         LocalDate date = new LocalDate(); // LocalDate | None
-        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        OffsetDateTime dateTime = OffsetDateTime.now(); // OffsetDateTime | None
         String password = "password_example"; // String | None
         String paramCallback = "paramCallback_example"; // String | None
         try {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This fixes a bunch of issues with Java examples, including:
 * Adds imports to basic types
 * Generate proper example for enums
 * Generate useful default for OffsetDatetime
 * Wrap schema examples when necessary (quotes, longs, etc).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.