### PR TITLE
Enable useOneOfInterfaces for the ruby generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -615,6 +615,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @param objs Map of models
      * @return maps of models with better enum support
+     * 
      */
     public Map<String, Object> postProcessModelsEnum(Map<String, Object> objs) {
         List<Object> models = (List<Object>) objs.get("models");
@@ -6484,6 +6485,7 @@ public class DefaultCodegen implements CodegenConfig {
         cm.classname = type;
         cm.vendorExtensions.put("x-is-one-of-interface", true);
         cm.interfaceModels = new ArrayList<CodegenModel>();
+        cm.classFilename = toModelFilename(type);
 
         addOneOfInterfaces.add(cm);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -100,6 +100,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         );
 
         supportsInheritance = true;
+        useOneOfInterfaces = true;
 
         // clear import mapping (from default generator) as ruby does not use it
         // at the moment


### PR DESCRIPTION
Tested against https://ftc-events.firstinspires.org/swagger/v2.0/swagger.json

Used to generate un-runnable code, now it works.  Try running against any openapi
spec with oneof.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)
