### PR TITLE
[cpprest] Deserialize Float without decimal point

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-source.mustache
@@ -224,6 +224,10 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
         localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
         {{/bodyParam}}
     }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
+    }
     else
     {
         throw ApiException(415, utility::conversions::to_string_t("{{classname}}->{{operationId}} does not consume any supported media type"));

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-header.mustache
@@ -126,7 +126,7 @@ public:
     static bool fromHttpContent( std::shared_ptr<HttpContent> val, utility::datetime & );
     static bool fromHttpContent( std::shared_ptr<HttpContent> val, web::json::value & );
     static bool fromHttpContent( std::shared_ptr<HttpContent> val, std::shared_ptr<HttpContent>& );
-    template <typename T>    
+    template <typename T>
     static bool fromHttpContent( std::shared_ptr<HttpContent> val, std::shared_ptr<T>& );
     template <typename T>
     static bool fromHttpContent( std::shared_ptr<HttpContent> val, std::vector<T> & );

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-source.mustache
@@ -136,7 +136,12 @@ bool ModelBase::fromString( const utility::string_t& val, float &outVal )
     }
     catch (...)
     {
-        success = false;
+        int64_t intVal = 0;
+        success = ModelBase::fromString(val, intVal);
+        if(success)
+        {
+            outVal = static_cast<float>(intVal);
+        }
     }
     return success;
 }
@@ -150,7 +155,12 @@ bool ModelBase::fromString( const utility::string_t& val, double &outVal )
     }
     catch (...)
     {
-        success = false;
+        int64_t intVal = 0;
+        success = ModelBase::fromString(val, intVal);
+        if(success)
+        {
+            outVal = static_cast<double>(intVal);
+        }
     }
     return success;
 }
@@ -281,7 +291,7 @@ bool ModelBase::fromJson( const web::json::value& val, std::shared_ptr<HttpConte
         if(content == nullptr)
         {
             content = std::shared_ptr<HttpContent>(new HttpContent());
-        }        
+        }
         if(val.has_field(utility::conversions::to_string_t("ContentDisposition")))
         {
             utility::string_t value;

--- a/samples/client/petstore/cpp-restsdk/client/ModelBase.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/ModelBase.cpp
@@ -147,7 +147,12 @@ bool ModelBase::fromString( const utility::string_t& val, float &outVal )
     }
     catch (...)
     {
-        success = false;
+        int64_t intVal = 0;
+        success = ModelBase::fromString(val, intVal);
+        if(success)
+        {
+            outVal = static_cast<float>(intVal);
+        }
     }
     return success;
 }
@@ -161,7 +166,12 @@ bool ModelBase::fromString( const utility::string_t& val, double &outVal )
     }
     catch (...)
     {
-        success = false;
+        int64_t intVal = 0;
+        success = ModelBase::fromString(val, intVal);
+        if(success)
+        {
+            outVal = static_cast<double>(intVal);
+        }
     }
     return success;
 }
@@ -292,7 +302,7 @@ bool ModelBase::fromJson( const web::json::value& val, std::shared_ptr<HttpConte
         if(content == nullptr)
         {
             content = std::shared_ptr<HttpContent>(new HttpContent());
-        }        
+        }
         if(val.has_field(utility::conversions::to_string_t("ContentDisposition")))
         {
             utility::string_t value;

--- a/samples/client/petstore/cpp-restsdk/client/ModelBase.h
+++ b/samples/client/petstore/cpp-restsdk/client/ModelBase.h
@@ -137,7 +137,7 @@ public:
     static bool fromHttpContent( std::shared_ptr<HttpContent> val, utility::datetime & );
     static bool fromHttpContent( std::shared_ptr<HttpContent> val, web::json::value & );
     static bool fromHttpContent( std::shared_ptr<HttpContent> val, std::shared_ptr<HttpContent>& );
-    template <typename T>    
+    template <typename T>
     static bool fromHttpContent( std::shared_ptr<HttpContent> val, std::shared_ptr<T>& );
     template <typename T>
     static bool fromHttpContent( std::shared_ptr<HttpContent> val, std::vector<T> & );

--- a/samples/client/petstore/cpp-restsdk/client/api/PetApi.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/api/PetApi.cpp
@@ -113,6 +113,10 @@ pplx::task<void> PetApi::addPet(std::shared_ptr<Pet> body) const
         localVarHttpBody = localVarMultipart;
         localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
     }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
