### PR TITLE
[ruby] make the generated ruby oneOf specs pass

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/model_test.mustache
@@ -41,9 +41,8 @@ describe {{moduleName}}::{{classname}} do
 {{#oneOf}}
 {{#-first}}
   describe '.openapi_one_of' do
-    it 'lists the models referenced in the oneOf array' do
+    it 'lists the items referenced in the oneOf array' do
       expect(described_class.openapi_one_of).to_not be_empty
-      described_class.openapi_one_of.each { |klass| expect { {{moduleName}}.const_get(klass) }.to_not raise_error }
     end
   end
 


### PR DESCRIPTION
The spec wrongly assumed the items in the oneOf schema were all models.

Solves the issue described in https://github.com/OpenAPITools/openapi-generator/pull/5706#issuecomment-732983709

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@cliffano (2017/07) @zlx (2017/09) @autopp (2019/02) @zippolyte @wing328 