### PR TITLE
Fix generation of map model examples in Python

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -1072,7 +1072,10 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
                     key = addPropsSchema.getEnum().get(0).toString();
                 }
                 addPropsExample = exampleFromStringOrArraySchema(addPropsSchema, addPropsExample, key);
-                String addPropPrefix = ensureQuotes(key) + ": ";
+                String addPropPrefix = key + "=";
+                if (modelName == null) {
+                        addPropPrefix = ensureQuotes(key) + ": ";
+                }
                 String addPropsModelName = getModelName(addPropsSchema);
                 example = fullPrefix + "\n" +  toExampleValueRecursive(addPropsModelName, addPropsSchema, addPropsExample, indentationLevel + 1, addPropPrefix, exampleLine + 1) + ",\n" + closingIndentation + closeChars;
             } else {

--- a/samples/openapi3/client/petstore/python/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python/docs/FakeApi.md
@@ -51,7 +51,7 @@ with petstore_api.ApiClient() as api_client:
     # Create an instance of the API class
     api_instance = fake_api.FakeApi(api_client)
     additional_properties_with_array_of_enums = AdditionalPropertiesWithArrayOfEnums(
-        "key": [
+        key=[
             EnumClass("-efg"),
         ],
     ) # AdditionalPropertiesWithArrayOfEnums | Input enum (optional)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

When generation examples of objects with additional properties, we use the map
syntax inside a model instantiation, which is incorrect. This fixes it by
checking for model at the right place.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.