### PR TITLE
[ruby] Improve ruby client examples

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -606,10 +606,10 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         } else if (codegenParameter.isPrimitiveType) { // primitive type
             if (codegenParameter.isEnum) {
                 // When inline enum, set example to first allowable value
-                List<Map<String, String>> enumVars = (List<Map<String, String>>) codegenParameter.allowableValues.get("enumVars");
-                codegenParameter.example = enumVars.get(0).get("value");
+                List<Object> values = (List<Object>) codegenParameter.allowableValues.get("values");
+                codegenParameter.example = String.valueOf(values.get(0));
             }
-            if (codegenParameter.isString) {
+            if (codegenParameter.isString || "String".equalsIgnoreCase(codegenParameter.baseType)) {
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
                     return "'" + codegenParameter.example + "'";
                 }
@@ -669,7 +669,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
                 List<Object> values = (List<Object>) codegenProperty.allowableValues.get("values");
                 codegenProperty.example = String.valueOf(values.get(0));
             }
-            if (codegenProperty.isString) {
+            if (codegenProperty.isString || "String".equalsIgnoreCase(codegenProperty.baseType)) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
                     return "'" + codegenProperty.example + "'";
                 } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -638,9 +638,9 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
                 return "'https://example.com'";
             } else if (codegenParameter.isDateTime) {
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
-                    return "DateTime.parse('" + codegenParameter.example + "')";
+                    return "Time.parse('" + codegenParameter.example + "')";
                 }
-                return "DateTime.now";
+                return "Time.now";
             } else if (codegenParameter.isDate) {
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
                     return "Date.parse('" + codegenParameter.example + "')";
@@ -700,9 +700,9 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
                 return "'https://example.com'";
             } else if (codegenProperty.isDateTime) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
-                    return "DateTime.parse('" + codegenProperty.example + "')";
+                    return "Time.parse('" + codegenProperty.example + "')";
                 }
-                return "DateTime.now";
+                return "Time.now";
             } else if (codegenProperty.isDate) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
                     return "Date.parse('" + codegenProperty.example + "')";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -17,28 +17,20 @@
 
 package org.openapitools.codegen.languages;
 
-import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.parameters.Parameter;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
-import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
 public class RubyClientCodegen extends AbstractRubyCodegen {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RubyClientCodegen.class);
-    private static final String NUMERIC_ENUM_PREFIX = "N";
     public static final String GEM_VERSION = "gemVersion";
     public static final String GEM_LICENSE = "gemLicense";
     public static final String GEM_REQUIRED_RUBY_VERSION = "gemRequiredRubyVersion";
@@ -49,7 +41,9 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
     public static final String GEM_AUTHOR_EMAIL = "gemAuthorEmail";
     public static final String FARADAY = "faraday";
     public static final String TYPHOEUS = "typhoeus";
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(RubyClientCodegen.class);
+    private static final String NUMERIC_ENUM_PREFIX = "N";
+    protected static int emptyMethodNameCounter = 0;
     protected String gemName;
     protected String moduleName;
     protected String gemVersion = "1.0.0";
@@ -64,8 +58,6 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
     protected String gemAuthorEmail = "";
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
-
-    protected static int emptyMethodNameCounter = 0;
 
     public RubyClientCodegen() {
         super();
@@ -266,7 +258,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
             // for Faraday
             additionalProperties.put("isFaraday", Boolean.TRUE);
         } else {
-            throw new RuntimeException("Invalid HTTP library " +  getLibrary() + ". Only faraday, typhoeus are supported.");
+            throw new RuntimeException("Invalid HTTP library " + getLibrary() + ". Only faraday, typhoeus are supported.");
         }
 
         // test files should not be overwritten
@@ -299,6 +291,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
      * Generate Ruby module name from the gem name, e.g. use "OpenAPIClient" for "openapi_client".
      *
      * @param gemName Ruby gem name
+     *
      * @return Ruby module naame
      */
     @SuppressWarnings("static-method")
@@ -310,6 +303,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
      * Generate Ruby gem name from the module name, e.g. use "openapi_client" for "OpenAPIClient".
      *
      * @param moduleName Ruby module naame
+     *
      * @return Ruby gem name
      */
     @SuppressWarnings("static-method")
@@ -413,7 +407,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         // replace - with _ e.g. created-at => created_at
         String filename = name;
         if (apiNameSuffix != null && apiNameSuffix.length() > 0) {
-            filename = filename + "_"  + apiNameSuffix;
+            filename = filename + "_" + apiNameSuffix;
         }
 
         filename = filename.replaceAll("-", "_");
@@ -527,98 +521,6 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         return gemName + "/" + apiPackage() + "/" + toApiFilename(name);
     }
 
-    @Override
-    public void setParameterExampleValue(CodegenParameter p) {
-        String example;
-
-        if (p.defaultValue == null) {
-            example = p.example;
-        } else {
-            p.example = p.defaultValue;
-            return;
-        }
-
-        String type = p.baseType;
-        if (type == null) {
-            type = p.dataType;
-        }
-
-        if ("String".equalsIgnoreCase(type)) {
-            if (example == null) {
-                example = p.paramName + "_example";
-            }
-            example = "'" + escapeText(example) + "'";
-        } else if ("Integer".equalsIgnoreCase(type)) {
-            if (example == null) {
-                example = "56";
-            }
-        } else if ("Float".equalsIgnoreCase(type)) {
-            if (example == null) {
-                example = "3.4";
-            }
-        } else if ("BOOLEAN".equalsIgnoreCase(type)) {
-            if (example == null) {
-                example = "true";
-            }
-        } else if ("File".equalsIgnoreCase(type)) {
-            if (example == null) {
-                example = "/path/to/file";
-            }
-            example = "File.new('" + escapeText(example) + "')";
-        } else if ("Date".equalsIgnoreCase(type)) {
-            if (example == null) {
-                example = "2013-10-20";
-            }
-            example = "Date.parse('" + escapeText(example) + "')";
-        } else if ("Time".equalsIgnoreCase(type)) {
-            if (example == null) {
-                example = "2013-10-20T19:20:30+01:00";
-            }
-            example = "Time.parse('" + escapeText(example) + "')";
-        } else if (!languageSpecificPrimitives.contains(type)) {
-            // type is a model class, e.g. User
-            example = moduleName + "::" + type + ".new";
-        }
-
-        if (example == null) {
-            example = "nil";
-        } else if (Boolean.TRUE.equals(p.isArray)) {
-            example = "[" + example + "]";
-        } else if (Boolean.TRUE.equals(p.isMap)) {
-            example = "{'key' => " + example + "}";
-        }
-
-        p.example = example;
-    }
-
-    /**
-     * Return the example value of the parameter. Overrides the
-     * setParameterExampleValue(CodegenParameter, Parameter) method in
-     * DefaultCodegen to always call setParameterExampleValue(CodegenParameter)
-     * in this class, which adds single quotes around strings from the
-     * x-example property.
-     *
-     * @param codegenParameter Codegen parameter
-     * @param parameter        Parameter
-     */
-    public void setParameterExampleValue(CodegenParameter codegenParameter, Parameter parameter) {
-        if (parameter.getExample() != null) {
-            codegenParameter.example = parameter.getExample().toString();
-        } else if (parameter.getExamples() != null && !parameter.getExamples().isEmpty()) {
-            Example example = parameter.getExamples().values().iterator().next();
-            if (example.getValue() != null) {
-                codegenParameter.example = example.getValue().toString();
-            }
-        } else {
-            Schema schema = parameter.getSchema();
-            if (schema != null && schema.getExample() != null) {
-                codegenParameter.example = schema.getExample().toString();
-            }
-        }
-
-        setParameterExampleValue(codegenParameter);
-    }
-
     public void setGemName(String gemName) {
         this.gemName = gemName;
     }
@@ -666,5 +568,179 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         if (additionalProperties != null) {
             codegenModel.additionalPropertiesType = getSchemaType(additionalProperties);
         }
