### PR TITLE
[java]Fix incompatible types error for number

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -883,8 +883,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             if (schema.getDefault() != null) {
                 if (SchemaTypeUtil.FLOAT_FORMAT.equals(schema.getFormat())) {
                     return schema.getDefault().toString() + "f";
-                } else {
+                } else if (SchemaTypeUtil.DOUBLE_FORMAT.equals(schema.getFormat())) {
                     return schema.getDefault().toString() + "d";
+                } else {
+                    return "new BigDecimal(\"" + schema.getDefault().toString() + "\")";
                 }
             }
             return null;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -448,6 +448,18 @@ public class AbstractJavaCodegenTest {
         dateSchema.setDefault(date);
         defaultValue = codegen.toDefaultValue(dateSchema);
         Assert.assertEquals(defaultLocalDate, LocalDate.parse(defaultValue));
+
+        // Test default value for number without format
+        NumberSchema numberSchema = new NumberSchema();
+        Double doubleValue = 100.0;
+        numberSchema.setDefault(doubleValue);
+        defaultValue = codegen.toDefaultValue(numberSchema);
+        Assert.assertEquals(defaultValue, "new BigDecimal(\"" + doubleValue.toString() + "\")");
+
+        // Test default value for number with format set to double
+        numberSchema.setFormat("double");
+        defaultValue = codegen.toDefaultValue(numberSchema);
+        Assert.assertEquals(defaultValue, doubleValue + "d");
     }
 
     @Test


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR fixes the incompatible types error for `numberSchema` which has a default value but no `format` or the `format` is not `double` or `float`.

About issue detail, please see https://github.com/OpenAPITools/openapi-generator/issues/4612 
 
@wing328 @sebastien-rosset @cbornet @jeff9finger @bbdouglas @sreeshas @jfiala @lukoyanov @karismann @Zomzog @lwlee2608 @bkabrda @jfeltesse-mdsol @jcarres-mdsol @ykitamura-mdsol

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
