### PR TITLE
Fix port when the URL doesn't have port specified

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -769,7 +769,7 @@ public class DefaultGenerator implements Generator {
         bundle.put("basePathWithoutHost", basePathWithoutHost);
         bundle.put("scheme", URLPathUtils.getScheme(url, config));
         bundle.put("host", url.getHost());
-        if (url.getPort() != 80 && url.getPort() != 443 ) {
+        if (url.getPort() != 80 && url.getPort() != 443 && url.getPort() != -1) {
             bundle.put("port", url.getPort());
         }
         bundle.put("contextPath", contextPath);

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/configuration.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/configuration.rb
@@ -139,7 +139,7 @@ module Petstore
 
     def initialize
       @scheme = 'http'
-      @host = 'petstore.swagger.io:-1'
+      @host = 'petstore.swagger.io'
       @base_path = '/v2'
       @server_index = 0
       @server_operation_index = {}


### PR DESCRIPTION
To fix https://github.com/OpenAPITools/openapi-generator/issues/8047

TODO: will add a test case shortly

cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