+    }
+
+    @Override
+    public Map<String, Object> postProcessOperationsWithModels(Map<String, Object> objs, List<Object> allModels) {
+        objs = super.postProcessOperationsWithModels(objs, allModels);
+        Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
+        HashMap<String, CodegenModel> modelMaps = new HashMap<String, CodegenModel>();
+        HashMap<String, Integer> processedModelMaps = new HashMap<String, Integer>();
+
+        for (Object o : allModels) {
+            HashMap<String, Object> h = (HashMap<String, Object>) o;
+            CodegenModel m = (CodegenModel) h.get("model");
+            modelMaps.put(m.classname, m);
+        }
+
+        List<CodegenOperation> operationList = (List<CodegenOperation>) operations.get("operation");
+        for (CodegenOperation op : operationList) {
+            for (CodegenParameter p : op.requiredParams) {
+                p.vendorExtensions.put("x-ruby-example", constructExampleCode(p, modelMaps, processedModelMaps));
+            }
+            processedModelMaps.clear();
+            for (CodegenParameter p : op.optionalParams) {
+                p.vendorExtensions.put("x-ruby-example", constructExampleCode(p, modelMaps, processedModelMaps));
+            }
+            processedModelMaps.clear();
+        }
+
+        return objs;
+    }
+
+    private String constructExampleCode(CodegenParameter codegenParameter, HashMap<String, CodegenModel> modelMaps, HashMap<String, Integer> processedModelMap) {
+        if (codegenParameter.isArray) { // array
+            return "[" + constructExampleCode(codegenParameter.items, modelMaps, processedModelMap) + "]";
+        } else if (codegenParameter.isMap) {
+            return "{ key: " + constructExampleCode(codegenParameter.items, modelMaps, processedModelMap) + "}";
+        } else if (codegenParameter.isPrimitiveType) { // primitive type
+            if (codegenParameter.isString) {
+                if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
+                    return "\"" + codegenParameter.example + "\"";
+                }
+                return "\"" + codegenParameter.paramName + "_example\"";
+            } else if (codegenParameter.isBoolean) { // boolean
+                if (Boolean.parseBoolean(codegenParameter.example)) {
+                    return "true";
+                }
+                return "false";
+            } else if (codegenParameter.isUri) {
+                if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
+                    return "\"" + codegenParameter.example + "\"";
+                }
+                return "\"https://example.com\"";
+            } else if (codegenParameter.isDateTime) {
+                if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
+                    return "DateTime.parse(" + codegenParameter.example + ")";
+                }
+                return "DateTime.now";
+            } else if (codegenParameter.isDate) {
+                if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
+                    return "Date.parse(" + codegenParameter.example + ")";
+                }
+                return "Date.today";
+            } else if (codegenParameter.isFile) {
+                return "File.new('/path/to/some/file')";
+            } else if (codegenParameter.isInteger) {
+                if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
+                    return codegenParameter.example;
+                }
+                return "37";
+            } else { // number
+                if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
+                    return codegenParameter.example;
+                }
+                return "3.56";
+            }
+        } else { // model
+            // look up the model
+            if (modelMaps.containsKey(codegenParameter.dataType)) {
+                return constructExampleCode(modelMaps.get(codegenParameter.dataType), modelMaps, processedModelMap);
+            } else {
+                //LOGGER.error("Error in constructing examples. Failed to look up the model " + codegenParameter.dataType);
+                return "TODO";
+            }
+        }
+    }
+
+    private String constructExampleCode(CodegenProperty codegenProperty, HashMap<String, CodegenModel> modelMaps, HashMap<String, Integer> processedModelMap) {
+        if (codegenProperty.isArray) { // array
+            return "[" + constructExampleCode(codegenProperty.items, modelMaps, processedModelMap) + "]";
+        } else if (codegenProperty.isMap) {
+            return "{ key: " + constructExampleCode(codegenProperty.items, modelMaps, processedModelMap) + "}";
+        } else if (codegenProperty.isPrimitiveType) { // primitive type
+            if (codegenProperty.isString) {
+                if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
+                    return "\"" + codegenProperty.example + "\"";
+                } else {
+                    return "\"" + codegenProperty.name + "_example\"";
+                }
+            } else if (codegenProperty.isBoolean) { // boolean
+                if (Boolean.parseBoolean(codegenProperty.example)) {
+                    return "true";
+                } else {
+                    return "false";
+                }
+            } else if (codegenProperty.isUri) {
+                if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
+                    return "\"" + codegenProperty.example + "\"";
+                }
+                return "\"https://example.com\"";
+            } else if (codegenProperty.isDateTime) {
+                if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
+                    return "DateTime.parse(" + codegenProperty.example + ")";
+                }
+                return "DateTime.now";
+            } else if (codegenProperty.isDate) {
+                if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
+                    return "Date.parse(" + codegenProperty.example + ")";
+                }
+                return "Date.today";
+            } else if (codegenProperty.isFile) {
+                return "File.new('/path/to/some/file')";
+            } else if (codegenProperty.isInteger) {
+                if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
+                    return codegenProperty.example;
+                }
+                return "37";
+            } else { // number
+                if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
+                    return codegenProperty.example;
+                }
+                return "3.56";
+            }
+        } else { // model
+            // look up the model
+            if (modelMaps.containsKey(codegenProperty.dataType)) {
+                return constructExampleCode(modelMaps.get(codegenProperty.dataType), modelMaps, processedModelMap);
+            } else {
+                //LOGGER.error("Error in constructing examples. Failed to look up the model " + codegenParameter.dataType);
+                return "TODO";
+            }
+        }
+    }
+
+    private String constructExampleCode(CodegenModel codegenModel, HashMap<String, CodegenModel> modelMaps, HashMap<String, Integer> processedModelMap) {
+        // break infinite recursion. Return, in case a model is already processed in the current context.
+        String model = codegenModel.name;
+        if (processedModelMap.containsKey(model)) {
+            int count = processedModelMap.get(model);
+            if (count == 1) {
+                processedModelMap.put(model, 2);
+            } else if (count == 2) {
+                return "";
+            } else {
+                throw new RuntimeException("Invalid count when constructing example: " + count);
+            }
+        } else if (codegenModel.isEnum) {
+            List<Map<String, String>> enumVars = (List<Map<String, String>>) codegenModel.allowableValues.get("enumVars");
+            return moduleName + "::" + codegenModel.classname + "::" + enumVars.get(0).get("name");
+        } else if (codegenModel.oneOf != null && !codegenModel.oneOf.isEmpty()) {
+            String subModel = (String) codegenModel.oneOf.toArray()[0];
+            String oneOf = constructExampleCode(modelMaps.get(subModel), modelMaps, processedModelMap);
+            return oneOf;
+        } else {
+            processedModelMap.put(model, 1);
+        }
+
+        List<String> propertyExamples = new ArrayList<>();
+        for (CodegenProperty codegenProperty : codegenModel.requiredVars) {
+            propertyExamples.add(codegenProperty.name + ": " + constructExampleCode(codegenProperty, modelMaps, processedModelMap));
+        }
+        String example = moduleName + "::" + toModelName(model) + ".new";
+        if (!propertyExamples.isEmpty()) {
+            example += "({" + StringUtils.join(propertyExamples, ", ") + "})";
+        }
+        return example;
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -604,11 +604,16 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         } else if (codegenParameter.isMap) {
             return "{ key: " + constructExampleCode(codegenParameter.items, modelMaps, processedModelMap) + "}";
         } else if (codegenParameter.isPrimitiveType) { // primitive type
+            if (codegenParameter.isEnum) {
+                // When inline enum, set example to first allowable value
+                List<Map<String, String>> enumVars = (List<Map<String, String>>) codegenParameter.allowableValues.get("enumVars");
+                codegenParameter.example = enumVars.get(0).get("value");
+            }
             if (codegenParameter.isString) {
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
-                    return "\"" + codegenParameter.example + "\"";
+                    return "'" + codegenParameter.example + "'";
                 }
-                return "\"" + codegenParameter.paramName + "_example\"";
+                return "'" + codegenParameter.paramName + "_example'";
             } else if (codegenParameter.isBoolean) { // boolean
                 if (Boolean.parseBoolean(codegenParameter.example)) {
                     return "true";
@@ -616,21 +621,21 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
                 return "false";
             } else if (codegenParameter.isUri) {
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
-                    return "\"" + codegenParameter.example + "\"";
+                    return "'" + codegenParameter.example + "'";
                 }
-                return "\"https://example.com\"";
+                return "'https://example.com'";
             } else if (codegenParameter.isDateTime) {
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
-                    return "DateTime.parse(\"" + codegenParameter.example + "\")";
+                    return "DateTime.parse('" + codegenParameter.example + "')";
                 }
                 return "DateTime.now";
             } else if (codegenParameter.isDate) {
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
-                    return "Date.parse(\"" + codegenParameter.example + "\")";
+                    return "Date.parse('" + codegenParameter.example + "')";
                 }
                 return "Date.today";
             } else if (codegenParameter.isFile) {
-                return "File.new(\"/path/to/some/file\")";
+                return "File.new('/path/to/some/file')";
             } else if (codegenParameter.isInteger) {
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
                     return codegenParameter.example;
@@ -659,11 +664,16 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         } else if (codegenProperty.isMap) {
             return "{ key: " + constructExampleCode(codegenProperty.items, modelMaps, processedModelMap) + "}";
         } else if (codegenProperty.isPrimitiveType) { // primitive type
+            if (codegenProperty.isEnum) {
+                // When inline enum, set example to first allowable value
+                List<Object> values = (List<Object>) codegenProperty.allowableValues.get("values");
+                codegenProperty.example = String.valueOf(values.get(0));
+            }
             if (codegenProperty.isString) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
-                    return "\"" + codegenProperty.example + "\"";
+                    return "'" + codegenProperty.example + "'";
                 } else {
-                    return "\"" + codegenProperty.name + "_example\"";
+                    return "'" + codegenProperty.name + "_example'";
                 }
             } else if (codegenProperty.isBoolean) { // boolean
                 if (Boolean.parseBoolean(codegenProperty.example)) {
@@ -673,21 +683,21 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
                 }
             } else if (codegenProperty.isUri) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
-                    return "\"" + codegenProperty.example + "\"";
+                    return "'" + codegenProperty.example + "'";
                 }
-                return "\"https://example.com\"";
+                return "'https://example.com'";
             } else if (codegenProperty.isDateTime) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
-                    return "DateTime.parse(\"" + codegenProperty.example + "\")";
+                    return "DateTime.parse('" + codegenProperty.example + "')";
                 }
                 return "DateTime.now";
             } else if (codegenProperty.isDate) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
-                    return "Date.parse(\"" + codegenProperty.example + "\")";
+                    return "Date.parse('" + codegenProperty.example + "')";
                 }
                 return "Date.today";
             } else if (codegenProperty.isFile) {
-                return "File.new(\"/path/to/some/file\")";
+                return "File.new('/path/to/some/file')";
             } else if (codegenProperty.isInteger) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
                     return codegenProperty.example;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -585,11 +585,23 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
 
         List<CodegenOperation> operationList = (List<CodegenOperation>) operations.get("operation");
         for (CodegenOperation op : operationList) {
+            for (CodegenParameter p : op.allParams) {
+                p.vendorExtensions.put("x-ruby-example", constructExampleCode(p, modelMaps, processedModelMaps));
+            }
+            processedModelMaps.clear();
             for (CodegenParameter p : op.requiredParams) {
                 p.vendorExtensions.put("x-ruby-example", constructExampleCode(p, modelMaps, processedModelMaps));
             }
             processedModelMaps.clear();
             for (CodegenParameter p : op.optionalParams) {
+                p.vendorExtensions.put("x-ruby-example", constructExampleCode(p, modelMaps, processedModelMaps));
+            }
+            processedModelMaps.clear();
+            for (CodegenParameter p : op.bodyParams) {
+                p.vendorExtensions.put("x-ruby-example", constructExampleCode(p, modelMaps, processedModelMaps));
+            }
+            processedModelMaps.clear();
+            for (CodegenParameter p : op.pathParams) {
                 p.vendorExtensions.put("x-ruby-example", constructExampleCode(p, modelMaps, processedModelMaps));
             }
             processedModelMaps.clear();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -621,16 +621,16 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
                 return "\"https://example.com\"";
             } else if (codegenParameter.isDateTime) {
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
-                    return "DateTime.parse(" + codegenParameter.example + ")";
+                    return "DateTime.parse(\"" + codegenParameter.example + "\")";
                 }
                 return "DateTime.now";
             } else if (codegenParameter.isDate) {
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
-                    return "Date.parse(" + codegenParameter.example + ")";
+                    return "Date.parse(\"" + codegenParameter.example + "\")";
                 }
                 return "Date.today";
             } else if (codegenParameter.isFile) {
-                return "File.new('/path/to/some/file')";
+                return "File.new(\"/path/to/some/file\")";
             } else if (codegenParameter.isInteger) {
                 if (!StringUtils.isEmpty(codegenParameter.example) && !"null".equals(codegenParameter.example)) {
                     return codegenParameter.example;
@@ -678,16 +678,16 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
                 return "\"https://example.com\"";
             } else if (codegenProperty.isDateTime) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
-                    return "DateTime.parse(" + codegenProperty.example + ")";
+                    return "DateTime.parse(\"" + codegenProperty.example + "\")";
                 }
                 return "DateTime.now";
             } else if (codegenProperty.isDate) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