+    }
     else
     {
         throw ApiException(415, utility::conversions::to_string_t("PetApi->addPet does not consume any supported media type"));
@@ -219,6 +223,10 @@ pplx::task<void> PetApi::deletePet(int64_t petId, boost::optional<utility::strin
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
+    }
     else
     {
         throw ApiException(415, utility::conversions::to_string_t("PetApi->deletePet does not consume any supported media type"));
@@ -324,6 +332,10 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByStatus(std::vect
     else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+    }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
     }
     else
     {
@@ -453,6 +465,10 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
+    }
     else
     {
         throw ApiException(415, utility::conversions::to_string_t("PetApi->findPetsByTags does not consume any supported media type"));
@@ -578,6 +594,10 @@ pplx::task<std::shared_ptr<Pet>> PetApi::getPetById(int64_t petId) const
     else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+    }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
     }
     else
     {
@@ -728,6 +748,10 @@ pplx::task<void> PetApi::updatePet(std::shared_ptr<Pet> body) const
         localVarHttpBody = localVarMultipart;
         localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
     }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
+    }
     else
     {
         throw ApiException(415, utility::conversions::to_string_t("PetApi->updatePet does not consume any supported media type"));
@@ -838,6 +862,10 @@ pplx::task<void> PetApi::updatePetWithForm(int64_t petId, boost::optional<utilit
     else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+    }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
     }
     else
     {
@@ -950,6 +978,10 @@ pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, boost
     else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+    }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
     }
     else
     {

--- a/samples/client/petstore/cpp-restsdk/client/api/StoreApi.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/api/StoreApi.cpp
@@ -90,6 +90,10 @@ pplx::task<void> StoreApi::deleteOrder(utility::string_t orderId) const
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
+    }
     else
     {
         throw ApiException(415, utility::conversions::to_string_t("StoreApi->deleteOrder does not consume any supported media type"));
@@ -189,6 +193,10 @@ pplx::task<std::map<utility::string_t, int32_t>> StoreApi::getInventory() const
     else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+    }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
     }
     else
     {
@@ -322,6 +330,10 @@ pplx::task<std::shared_ptr<Order>> StoreApi::getOrderById(int64_t orderId) const
     else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+    }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
     }
     else
     {
@@ -463,6 +475,10 @@ pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> b
 
         localVarHttpBody = localVarMultipart;
         localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
+    }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
     }
     else
     {

--- a/samples/client/petstore/cpp-restsdk/client/api/UserApi.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/api/UserApi.cpp
@@ -111,6 +111,10 @@ pplx::task<void> UserApi::createUser(std::shared_ptr<User> body) const
         localVarHttpBody = localVarMultipart;
         localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
     }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
+    }
     else
     {
         throw ApiException(415, utility::conversions::to_string_t("UserApi->createUser does not consume any supported media type"));
@@ -236,6 +240,10 @@ pplx::task<void> UserApi::createUsersWithArrayInput(std::vector<std::shared_ptr<
 
         localVarHttpBody = localVarMultipart;
         localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
+    }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
     }
     else
     {
@@ -363,6 +371,10 @@ pplx::task<void> UserApi::createUsersWithListInput(std::vector<std::shared_ptr<U
         localVarHttpBody = localVarMultipart;
         localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
     }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
+    }
     else
     {
         throw ApiException(415, utility::conversions::to_string_t("UserApi->createUsersWithListInput does not consume any supported media type"));
@@ -462,6 +474,10 @@ pplx::task<void> UserApi::deleteUser(utility::string_t username) const
     else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+    }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
     }
     else
     {
@@ -564,6 +580,10 @@ pplx::task<std::shared_ptr<User>> UserApi::getUserByName(utility::string_t usern
     else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+    }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
     }
     else
     {
@@ -695,6 +715,10 @@ pplx::task<utility::string_t> UserApi::loginUser(utility::string_t username, uti
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
+    }
     else
     {
         throw ApiException(415, utility::conversions::to_string_t("UserApi->loginUser does not consume any supported media type"));
@@ -815,6 +839,10 @@ pplx::task<void> UserApi::logoutUser() const
     else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
         localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+    }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
     }
     else
     {
@@ -937,6 +965,10 @@ pplx::task<void> UserApi::updateUser(utility::string_t username, std::shared_ptr
 
         localVarHttpBody = localVarMultipart;
         localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
+    }
+    else if (localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/x-www-form-urlencoded")) != localVarConsumeHttpContentTypes.end())
+    {
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/x-www-form-urlencoded");
     }
     else
     {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
- Expected Float/Double types will be deserialized even if missing the decimal point
- Add the case for application/x-www-form-urlencoded

Fixes #6994
Fixes #7751

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

`cc`
@MartinDelille @ravinikam @stkrwork @muttleyxd 