-                    return "Date.parse(" + codegenProperty.example + ")";
+                    return "Date.parse(\"" + codegenProperty.example + "\")";
                 }
                 return "Date.today";
             } else if (codegenProperty.isFile) {
-                return "File.new('/path/to/some/file')";
+                return "File.new(\"/path/to/some/file\")";
             } else if (codegenProperty.isInteger) {
                 if (!StringUtils.isEmpty(codegenProperty.example) && !"null".equals(codegenProperty.example)) {
                     return codegenProperty.example;

--- a/modules/openapi-generator/src/main/resources/ruby-client/README.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/README.mustache
@@ -82,13 +82,13 @@ require '{{{gemName}}}'
 
 api_instance = {{{moduleName}}}::{{{classname}}}.new
 {{#requiredParams}}
-{{{paramName}}} = {{{example}}} # {{{dataType}}} | {{{description}}}
+{{{paramName}}} = {{{vendorExtensions.x-ruby-example}}} # {{{dataType}}} | {{{description}}}
 {{/requiredParams}}
 {{#optionalParams}}
 {{#-first}}
 opts = {
 {{/-first}}
-  {{{paramName}}}: {{{example}}}{{^-last}},{{/-last}} # {{{dataType}}} | {{{description}}}
+  {{{paramName}}}: {{{vendorExtensions.x-ruby-example}}}{{^-last}},{{/-last}} # {{{dataType}}} | {{{description}}}
 {{#-last}}
 }
 {{/-last}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
@@ -46,13 +46,13 @@ require '{{{gemName}}}'
 
 api_instance = {{{moduleName}}}::{{{classname}}}.new
 {{#requiredParams}}
-{{{paramName}}} = {{{example}}} # {{{dataType}}} | {{{description}}}
+{{{paramName}}} = {{{vendorExtensions.x-ruby-example}}} # {{{dataType}}} | {{{description}}}
 {{/requiredParams}}
 {{#optionalParams}}
 {{#-first}}
 opts = {
 {{/-first}}
-  {{{paramName}}}: {{{example}}}{{^-last}},{{/-last}} # {{{dataType}}} | {{{description}}}
+  {{{paramName}}}: {{{vendorExtensions.x-ruby-example}}}{{^-last}},{{/-last}} # {{{dataType}}} | {{{description}}}
 {{#-last}}
 }
 {{/-last}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
@@ -26,6 +26,7 @@ All URIs are relative to *{{basePath}}*
 ### Examples
 
 ```ruby
+require 'time'
 require '{{{gemName}}}'
 {{#hasAuthMethods}}
 # setup authorization

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
@@ -38,7 +38,7 @@ require '{{{gemName}}}'
   # Configure API key authorization: {{{name}}}
   config.api_key['{{{keyParamName}}}'] = 'YOUR API KEY'
   # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
-  #config.api_key_prefix['{{{keyParamName}}}'] = 'Bearer'{{/isApiKey}}{{#isOAuth}}
+  # config.api_key_prefix['{{{keyParamName}}}'] = 'Bearer'{{/isApiKey}}{{#isOAuth}}
   # Configure OAuth2 access token for authorization: {{{name}}}
   config.access_token = 'YOUR ACCESS TOKEN'{{/isOAuth}}
 {{/authMethods}}end

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -151,19 +151,19 @@ public class RubyClientCodegenTest {
         Assert.assertEquals(fp.enumName, "ENUM_FORM_STRING_ARRAY");
     }
 
-    @Test(description = "test example value for body parameter")
-    public void bodyParameterTest() {
-        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
-        final RubyClientCodegen codegen = new RubyClientCodegen();
-        codegen.setModuleName("OnlinePetstore");
-        codegen.setOpenAPI(openAPI);
-        final String path = "/pet";
-        final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
-        Assert.assertEquals(op.bodyParams.size(), 1);
-        CodegenParameter bp = op.bodyParams.get(0);
-        Assert.assertEquals(bp.example, "OnlinePetstore::Pet.new");
-    }
+//    @Test(description = "test example value for body parameter")
+//    public void bodyParameterTest() {
+//        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+//        final RubyClientCodegen codegen = new RubyClientCodegen();
+//        codegen.setModuleName("OnlinePetstore");
+//        codegen.setOpenAPI(openAPI);
+//        final String path = "/pet";
+//        final Operation p = openAPI.getPaths().get(path).getPost();
+//        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+//        Assert.assertEquals(op.bodyParams.size(), 1);
+//        CodegenParameter bp = op.bodyParams.get(0);
+//        Assert.assertEquals(bp.example, "OnlinePetstore::Pet.new");
+//    }
 
 
     @Test(description = "test nullable for properties")
@@ -609,35 +609,35 @@ public class RubyClientCodegenTest {
     }
 
 
-    @Test(description = "test example string imported from x-example parameterr (OAS2)")
-    public void exampleStringFromExampleParameterOAS2Test() {
-        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-nullable.yaml");
-        final RubyClientCodegen codegen = new RubyClientCodegen();
-        codegen.setModuleName("OnlinePetstore");
-        codegen.setOpenAPI(openAPI);
-        final String path = "/store/order/{orderId}";
+//    @Test(description = "test example string imported from x-example parameterr (OAS2)")
+//    public void exampleStringFromExampleParameterOAS2Test() {
+//        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-nullable.yaml");
+//        final RubyClientCodegen codegen = new RubyClientCodegen();
+//        codegen.setModuleName("OnlinePetstore");
+//        codegen.setOpenAPI(openAPI);
+//        final String path = "/store/order/{orderId}";
+//
+//        final Operation p = openAPI.getPaths().get(path).getDelete();
+//        final CodegenOperation op = codegen.fromOperation(path, "delete", p, null);
+//
+//        CodegenParameter pp = op.pathParams.get(0);
+//        Assert.assertEquals(pp.example, "'orderid123'");
+//    }
 
-        final Operation p = openAPI.getPaths().get(path).getDelete();
-        final CodegenOperation op = codegen.fromOperation(path, "delete", p, null);
-
-        CodegenParameter pp = op.pathParams.get(0);
-        Assert.assertEquals(pp.example, "'orderid123'");
-    }
-
-    @Test(description = "test example string imported from example in schema (OAS3)")
-    public void exampleStringFromXExampleParameterOAS3Test() {
-        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore_oas3_test.yaml");
-        final RubyClientCodegen codegen = new RubyClientCodegen();
-        codegen.setModuleName("OnlinePetstore");
-        codegen.setOpenAPI(openAPI);
-        final String path = "/store/order/{orderId}";
-
-        final Operation p = openAPI.getPaths().get(path).getDelete();
-        final CodegenOperation op = codegen.fromOperation(path, "delete", p, null);
-
-        CodegenParameter pp = op.pathParams.get(0);
-        Assert.assertEquals(pp.example, "'orderid123'");
-    }
+//    @Test(description = "test example string imported from example in schema (OAS3)")
+//    public void exampleStringFromXExampleParameterOAS3Test() {
+//        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore_oas3_test.yaml");
+//        final RubyClientCodegen codegen = new RubyClientCodegen();
+//        codegen.setModuleName("OnlinePetstore");
+//        codegen.setOpenAPI(openAPI);
+//        final String path = "/store/order/{orderId}";
+//
+//        final Operation p = openAPI.getPaths().get(path).getDelete();
+//        final CodegenOperation op = codegen.fromOperation(path, "delete", p, null);
+//
+//        CodegenParameter pp = op.pathParams.get(0);
+//        Assert.assertEquals(pp.example, "'orderid123'");
+//    }
 
     /**
      * We want to make sure that all Regex patterns:

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -17,6 +17,7 @@
 
 package org.openapitools.codegen.ruby;
 
+import com.google.common.collect.ImmutableMap;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
@@ -29,12 +30,8 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
-import java.util.TreeSet;
 
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -151,19 +148,29 @@ public class RubyClientCodegenTest {
         Assert.assertEquals(fp.enumName, "ENUM_FORM_STRING_ARRAY");
     }
 
-//    @Test(description = "test example value for body parameter")
-//    public void bodyParameterTest() {
-//        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
-//        final RubyClientCodegen codegen = new RubyClientCodegen();
-//        codegen.setModuleName("OnlinePetstore");
-//        codegen.setOpenAPI(openAPI);
-//        final String path = "/pet";
-//        final Operation p = openAPI.getPaths().get(path).getPost();
-//        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
-//        Assert.assertEquals(op.bodyParams.size(), 1);
-//        CodegenParameter bp = op.bodyParams.get(0);
-//        Assert.assertEquals(bp.example, "OnlinePetstore::Pet.new");
-//    }
+    @Test(description = "test example value for body parameter")
+    public void bodyParameterTest() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        final RubyClientCodegen codegen = new RubyClientCodegen();
+        codegen.setModuleName("OnlinePetstore");
+        codegen.setOpenAPI(openAPI);
+
+        final String path = "/pet";
+        final Operation p = openAPI.getPaths().get(path).getPost();
+        Schema schema = openAPI.getComponents().getSchemas().get("Pet");
+        CodegenModel model = codegen.fromModel("Pet", schema);
+        Map<String, Object> modelMap = new HashMap<>();
+        modelMap.put("model", model);
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+
+        Map<String, Object> operations = ImmutableMap.<String, Object>of("operation", Collections.singletonList(op));
+        Map<String, Object> objs = ImmutableMap.of("operations", operations, "imports", new ArrayList<Map<String, String>>());
+        objs = codegen.postProcessOperationsWithModels(objs, Collections.singletonList(modelMap));
+        CodegenOperation postProcessedOp = ((List<CodegenOperation>) ((Map<String, Object>) objs.get("operations")).get("operation")).get(0);
+        Assert.assertEquals(postProcessedOp.bodyParams.size(), 1);
+        CodegenParameter bp = postProcessedOp.bodyParams.get(0);
+        Assert.assertEquals(bp.vendorExtensions.get("x-ruby-example"), "OnlinePetstore::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']})");
+    }
 
 
     @Test(description = "test nullable for properties")
@@ -609,35 +616,45 @@ public class RubyClientCodegenTest {
     }
 
 
-//    @Test(description = "test example string imported from x-example parameterr (OAS2)")
-//    public void exampleStringFromExampleParameterOAS2Test() {
-//        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-nullable.yaml");
-//        final RubyClientCodegen codegen = new RubyClientCodegen();
-//        codegen.setModuleName("OnlinePetstore");
-//        codegen.setOpenAPI(openAPI);
-//        final String path = "/store/order/{orderId}";
-//
-//        final Operation p = openAPI.getPaths().get(path).getDelete();
-//        final CodegenOperation op = codegen.fromOperation(path, "delete", p, null);
-//
-//        CodegenParameter pp = op.pathParams.get(0);
-//        Assert.assertEquals(pp.example, "'orderid123'");
-//    }
+    @Test(description = "test example string imported from x-example parameterr (OAS2)")
+    public void exampleStringFromExampleParameterOAS2Test() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-nullable.yaml");
+        final RubyClientCodegen codegen = new RubyClientCodegen();
+        codegen.setModuleName("OnlinePetstore");
+        codegen.setOpenAPI(openAPI);
+        final String path = "/store/order/{orderId}";
 
-//    @Test(description = "test example string imported from example in schema (OAS3)")
-//    public void exampleStringFromXExampleParameterOAS3Test() {
-//        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore_oas3_test.yaml");
-//        final RubyClientCodegen codegen = new RubyClientCodegen();
-//        codegen.setModuleName("OnlinePetstore");
-//        codegen.setOpenAPI(openAPI);
-//        final String path = "/store/order/{orderId}";
-//
-//        final Operation p = openAPI.getPaths().get(path).getDelete();
-//        final CodegenOperation op = codegen.fromOperation(path, "delete", p, null);
-//
-//        CodegenParameter pp = op.pathParams.get(0);
-//        Assert.assertEquals(pp.example, "'orderid123'");
-//    }
+        final Operation p = openAPI.getPaths().get(path).getDelete();
+        final CodegenOperation op = codegen.fromOperation(path, "delete", p, null);
+
+        Map<String, Object> operations = ImmutableMap.<String, Object>of("operation", Collections.singletonList(op));
+        Map<String, Object> objs = ImmutableMap.of("operations", operations, "imports", new ArrayList<Map<String, String>>());
+        objs = codegen.postProcessOperationsWithModels(objs, Collections.emptyList());
+        CodegenOperation postProcessedOp = ((List<CodegenOperation>) ((Map<String, Object>) objs.get("operations")).get("operation")).get(0);
+
+        CodegenParameter pp = postProcessedOp.pathParams.get(0);
+        Assert.assertEquals(pp.vendorExtensions.get("x-ruby-example"), "'orderid123'");
+    }
+
+    @Test(description = "test example string imported from example in schema (OAS3)")
+    public void exampleStringFromXExampleParameterOAS3Test() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore_oas3_test.yaml");
+        final RubyClientCodegen codegen = new RubyClientCodegen();
+        codegen.setModuleName("OnlinePetstore");
+        codegen.setOpenAPI(openAPI);
+        final String path = "/store/order/{orderId}";
+
+        final Operation p = openAPI.getPaths().get(path).getDelete();
+        final CodegenOperation op = codegen.fromOperation(path, "delete", p, null);
+
+        Map<String, Object> operations = ImmutableMap.<String, Object>of("operation", Collections.singletonList(op));
+        Map<String, Object> objs = ImmutableMap.of("operations", operations, "imports", new ArrayList<Map<String, String>>());
+        objs = codegen.postProcessOperationsWithModels(objs, Collections.emptyList());
+        CodegenOperation postProcessedOp = ((List<CodegenOperation>) ((Map<String, Object>) objs.get("operations")).get("operation")).get(0);
+
+        CodegenParameter pp = postProcessedOp.pathParams.get(0);
+        Assert.assertEquals(pp.vendorExtensions.get("x-ruby-example"), "'orderid123'");
+    }
 
     /**
      * We want to make sure that all Regex patterns:

--- a/samples/client/petstore/ruby-faraday/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/AnotherFakeApi.md
@@ -18,6 +18,7 @@ To test special tags and operation ID starting with number
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::AnotherFakeApi.new

--- a/samples/client/petstore/ruby-faraday/docs/DefaultApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/DefaultApi.md
@@ -16,6 +16,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::DefaultApi.new

--- a/samples/client/petstore/ruby-faraday/docs/FakeApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeApi.md
@@ -618,7 +618,7 @@ api_instance = Petstore::FakeApi.new
 number = 8.14 # Float | None
 double = 1.2 # Float | None
 pattern_without_delimiter = 'pattern_without_delimiter_example' # String | None
-byte = BYTE_ARRAY_DATA_HERE # String | None
+byte = 'BYTE_ARRAY_DATA_HERE' # String | None
 opts = {
   integer: 56, # Integer | None
   int32: 56, # Integer | None
@@ -707,13 +707,13 @@ require 'petstore'
 api_instance = Petstore::FakeApi.new
 opts = {
   enum_header_string_array: ['>'], # Array<String> | Header parameter enum test (string array)
-  enum_header_string: '"_abc"', # String | Header parameter enum test (string)
+  enum_header_string: '_abc', # String | Header parameter enum test (string)
   enum_query_string_array: ['>'], # Array<String> | Query parameter enum test (string array)
-  enum_query_string: '"_abc"', # String | Query parameter enum test (string)
+  enum_query_string: '_abc', # String | Query parameter enum test (string)
   enum_query_integer: 1, # Integer | Query parameter enum test (double)
   enum_query_double: 1.1, # Float | Query parameter enum test (double)
   enum_form_string_array: ['>'], # Array<String> | Form parameter enum test (string array)
-  enum_form_string: '"_abc"' # String | Form parameter enum test (string)
+  enum_form_string: '_abc' # String | Form parameter enum test (string)
 }
 
 begin

--- a/samples/client/petstore/ruby-faraday/docs/FakeApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeApi.md
@@ -94,10 +94,10 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::FakeApi.new
-pet = Petstore::Pet.new({name: "doggie", photo_urls: ["photo_urls_example"]}) # Pet | Pet object that needs to be added to the store
+pet = Petstore::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']}) # Pet | Pet object that needs to be added to the store
 opts = {
-  query_1: "query_1_example", # String | query parameter
-  header_1: "header_1_example" # String | header parameter
+  query_1: 'query_1_example', # String | query parameter
+  header_1: 'header_1_example' # String | header parameter
 }
 
 begin
@@ -358,7 +358,7 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 opts = {
-  body: "body_example" # String | Input string as post body
+  body: 'body_example' # String | Input string as post body
 }
 
 begin
@@ -482,7 +482,7 @@ No authorization required
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-query = "query_example" # String | 
+query = 'query_example' # String | 
 user = Petstore::User.new # User | 
 
 begin
@@ -617,19 +617,19 @@ end
 api_instance = Petstore::FakeApi.new
 number = 8.14 # Float | None
 double = 1.2 # Float | None
-pattern_without_delimiter = "pattern_without_delimiter_example" # String | None
+pattern_without_delimiter = 'pattern_without_delimiter_example' # String | None
 byte = BYTE_ARRAY_DATA_HERE # String | None
 opts = {
   integer: 56, # Integer | None
   int32: 56, # Integer | None
   int64: 789, # Integer | None
   float: 3.4, # Float | None
-  string: "string_example", # String | None
+  string: 'string_example', # String | None
   binary: File.new('/path/to/some/file'), # File | None
-  date: Date.parse(2013-10-20), # Date | None
-  date_time: DateTime.parse(2013-10-20T19:20:30+01:00), # Time | None
-  password: "password_example", # String | None
-  callback: "callback_example" # String | None
+  date: Date.parse('2013-10-20'), # Date | None
+  date_time: DateTime.parse('2013-10-20T19:20:30+01:00'), # Time | None
+  password: 'password_example', # String | None
+  callback: 'callback_example' # String | None
 }
 
 begin
@@ -706,14 +706,14 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 opts = {
-  enum_header_string_array: ["enum_header_string_array_example"], # Array<String> | Header parameter enum test (string array)
-  enum_header_string: "enum_header_string_example", # String | Header parameter enum test (string)
-  enum_query_string_array: ["enum_query_string_array_example"], # Array<String> | Query parameter enum test (string array)
-  enum_query_string: "enum_query_string_example", # String | Query parameter enum test (string)
-  enum_query_integer: 56, # Integer | Query parameter enum test (double)
-  enum_query_double: 1.2, # Float | Query parameter enum test (double)
-  enum_form_string_array: ["inner_example"], # Array<String> | Form parameter enum test (string array)
-  enum_form_string: "enum_form_string_example" # String | Form parameter enum test (string)
+  enum_header_string_array: ['>'], # Array<String> | Header parameter enum test (string array)
+  enum_header_string: '"_abc"', # String | Header parameter enum test (string)
+  enum_query_string_array: ['>'], # Array<String> | Query parameter enum test (string array)
+  enum_query_string: '"_abc"', # String | Query parameter enum test (string)
+  enum_query_integer: 1, # Integer | Query parameter enum test (double)
+  enum_query_double: 1.1, # Float | Query parameter enum test (double)
+  enum_form_string_array: ['>'], # Array<String> | Form parameter enum test (string array)
+  enum_form_string: '"_abc"' # String | Form parameter enum test (string)
 }
 
 begin
@@ -860,7 +860,7 @@ test inline additionalProperties
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-request_body = { key: "inner_example"} # Hash<String, String> | request body
+request_body = { key: 'inner_example'} # Hash<String, String> | request body
 
 begin
   # test inline additionalProperties
@@ -920,8 +920,8 @@ test json serialization of form data
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-param = "param_example" # String | field1
-param2 = "param2_example" # String | field2
+param = 'param_example' # String | field1
+param2 = 'param2_example' # String | field2
 
 begin
   # test json serialization of form data
@@ -984,11 +984,11 @@ To test the collection format in query parameters
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-pipe = ["inner_example"] # Array<String> | 
-ioutil = ["inner_example"] # Array<String> | 
-http = ["inner_example"] # Array<String> | 
-url = ["inner_example"] # Array<String> | 
-context = ["inner_example"] # Array<String> | 
+pipe = ['inner_example'] # Array<String> | 
+ioutil = ['inner_example'] # Array<String> | 
+http = ['inner_example'] # Array<String> | 
+url = ['inner_example'] # Array<String> | 
+context = ['inner_example'] # Array<String> | 
 
 begin
   

--- a/samples/client/petstore/ruby-faraday/docs/FakeApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeApi.md
@@ -30,6 +30,7 @@ Health check endpoint
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -88,6 +89,7 @@ test http signature authentication
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -159,6 +161,7 @@ Test serialization of outer boolean types
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -224,6 +227,7 @@ Test serialization of object with outer number type
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -289,6 +293,7 @@ Test serialization of outer number types
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -354,6 +359,7 @@ Test serialization of outer string types
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -419,6 +425,7 @@ For this test, the body for this request much reference a schema named `File`.
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -479,6 +486,7 @@ No authorization required
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -543,6 +551,7 @@ To test \"client\" model
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -606,6 +615,7 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -627,7 +637,7 @@ opts = {
   string: 'string_example', # String | None
   binary: File.new('/path/to/some/file'), # File | None
   date: Date.parse('2013-10-20'), # Date | None
-  date_time: DateTime.parse('2013-10-20T19:20:30+01:00'), # Time | None
+  date_time: Time.parse('2013-10-20T19:20:30+01:00'), # Time | None
   password: 'password_example', # String | None
   callback: 'callback_example' # String | None
 }
@@ -702,6 +712,7 @@ To test enum parameters
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -780,6 +791,7 @@ Fake endpoint to test group parameters (optional)
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -857,6 +869,7 @@ test inline additionalProperties
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -917,6 +930,7 @@ test json serialization of form data
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -981,6 +995,7 @@ To test the collection format in query parameters
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new

--- a/samples/client/petstore/ruby-faraday/docs/FakeApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeApi.md
@@ -94,10 +94,10 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::FakeApi.new
-pet = Petstore::Pet.new # Pet | Pet object that needs to be added to the store
+pet = Petstore::Pet.new({name: "doggie", photo_urls: ["photo_urls_example"]}) # Pet | Pet object that needs to be added to the store
 opts = {
-  query_1: 'query_1_example', # String | query parameter
-  header_1: 'header_1_example' # String | header parameter
+  query_1: "query_1_example", # String | query parameter
+  header_1: "header_1_example" # String | header parameter
 }
 
 begin
@@ -293,7 +293,7 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 opts = {
-  body: 3.4 # Float | Input number as post body
+  body: 8.14 # Float | Input number as post body
 }
 
 begin
@@ -358,7 +358,7 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 opts = {
-  body: 'body_example' # String | Input string as post body
+  body: "body_example" # String | Input string as post body
 }
 
 begin
@@ -482,7 +482,7 @@ No authorization required
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-query = 'query_example' # String | 
+query = "query_example" # String | 
 user = Petstore::User.new # User | 
 
 begin
@@ -615,21 +615,21 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::FakeApi.new
-number = 3.4 # Float | None
-double = 3.4 # Float | None
-pattern_without_delimiter = 'pattern_without_delimiter_example' # String | None
-byte = 'byte_example' # String | None
+number = 8.14 # Float | None
+double = 1.2 # Float | None
+pattern_without_delimiter = "pattern_without_delimiter_example" # String | None
+byte = BYTE_ARRAY_DATA_HERE # String | None
 opts = {
   integer: 56, # Integer | None
   int32: 56, # Integer | None
-  int64: 56, # Integer | None
+  int64: 789, # Integer | None
   float: 3.4, # Float | None
-  string: 'string_example', # String | None
-  binary: File.new('/path/to/file'), # File | None
-  date: Date.parse('2013-10-20'), # Date | None
-  date_time: Time.parse('2013-10-20T19:20:30+01:00'), # Time | None
-  password: 'password_example', # String | None
-  callback: 'callback_example' # String | None
+  string: "string_example", # String | None
+  binary: File.new('/path/to/some/file'), # File | None
+  date: Date.parse(2013-10-20), # Date | None
+  date_time: DateTime.parse(2013-10-20T19:20:30+01:00), # Time | None
+  password: "password_example", # String | None
+  callback: "callback_example" # String | None
 }
 
 begin
@@ -706,14 +706,14 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 opts = {
-  enum_header_string_array: ['enum_header_string_array_example'], # Array<String> | Header parameter enum test (string array)
-  enum_header_string: '-efg', # String | Header parameter enum test (string)
-  enum_query_string_array: ['enum_query_string_array_example'], # Array<String> | Query parameter enum test (string array)
-  enum_query_string: '-efg', # String | Query parameter enum test (string)
+  enum_header_string_array: ["enum_header_string_array_example"], # Array<String> | Header parameter enum test (string array)
+  enum_header_string: "enum_header_string_example", # String | Header parameter enum test (string)
+  enum_query_string_array: ["enum_query_string_array_example"], # Array<String> | Query parameter enum test (string array)
+  enum_query_string: "enum_query_string_example", # String | Query parameter enum test (string)
   enum_query_integer: 56, # Integer | Query parameter enum test (double)
-  enum_query_double: 3.4, # Float | Query parameter enum test (double)
-  enum_form_string_array: '$', # Array<String> | Form parameter enum test (string array)
-  enum_form_string: '-efg' # String | Form parameter enum test (string)
+  enum_query_double: 1.2, # Float | Query parameter enum test (double)
+  enum_form_string_array: ["inner_example"], # Array<String> | Form parameter enum test (string array)
+  enum_form_string: "enum_form_string_example" # String | Form parameter enum test (string)
 }
 
 begin
@@ -790,11 +790,11 @@ end
 api_instance = Petstore::FakeApi.new
 required_string_group = 56 # Integer | Required String in group parameters
 required_boolean_group = true # Boolean | Required Boolean in group parameters
-required_int64_group = 56 # Integer | Required Integer in group parameters
+required_int64_group = 789 # Integer | Required Integer in group parameters
 opts = {
   string_group: 56, # Integer | String in group parameters
   boolean_group: true, # Boolean | Boolean in group parameters
-  int64_group: 56 # Integer | Integer in group parameters
+  int64_group: 789 # Integer | Integer in group parameters
 }
 
 begin
@@ -860,7 +860,7 @@ test inline additionalProperties
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-request_body = {'key' => 'request_body_example'} # Hash<String, String> | request body
+request_body = { key: "inner_example"} # Hash<String, String> | request body
 
 begin
   # test inline additionalProperties
@@ -920,8 +920,8 @@ test json serialization of form data
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-param = 'param_example' # String | field1
-param2 = 'param2_example' # String | field2
+param = "param_example" # String | field1
+param2 = "param2_example" # String | field2
 
 begin
   # test json serialization of form data
@@ -984,11 +984,11 @@ To test the collection format in query parameters
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-pipe = ['pipe_example'] # Array<String> | 
-ioutil = ['ioutil_example'] # Array<String> | 
-http = ['http_example'] # Array<String> | 
-url = ['url_example'] # Array<String> | 
-context = ['context_example'] # Array<String> | 
+pipe = ["inner_example"] # Array<String> | 
+ioutil = ["inner_example"] # Array<String> | 
+http = ["inner_example"] # Array<String> | 
+url = ["inner_example"] # Array<String> | 
+context = ["inner_example"] # Array<String> | 
 
 begin
   

--- a/samples/client/petstore/ruby-faraday/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeClassnameTags123Api.md
@@ -24,7 +24,7 @@ Petstore.configure do |config|
   # Configure API key authorization: api_key_query
   config.api_key['api_key_query'] = 'YOUR API KEY'
   # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
-  #config.api_key_prefix['api_key_query'] = 'Bearer'
+  # config.api_key_prefix['api_key_query'] = 'Bearer'
 end
 
 api_instance = Petstore::FakeClassnameTags123Api.new

--- a/samples/client/petstore/ruby-faraday/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeClassnameTags123Api.md
@@ -18,6 +18,7 @@ To test class name in snake case
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|

--- a/samples/client/petstore/ruby-faraday/docs/PetApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/PetApi.md
@@ -32,7 +32,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet = Petstore::Pet.new # Pet | Pet object that needs to be added to the store
+pet = Petstore::Pet.new({name: "doggie", photo_urls: ["photo_urls_example"]}) # Pet | Pet object that needs to be added to the store
 
 begin
   # Add a new pet to the store
@@ -97,9 +97,9 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet_id = 56 # Integer | Pet id to delete
+pet_id = 789 # Integer | Pet id to delete
 opts = {
-  api_key: 'api_key_example' # String | 
+  api_key: "api_key_example" # String | 
 }
 
 begin
@@ -168,7 +168,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-status = ['status_example'] # Array<String> | Status values that need to be considered for filter
+status = ["status_example"] # Array<String> | Status values that need to be considered for filter
 
 begin
   # Finds Pets by status
@@ -236,7 +236,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-tags = ['tags_example'] # Array<String> | Tags to filter by
+tags = ["inner_example"] # Array<String> | Tags to filter by
 
 begin
   # Finds Pets by tags
@@ -306,7 +306,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet_id = 56 # Integer | ID of pet to return
+pet_id = 789 # Integer | ID of pet to return
 
 begin
   # Find pet by ID
@@ -372,7 +372,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet = Petstore::Pet.new # Pet | Pet object that needs to be added to the store
+pet = Petstore::Pet.new({name: "doggie", photo_urls: ["photo_urls_example"]}) # Pet | Pet object that needs to be added to the store
 
 begin
   # Update an existing pet
@@ -437,10 +437,10 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet_id = 56 # Integer | ID of pet that needs to be updated
+pet_id = 789 # Integer | ID of pet that needs to be updated
 opts = {
-  name: 'name_example', # String | Updated name of the pet
-  status: 'status_example' # String | Updated status of the pet
+  name: "name_example", # String | Updated name of the pet
+  status: "status_example" # String | Updated status of the pet
 }
 
 begin
@@ -508,10 +508,10 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet_id = 56 # Integer | ID of pet to update
+pet_id = 789 # Integer | ID of pet to update
 opts = {
-  additional_metadata: 'additional_metadata_example', # String | Additional data to pass to server
-  file: File.new('/path/to/file') # File | file to upload
+  additional_metadata: "additional_metadata_example", # String | Additional data to pass to server
+  file: File.new('/path/to/some/file') # File | file to upload
 }
 
 begin
@@ -580,10 +580,10 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet_id = 56 # Integer | ID of pet to update
-required_file = File.new('/path/to/file') # File | file to upload
+pet_id = 789 # Integer | ID of pet to update
+required_file = File.new('/path/to/some/file') # File | file to upload
 opts = {
-  additional_metadata: 'additional_metadata_example' # String | Additional data to pass to server
+  additional_metadata: "additional_metadata_example" # String | Additional data to pass to server
 }
 
 begin

--- a/samples/client/petstore/ruby-faraday/docs/PetApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/PetApi.md
@@ -302,7 +302,7 @@ Petstore.configure do |config|
   # Configure API key authorization: api_key
   config.api_key['api_key'] = 'YOUR API KEY'
   # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
-  #config.api_key_prefix['api_key'] = 'Bearer'
+  # config.api_key_prefix['api_key'] = 'Bearer'
 end
 
 api_instance = Petstore::PetApi.new

--- a/samples/client/petstore/ruby-faraday/docs/PetApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/PetApi.md
@@ -24,6 +24,7 @@ Add a new pet to the store
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -89,6 +90,7 @@ Deletes a pet
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -160,6 +162,7 @@ Multiple status values can be provided with comma separated strings
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -228,6 +231,7 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -296,6 +300,7 @@ Returns a single pet
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -364,6 +369,7 @@ Update an existing pet
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -429,6 +435,7 @@ Updates a pet in the store with form data
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -500,6 +507,7 @@ uploads an image
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -572,6 +580,7 @@ uploads an image (required)
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|

--- a/samples/client/petstore/ruby-faraday/docs/PetApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/PetApi.md
@@ -32,7 +32,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet = Petstore::Pet.new({name: "doggie", photo_urls: ["photo_urls_example"]}) # Pet | Pet object that needs to be added to the store
+pet = Petstore::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']}) # Pet | Pet object that needs to be added to the store
 
 begin
   # Add a new pet to the store
@@ -99,7 +99,7 @@ end
 api_instance = Petstore::PetApi.new
 pet_id = 789 # Integer | Pet id to delete
 opts = {
-  api_key: "api_key_example" # String | 
+  api_key: 'api_key_example' # String | 
 }
 
 begin
@@ -168,7 +168,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-status = ["status_example"] # Array<String> | Status values that need to be considered for filter
+status = ['available'] # Array<String> | Status values that need to be considered for filter
 
 begin
   # Finds Pets by status
@@ -236,7 +236,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-tags = ["inner_example"] # Array<String> | Tags to filter by
+tags = ['inner_example'] # Array<String> | Tags to filter by
 
 begin
   # Finds Pets by tags
@@ -372,7 +372,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet = Petstore::Pet.new({name: "doggie", photo_urls: ["photo_urls_example"]}) # Pet | Pet object that needs to be added to the store
+pet = Petstore::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']}) # Pet | Pet object that needs to be added to the store
 
 begin
   # Update an existing pet
@@ -439,8 +439,8 @@ end
 api_instance = Petstore::PetApi.new
 pet_id = 789 # Integer | ID of pet that needs to be updated
 opts = {
-  name: "name_example", # String | Updated name of the pet
-  status: "status_example" # String | Updated status of the pet
+  name: 'name_example', # String | Updated name of the pet
+  status: 'status_example' # String | Updated status of the pet
 }
 
 begin
@@ -510,7 +510,7 @@ end
 api_instance = Petstore::PetApi.new
 pet_id = 789 # Integer | ID of pet to update
 opts = {
-  additional_metadata: "additional_metadata_example", # String | Additional data to pass to server
+  additional_metadata: 'additional_metadata_example', # String | Additional data to pass to server
   file: File.new('/path/to/some/file') # File | file to upload
 }
 
@@ -583,7 +583,7 @@ api_instance = Petstore::PetApi.new
 pet_id = 789 # Integer | ID of pet to update
 required_file = File.new('/path/to/some/file') # File | file to upload
 opts = {
-  additional_metadata: "additional_metadata_example" # String | Additional data to pass to server
+  additional_metadata: 'additional_metadata_example' # String | Additional data to pass to server
 }
 
 begin

--- a/samples/client/petstore/ruby-faraday/docs/StoreApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/StoreApi.md
@@ -89,7 +89,7 @@ Petstore.configure do |config|
   # Configure API key authorization: api_key
   config.api_key['api_key'] = 'YOUR API KEY'
   # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
-  #config.api_key_prefix['api_key'] = 'Bearer'
+  # config.api_key_prefix['api_key'] = 'Bearer'
 end
 
 api_instance = Petstore::StoreApi.new

--- a/samples/client/petstore/ruby-faraday/docs/StoreApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/StoreApi.md
@@ -21,6 +21,7 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
@@ -83,6 +84,7 @@ Returns a map of status codes to quantities
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -150,6 +152,7 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
@@ -211,6 +214,7 @@ Place an order for a pet
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new

--- a/samples/client/petstore/ruby-faraday/docs/StoreApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/StoreApi.md
@@ -24,7 +24,7 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
-order_id = "order_id_example" # String | ID of the order that needs to be deleted
+order_id = 'order_id_example' # String | ID of the order that needs to be deleted
 
 begin
   # Delete purchase order by ID

--- a/samples/client/petstore/ruby-faraday/docs/StoreApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/StoreApi.md
@@ -24,7 +24,7 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
-order_id = 'order_id_example' # String | ID of the order that needs to be deleted
+order_id = "order_id_example" # String | ID of the order that needs to be deleted
 
 begin
   # Delete purchase order by ID
@@ -153,7 +153,7 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
-order_id = 56 # Integer | ID of pet that needs to be fetched
+order_id = 789 # Integer | ID of pet that needs to be fetched
 
 begin
   # Find purchase order by ID

--- a/samples/client/petstore/ruby-faraday/docs/UserApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/UserApi.md
@@ -25,6 +25,7 @@ This can only be done by the logged in user.
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -85,6 +86,7 @@ Creates list of users with given input array
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -145,6 +147,7 @@ Creates list of users with given input array
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -207,6 +210,7 @@ This can only be done by the logged in user.
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -267,6 +271,7 @@ Get user by user name
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -328,6 +333,7 @@ Logs user into the system
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -391,6 +397,7 @@ Logs out current logged in user session
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -450,6 +457,7 @@ This can only be done by the logged in user.
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new

--- a/samples/client/petstore/ruby-faraday/docs/UserApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/UserApi.md
@@ -210,7 +210,7 @@ This can only be done by the logged in user.
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = 'username_example' # String | The name that needs to be deleted
+username = "username_example" # String | The name that needs to be deleted
 
 begin
   # Delete user
@@ -270,7 +270,7 @@ Get user by user name
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = 'username_example' # String | The name that needs to be fetched. Use user1 for testing.
+username = "username_example" # String | The name that needs to be fetched. Use user1 for testing.
 
 begin
   # Get user by user name
@@ -331,8 +331,8 @@ Logs user into the system
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = 'username_example' # String | The user name for login
-password = 'password_example' # String | The password for login in clear text
+username = "username_example" # String | The user name for login
+password = "password_example" # String | The password for login in clear text
 
 begin
   # Logs user into the system
@@ -453,7 +453,7 @@ This can only be done by the logged in user.
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = 'username_example' # String | name that need to be deleted
+username = "username_example" # String | name that need to be deleted
 user = Petstore::User.new # User | Updated user object
 
 begin

--- a/samples/client/petstore/ruby-faraday/docs/UserApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/UserApi.md
@@ -210,7 +210,7 @@ This can only be done by the logged in user.
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = "username_example" # String | The name that needs to be deleted
+username = 'username_example' # String | The name that needs to be deleted
 
 begin
   # Delete user
@@ -270,7 +270,7 @@ Get user by user name
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = "username_example" # String | The name that needs to be fetched. Use user1 for testing.
+username = 'username_example' # String | The name that needs to be fetched. Use user1 for testing.
 
 begin
   # Get user by user name
@@ -331,8 +331,8 @@ Logs user into the system
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = "username_example" # String | The user name for login
-password = "password_example" # String | The password for login in clear text
+username = 'username_example' # String | The user name for login
+password = 'password_example' # String | The password for login in clear text
 
 begin
   # Logs user into the system
@@ -453,7 +453,7 @@ This can only be done by the logged in user.
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = "username_example" # String | name that need to be deleted
+username = 'username_example' # String | name that need to be deleted
 user = Petstore::User.new # User | Updated user object
 
 begin

--- a/samples/client/petstore/ruby/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/ruby/docs/AnotherFakeApi.md
@@ -18,6 +18,7 @@ To test special tags and operation ID starting with number
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::AnotherFakeApi.new

--- a/samples/client/petstore/ruby/docs/DefaultApi.md
+++ b/samples/client/petstore/ruby/docs/DefaultApi.md
@@ -16,6 +16,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::DefaultApi.new

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -618,7 +618,7 @@ api_instance = Petstore::FakeApi.new
 number = 8.14 # Float | None
 double = 1.2 # Float | None
 pattern_without_delimiter = 'pattern_without_delimiter_example' # String | None
-byte = BYTE_ARRAY_DATA_HERE # String | None
+byte = 'BYTE_ARRAY_DATA_HERE' # String | None
 opts = {
   integer: 56, # Integer | None
   int32: 56, # Integer | None
@@ -707,13 +707,13 @@ require 'petstore'
 api_instance = Petstore::FakeApi.new
 opts = {
   enum_header_string_array: ['>'], # Array<String> | Header parameter enum test (string array)
-  enum_header_string: '"_abc"', # String | Header parameter enum test (string)
+  enum_header_string: '_abc', # String | Header parameter enum test (string)
   enum_query_string_array: ['>'], # Array<String> | Query parameter enum test (string array)
-  enum_query_string: '"_abc"', # String | Query parameter enum test (string)
+  enum_query_string: '_abc', # String | Query parameter enum test (string)
   enum_query_integer: 1, # Integer | Query parameter enum test (double)
   enum_query_double: 1.1, # Float | Query parameter enum test (double)
   enum_form_string_array: ['>'], # Array<String> | Form parameter enum test (string array)
-  enum_form_string: '"_abc"' # String | Form parameter enum test (string)
+  enum_form_string: '_abc' # String | Form parameter enum test (string)
 }
 
 begin

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -94,10 +94,10 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::FakeApi.new
-pet = Petstore::Pet.new({name: "doggie", photo_urls: ["photo_urls_example"]}) # Pet | Pet object that needs to be added to the store
+pet = Petstore::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']}) # Pet | Pet object that needs to be added to the store
 opts = {
-  query_1: "query_1_example", # String | query parameter
-  header_1: "header_1_example" # String | header parameter
+  query_1: 'query_1_example', # String | query parameter
+  header_1: 'header_1_example' # String | header parameter
 }
 
 begin
@@ -358,7 +358,7 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 opts = {
-  body: "body_example" # String | Input string as post body
+  body: 'body_example' # String | Input string as post body
 }
 
 begin
@@ -482,7 +482,7 @@ No authorization required
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-query = "query_example" # String | 
+query = 'query_example' # String | 
 user = Petstore::User.new # User | 
 
 begin
@@ -617,19 +617,19 @@ end
 api_instance = Petstore::FakeApi.new
 number = 8.14 # Float | None
 double = 1.2 # Float | None
-pattern_without_delimiter = "pattern_without_delimiter_example" # String | None
+pattern_without_delimiter = 'pattern_without_delimiter_example' # String | None
 byte = BYTE_ARRAY_DATA_HERE # String | None
 opts = {
   integer: 56, # Integer | None
   int32: 56, # Integer | None
   int64: 789, # Integer | None
   float: 3.4, # Float | None
-  string: "string_example", # String | None
+  string: 'string_example', # String | None
   binary: File.new('/path/to/some/file'), # File | None
-  date: Date.parse(2013-10-20), # Date | None
-  date_time: DateTime.parse(2013-10-20T19:20:30+01:00), # Time | None
-  password: "password_example", # String | None
-  callback: "callback_example" # String | None
+  date: Date.parse('2013-10-20'), # Date | None
+  date_time: DateTime.parse('2013-10-20T19:20:30+01:00'), # Time | None
+  password: 'password_example', # String | None
+  callback: 'callback_example' # String | None
 }
 
 begin
@@ -706,14 +706,14 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 opts = {
-  enum_header_string_array: ["enum_header_string_array_example"], # Array<String> | Header parameter enum test (string array)
-  enum_header_string: "enum_header_string_example", # String | Header parameter enum test (string)
-  enum_query_string_array: ["enum_query_string_array_example"], # Array<String> | Query parameter enum test (string array)
-  enum_query_string: "enum_query_string_example", # String | Query parameter enum test (string)
-  enum_query_integer: 56, # Integer | Query parameter enum test (double)
-  enum_query_double: 1.2, # Float | Query parameter enum test (double)
-  enum_form_string_array: ["inner_example"], # Array<String> | Form parameter enum test (string array)
-  enum_form_string: "enum_form_string_example" # String | Form parameter enum test (string)
+  enum_header_string_array: ['>'], # Array<String> | Header parameter enum test (string array)
+  enum_header_string: '"_abc"', # String | Header parameter enum test (string)
+  enum_query_string_array: ['>'], # Array<String> | Query parameter enum test (string array)
+  enum_query_string: '"_abc"', # String | Query parameter enum test (string)
+  enum_query_integer: 1, # Integer | Query parameter enum test (double)
+  enum_query_double: 1.1, # Float | Query parameter enum test (double)
+  enum_form_string_array: ['>'], # Array<String> | Form parameter enum test (string array)
+  enum_form_string: '"_abc"' # String | Form parameter enum test (string)
 }
 
 begin
@@ -860,7 +860,7 @@ test inline additionalProperties
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-request_body = { key: "inner_example"} # Hash<String, String> | request body
+request_body = { key: 'inner_example'} # Hash<String, String> | request body
 
 begin
   # test inline additionalProperties
@@ -920,8 +920,8 @@ test json serialization of form data
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-param = "param_example" # String | field1
-param2 = "param2_example" # String | field2
+param = 'param_example' # String | field1
+param2 = 'param2_example' # String | field2
 
 begin
   # test json serialization of form data
@@ -984,11 +984,11 @@ To test the collection format in query parameters
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-pipe = ["inner_example"] # Array<String> | 
-ioutil = ["inner_example"] # Array<String> | 
-http = ["inner_example"] # Array<String> | 
-url = ["inner_example"] # Array<String> | 
-context = ["inner_example"] # Array<String> | 
+pipe = ['inner_example'] # Array<String> | 
+ioutil = ['inner_example'] # Array<String> | 
+http = ['inner_example'] # Array<String> | 
+url = ['inner_example'] # Array<String> | 
+context = ['inner_example'] # Array<String> | 
 
 begin
   

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -30,6 +30,7 @@ Health check endpoint
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -88,6 +89,7 @@ test http signature authentication
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -159,6 +161,7 @@ Test serialization of outer boolean types
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -224,6 +227,7 @@ Test serialization of object with outer number type
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -289,6 +293,7 @@ Test serialization of outer number types
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -354,6 +359,7 @@ Test serialization of outer string types
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -419,6 +425,7 @@ For this test, the body for this request much reference a schema named `File`.
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -479,6 +486,7 @@ No authorization required
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -543,6 +551,7 @@ To test \"client\" model
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -606,6 +615,7 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -627,7 +637,7 @@ opts = {
   string: 'string_example', # String | None
   binary: File.new('/path/to/some/file'), # File | None
   date: Date.parse('2013-10-20'), # Date | None
-  date_time: DateTime.parse('2013-10-20T19:20:30+01:00'), # Time | None
+  date_time: Time.parse('2013-10-20T19:20:30+01:00'), # Time | None
   password: 'password_example', # String | None
   callback: 'callback_example' # String | None
 }
@@ -702,6 +712,7 @@ To test enum parameters
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -780,6 +791,7 @@ Fake endpoint to test group parameters (optional)
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -857,6 +869,7 @@ test inline additionalProperties
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -917,6 +930,7 @@ test json serialization of form data
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -981,6 +995,7 @@ To test the collection format in query parameters
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -94,10 +94,10 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::FakeApi.new
-pet = Petstore::Pet.new # Pet | Pet object that needs to be added to the store
+pet = Petstore::Pet.new({name: "doggie", photo_urls: ["photo_urls_example"]}) # Pet | Pet object that needs to be added to the store
 opts = {
-  query_1: 'query_1_example', # String | query parameter
-  header_1: 'header_1_example' # String | header parameter
+  query_1: "query_1_example", # String | query parameter
+  header_1: "header_1_example" # String | header parameter
 }
 
 begin
@@ -293,7 +293,7 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 opts = {
-  body: 3.4 # Float | Input number as post body
+  body: 8.14 # Float | Input number as post body
 }
 
 begin
@@ -358,7 +358,7 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 opts = {
-  body: 'body_example' # String | Input string as post body
+  body: "body_example" # String | Input string as post body
 }
 
 begin
@@ -482,7 +482,7 @@ No authorization required
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-query = 'query_example' # String | 
+query = "query_example" # String | 
 user = Petstore::User.new # User | 
 
 begin
@@ -615,21 +615,21 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::FakeApi.new
-number = 3.4 # Float | None
-double = 3.4 # Float | None
-pattern_without_delimiter = 'pattern_without_delimiter_example' # String | None
-byte = 'byte_example' # String | None
+number = 8.14 # Float | None
+double = 1.2 # Float | None
+pattern_without_delimiter = "pattern_without_delimiter_example" # String | None
+byte = BYTE_ARRAY_DATA_HERE # String | None
 opts = {
   integer: 56, # Integer | None
   int32: 56, # Integer | None
-  int64: 56, # Integer | None
+  int64: 789, # Integer | None
   float: 3.4, # Float | None
-  string: 'string_example', # String | None
-  binary: File.new('/path/to/file'), # File | None
-  date: Date.parse('2013-10-20'), # Date | None
-  date_time: Time.parse('2013-10-20T19:20:30+01:00'), # Time | None
-  password: 'password_example', # String | None
-  callback: 'callback_example' # String | None
+  string: "string_example", # String | None
+  binary: File.new('/path/to/some/file'), # File | None
+  date: Date.parse(2013-10-20), # Date | None
+  date_time: DateTime.parse(2013-10-20T19:20:30+01:00), # Time | None
+  password: "password_example", # String | None
+  callback: "callback_example" # String | None
 }
 
 begin
@@ -706,14 +706,14 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 opts = {
-  enum_header_string_array: ['enum_header_string_array_example'], # Array<String> | Header parameter enum test (string array)
-  enum_header_string: '-efg', # String | Header parameter enum test (string)
-  enum_query_string_array: ['enum_query_string_array_example'], # Array<String> | Query parameter enum test (string array)
-  enum_query_string: '-efg', # String | Query parameter enum test (string)
+  enum_header_string_array: ["enum_header_string_array_example"], # Array<String> | Header parameter enum test (string array)
+  enum_header_string: "enum_header_string_example", # String | Header parameter enum test (string)
+  enum_query_string_array: ["enum_query_string_array_example"], # Array<String> | Query parameter enum test (string array)
+  enum_query_string: "enum_query_string_example", # String | Query parameter enum test (string)
   enum_query_integer: 56, # Integer | Query parameter enum test (double)
-  enum_query_double: 3.4, # Float | Query parameter enum test (double)
-  enum_form_string_array: '$', # Array<String> | Form parameter enum test (string array)
-  enum_form_string: '-efg' # String | Form parameter enum test (string)
+  enum_query_double: 1.2, # Float | Query parameter enum test (double)
+  enum_form_string_array: ["inner_example"], # Array<String> | Form parameter enum test (string array)
+  enum_form_string: "enum_form_string_example" # String | Form parameter enum test (string)
 }
 
 begin
@@ -790,11 +790,11 @@ end
 api_instance = Petstore::FakeApi.new
 required_string_group = 56 # Integer | Required String in group parameters
 required_boolean_group = true # Boolean | Required Boolean in group parameters
-required_int64_group = 56 # Integer | Required Integer in group parameters
+required_int64_group = 789 # Integer | Required Integer in group parameters
 opts = {
   string_group: 56, # Integer | String in group parameters
   boolean_group: true, # Boolean | Boolean in group parameters
-  int64_group: 56 # Integer | Integer in group parameters
+  int64_group: 789 # Integer | Integer in group parameters
 }
 
 begin
@@ -860,7 +860,7 @@ test inline additionalProperties
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-request_body = {'key' => 'request_body_example'} # Hash<String, String> | request body
+request_body = { key: "inner_example"} # Hash<String, String> | request body
 
 begin
   # test inline additionalProperties
@@ -920,8 +920,8 @@ test json serialization of form data
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-param = 'param_example' # String | field1
-param2 = 'param2_example' # String | field2
+param = "param_example" # String | field1
+param2 = "param2_example" # String | field2
 
 begin
   # test json serialization of form data
@@ -984,11 +984,11 @@ To test the collection format in query parameters
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
-pipe = ['pipe_example'] # Array<String> | 
-ioutil = ['ioutil_example'] # Array<String> | 
-http = ['http_example'] # Array<String> | 
-url = ['url_example'] # Array<String> | 
-context = ['context_example'] # Array<String> | 
+pipe = ["inner_example"] # Array<String> | 
+ioutil = ["inner_example"] # Array<String> | 
+http = ["inner_example"] # Array<String> | 
+url = ["inner_example"] # Array<String> | 
+context = ["inner_example"] # Array<String> | 
 
 begin
   

--- a/samples/client/petstore/ruby/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/ruby/docs/FakeClassnameTags123Api.md
@@ -24,7 +24,7 @@ Petstore.configure do |config|
   # Configure API key authorization: api_key_query
   config.api_key['api_key_query'] = 'YOUR API KEY'
   # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
-  #config.api_key_prefix['api_key_query'] = 'Bearer'
+  # config.api_key_prefix['api_key_query'] = 'Bearer'
 end
 
 api_instance = Petstore::FakeClassnameTags123Api.new

--- a/samples/client/petstore/ruby/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/ruby/docs/FakeClassnameTags123Api.md
@@ -18,6 +18,7 @@ To test class name in snake case
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|

--- a/samples/client/petstore/ruby/docs/PetApi.md
+++ b/samples/client/petstore/ruby/docs/PetApi.md
@@ -32,7 +32,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet = Petstore::Pet.new # Pet | Pet object that needs to be added to the store
+pet = Petstore::Pet.new({name: "doggie", photo_urls: ["photo_urls_example"]}) # Pet | Pet object that needs to be added to the store
 
 begin
   # Add a new pet to the store
@@ -97,9 +97,9 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet_id = 56 # Integer | Pet id to delete
+pet_id = 789 # Integer | Pet id to delete
 opts = {
-  api_key: 'api_key_example' # String | 
+  api_key: "api_key_example" # String | 
 }
 
 begin
@@ -168,7 +168,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-status = ['status_example'] # Array<String> | Status values that need to be considered for filter
+status = ["status_example"] # Array<String> | Status values that need to be considered for filter
 
 begin
   # Finds Pets by status
@@ -236,7 +236,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-tags = ['tags_example'] # Array<String> | Tags to filter by
+tags = ["inner_example"] # Array<String> | Tags to filter by
 
 begin
   # Finds Pets by tags
@@ -306,7 +306,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet_id = 56 # Integer | ID of pet to return
+pet_id = 789 # Integer | ID of pet to return
 
 begin
   # Find pet by ID
@@ -372,7 +372,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet = Petstore::Pet.new # Pet | Pet object that needs to be added to the store
+pet = Petstore::Pet.new({name: "doggie", photo_urls: ["photo_urls_example"]}) # Pet | Pet object that needs to be added to the store
 
 begin
   # Update an existing pet
@@ -437,10 +437,10 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet_id = 56 # Integer | ID of pet that needs to be updated
+pet_id = 789 # Integer | ID of pet that needs to be updated
 opts = {
-  name: 'name_example', # String | Updated name of the pet
-  status: 'status_example' # String | Updated status of the pet
+  name: "name_example", # String | Updated name of the pet
+  status: "status_example" # String | Updated status of the pet
 }
 
 begin
@@ -508,10 +508,10 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet_id = 56 # Integer | ID of pet to update
+pet_id = 789 # Integer | ID of pet to update
 opts = {
-  additional_metadata: 'additional_metadata_example', # String | Additional data to pass to server
-  file: File.new('/path/to/file') # File | file to upload
+  additional_metadata: "additional_metadata_example", # String | Additional data to pass to server
+  file: File.new('/path/to/some/file') # File | file to upload
 }
 
 begin
@@ -580,10 +580,10 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet_id = 56 # Integer | ID of pet to update
-required_file = File.new('/path/to/file') # File | file to upload
+pet_id = 789 # Integer | ID of pet to update
+required_file = File.new('/path/to/some/file') # File | file to upload
 opts = {
-  additional_metadata: 'additional_metadata_example' # String | Additional data to pass to server
+  additional_metadata: "additional_metadata_example" # String | Additional data to pass to server
 }
 
 begin

--- a/samples/client/petstore/ruby/docs/PetApi.md
+++ b/samples/client/petstore/ruby/docs/PetApi.md
@@ -302,7 +302,7 @@ Petstore.configure do |config|
   # Configure API key authorization: api_key
   config.api_key['api_key'] = 'YOUR API KEY'
   # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
-  #config.api_key_prefix['api_key'] = 'Bearer'
+  # config.api_key_prefix['api_key'] = 'Bearer'
 end
 
 api_instance = Petstore::PetApi.new

--- a/samples/client/petstore/ruby/docs/PetApi.md
+++ b/samples/client/petstore/ruby/docs/PetApi.md
@@ -24,6 +24,7 @@ Add a new pet to the store
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -89,6 +90,7 @@ Deletes a pet
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -160,6 +162,7 @@ Multiple status values can be provided with comma separated strings
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -228,6 +231,7 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -296,6 +300,7 @@ Returns a single pet
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -364,6 +369,7 @@ Update an existing pet
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -429,6 +435,7 @@ Updates a pet in the store with form data
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -500,6 +507,7 @@ uploads an image
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -572,6 +580,7 @@ uploads an image (required)
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|

--- a/samples/client/petstore/ruby/docs/PetApi.md
+++ b/samples/client/petstore/ruby/docs/PetApi.md
@@ -32,7 +32,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet = Petstore::Pet.new({name: "doggie", photo_urls: ["photo_urls_example"]}) # Pet | Pet object that needs to be added to the store
+pet = Petstore::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']}) # Pet | Pet object that needs to be added to the store
 
 begin
   # Add a new pet to the store
@@ -99,7 +99,7 @@ end
 api_instance = Petstore::PetApi.new
 pet_id = 789 # Integer | Pet id to delete
 opts = {
-  api_key: "api_key_example" # String | 
+  api_key: 'api_key_example' # String | 
 }
 
 begin
@@ -168,7 +168,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-status = ["status_example"] # Array<String> | Status values that need to be considered for filter
+status = ['available'] # Array<String> | Status values that need to be considered for filter
 
 begin
   # Finds Pets by status
@@ -236,7 +236,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-tags = ["inner_example"] # Array<String> | Tags to filter by
+tags = ['inner_example'] # Array<String> | Tags to filter by
 
 begin
   # Finds Pets by tags
@@ -372,7 +372,7 @@ Petstore.configure do |config|
 end
 
 api_instance = Petstore::PetApi.new
-pet = Petstore::Pet.new({name: "doggie", photo_urls: ["photo_urls_example"]}) # Pet | Pet object that needs to be added to the store
+pet = Petstore::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']}) # Pet | Pet object that needs to be added to the store
 
 begin
   # Update an existing pet
@@ -439,8 +439,8 @@ end
 api_instance = Petstore::PetApi.new
 pet_id = 789 # Integer | ID of pet that needs to be updated
 opts = {
-  name: "name_example", # String | Updated name of the pet
-  status: "status_example" # String | Updated status of the pet
+  name: 'name_example', # String | Updated name of the pet
+  status: 'status_example' # String | Updated status of the pet
 }
 
 begin
@@ -510,7 +510,7 @@ end
 api_instance = Petstore::PetApi.new
 pet_id = 789 # Integer | ID of pet to update
 opts = {
-  additional_metadata: "additional_metadata_example", # String | Additional data to pass to server
+  additional_metadata: 'additional_metadata_example', # String | Additional data to pass to server
   file: File.new('/path/to/some/file') # File | file to upload
 }
 
@@ -583,7 +583,7 @@ api_instance = Petstore::PetApi.new
 pet_id = 789 # Integer | ID of pet to update
 required_file = File.new('/path/to/some/file') # File | file to upload
 opts = {
-  additional_metadata: "additional_metadata_example" # String | Additional data to pass to server
+  additional_metadata: 'additional_metadata_example' # String | Additional data to pass to server
 }
 
 begin

--- a/samples/client/petstore/ruby/docs/StoreApi.md
+++ b/samples/client/petstore/ruby/docs/StoreApi.md
@@ -89,7 +89,7 @@ Petstore.configure do |config|
   # Configure API key authorization: api_key
   config.api_key['api_key'] = 'YOUR API KEY'
   # Uncomment the following line to set a prefix for the API key, e.g. 'Bearer' (defaults to nil)
-  #config.api_key_prefix['api_key'] = 'Bearer'
+  # config.api_key_prefix['api_key'] = 'Bearer'
 end
 
 api_instance = Petstore::StoreApi.new

--- a/samples/client/petstore/ruby/docs/StoreApi.md
+++ b/samples/client/petstore/ruby/docs/StoreApi.md
@@ -21,6 +21,7 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
@@ -83,6 +84,7 @@ Returns a map of status codes to quantities
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -150,6 +152,7 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
@@ -211,6 +214,7 @@ Place an order for a pet
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new

--- a/samples/client/petstore/ruby/docs/StoreApi.md
+++ b/samples/client/petstore/ruby/docs/StoreApi.md
@@ -24,7 +24,7 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
-order_id = "order_id_example" # String | ID of the order that needs to be deleted
+order_id = 'order_id_example' # String | ID of the order that needs to be deleted
 
 begin
   # Delete purchase order by ID

--- a/samples/client/petstore/ruby/docs/StoreApi.md
+++ b/samples/client/petstore/ruby/docs/StoreApi.md
@@ -24,7 +24,7 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
-order_id = 'order_id_example' # String | ID of the order that needs to be deleted
+order_id = "order_id_example" # String | ID of the order that needs to be deleted
 
 begin
   # Delete purchase order by ID
@@ -153,7 +153,7 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
-order_id = 56 # Integer | ID of pet that needs to be fetched
+order_id = 789 # Integer | ID of pet that needs to be fetched
 
 begin
   # Find purchase order by ID

--- a/samples/client/petstore/ruby/docs/UserApi.md
+++ b/samples/client/petstore/ruby/docs/UserApi.md
@@ -25,6 +25,7 @@ This can only be done by the logged in user.
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -85,6 +86,7 @@ Creates list of users with given input array
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -145,6 +147,7 @@ Creates list of users with given input array
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -207,6 +210,7 @@ This can only be done by the logged in user.
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -267,6 +271,7 @@ Get user by user name
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -328,6 +333,7 @@ Logs user into the system
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -391,6 +397,7 @@ Logs out current logged in user session
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -450,6 +457,7 @@ This can only be done by the logged in user.
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UserApi.new

--- a/samples/client/petstore/ruby/docs/UserApi.md
+++ b/samples/client/petstore/ruby/docs/UserApi.md
@@ -210,7 +210,7 @@ This can only be done by the logged in user.
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = 'username_example' # String | The name that needs to be deleted
+username = "username_example" # String | The name that needs to be deleted
 
 begin
   # Delete user
@@ -270,7 +270,7 @@ Get user by user name
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = 'username_example' # String | The name that needs to be fetched. Use user1 for testing.
+username = "username_example" # String | The name that needs to be fetched. Use user1 for testing.
 
 begin
   # Get user by user name
@@ -331,8 +331,8 @@ Logs user into the system
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = 'username_example' # String | The user name for login
-password = 'password_example' # String | The password for login in clear text
+username = "username_example" # String | The user name for login
+password = "password_example" # String | The password for login in clear text
 
 begin
   # Logs user into the system
@@ -453,7 +453,7 @@ This can only be done by the logged in user.
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = 'username_example' # String | name that need to be deleted
+username = "username_example" # String | name that need to be deleted
 user = Petstore::User.new # User | Updated user object
 
 begin

--- a/samples/client/petstore/ruby/docs/UserApi.md
+++ b/samples/client/petstore/ruby/docs/UserApi.md
@@ -210,7 +210,7 @@ This can only be done by the logged in user.
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = "username_example" # String | The name that needs to be deleted
+username = 'username_example' # String | The name that needs to be deleted
 
 begin
   # Delete user
@@ -270,7 +270,7 @@ Get user by user name
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = "username_example" # String | The name that needs to be fetched. Use user1 for testing.
+username = 'username_example' # String | The name that needs to be fetched. Use user1 for testing.
 
 begin
   # Get user by user name
@@ -331,8 +331,8 @@ Logs user into the system
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = "username_example" # String | The user name for login
-password = "password_example" # String | The password for login in clear text
+username = 'username_example' # String | The user name for login
+password = 'password_example' # String | The password for login in clear text
 
 begin
   # Logs user into the system
@@ -453,7 +453,7 @@ This can only be done by the logged in user.
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
-username = "username_example" # String | name that need to be deleted
+username = 'username_example' # String | name that need to be deleted
 user = Petstore::User.new # User | Updated user object
 
 begin

--- a/samples/openapi3/client/features/dynamic-servers/ruby/docs/UsageApi.md
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/docs/UsageApi.md
@@ -19,6 +19,7 @@ Use custom server
 ### Examples
 
 ```ruby
+require 'time'
 require 'dynamic_servers'
 
 api_instance = DynamicServers::UsageApi.new
@@ -79,6 +80,7 @@ Use default server
 ### Examples
 
 ```ruby
+require 'time'
 require 'dynamic_servers'
 
 api_instance = DynamicServers::UsageApi.new

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/UsageApi.md
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/UsageApi.md
@@ -19,6 +19,7 @@ Use alias to array
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UsageApi.new
@@ -84,6 +85,7 @@ Use alias to map
 ### Examples
 
 ```ruby
+require 'time'
 require 'petstore'
 
 api_instance = Petstore::UsageApi.new


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Improve ruby client examples for models, by building models with required properties set.
Goal is to have examples a bit more copy/pastable directly
Adds `constructExampleCode` methods, similarly to a few other clients like go, or powershell

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
