### PR TITLE
[ruby] document the *_with_http_info methods

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_doc.mustache
@@ -17,16 +17,15 @@ All URIs are relative to *{{basePath}}*
 
 ## {{operationId}}
 
-> {{#returnType}}{{returnType}} {{/returnType}}{{operationId}}{{#hasParams}}({{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}){{/hasParams}}
+> {{#returnType}}{{#returnTypeIsPrimitive}}{{returnType}}{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}<{{{returnType}}}>{{/returnTypeIsPrimitive}} {{/returnType}}{{operationId}}{{#hasParams}}({{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}){{/hasParams}}
 
 {{{summary}}}{{#notes}}
 
 {{{notes}}}{{/notes}}
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require '{{{gemName}}}'
 {{#hasAuthMethods}}
 # setup authorization
@@ -60,11 +59,31 @@ opts = {
 {{/optionalParams}}
 
 begin
-{{#summary}}  #{{{.}}}
-{{/summary}}  {{#returnType}}result = {{/returnType}}api_instance.{{{operationId}}}{{#hasParams}}({{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}){{/hasParams}}{{#returnType}}
-  p result{{/returnType}}
+  {{#summary}}# {{{.}}}{{/summary}}
+  {{#returnType}}result = {{/returnType}}api_instance.{{{operationId}}}{{#hasParams}}({{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}){{/hasParams}}
+  {{#returnType}}
+  p result
+  {{/returnType}}
 rescue {{{moduleName}}}::ApiError => e
-  puts "Exception when calling {{classname}}->{{{operationId}}}: #{e}"
+  puts "Error when calling {{classname}}->{{{operationId}}}: #{e}"
+end
+```
+
+#### Using the {{operationId}}_with_http_info variant
+
+This returns an Array which contains the response data{{^returnType}} (`nil` in this case){{/returnType}}, status code and headers.
+
+> <Array({{#returnType}}{{#returnTypeIsPrimitive}}{{returnType}}{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}<{{{returnType}}}>{{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}}nil{{/returnType}}, Integer, Hash)> {{operationId}}_with_http_info{{#hasParams}}({{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}){{/hasParams}}
+
+```ruby
+begin
+  {{#summary}}# {{{.}}}{{/summary}}
+  data, status_code, headers = api_instance.{{{operationId}}}_with_http_info{{#hasParams}}({{#requiredParams}}{{{paramName}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#optionalParams}}{{#-last}}{{#hasRequiredParams}}, {{/hasRequiredParams}}opts{{/-last}}{{/optionalParams}}){{/hasParams}}
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => {{#returnType}}{{#returnTypeIsPrimitive}}{{returnType}}{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}<{{{returnType}}}>{{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}}nil{{/returnType}}
+rescue {{{moduleName}}}::ApiError => e
+  puts "Error when calling {{classname}}->{{{operationId}}}_with_http_info: #{e}"
 end
 ```
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic_doc.mustache
@@ -8,7 +8,7 @@
 | **{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional]{{/required}}{{#isReadOnly}}[readonly]{{/isReadOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}} |
 {{/vars}}
 
-## Code Sample
+## Example
 
 ```ruby
 require '{{{gemName}}}'

--- a/samples/client/petstore/ruby-faraday/docs/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/ruby-faraday/docs/AdditionalPropertiesClass.md
@@ -7,7 +7,7 @@
 | **map_property** | **Hash&lt;String, String&gt;** |  | [optional] |
 | **map_of_map_property** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/Animal.md
+++ b/samples/client/petstore/ruby-faraday/docs/Animal.md
@@ -7,7 +7,7 @@
 | **class_name** | **String** |  |  |
 | **color** | **String** |  | [optional][default to &#39;red&#39;] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/AnotherFakeApi.md
@@ -9,27 +9,44 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 ## call_123_test_special_tags
 
-> Client call_123_test_special_tags(client)
+> <Client> call_123_test_special_tags(client)
 
 To test special tags
 
 To test special tags and operation ID starting with number
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::AnotherFakeApi.new
 client = Petstore::Client.new # Client | client model
 
 begin
-  #To test special tags
+  # To test special tags
   result = api_instance.call_123_test_special_tags(client)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling AnotherFakeApi->call_123_test_special_tags: #{e}"
+  puts "Error when calling AnotherFakeApi->call_123_test_special_tags: #{e}"
+end
+```
+
+#### Using the call_123_test_special_tags_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Client>, Integer, Hash)> call_123_test_special_tags_with_http_info(client)
+
+```ruby
+begin
+  # To test special tags
+  data, status_code, headers = api_instance.call_123_test_special_tags_with_http_info(client)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Client>
+rescue Petstore::ApiError => e
+  puts "Error when calling AnotherFakeApi->call_123_test_special_tags_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby-faraday/docs/ApiResponse.md
+++ b/samples/client/petstore/ruby-faraday/docs/ApiResponse.md
@@ -8,7 +8,7 @@
 | **type** | **String** |  | [optional] |
 | **message** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/ruby-faraday/docs/ArrayOfArrayOfNumberOnly.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **array_array_number** | **Array&lt;Array&lt;Float&gt;&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/ArrayOfNumberOnly.md
+++ b/samples/client/petstore/ruby-faraday/docs/ArrayOfNumberOnly.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **array_number** | **Array&lt;Float&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/ArrayTest.md
+++ b/samples/client/petstore/ruby-faraday/docs/ArrayTest.md
@@ -8,7 +8,7 @@
 | **array_array_of_integer** | **Array&lt;Array&lt;Integer&gt;&gt;** |  | [optional] |
 | **array_array_of_model** | **Array&lt;Array&lt;ReadOnlyFirst&gt;&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/Capitalization.md
+++ b/samples/client/petstore/ruby-faraday/docs/Capitalization.md
@@ -11,7 +11,7 @@
 | **sca_eth_flow_points** | **String** |  | [optional] |
 | **att_name** | **String** | Name of the pet  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/Cat.md
+++ b/samples/client/petstore/ruby-faraday/docs/Cat.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **declawed** | **Boolean** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/CatAllOf.md
+++ b/samples/client/petstore/ruby-faraday/docs/CatAllOf.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **declawed** | **Boolean** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/Category.md
+++ b/samples/client/petstore/ruby-faraday/docs/Category.md
@@ -7,7 +7,7 @@
 | **id** | **Integer** |  | [optional] |
 | **name** | **String** |  | [default to &#39;default-name&#39;] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/ClassModel.md
+++ b/samples/client/petstore/ruby-faraday/docs/ClassModel.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **_class** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/Client.md
+++ b/samples/client/petstore/ruby-faraday/docs/Client.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **client** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/DefaultApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/DefaultApi.md
@@ -9,23 +9,41 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 ## foo_get
 
-> InlineResponseDefault foo_get
+> <InlineResponseDefault> foo_get
 
 
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::DefaultApi.new
 
 begin
+  
   result = api_instance.foo_get
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling DefaultApi->foo_get: #{e}"
+  puts "Error when calling DefaultApi->foo_get: #{e}"
+end
+```
+
+#### Using the foo_get_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<InlineResponseDefault>, Integer, Hash)> foo_get_with_http_info
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.foo_get_with_http_info
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <InlineResponseDefault>
+rescue Petstore::ApiError => e
+  puts "Error when calling DefaultApi->foo_get_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby-faraday/docs/Dog.md
+++ b/samples/client/petstore/ruby-faraday/docs/Dog.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **breed** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/DogAllOf.md
+++ b/samples/client/petstore/ruby-faraday/docs/DogAllOf.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **breed** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/EnumArrays.md
+++ b/samples/client/petstore/ruby-faraday/docs/EnumArrays.md
@@ -7,7 +7,7 @@
 | **just_symbol** | **String** |  | [optional] |
 | **array_enum** | **Array&lt;String&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/EnumClass.md
+++ b/samples/client/petstore/ruby-faraday/docs/EnumClass.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/EnumTest.md
+++ b/samples/client/petstore/ruby-faraday/docs/EnumTest.md
@@ -13,7 +13,7 @@
 | **outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional][default to &#39;placed&#39;] |
 | **outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional][default to OuterEnumIntegerDefaultValue::N0] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/FakeApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeApi.md
@@ -23,24 +23,41 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 ## fake_health_get
 
-> HealthCheckResult fake_health_get
+> <HealthCheckResult> fake_health_get
 
 Health check endpoint
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 
 begin
-  #Health check endpoint
+  # Health check endpoint
   result = api_instance.fake_health_get
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->fake_health_get: #{e}"
+  puts "Error when calling FakeApi->fake_health_get: #{e}"
+end
+```
+
+#### Using the fake_health_get_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<HealthCheckResult>, Integer, Hash)> fake_health_get_with_http_info
+
+```ruby
+begin
+  # Health check endpoint
+  data, status_code, headers = api_instance.fake_health_get_with_http_info
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <HealthCheckResult>
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->fake_health_get_with_http_info: #{e}"
 end
 ```
 
@@ -68,10 +85,9 @@ No authorization required
 
 test http signature authentication
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -85,10 +101,28 @@ opts = {
 }
 
 begin
-  #test http signature authentication
+  # test http signature authentication
   api_instance.fake_http_signature_test(pet, opts)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->fake_http_signature_test: #{e}"
+  puts "Error when calling FakeApi->fake_http_signature_test: #{e}"
+end
+```
+
+#### Using the fake_http_signature_test_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> fake_http_signature_test_with_http_info(pet, opts)
+
+```ruby
+begin
+  # test http signature authentication
+  data, status_code, headers = api_instance.fake_http_signature_test_with_http_info(pet, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->fake_http_signature_test_with_http_info: #{e}"
 end
 ```
 
@@ -122,10 +156,9 @@ nil (empty response body)
 
 Test serialization of outer boolean types
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -134,10 +167,29 @@ opts = {
 }
 
 begin
+  
   result = api_instance.fake_outer_boolean_serialize(opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->fake_outer_boolean_serialize: #{e}"
+  puts "Error when calling FakeApi->fake_outer_boolean_serialize: #{e}"
+end
+```
+
+#### Using the fake_outer_boolean_serialize_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(Boolean, Integer, Hash)> fake_outer_boolean_serialize_with_http_info(opts)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.fake_outer_boolean_serialize_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => Boolean
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->fake_outer_boolean_serialize_with_http_info: #{e}"
 end
 ```
 
@@ -163,16 +215,15 @@ No authorization required
 
 ## fake_outer_composite_serialize
 
-> OuterComposite fake_outer_composite_serialize(opts)
+> <OuterComposite> fake_outer_composite_serialize(opts)
 
 
 
 Test serialization of object with outer number type
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -181,10 +232,29 @@ opts = {
 }
 
 begin
+  
   result = api_instance.fake_outer_composite_serialize(opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->fake_outer_composite_serialize: #{e}"
+  puts "Error when calling FakeApi->fake_outer_composite_serialize: #{e}"
+end
+```
+
+#### Using the fake_outer_composite_serialize_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<OuterComposite>, Integer, Hash)> fake_outer_composite_serialize_with_http_info(opts)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.fake_outer_composite_serialize_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <OuterComposite>
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->fake_outer_composite_serialize_with_http_info: #{e}"
 end
 ```
 
@@ -216,10 +286,9 @@ No authorization required
 
 Test serialization of outer number types
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -228,10 +297,29 @@ opts = {
 }
 
 begin
+  
   result = api_instance.fake_outer_number_serialize(opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->fake_outer_number_serialize: #{e}"
+  puts "Error when calling FakeApi->fake_outer_number_serialize: #{e}"
+end
+```
+
+#### Using the fake_outer_number_serialize_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(Float, Integer, Hash)> fake_outer_number_serialize_with_http_info(opts)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.fake_outer_number_serialize_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => Float
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->fake_outer_number_serialize_with_http_info: #{e}"
 end
 ```
 
@@ -263,10 +351,9 @@ No authorization required
 
 Test serialization of outer string types
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -275,10 +362,29 @@ opts = {
 }
 
 begin
+  
   result = api_instance.fake_outer_string_serialize(opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->fake_outer_string_serialize: #{e}"
+  puts "Error when calling FakeApi->fake_outer_string_serialize: #{e}"
+end
+```
+
+#### Using the fake_outer_string_serialize_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(String, Integer, Hash)> fake_outer_string_serialize_with_http_info(opts)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.fake_outer_string_serialize_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => String
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->fake_outer_string_serialize_with_http_info: #{e}"
 end
 ```
 
@@ -310,19 +416,37 @@ No authorization required
 
 For this test, the body for this request much reference a schema named `File`.
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 file_schema_test_class = Petstore::FileSchemaTestClass.new # FileSchemaTestClass | 
 
 begin
+  
   api_instance.test_body_with_file_schema(file_schema_test_class)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_body_with_file_schema: #{e}"
+  puts "Error when calling FakeApi->test_body_with_file_schema: #{e}"
+end
+```
+
+#### Using the test_body_with_file_schema_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_body_with_file_schema_with_http_info(file_schema_test_class)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.test_body_with_file_schema_with_http_info(file_schema_test_class)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_body_with_file_schema_with_http_info: #{e}"
 end
 ```
 
@@ -352,10 +476,9 @@ No authorization required
 
 
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -363,9 +486,28 @@ query = 'query_example' # String |
 user = Petstore::User.new # User | 
 
 begin
+  
   api_instance.test_body_with_query_params(query, user)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_body_with_query_params: #{e}"
+  puts "Error when calling FakeApi->test_body_with_query_params: #{e}"
+end
+```
+
+#### Using the test_body_with_query_params_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_body_with_query_params_with_http_info(query, user)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.test_body_with_query_params_with_http_info(query, user)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_body_with_query_params_with_http_info: #{e}"
 end
 ```
 
@@ -392,27 +534,44 @@ No authorization required
 
 ## test_client_model
 
-> Client test_client_model(client)
+> <Client> test_client_model(client)
 
 To test \"client\" model
 
 To test \"client\" model
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 client = Petstore::Client.new # Client | client model
 
 begin
-  #To test \"client\" model
+  # To test \"client\" model
   result = api_instance.test_client_model(client)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_client_model: #{e}"
+  puts "Error when calling FakeApi->test_client_model: #{e}"
+end
+```
+
+#### Using the test_client_model_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Client>, Integer, Hash)> test_client_model_with_http_info(client)
+
+```ruby
+begin
+  # To test \"client\" model
+  data, status_code, headers = api_instance.test_client_model_with_http_info(client)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Client>
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_client_model_with_http_info: #{e}"
 end
 ```
 
@@ -444,10 +603,9 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -475,10 +633,28 @@ opts = {
 }
 
 begin
-  #Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+  # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
   api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, opts)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_endpoint_parameters: #{e}"
+  puts "Error when calling FakeApi->test_endpoint_parameters: #{e}"
+end
+```
+
+#### Using the test_endpoint_parameters_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, opts)
+
+```ruby
+begin
+  # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+  data, status_code, headers = api_instance.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_endpoint_parameters_with_http_info: #{e}"
 end
 ```
 
@@ -523,10 +699,9 @@ To test enum parameters
 
 To test enum parameters
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -542,10 +717,28 @@ opts = {
 }
 
 begin
-  #To test enum parameters
+  # To test enum parameters
   api_instance.test_enum_parameters(opts)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_enum_parameters: #{e}"
+  puts "Error when calling FakeApi->test_enum_parameters: #{e}"
+end
+```
+
+#### Using the test_enum_parameters_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_enum_parameters_with_http_info(opts)
+
+```ruby
+begin
+  # To test enum parameters
+  data, status_code, headers = api_instance.test_enum_parameters_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_enum_parameters_with_http_info: #{e}"
 end
 ```
 
@@ -584,10 +777,9 @@ Fake endpoint to test group parameters (optional)
 
 Fake endpoint to test group parameters (optional)
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -606,10 +798,28 @@ opts = {
 }
 
 begin
-  #Fake endpoint to test group parameters (optional)
+  # Fake endpoint to test group parameters (optional)
   api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, opts)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_group_parameters: #{e}"
+  puts "Error when calling FakeApi->test_group_parameters: #{e}"
+end
+```
+
+#### Using the test_group_parameters_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts)
+
+```ruby
+begin
+  # Fake endpoint to test group parameters (optional)
+  data, status_code, headers = api_instance.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_group_parameters_with_http_info: #{e}"
 end
 ```
 
@@ -644,20 +854,37 @@ nil (empty response body)
 
 test inline additionalProperties
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 request_body = {'key' => 'request_body_example'} # Hash<String, String> | request body
 
 begin
-  #test inline additionalProperties
+  # test inline additionalProperties
   api_instance.test_inline_additional_properties(request_body)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_inline_additional_properties: #{e}"
+  puts "Error when calling FakeApi->test_inline_additional_properties: #{e}"
+end
+```
+
+#### Using the test_inline_additional_properties_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_inline_additional_properties_with_http_info(request_body)
+
+```ruby
+begin
+  # test inline additionalProperties
+  data, status_code, headers = api_instance.test_inline_additional_properties_with_http_info(request_body)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_inline_additional_properties_with_http_info: #{e}"
 end
 ```
 
@@ -687,10 +914,9 @@ No authorization required
 
 test json serialization of form data
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -698,10 +924,28 @@ param = 'param_example' # String | field1
 param2 = 'param2_example' # String | field2
 
 begin
-  #test json serialization of form data
+  # test json serialization of form data
   api_instance.test_json_form_data(param, param2)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_json_form_data: #{e}"
+  puts "Error when calling FakeApi->test_json_form_data: #{e}"
+end
+```
+
+#### Using the test_json_form_data_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_json_form_data_with_http_info(param, param2)
+
+```ruby
+begin
+  # test json serialization of form data
+  data, status_code, headers = api_instance.test_json_form_data_with_http_info(param, param2)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_json_form_data_with_http_info: #{e}"
 end
 ```
 
@@ -734,10 +978,9 @@ No authorization required
 
 To test the collection format in query parameters
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -748,9 +991,28 @@ url = ['url_example'] # Array<String> |
 context = ['context_example'] # Array<String> | 
 
 begin
+  
   api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_query_parameter_collection_format: #{e}"
+  puts "Error when calling FakeApi->test_query_parameter_collection_format: #{e}"
+end
+```
+
+#### Using the test_query_parameter_collection_format_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_query_parameter_collection_format_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby-faraday/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeClassnameTags123Api.md
@@ -9,16 +9,15 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 ## test_classname
 
-> Client test_classname(client)
+> <Client> test_classname(client)
 
 To test class name in snake case
 
 To test class name in snake case
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -32,11 +31,29 @@ api_instance = Petstore::FakeClassnameTags123Api.new
 client = Petstore::Client.new # Client | client model
 
 begin
-  #To test class name in snake case
+  # To test class name in snake case
   result = api_instance.test_classname(client)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeClassnameTags123Api->test_classname: #{e}"
+  puts "Error when calling FakeClassnameTags123Api->test_classname: #{e}"
+end
+```
+
+#### Using the test_classname_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Client>, Integer, Hash)> test_classname_with_http_info(client)
+
+```ruby
+begin
+  # To test class name in snake case
+  data, status_code, headers = api_instance.test_classname_with_http_info(client)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Client>
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeClassnameTags123Api->test_classname_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby-faraday/docs/File.md
+++ b/samples/client/petstore/ruby-faraday/docs/File.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **source_uri** | **String** | Test capitalization | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/FileSchemaTestClass.md
+++ b/samples/client/petstore/ruby-faraday/docs/FileSchemaTestClass.md
@@ -7,7 +7,7 @@
 | **file** | **File** |  | [optional] |
 | **files** | **Array&lt;File&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/Foo.md
+++ b/samples/client/petstore/ruby-faraday/docs/Foo.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **bar** | **String** |  | [optional][default to &#39;bar&#39;] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/FormatTest.md
+++ b/samples/client/petstore/ruby-faraday/docs/FormatTest.md
@@ -21,7 +21,7 @@
 | **pattern_with_digits** | **String** | A string that is a 10 digit number. Can have leading zeros. | [optional] |
 | **pattern_with_digits_and_delimiter** | **String** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/ruby-faraday/docs/HasOnlyReadOnly.md
@@ -7,7 +7,7 @@
 | **bar** | **String** |  | [optional][readonly] |
 | **foo** | **String** |  | [optional][readonly] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/HealthCheckResult.md
+++ b/samples/client/petstore/ruby-faraday/docs/HealthCheckResult.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **nullable_message** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/InlineObject.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineObject.md
@@ -7,7 +7,7 @@
 | **name** | **String** | Updated name of the pet | [optional] |
 | **status** | **String** | Updated status of the pet | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/InlineObject1.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineObject1.md
@@ -7,7 +7,7 @@
 | **additional_metadata** | **String** | Additional data to pass to server | [optional] |
 | **file** | **File** | file to upload | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/InlineObject2.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineObject2.md
@@ -7,7 +7,7 @@
 | **enum_form_string_array** | **Array&lt;String&gt;** | Form parameter enum test (string array) | [optional] |
 | **enum_form_string** | **String** | Form parameter enum test (string) | [optional][default to &#39;-efg&#39;] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/InlineObject3.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineObject3.md
@@ -19,7 +19,7 @@
 | **password** | **String** | None | [optional] |
 | **callback** | **String** | None | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/InlineObject4.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineObject4.md
@@ -7,7 +7,7 @@
 | **param** | **String** | field1 |  |
 | **param2** | **String** | field2 |  |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/InlineObject5.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineObject5.md
@@ -7,7 +7,7 @@
 | **additional_metadata** | **String** | Additional data to pass to server | [optional] |
 | **required_file** | **File** | file to upload |  |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/InlineResponseDefault.md
+++ b/samples/client/petstore/ruby-faraday/docs/InlineResponseDefault.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **string** | [**Foo**](Foo.md) |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/List.md
+++ b/samples/client/petstore/ruby-faraday/docs/List.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **_123_list** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/MapTest.md
+++ b/samples/client/petstore/ruby-faraday/docs/MapTest.md
@@ -9,7 +9,7 @@
 | **direct_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
 | **indirect_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/ruby-faraday/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -8,7 +8,7 @@
 | **date_time** | **Time** |  | [optional] |
 | **map** | [**Hash&lt;String, Animal&gt;**](Animal.md) |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/Model200Response.md
+++ b/samples/client/petstore/ruby-faraday/docs/Model200Response.md
@@ -7,7 +7,7 @@
 | **name** | **Integer** |  | [optional] |
 | **_class** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/ModelReturn.md
+++ b/samples/client/petstore/ruby-faraday/docs/ModelReturn.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **_return** | **Integer** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/Name.md
+++ b/samples/client/petstore/ruby-faraday/docs/Name.md
@@ -9,7 +9,7 @@
 | **property** | **String** |  | [optional] |
 | **_123_number** | **Integer** |  | [optional][readonly] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/NullableClass.md
+++ b/samples/client/petstore/ruby-faraday/docs/NullableClass.md
@@ -17,7 +17,7 @@
 | **object_and_items_nullable_prop** | **Hash&lt;String, Object&gt;** |  | [optional] |
 | **object_items_nullable** | **Hash&lt;String, Object&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/NumberOnly.md
+++ b/samples/client/petstore/ruby-faraday/docs/NumberOnly.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **just_number** | **Float** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/Order.md
+++ b/samples/client/petstore/ruby-faraday/docs/Order.md
@@ -11,7 +11,7 @@
 | **status** | **String** | Order Status | [optional] |
 | **complete** | **Boolean** |  | [optional][default to false] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/OuterComposite.md
+++ b/samples/client/petstore/ruby-faraday/docs/OuterComposite.md
@@ -8,7 +8,7 @@
 | **my_string** | **String** |  | [optional] |
 | **my_boolean** | **Boolean** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/OuterEnum.md
+++ b/samples/client/petstore/ruby-faraday/docs/OuterEnum.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/OuterEnumDefaultValue.md
+++ b/samples/client/petstore/ruby-faraday/docs/OuterEnumDefaultValue.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/OuterEnumInteger.md
+++ b/samples/client/petstore/ruby-faraday/docs/OuterEnumInteger.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/OuterEnumIntegerDefaultValue.md
+++ b/samples/client/petstore/ruby-faraday/docs/OuterEnumIntegerDefaultValue.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/Pet.md
+++ b/samples/client/petstore/ruby-faraday/docs/Pet.md
@@ -11,7 +11,7 @@
 | **tags** | [**Array&lt;Tag&gt;**](Tag.md) |  | [optional] |
 | **status** | **String** | pet status in the store | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/PetApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/PetApi.md
@@ -21,10 +21,9 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Add a new pet to the store
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -36,10 +35,28 @@ api_instance = Petstore::PetApi.new
 pet = Petstore::Pet.new # Pet | Pet object that needs to be added to the store
 
 begin
-  #Add a new pet to the store
+  # Add a new pet to the store
   api_instance.add_pet(pet)
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->add_pet: #{e}"
+  puts "Error when calling PetApi->add_pet: #{e}"
+end
+```
+
+#### Using the add_pet_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> add_pet_with_http_info(pet)
+
+```ruby
+begin
+  # Add a new pet to the store
+  data, status_code, headers = api_instance.add_pet_with_http_info(pet)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->add_pet_with_http_info: #{e}"
 end
 ```
 
@@ -69,10 +86,9 @@ nil (empty response body)
 
 Deletes a pet
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -87,10 +103,28 @@ opts = {
 }
 
 begin
-  #Deletes a pet
+  # Deletes a pet
   api_instance.delete_pet(pet_id, opts)
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->delete_pet: #{e}"
+  puts "Error when calling PetApi->delete_pet: #{e}"
+end
+```
+
+#### Using the delete_pet_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> delete_pet_with_http_info(pet_id, opts)
+
+```ruby
+begin
+  # Deletes a pet
+  data, status_code, headers = api_instance.delete_pet_with_http_info(pet_id, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->delete_pet_with_http_info: #{e}"
 end
 ```
 
@@ -117,16 +151,15 @@ nil (empty response body)
 
 ## find_pets_by_status
 
-> Array&lt;Pet&gt; find_pets_by_status(status)
+> <Array<Pet>> find_pets_by_status(status)
 
 Finds Pets by status
 
 Multiple status values can be provided with comma separated strings
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -138,11 +171,29 @@ api_instance = Petstore::PetApi.new
 status = ['status_example'] # Array<String> | Status values that need to be considered for filter
 
 begin
-  #Finds Pets by status
+  # Finds Pets by status
   result = api_instance.find_pets_by_status(status)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->find_pets_by_status: #{e}"
+  puts "Error when calling PetApi->find_pets_by_status: #{e}"
+end
+```
+
+#### Using the find_pets_by_status_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Array<Pet>>, Integer, Hash)> find_pets_by_status_with_http_info(status)
+
+```ruby
+begin
+  # Finds Pets by status
+  data, status_code, headers = api_instance.find_pets_by_status_with_http_info(status)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Array<Pet>>
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->find_pets_by_status_with_http_info: #{e}"
 end
 ```
 
@@ -168,16 +219,15 @@ end
 
 ## find_pets_by_tags
 
-> Array&lt;Pet&gt; find_pets_by_tags(tags)
+> <Array<Pet>> find_pets_by_tags(tags)
 
 Finds Pets by tags
 
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -189,11 +239,29 @@ api_instance = Petstore::PetApi.new
 tags = ['tags_example'] # Array<String> | Tags to filter by
 
 begin
-  #Finds Pets by tags
+  # Finds Pets by tags
   result = api_instance.find_pets_by_tags(tags)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->find_pets_by_tags: #{e}"
+  puts "Error when calling PetApi->find_pets_by_tags: #{e}"
+end
+```
+
+#### Using the find_pets_by_tags_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Array<Pet>>, Integer, Hash)> find_pets_by_tags_with_http_info(tags)
+
+```ruby
+begin
+  # Finds Pets by tags
+  data, status_code, headers = api_instance.find_pets_by_tags_with_http_info(tags)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Array<Pet>>
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->find_pets_by_tags_with_http_info: #{e}"
 end
 ```
 
@@ -219,16 +287,15 @@ end
 
 ## get_pet_by_id
 
-> Pet get_pet_by_id(pet_id)
+> <Pet> get_pet_by_id(pet_id)
 
 Find pet by ID
 
 Returns a single pet
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -242,11 +309,29 @@ api_instance = Petstore::PetApi.new
 pet_id = 56 # Integer | ID of pet to return
 
 begin
-  #Find pet by ID
+  # Find pet by ID
   result = api_instance.get_pet_by_id(pet_id)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->get_pet_by_id: #{e}"
+  puts "Error when calling PetApi->get_pet_by_id: #{e}"
+end
+```
+
+#### Using the get_pet_by_id_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Pet>, Integer, Hash)> get_pet_by_id_with_http_info(pet_id)
+
+```ruby
+begin
+  # Find pet by ID
+  data, status_code, headers = api_instance.get_pet_by_id_with_http_info(pet_id)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Pet>
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->get_pet_by_id_with_http_info: #{e}"
 end
 ```
 
@@ -276,10 +361,9 @@ end
 
 Update an existing pet
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -291,10 +375,28 @@ api_instance = Petstore::PetApi.new
 pet = Petstore::Pet.new # Pet | Pet object that needs to be added to the store
 
 begin
-  #Update an existing pet
+  # Update an existing pet
   api_instance.update_pet(pet)
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->update_pet: #{e}"
+  puts "Error when calling PetApi->update_pet: #{e}"
+end
+```
+
+#### Using the update_pet_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> update_pet_with_http_info(pet)
+
+```ruby
+begin
+  # Update an existing pet
+  data, status_code, headers = api_instance.update_pet_with_http_info(pet)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->update_pet_with_http_info: #{e}"
 end
 ```
 
@@ -324,10 +426,9 @@ nil (empty response body)
 
 Updates a pet in the store with form data
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -343,10 +444,28 @@ opts = {
 }
 
 begin
-  #Updates a pet in the store with form data
+  # Updates a pet in the store with form data
   api_instance.update_pet_with_form(pet_id, opts)
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->update_pet_with_form: #{e}"
+  puts "Error when calling PetApi->update_pet_with_form: #{e}"
+end
+```
+
+#### Using the update_pet_with_form_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> update_pet_with_form_with_http_info(pet_id, opts)
+
+```ruby
+begin
+  # Updates a pet in the store with form data
+  data, status_code, headers = api_instance.update_pet_with_form_with_http_info(pet_id, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->update_pet_with_form_with_http_info: #{e}"
 end
 ```
 
@@ -374,14 +493,13 @@ nil (empty response body)
 
 ## upload_file
 
-> ApiResponse upload_file(pet_id, opts)
+> <ApiResponse> upload_file(pet_id, opts)
 
 uploads an image
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -397,11 +515,29 @@ opts = {
 }
 
 begin
-  #uploads an image
+  # uploads an image
   result = api_instance.upload_file(pet_id, opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->upload_file: #{e}"
+  puts "Error when calling PetApi->upload_file: #{e}"
+end
+```
+
+#### Using the upload_file_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<ApiResponse>, Integer, Hash)> upload_file_with_http_info(pet_id, opts)
+
+```ruby
+begin
+  # uploads an image
+  data, status_code, headers = api_instance.upload_file_with_http_info(pet_id, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <ApiResponse>
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->upload_file_with_http_info: #{e}"
 end
 ```
 
@@ -429,14 +565,13 @@ end
 
 ## upload_file_with_required_file
 
-> ApiResponse upload_file_with_required_file(pet_id, required_file, opts)
+> <ApiResponse> upload_file_with_required_file(pet_id, required_file, opts)
 
 uploads an image (required)
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -452,11 +587,29 @@ opts = {
 }
 
 begin
-  #uploads an image (required)
+  # uploads an image (required)
   result = api_instance.upload_file_with_required_file(pet_id, required_file, opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->upload_file_with_required_file: #{e}"
+  puts "Error when calling PetApi->upload_file_with_required_file: #{e}"
+end
+```
+
+#### Using the upload_file_with_required_file_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<ApiResponse>, Integer, Hash)> upload_file_with_required_file_with_http_info(pet_id, required_file, opts)
+
+```ruby
+begin
+  # uploads an image (required)
+  data, status_code, headers = api_instance.upload_file_with_required_file_with_http_info(pet_id, required_file, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <ApiResponse>
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->upload_file_with_required_file_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby-faraday/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/ruby-faraday/docs/ReadOnlyFirst.md
@@ -7,7 +7,7 @@
 | **bar** | **String** |  | [optional][readonly] |
 | **baz** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/SpecialModelName.md
+++ b/samples/client/petstore/ruby-faraday/docs/SpecialModelName.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **special_property_name** | **Integer** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/StoreApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/StoreApi.md
@@ -18,20 +18,37 @@ Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
 order_id = 'order_id_example' # String | ID of the order that needs to be deleted
 
 begin
-  #Delete purchase order by ID
+  # Delete purchase order by ID
   api_instance.delete_order(order_id)
 rescue Petstore::ApiError => e
-  puts "Exception when calling StoreApi->delete_order: #{e}"
+  puts "Error when calling StoreApi->delete_order: #{e}"
+end
+```
+
+#### Using the delete_order_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> delete_order_with_http_info(order_id)
+
+```ruby
+begin
+  # Delete purchase order by ID
+  data, status_code, headers = api_instance.delete_order_with_http_info(order_id)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling StoreApi->delete_order_with_http_info: #{e}"
 end
 ```
 
@@ -63,10 +80,9 @@ Returns pet inventories by status
 
 Returns a map of status codes to quantities
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -79,11 +95,29 @@ end
 api_instance = Petstore::StoreApi.new
 
 begin
-  #Returns pet inventories by status
+  # Returns pet inventories by status
   result = api_instance.get_inventory
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling StoreApi->get_inventory: #{e}"
+  puts "Error when calling StoreApi->get_inventory: #{e}"
+end
+```
+
+#### Using the get_inventory_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(Hash&lt;String, Integer&gt;, Integer, Hash)> get_inventory_with_http_info
+
+```ruby
+begin
+  # Returns pet inventories by status
+  data, status_code, headers = api_instance.get_inventory_with_http_info
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => Hash&lt;String, Integer&gt;
+rescue Petstore::ApiError => e
+  puts "Error when calling StoreApi->get_inventory_with_http_info: #{e}"
 end
 ```
 
@@ -107,27 +141,44 @@ This endpoint does not need any parameter.
 
 ## get_order_by_id
 
-> Order get_order_by_id(order_id)
+> <Order> get_order_by_id(order_id)
 
 Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
 order_id = 56 # Integer | ID of pet that needs to be fetched
 
 begin
-  #Find purchase order by ID
+  # Find purchase order by ID
   result = api_instance.get_order_by_id(order_id)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling StoreApi->get_order_by_id: #{e}"
+  puts "Error when calling StoreApi->get_order_by_id: #{e}"
+end
+```
+
+#### Using the get_order_by_id_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Order>, Integer, Hash)> get_order_by_id_with_http_info(order_id)
+
+```ruby
+begin
+  # Find purchase order by ID
+  data, status_code, headers = api_instance.get_order_by_id_with_http_info(order_id)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Order>
+rescue Petstore::ApiError => e
+  puts "Error when calling StoreApi->get_order_by_id_with_http_info: #{e}"
 end
 ```
 
@@ -153,25 +204,42 @@ No authorization required
 
 ## place_order
 
-> Order place_order(order)
+> <Order> place_order(order)
 
 Place an order for a pet
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
 order = Petstore::Order.new # Order | order placed for purchasing the pet
 
 begin
-  #Place an order for a pet
+  # Place an order for a pet
   result = api_instance.place_order(order)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling StoreApi->place_order: #{e}"
+  puts "Error when calling StoreApi->place_order: #{e}"
+end
+```
+
+#### Using the place_order_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Order>, Integer, Hash)> place_order_with_http_info(order)
+
+```ruby
+begin
+  # Place an order for a pet
+  data, status_code, headers = api_instance.place_order_with_http_info(order)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Order>
+rescue Petstore::ApiError => e
+  puts "Error when calling StoreApi->place_order_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby-faraday/docs/Tag.md
+++ b/samples/client/petstore/ruby-faraday/docs/Tag.md
@@ -7,7 +7,7 @@
 | **id** | **Integer** |  | [optional] |
 | **name** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/User.md
+++ b/samples/client/petstore/ruby-faraday/docs/User.md
@@ -13,7 +13,7 @@
 | **phone** | **String** |  | [optional] |
 | **user_status** | **Integer** | User Status | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby-faraday/docs/UserApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/UserApi.md
@@ -22,20 +22,37 @@ Create user
 
 This can only be done by the logged in user.
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
 user = Petstore::User.new # User | Created user object
 
 begin
-  #Create user
+  # Create user
   api_instance.create_user(user)
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->create_user: #{e}"
+  puts "Error when calling UserApi->create_user: #{e}"
+end
+```
+
+#### Using the create_user_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> create_user_with_http_info(user)
+
+```ruby
+begin
+  # Create user
+  data, status_code, headers = api_instance.create_user_with_http_info(user)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->create_user_with_http_info: #{e}"
 end
 ```
 
@@ -65,20 +82,37 @@ No authorization required
 
 Creates list of users with given input array
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
 user = [Petstore::User.new] # Array<User> | List of user object
 
 begin
-  #Creates list of users with given input array
+  # Creates list of users with given input array
   api_instance.create_users_with_array_input(user)
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->create_users_with_array_input: #{e}"
+  puts "Error when calling UserApi->create_users_with_array_input: #{e}"
+end
+```
+
+#### Using the create_users_with_array_input_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> create_users_with_array_input_with_http_info(user)
+
+```ruby
+begin
+  # Creates list of users with given input array
+  data, status_code, headers = api_instance.create_users_with_array_input_with_http_info(user)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->create_users_with_array_input_with_http_info: #{e}"
 end
 ```
 
@@ -108,20 +142,37 @@ No authorization required
 
 Creates list of users with given input array
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
 user = [Petstore::User.new] # Array<User> | List of user object
 
 begin
-  #Creates list of users with given input array
+  # Creates list of users with given input array
   api_instance.create_users_with_list_input(user)
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->create_users_with_list_input: #{e}"
+  puts "Error when calling UserApi->create_users_with_list_input: #{e}"
+end
+```
+
+#### Using the create_users_with_list_input_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> create_users_with_list_input_with_http_info(user)
+
+```ruby
+begin
+  # Creates list of users with given input array
+  data, status_code, headers = api_instance.create_users_with_list_input_with_http_info(user)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->create_users_with_list_input_with_http_info: #{e}"
 end
 ```
 
@@ -153,20 +204,37 @@ Delete user
 
 This can only be done by the logged in user.
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
 username = 'username_example' # String | The name that needs to be deleted
 
 begin
-  #Delete user
+  # Delete user
   api_instance.delete_user(username)
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->delete_user: #{e}"
+  puts "Error when calling UserApi->delete_user: #{e}"
+end
+```
+
+#### Using the delete_user_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> delete_user_with_http_info(username)
+
+```ruby
+begin
+  # Delete user
+  data, status_code, headers = api_instance.delete_user_with_http_info(username)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->delete_user_with_http_info: #{e}"
 end
 ```
 
@@ -192,25 +260,42 @@ No authorization required
 
 ## get_user_by_name
 
-> User get_user_by_name(username)
+> <User> get_user_by_name(username)
 
 Get user by user name
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
 username = 'username_example' # String | The name that needs to be fetched. Use user1 for testing.
 
 begin
-  #Get user by user name
+  # Get user by user name
   result = api_instance.get_user_by_name(username)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->get_user_by_name: #{e}"
+  puts "Error when calling UserApi->get_user_by_name: #{e}"
+end
+```
+
+#### Using the get_user_by_name_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<User>, Integer, Hash)> get_user_by_name_with_http_info(username)
+
+```ruby
+begin
+  # Get user by user name
+  data, status_code, headers = api_instance.get_user_by_name_with_http_info(username)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <User>
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->get_user_by_name_with_http_info: #{e}"
 end
 ```
 
@@ -240,10 +325,9 @@ No authorization required
 
 Logs user into the system
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -251,11 +335,29 @@ username = 'username_example' # String | The user name for login
 password = 'password_example' # String | The password for login in clear text
 
 begin
-  #Logs user into the system
+  # Logs user into the system
   result = api_instance.login_user(username, password)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->login_user: #{e}"
+  puts "Error when calling UserApi->login_user: #{e}"
+end
+```
+
+#### Using the login_user_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(String, Integer, Hash)> login_user_with_http_info(username, password)
+
+```ruby
+begin
+  # Logs user into the system
+  data, status_code, headers = api_instance.login_user_with_http_info(username, password)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => String
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->login_user_with_http_info: #{e}"
 end
 ```
 
@@ -286,19 +388,36 @@ No authorization required
 
 Logs out current logged in user session
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
 
 begin
-  #Logs out current logged in user session
+  # Logs out current logged in user session
   api_instance.logout_user
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->logout_user: #{e}"
+  puts "Error when calling UserApi->logout_user: #{e}"
+end
+```
+
+#### Using the logout_user_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> logout_user_with_http_info
+
+```ruby
+begin
+  # Logs out current logged in user session
+  data, status_code, headers = api_instance.logout_user_with_http_info
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->logout_user_with_http_info: #{e}"
 end
 ```
 
@@ -328,10 +447,9 @@ Updated user
 
 This can only be done by the logged in user.
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -339,10 +457,28 @@ username = 'username_example' # String | name that need to be deleted
 user = Petstore::User.new # User | Updated user object
 
 begin
-  #Updated user
+  # Updated user
   api_instance.update_user(username, user)
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->update_user: #{e}"
+  puts "Error when calling UserApi->update_user: #{e}"
+end
+```
+
+#### Using the update_user_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> update_user_with_http_info(username, user)
+
+```ruby
+begin
+  # Updated user
+  data, status_code, headers = api_instance.update_user_with_http_info(username, user)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->update_user_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby/docs/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/ruby/docs/AdditionalPropertiesClass.md
@@ -7,7 +7,7 @@
 | **map_property** | **Hash&lt;String, String&gt;** |  | [optional] |
 | **map_of_map_property** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/Animal.md
+++ b/samples/client/petstore/ruby/docs/Animal.md
@@ -7,7 +7,7 @@
 | **class_name** | **String** |  |  |
 | **color** | **String** |  | [optional][default to &#39;red&#39;] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/ruby/docs/AnotherFakeApi.md
@@ -9,27 +9,44 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 ## call_123_test_special_tags
 
-> Client call_123_test_special_tags(client)
+> <Client> call_123_test_special_tags(client)
 
 To test special tags
 
 To test special tags and operation ID starting with number
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::AnotherFakeApi.new
 client = Petstore::Client.new # Client | client model
 
 begin
-  #To test special tags
+  # To test special tags
   result = api_instance.call_123_test_special_tags(client)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling AnotherFakeApi->call_123_test_special_tags: #{e}"
+  puts "Error when calling AnotherFakeApi->call_123_test_special_tags: #{e}"
+end
+```
+
+#### Using the call_123_test_special_tags_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Client>, Integer, Hash)> call_123_test_special_tags_with_http_info(client)
+
+```ruby
+begin
+  # To test special tags
+  data, status_code, headers = api_instance.call_123_test_special_tags_with_http_info(client)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Client>
+rescue Petstore::ApiError => e
+  puts "Error when calling AnotherFakeApi->call_123_test_special_tags_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby/docs/ApiResponse.md
+++ b/samples/client/petstore/ruby/docs/ApiResponse.md
@@ -8,7 +8,7 @@
 | **type** | **String** |  | [optional] |
 | **message** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/ruby/docs/ArrayOfArrayOfNumberOnly.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **array_array_number** | **Array&lt;Array&lt;Float&gt;&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/ArrayOfNumberOnly.md
+++ b/samples/client/petstore/ruby/docs/ArrayOfNumberOnly.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **array_number** | **Array&lt;Float&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/ArrayTest.md
+++ b/samples/client/petstore/ruby/docs/ArrayTest.md
@@ -8,7 +8,7 @@
 | **array_array_of_integer** | **Array&lt;Array&lt;Integer&gt;&gt;** |  | [optional] |
 | **array_array_of_model** | **Array&lt;Array&lt;ReadOnlyFirst&gt;&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/Capitalization.md
+++ b/samples/client/petstore/ruby/docs/Capitalization.md
@@ -11,7 +11,7 @@
 | **sca_eth_flow_points** | **String** |  | [optional] |
 | **att_name** | **String** | Name of the pet  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/Cat.md
+++ b/samples/client/petstore/ruby/docs/Cat.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **declawed** | **Boolean** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/CatAllOf.md
+++ b/samples/client/petstore/ruby/docs/CatAllOf.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **declawed** | **Boolean** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/Category.md
+++ b/samples/client/petstore/ruby/docs/Category.md
@@ -7,7 +7,7 @@
 | **id** | **Integer** |  | [optional] |
 | **name** | **String** |  | [default to &#39;default-name&#39;] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/ClassModel.md
+++ b/samples/client/petstore/ruby/docs/ClassModel.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **_class** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/Client.md
+++ b/samples/client/petstore/ruby/docs/Client.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **client** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/DefaultApi.md
+++ b/samples/client/petstore/ruby/docs/DefaultApi.md
@@ -9,23 +9,41 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 ## foo_get
 
-> InlineResponseDefault foo_get
+> <InlineResponseDefault> foo_get
 
 
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::DefaultApi.new
 
 begin
+  
   result = api_instance.foo_get
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling DefaultApi->foo_get: #{e}"
+  puts "Error when calling DefaultApi->foo_get: #{e}"
+end
+```
+
+#### Using the foo_get_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<InlineResponseDefault>, Integer, Hash)> foo_get_with_http_info
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.foo_get_with_http_info
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <InlineResponseDefault>
+rescue Petstore::ApiError => e
+  puts "Error when calling DefaultApi->foo_get_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby/docs/Dog.md
+++ b/samples/client/petstore/ruby/docs/Dog.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **breed** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/DogAllOf.md
+++ b/samples/client/petstore/ruby/docs/DogAllOf.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **breed** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/EnumArrays.md
+++ b/samples/client/petstore/ruby/docs/EnumArrays.md
@@ -7,7 +7,7 @@
 | **just_symbol** | **String** |  | [optional] |
 | **array_enum** | **Array&lt;String&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/EnumClass.md
+++ b/samples/client/petstore/ruby/docs/EnumClass.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/EnumTest.md
+++ b/samples/client/petstore/ruby/docs/EnumTest.md
@@ -13,7 +13,7 @@
 | **outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional][default to &#39;placed&#39;] |
 | **outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional][default to OuterEnumIntegerDefaultValue::N0] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -23,24 +23,41 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 ## fake_health_get
 
-> HealthCheckResult fake_health_get
+> <HealthCheckResult> fake_health_get
 
 Health check endpoint
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 
 begin
-  #Health check endpoint
+  # Health check endpoint
   result = api_instance.fake_health_get
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->fake_health_get: #{e}"
+  puts "Error when calling FakeApi->fake_health_get: #{e}"
+end
+```
+
+#### Using the fake_health_get_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<HealthCheckResult>, Integer, Hash)> fake_health_get_with_http_info
+
+```ruby
+begin
+  # Health check endpoint
+  data, status_code, headers = api_instance.fake_health_get_with_http_info
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <HealthCheckResult>
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->fake_health_get_with_http_info: #{e}"
 end
 ```
 
@@ -68,10 +85,9 @@ No authorization required
 
 test http signature authentication
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -85,10 +101,28 @@ opts = {
 }
 
 begin
-  #test http signature authentication
+  # test http signature authentication
   api_instance.fake_http_signature_test(pet, opts)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->fake_http_signature_test: #{e}"
+  puts "Error when calling FakeApi->fake_http_signature_test: #{e}"
+end
+```
+
+#### Using the fake_http_signature_test_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> fake_http_signature_test_with_http_info(pet, opts)
+
+```ruby
+begin
+  # test http signature authentication
+  data, status_code, headers = api_instance.fake_http_signature_test_with_http_info(pet, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->fake_http_signature_test_with_http_info: #{e}"
 end
 ```
 
@@ -122,10 +156,9 @@ nil (empty response body)
 
 Test serialization of outer boolean types
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -134,10 +167,29 @@ opts = {
 }
 
 begin
+  
   result = api_instance.fake_outer_boolean_serialize(opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->fake_outer_boolean_serialize: #{e}"
+  puts "Error when calling FakeApi->fake_outer_boolean_serialize: #{e}"
+end
+```
+
+#### Using the fake_outer_boolean_serialize_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(Boolean, Integer, Hash)> fake_outer_boolean_serialize_with_http_info(opts)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.fake_outer_boolean_serialize_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => Boolean
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->fake_outer_boolean_serialize_with_http_info: #{e}"
 end
 ```
 
@@ -163,16 +215,15 @@ No authorization required
 
 ## fake_outer_composite_serialize
 
-> OuterComposite fake_outer_composite_serialize(opts)
+> <OuterComposite> fake_outer_composite_serialize(opts)
 
 
 
 Test serialization of object with outer number type
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -181,10 +232,29 @@ opts = {
 }
 
 begin
+  
   result = api_instance.fake_outer_composite_serialize(opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->fake_outer_composite_serialize: #{e}"
+  puts "Error when calling FakeApi->fake_outer_composite_serialize: #{e}"
+end
+```
+
+#### Using the fake_outer_composite_serialize_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<OuterComposite>, Integer, Hash)> fake_outer_composite_serialize_with_http_info(opts)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.fake_outer_composite_serialize_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <OuterComposite>
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->fake_outer_composite_serialize_with_http_info: #{e}"
 end
 ```
 
@@ -216,10 +286,9 @@ No authorization required
 
 Test serialization of outer number types
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -228,10 +297,29 @@ opts = {
 }
 
 begin
+  
   result = api_instance.fake_outer_number_serialize(opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->fake_outer_number_serialize: #{e}"
+  puts "Error when calling FakeApi->fake_outer_number_serialize: #{e}"
+end
+```
+
+#### Using the fake_outer_number_serialize_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(Float, Integer, Hash)> fake_outer_number_serialize_with_http_info(opts)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.fake_outer_number_serialize_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => Float
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->fake_outer_number_serialize_with_http_info: #{e}"
 end
 ```
 
@@ -263,10 +351,9 @@ No authorization required
 
 Test serialization of outer string types
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -275,10 +362,29 @@ opts = {
 }
 
 begin
+  
   result = api_instance.fake_outer_string_serialize(opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->fake_outer_string_serialize: #{e}"
+  puts "Error when calling FakeApi->fake_outer_string_serialize: #{e}"
+end
+```
+
+#### Using the fake_outer_string_serialize_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(String, Integer, Hash)> fake_outer_string_serialize_with_http_info(opts)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.fake_outer_string_serialize_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => String
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->fake_outer_string_serialize_with_http_info: #{e}"
 end
 ```
 
@@ -310,19 +416,37 @@ No authorization required
 
 For this test, the body for this request much reference a schema named `File`.
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 file_schema_test_class = Petstore::FileSchemaTestClass.new # FileSchemaTestClass | 
 
 begin
+  
   api_instance.test_body_with_file_schema(file_schema_test_class)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_body_with_file_schema: #{e}"
+  puts "Error when calling FakeApi->test_body_with_file_schema: #{e}"
+end
+```
+
+#### Using the test_body_with_file_schema_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_body_with_file_schema_with_http_info(file_schema_test_class)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.test_body_with_file_schema_with_http_info(file_schema_test_class)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_body_with_file_schema_with_http_info: #{e}"
 end
 ```
 
@@ -352,10 +476,9 @@ No authorization required
 
 
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -363,9 +486,28 @@ query = 'query_example' # String |
 user = Petstore::User.new # User | 
 
 begin
+  
   api_instance.test_body_with_query_params(query, user)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_body_with_query_params: #{e}"
+  puts "Error when calling FakeApi->test_body_with_query_params: #{e}"
+end
+```
+
+#### Using the test_body_with_query_params_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_body_with_query_params_with_http_info(query, user)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.test_body_with_query_params_with_http_info(query, user)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_body_with_query_params_with_http_info: #{e}"
 end
 ```
 
@@ -392,27 +534,44 @@ No authorization required
 
 ## test_client_model
 
-> Client test_client_model(client)
+> <Client> test_client_model(client)
 
 To test \"client\" model
 
 To test \"client\" model
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 client = Petstore::Client.new # Client | client model
 
 begin
-  #To test \"client\" model
+  # To test \"client\" model
   result = api_instance.test_client_model(client)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_client_model: #{e}"
+  puts "Error when calling FakeApi->test_client_model: #{e}"
+end
+```
+
+#### Using the test_client_model_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Client>, Integer, Hash)> test_client_model_with_http_info(client)
+
+```ruby
+begin
+  # To test \"client\" model
+  data, status_code, headers = api_instance.test_client_model_with_http_info(client)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Client>
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_client_model_with_http_info: #{e}"
 end
 ```
 
@@ -444,10 +603,9 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -475,10 +633,28 @@ opts = {
 }
 
 begin
-  #Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+  # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
   api_instance.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, opts)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_endpoint_parameters: #{e}"
+  puts "Error when calling FakeApi->test_endpoint_parameters: #{e}"
+end
+```
+
+#### Using the test_endpoint_parameters_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, opts)
+
+```ruby
+begin
+  # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+  data, status_code, headers = api_instance.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_endpoint_parameters_with_http_info: #{e}"
 end
 ```
 
@@ -523,10 +699,9 @@ To test enum parameters
 
 To test enum parameters
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -542,10 +717,28 @@ opts = {
 }
 
 begin
-  #To test enum parameters
+  # To test enum parameters
   api_instance.test_enum_parameters(opts)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_enum_parameters: #{e}"
+  puts "Error when calling FakeApi->test_enum_parameters: #{e}"
+end
+```
+
+#### Using the test_enum_parameters_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_enum_parameters_with_http_info(opts)
+
+```ruby
+begin
+  # To test enum parameters
+  data, status_code, headers = api_instance.test_enum_parameters_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_enum_parameters_with_http_info: #{e}"
 end
 ```
 
@@ -584,10 +777,9 @@ Fake endpoint to test group parameters (optional)
 
 Fake endpoint to test group parameters (optional)
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -606,10 +798,28 @@ opts = {
 }
 
 begin
-  #Fake endpoint to test group parameters (optional)
+  # Fake endpoint to test group parameters (optional)
   api_instance.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, opts)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_group_parameters: #{e}"
+  puts "Error when calling FakeApi->test_group_parameters: #{e}"
+end
+```
+
+#### Using the test_group_parameters_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts)
+
+```ruby
+begin
+  # Fake endpoint to test group parameters (optional)
+  data, status_code, headers = api_instance.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_group_parameters_with_http_info: #{e}"
 end
 ```
 
@@ -644,20 +854,37 @@ nil (empty response body)
 
 test inline additionalProperties
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 request_body = {'key' => 'request_body_example'} # Hash<String, String> | request body
 
 begin
-  #test inline additionalProperties
+  # test inline additionalProperties
   api_instance.test_inline_additional_properties(request_body)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_inline_additional_properties: #{e}"
+  puts "Error when calling FakeApi->test_inline_additional_properties: #{e}"
+end
+```
+
+#### Using the test_inline_additional_properties_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_inline_additional_properties_with_http_info(request_body)
+
+```ruby
+begin
+  # test inline additionalProperties
+  data, status_code, headers = api_instance.test_inline_additional_properties_with_http_info(request_body)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_inline_additional_properties_with_http_info: #{e}"
 end
 ```
 
@@ -687,10 +914,9 @@ No authorization required
 
 test json serialization of form data
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -698,10 +924,28 @@ param = 'param_example' # String | field1
 param2 = 'param2_example' # String | field2
 
 begin
-  #test json serialization of form data
+  # test json serialization of form data
   api_instance.test_json_form_data(param, param2)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_json_form_data: #{e}"
+  puts "Error when calling FakeApi->test_json_form_data: #{e}"
+end
+```
+
+#### Using the test_json_form_data_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_json_form_data_with_http_info(param, param2)
+
+```ruby
+begin
+  # test json serialization of form data
+  data, status_code, headers = api_instance.test_json_form_data_with_http_info(param, param2)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_json_form_data_with_http_info: #{e}"
 end
 ```
 
@@ -734,10 +978,9 @@ No authorization required
 
 To test the collection format in query parameters
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::FakeApi.new
@@ -748,9 +991,28 @@ url = ['url_example'] # Array<String> |
 context = ['context_example'] # Array<String> | 
 
 begin
+  
   api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeApi->test_query_parameter_collection_format: #{e}"
+  puts "Error when calling FakeApi->test_query_parameter_collection_format: #{e}"
+end
+```
+
+#### Using the test_query_parameter_collection_format_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context)
+
+```ruby
+begin
+  
+  data, status_code, headers = api_instance.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeApi->test_query_parameter_collection_format_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/ruby/docs/FakeClassnameTags123Api.md
@@ -9,16 +9,15 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 ## test_classname
 
-> Client test_classname(client)
+> <Client> test_classname(client)
 
 To test class name in snake case
 
 To test class name in snake case
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -32,11 +31,29 @@ api_instance = Petstore::FakeClassnameTags123Api.new
 client = Petstore::Client.new # Client | client model
 
 begin
-  #To test class name in snake case
+  # To test class name in snake case
   result = api_instance.test_classname(client)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling FakeClassnameTags123Api->test_classname: #{e}"
+  puts "Error when calling FakeClassnameTags123Api->test_classname: #{e}"
+end
+```
+
+#### Using the test_classname_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Client>, Integer, Hash)> test_classname_with_http_info(client)
+
+```ruby
+begin
+  # To test class name in snake case
+  data, status_code, headers = api_instance.test_classname_with_http_info(client)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Client>
+rescue Petstore::ApiError => e
+  puts "Error when calling FakeClassnameTags123Api->test_classname_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby/docs/File.md
+++ b/samples/client/petstore/ruby/docs/File.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **source_uri** | **String** | Test capitalization | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/FileSchemaTestClass.md
+++ b/samples/client/petstore/ruby/docs/FileSchemaTestClass.md
@@ -7,7 +7,7 @@
 | **file** | **File** |  | [optional] |
 | **files** | **Array&lt;File&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/Foo.md
+++ b/samples/client/petstore/ruby/docs/Foo.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **bar** | **String** |  | [optional][default to &#39;bar&#39;] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/FormatTest.md
+++ b/samples/client/petstore/ruby/docs/FormatTest.md
@@ -21,7 +21,7 @@
 | **pattern_with_digits** | **String** | A string that is a 10 digit number. Can have leading zeros. | [optional] |
 | **pattern_with_digits_and_delimiter** | **String** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/ruby/docs/HasOnlyReadOnly.md
@@ -7,7 +7,7 @@
 | **bar** | **String** |  | [optional][readonly] |
 | **foo** | **String** |  | [optional][readonly] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/HealthCheckResult.md
+++ b/samples/client/petstore/ruby/docs/HealthCheckResult.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **nullable_message** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/InlineObject.md
+++ b/samples/client/petstore/ruby/docs/InlineObject.md
@@ -7,7 +7,7 @@
 | **name** | **String** | Updated name of the pet | [optional] |
 | **status** | **String** | Updated status of the pet | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/InlineObject1.md
+++ b/samples/client/petstore/ruby/docs/InlineObject1.md
@@ -7,7 +7,7 @@
 | **additional_metadata** | **String** | Additional data to pass to server | [optional] |
 | **file** | **File** | file to upload | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/InlineObject2.md
+++ b/samples/client/petstore/ruby/docs/InlineObject2.md
@@ -7,7 +7,7 @@
 | **enum_form_string_array** | **Array&lt;String&gt;** | Form parameter enum test (string array) | [optional] |
 | **enum_form_string** | **String** | Form parameter enum test (string) | [optional][default to &#39;-efg&#39;] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/InlineObject3.md
+++ b/samples/client/petstore/ruby/docs/InlineObject3.md
@@ -19,7 +19,7 @@
 | **password** | **String** | None | [optional] |
 | **callback** | **String** | None | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/InlineObject4.md
+++ b/samples/client/petstore/ruby/docs/InlineObject4.md
@@ -7,7 +7,7 @@
 | **param** | **String** | field1 |  |
 | **param2** | **String** | field2 |  |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/InlineObject5.md
+++ b/samples/client/petstore/ruby/docs/InlineObject5.md
@@ -7,7 +7,7 @@
 | **additional_metadata** | **String** | Additional data to pass to server | [optional] |
 | **required_file** | **File** | file to upload |  |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/InlineResponseDefault.md
+++ b/samples/client/petstore/ruby/docs/InlineResponseDefault.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **string** | [**Foo**](Foo.md) |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/List.md
+++ b/samples/client/petstore/ruby/docs/List.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **_123_list** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/MapTest.md
+++ b/samples/client/petstore/ruby/docs/MapTest.md
@@ -9,7 +9,7 @@
 | **direct_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
 | **indirect_map** | **Hash&lt;String, Boolean&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/ruby/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -8,7 +8,7 @@
 | **date_time** | **Time** |  | [optional] |
 | **map** | [**Hash&lt;String, Animal&gt;**](Animal.md) |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/Model200Response.md
+++ b/samples/client/petstore/ruby/docs/Model200Response.md
@@ -7,7 +7,7 @@
 | **name** | **Integer** |  | [optional] |
 | **_class** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/ModelReturn.md
+++ b/samples/client/petstore/ruby/docs/ModelReturn.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **_return** | **Integer** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/Name.md
+++ b/samples/client/petstore/ruby/docs/Name.md
@@ -9,7 +9,7 @@
 | **property** | **String** |  | [optional] |
 | **_123_number** | **Integer** |  | [optional][readonly] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/NullableClass.md
+++ b/samples/client/petstore/ruby/docs/NullableClass.md
@@ -17,7 +17,7 @@
 | **object_and_items_nullable_prop** | **Hash&lt;String, Object&gt;** |  | [optional] |
 | **object_items_nullable** | **Hash&lt;String, Object&gt;** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/NumberOnly.md
+++ b/samples/client/petstore/ruby/docs/NumberOnly.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **just_number** | **Float** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/Order.md
+++ b/samples/client/petstore/ruby/docs/Order.md
@@ -11,7 +11,7 @@
 | **status** | **String** | Order Status | [optional] |
 | **complete** | **Boolean** |  | [optional][default to false] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/OuterComposite.md
+++ b/samples/client/petstore/ruby/docs/OuterComposite.md
@@ -8,7 +8,7 @@
 | **my_string** | **String** |  | [optional] |
 | **my_boolean** | **Boolean** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/OuterEnum.md
+++ b/samples/client/petstore/ruby/docs/OuterEnum.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/OuterEnumDefaultValue.md
+++ b/samples/client/petstore/ruby/docs/OuterEnumDefaultValue.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/OuterEnumInteger.md
+++ b/samples/client/petstore/ruby/docs/OuterEnumInteger.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/OuterEnumIntegerDefaultValue.md
+++ b/samples/client/petstore/ruby/docs/OuterEnumIntegerDefaultValue.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/Pet.md
+++ b/samples/client/petstore/ruby/docs/Pet.md
@@ -11,7 +11,7 @@
 | **tags** | [**Array&lt;Tag&gt;**](Tag.md) |  | [optional] |
 | **status** | **String** | pet status in the store | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/PetApi.md
+++ b/samples/client/petstore/ruby/docs/PetApi.md
@@ -21,10 +21,9 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Add a new pet to the store
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -36,10 +35,28 @@ api_instance = Petstore::PetApi.new
 pet = Petstore::Pet.new # Pet | Pet object that needs to be added to the store
 
 begin
-  #Add a new pet to the store
+  # Add a new pet to the store
   api_instance.add_pet(pet)
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->add_pet: #{e}"
+  puts "Error when calling PetApi->add_pet: #{e}"
+end
+```
+
+#### Using the add_pet_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> add_pet_with_http_info(pet)
+
+```ruby
+begin
+  # Add a new pet to the store
+  data, status_code, headers = api_instance.add_pet_with_http_info(pet)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->add_pet_with_http_info: #{e}"
 end
 ```
 
@@ -69,10 +86,9 @@ nil (empty response body)
 
 Deletes a pet
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -87,10 +103,28 @@ opts = {
 }
 
 begin
-  #Deletes a pet
+  # Deletes a pet
   api_instance.delete_pet(pet_id, opts)
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->delete_pet: #{e}"
+  puts "Error when calling PetApi->delete_pet: #{e}"
+end
+```
+
+#### Using the delete_pet_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> delete_pet_with_http_info(pet_id, opts)
+
+```ruby
+begin
+  # Deletes a pet
+  data, status_code, headers = api_instance.delete_pet_with_http_info(pet_id, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->delete_pet_with_http_info: #{e}"
 end
 ```
 
@@ -117,16 +151,15 @@ nil (empty response body)
 
 ## find_pets_by_status
 
-> Array&lt;Pet&gt; find_pets_by_status(status)
+> <Array<Pet>> find_pets_by_status(status)
 
 Finds Pets by status
 
 Multiple status values can be provided with comma separated strings
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -138,11 +171,29 @@ api_instance = Petstore::PetApi.new
 status = ['status_example'] # Array<String> | Status values that need to be considered for filter
 
 begin
-  #Finds Pets by status
+  # Finds Pets by status
   result = api_instance.find_pets_by_status(status)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->find_pets_by_status: #{e}"
+  puts "Error when calling PetApi->find_pets_by_status: #{e}"
+end
+```
+
+#### Using the find_pets_by_status_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Array<Pet>>, Integer, Hash)> find_pets_by_status_with_http_info(status)
+
+```ruby
+begin
+  # Finds Pets by status
+  data, status_code, headers = api_instance.find_pets_by_status_with_http_info(status)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Array<Pet>>
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->find_pets_by_status_with_http_info: #{e}"
 end
 ```
 
@@ -168,16 +219,15 @@ end
 
 ## find_pets_by_tags
 
-> Array&lt;Pet&gt; find_pets_by_tags(tags)
+> <Array<Pet>> find_pets_by_tags(tags)
 
 Finds Pets by tags
 
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -189,11 +239,29 @@ api_instance = Petstore::PetApi.new
 tags = ['tags_example'] # Array<String> | Tags to filter by
 
 begin
-  #Finds Pets by tags
+  # Finds Pets by tags
   result = api_instance.find_pets_by_tags(tags)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->find_pets_by_tags: #{e}"
+  puts "Error when calling PetApi->find_pets_by_tags: #{e}"
+end
+```
+
+#### Using the find_pets_by_tags_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Array<Pet>>, Integer, Hash)> find_pets_by_tags_with_http_info(tags)
+
+```ruby
+begin
+  # Finds Pets by tags
+  data, status_code, headers = api_instance.find_pets_by_tags_with_http_info(tags)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Array<Pet>>
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->find_pets_by_tags_with_http_info: #{e}"
 end
 ```
 
@@ -219,16 +287,15 @@ end
 
 ## get_pet_by_id
 
-> Pet get_pet_by_id(pet_id)
+> <Pet> get_pet_by_id(pet_id)
 
 Find pet by ID
 
 Returns a single pet
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -242,11 +309,29 @@ api_instance = Petstore::PetApi.new
 pet_id = 56 # Integer | ID of pet to return
 
 begin
-  #Find pet by ID
+  # Find pet by ID
   result = api_instance.get_pet_by_id(pet_id)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->get_pet_by_id: #{e}"
+  puts "Error when calling PetApi->get_pet_by_id: #{e}"
+end
+```
+
+#### Using the get_pet_by_id_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Pet>, Integer, Hash)> get_pet_by_id_with_http_info(pet_id)
+
+```ruby
+begin
+  # Find pet by ID
+  data, status_code, headers = api_instance.get_pet_by_id_with_http_info(pet_id)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Pet>
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->get_pet_by_id_with_http_info: #{e}"
 end
 ```
 
@@ -276,10 +361,9 @@ end
 
 Update an existing pet
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -291,10 +375,28 @@ api_instance = Petstore::PetApi.new
 pet = Petstore::Pet.new # Pet | Pet object that needs to be added to the store
 
 begin
-  #Update an existing pet
+  # Update an existing pet
   api_instance.update_pet(pet)
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->update_pet: #{e}"
+  puts "Error when calling PetApi->update_pet: #{e}"
+end
+```
+
+#### Using the update_pet_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> update_pet_with_http_info(pet)
+
+```ruby
+begin
+  # Update an existing pet
+  data, status_code, headers = api_instance.update_pet_with_http_info(pet)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->update_pet_with_http_info: #{e}"
 end
 ```
 
@@ -324,10 +426,9 @@ nil (empty response body)
 
 Updates a pet in the store with form data
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -343,10 +444,28 @@ opts = {
 }
 
 begin
-  #Updates a pet in the store with form data
+  # Updates a pet in the store with form data
   api_instance.update_pet_with_form(pet_id, opts)
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->update_pet_with_form: #{e}"
+  puts "Error when calling PetApi->update_pet_with_form: #{e}"
+end
+```
+
+#### Using the update_pet_with_form_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> update_pet_with_form_with_http_info(pet_id, opts)
+
+```ruby
+begin
+  # Updates a pet in the store with form data
+  data, status_code, headers = api_instance.update_pet_with_form_with_http_info(pet_id, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->update_pet_with_form_with_http_info: #{e}"
 end
 ```
 
@@ -374,14 +493,13 @@ nil (empty response body)
 
 ## upload_file
 
-> ApiResponse upload_file(pet_id, opts)
+> <ApiResponse> upload_file(pet_id, opts)
 
 uploads an image
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -397,11 +515,29 @@ opts = {
 }
 
 begin
-  #uploads an image
+  # uploads an image
   result = api_instance.upload_file(pet_id, opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->upload_file: #{e}"
+  puts "Error when calling PetApi->upload_file: #{e}"
+end
+```
+
+#### Using the upload_file_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<ApiResponse>, Integer, Hash)> upload_file_with_http_info(pet_id, opts)
+
+```ruby
+begin
+  # uploads an image
+  data, status_code, headers = api_instance.upload_file_with_http_info(pet_id, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <ApiResponse>
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->upload_file_with_http_info: #{e}"
 end
 ```
 
@@ -429,14 +565,13 @@ end
 
 ## upload_file_with_required_file
 
-> ApiResponse upload_file_with_required_file(pet_id, required_file, opts)
+> <ApiResponse> upload_file_with_required_file(pet_id, required_file, opts)
 
 uploads an image (required)
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -452,11 +587,29 @@ opts = {
 }
 
 begin
-  #uploads an image (required)
+  # uploads an image (required)
   result = api_instance.upload_file_with_required_file(pet_id, required_file, opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling PetApi->upload_file_with_required_file: #{e}"
+  puts "Error when calling PetApi->upload_file_with_required_file: #{e}"
+end
+```
+
+#### Using the upload_file_with_required_file_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<ApiResponse>, Integer, Hash)> upload_file_with_required_file_with_http_info(pet_id, required_file, opts)
+
+```ruby
+begin
+  # uploads an image (required)
+  data, status_code, headers = api_instance.upload_file_with_required_file_with_http_info(pet_id, required_file, opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <ApiResponse>
+rescue Petstore::ApiError => e
+  puts "Error when calling PetApi->upload_file_with_required_file_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/ruby/docs/ReadOnlyFirst.md
@@ -7,7 +7,7 @@
 | **bar** | **String** |  | [optional][readonly] |
 | **baz** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/SpecialModelName.md
+++ b/samples/client/petstore/ruby/docs/SpecialModelName.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ----------- | ----- |
 | **special_property_name** | **Integer** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/StoreApi.md
+++ b/samples/client/petstore/ruby/docs/StoreApi.md
@@ -18,20 +18,37 @@ Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
 order_id = 'order_id_example' # String | ID of the order that needs to be deleted
 
 begin
-  #Delete purchase order by ID
+  # Delete purchase order by ID
   api_instance.delete_order(order_id)
 rescue Petstore::ApiError => e
-  puts "Exception when calling StoreApi->delete_order: #{e}"
+  puts "Error when calling StoreApi->delete_order: #{e}"
+end
+```
+
+#### Using the delete_order_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> delete_order_with_http_info(order_id)
+
+```ruby
+begin
+  # Delete purchase order by ID
+  data, status_code, headers = api_instance.delete_order_with_http_info(order_id)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling StoreApi->delete_order_with_http_info: #{e}"
 end
 ```
 
@@ -63,10 +80,9 @@ Returns pet inventories by status
 
 Returns a map of status codes to quantities
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 # setup authorization
 Petstore.configure do |config|
@@ -79,11 +95,29 @@ end
 api_instance = Petstore::StoreApi.new
 
 begin
-  #Returns pet inventories by status
+  # Returns pet inventories by status
   result = api_instance.get_inventory
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling StoreApi->get_inventory: #{e}"
+  puts "Error when calling StoreApi->get_inventory: #{e}"
+end
+```
+
+#### Using the get_inventory_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(Hash&lt;String, Integer&gt;, Integer, Hash)> get_inventory_with_http_info
+
+```ruby
+begin
+  # Returns pet inventories by status
+  data, status_code, headers = api_instance.get_inventory_with_http_info
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => Hash&lt;String, Integer&gt;
+rescue Petstore::ApiError => e
+  puts "Error when calling StoreApi->get_inventory_with_http_info: #{e}"
 end
 ```
 
@@ -107,27 +141,44 @@ This endpoint does not need any parameter.
 
 ## get_order_by_id
 
-> Order get_order_by_id(order_id)
+> <Order> get_order_by_id(order_id)
 
 Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
 order_id = 56 # Integer | ID of pet that needs to be fetched
 
 begin
-  #Find purchase order by ID
+  # Find purchase order by ID
   result = api_instance.get_order_by_id(order_id)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling StoreApi->get_order_by_id: #{e}"
+  puts "Error when calling StoreApi->get_order_by_id: #{e}"
+end
+```
+
+#### Using the get_order_by_id_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Order>, Integer, Hash)> get_order_by_id_with_http_info(order_id)
+
+```ruby
+begin
+  # Find purchase order by ID
+  data, status_code, headers = api_instance.get_order_by_id_with_http_info(order_id)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Order>
+rescue Petstore::ApiError => e
+  puts "Error when calling StoreApi->get_order_by_id_with_http_info: #{e}"
 end
 ```
 
@@ -153,25 +204,42 @@ No authorization required
 
 ## place_order
 
-> Order place_order(order)
+> <Order> place_order(order)
 
 Place an order for a pet
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::StoreApi.new
 order = Petstore::Order.new # Order | order placed for purchasing the pet
 
 begin
-  #Place an order for a pet
+  # Place an order for a pet
   result = api_instance.place_order(order)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling StoreApi->place_order: #{e}"
+  puts "Error when calling StoreApi->place_order: #{e}"
+end
+```
+
+#### Using the place_order_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<Order>, Integer, Hash)> place_order_with_http_info(order)
+
+```ruby
+begin
+  # Place an order for a pet
+  data, status_code, headers = api_instance.place_order_with_http_info(order)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <Order>
+rescue Petstore::ApiError => e
+  puts "Error when calling StoreApi->place_order_with_http_info: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby/docs/Tag.md
+++ b/samples/client/petstore/ruby/docs/Tag.md
@@ -7,7 +7,7 @@
 | **id** | **Integer** |  | [optional] |
 | **name** | **String** |  | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/User.md
+++ b/samples/client/petstore/ruby/docs/User.md
@@ -13,7 +13,7 @@
 | **phone** | **String** |  | [optional] |
 | **user_status** | **Integer** | User Status | [optional] |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/client/petstore/ruby/docs/UserApi.md
+++ b/samples/client/petstore/ruby/docs/UserApi.md
@@ -22,20 +22,37 @@ Create user
 
 This can only be done by the logged in user.
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
 user = Petstore::User.new # User | Created user object
 
 begin
-  #Create user
+  # Create user
   api_instance.create_user(user)
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->create_user: #{e}"
+  puts "Error when calling UserApi->create_user: #{e}"
+end
+```
+
+#### Using the create_user_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> create_user_with_http_info(user)
+
+```ruby
+begin
+  # Create user
+  data, status_code, headers = api_instance.create_user_with_http_info(user)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->create_user_with_http_info: #{e}"
 end
 ```
 
@@ -65,20 +82,37 @@ No authorization required
 
 Creates list of users with given input array
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
 user = [Petstore::User.new] # Array<User> | List of user object
 
 begin
-  #Creates list of users with given input array
+  # Creates list of users with given input array
   api_instance.create_users_with_array_input(user)
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->create_users_with_array_input: #{e}"
+  puts "Error when calling UserApi->create_users_with_array_input: #{e}"
+end
+```
+
+#### Using the create_users_with_array_input_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> create_users_with_array_input_with_http_info(user)
+
+```ruby
+begin
+  # Creates list of users with given input array
+  data, status_code, headers = api_instance.create_users_with_array_input_with_http_info(user)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->create_users_with_array_input_with_http_info: #{e}"
 end
 ```
 
@@ -108,20 +142,37 @@ No authorization required
 
 Creates list of users with given input array
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
 user = [Petstore::User.new] # Array<User> | List of user object
 
 begin
-  #Creates list of users with given input array
+  # Creates list of users with given input array
   api_instance.create_users_with_list_input(user)
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->create_users_with_list_input: #{e}"
+  puts "Error when calling UserApi->create_users_with_list_input: #{e}"
+end
+```
+
+#### Using the create_users_with_list_input_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> create_users_with_list_input_with_http_info(user)
+
+```ruby
+begin
+  # Creates list of users with given input array
+  data, status_code, headers = api_instance.create_users_with_list_input_with_http_info(user)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->create_users_with_list_input_with_http_info: #{e}"
 end
 ```
 
@@ -153,20 +204,37 @@ Delete user
 
 This can only be done by the logged in user.
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
 username = 'username_example' # String | The name that needs to be deleted
 
 begin
-  #Delete user
+  # Delete user
   api_instance.delete_user(username)
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->delete_user: #{e}"
+  puts "Error when calling UserApi->delete_user: #{e}"
+end
+```
+
+#### Using the delete_user_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> delete_user_with_http_info(username)
+
+```ruby
+begin
+  # Delete user
+  data, status_code, headers = api_instance.delete_user_with_http_info(username)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->delete_user_with_http_info: #{e}"
 end
 ```
 
@@ -192,25 +260,42 @@ No authorization required
 
 ## get_user_by_name
 
-> User get_user_by_name(username)
+> <User> get_user_by_name(username)
 
 Get user by user name
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
 username = 'username_example' # String | The name that needs to be fetched. Use user1 for testing.
 
 begin
-  #Get user by user name
+  # Get user by user name
   result = api_instance.get_user_by_name(username)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->get_user_by_name: #{e}"
+  puts "Error when calling UserApi->get_user_by_name: #{e}"
+end
+```
+
+#### Using the get_user_by_name_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<User>, Integer, Hash)> get_user_by_name_with_http_info(username)
+
+```ruby
+begin
+  # Get user by user name
+  data, status_code, headers = api_instance.get_user_by_name_with_http_info(username)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <User>
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->get_user_by_name_with_http_info: #{e}"
 end
 ```
 
@@ -240,10 +325,9 @@ No authorization required
 
 Logs user into the system
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -251,11 +335,29 @@ username = 'username_example' # String | The user name for login
 password = 'password_example' # String | The password for login in clear text
 
 begin
-  #Logs user into the system
+  # Logs user into the system
   result = api_instance.login_user(username, password)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->login_user: #{e}"
+  puts "Error when calling UserApi->login_user: #{e}"
+end
+```
+
+#### Using the login_user_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(String, Integer, Hash)> login_user_with_http_info(username, password)
+
+```ruby
+begin
+  # Logs user into the system
+  data, status_code, headers = api_instance.login_user_with_http_info(username, password)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => String
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->login_user_with_http_info: #{e}"
 end
 ```
 
@@ -286,19 +388,36 @@ No authorization required
 
 Logs out current logged in user session
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
 
 begin
-  #Logs out current logged in user session
+  # Logs out current logged in user session
   api_instance.logout_user
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->logout_user: #{e}"
+  puts "Error when calling UserApi->logout_user: #{e}"
+end
+```
+
+#### Using the logout_user_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> logout_user_with_http_info
+
+```ruby
+begin
+  # Logs out current logged in user session
+  data, status_code, headers = api_instance.logout_user_with_http_info
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->logout_user_with_http_info: #{e}"
 end
 ```
 
@@ -328,10 +447,9 @@ Updated user
 
 This can only be done by the logged in user.
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UserApi.new
@@ -339,10 +457,28 @@ username = 'username_example' # String | name that need to be deleted
 user = Petstore::User.new # User | Updated user object
 
 begin
-  #Updated user
+  # Updated user
   api_instance.update_user(username, user)
 rescue Petstore::ApiError => e
-  puts "Exception when calling UserApi->update_user: #{e}"
+  puts "Error when calling UserApi->update_user: #{e}"
+end
+```
+
+#### Using the update_user_with_http_info variant
+
+This returns an Array which contains the response data (`nil` in this case), status code and headers.
+
+> <Array(nil, Integer, Hash)> update_user_with_http_info(username, user)
+
+```ruby
+begin
+  # Updated user
+  data, status_code, headers = api_instance.update_user_with_http_info(username, user)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => nil
+rescue Petstore::ApiError => e
+  puts "Error when calling UserApi->update_user_with_http_info: #{e}"
 end
 ```
 

--- a/samples/openapi3/client/features/dynamic-servers/ruby/docs/UsageApi.md
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/docs/UsageApi.md
@@ -16,20 +16,37 @@ Use custom server
 
 Use custom server
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'dynamic_servers'
 
 api_instance = DynamicServers::UsageApi.new
 
 begin
-  #Use custom server
+  # Use custom server
   result = api_instance.custom_server
   p result
 rescue DynamicServers::ApiError => e
-  puts "Exception when calling UsageApi->custom_server: #{e}"
+  puts "Error when calling UsageApi->custom_server: #{e}"
+end
+```
+
+#### Using the custom_server_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(Object, Integer, Hash)> custom_server_with_http_info
+
+```ruby
+begin
+  # Use custom server
+  data, status_code, headers = api_instance.custom_server_with_http_info
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => Object
+rescue DynamicServers::ApiError => e
+  puts "Error when calling UsageApi->custom_server_with_http_info: #{e}"
 end
 ```
 
@@ -59,20 +76,37 @@ Use default server
 
 Use default server
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'dynamic_servers'
 
 api_instance = DynamicServers::UsageApi.new
 
 begin
-  #Use default server
+  # Use default server
   result = api_instance.default_server
   p result
 rescue DynamicServers::ApiError => e
-  puts "Exception when calling UsageApi->default_server: #{e}"
+  puts "Error when calling UsageApi->default_server: #{e}"
+end
+```
+
+#### Using the default_server_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(Object, Integer, Hash)> default_server_with_http_info
+
+```ruby
+begin
+  # Use default server
+  data, status_code, headers = api_instance.default_server_with_http_info
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => Object
+rescue DynamicServers::ApiError => e
+  puts "Error when calling UsageApi->default_server_with_http_info: #{e}"
 end
 ```
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/ArrayAlias.md
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/ArrayAlias.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/MapAlias.md
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/MapAlias.md
@@ -5,7 +5,7 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 
-## Code Sample
+## Example
 
 ```ruby
 require 'petstore'

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/UsageApi.md
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/docs/UsageApi.md
@@ -16,10 +16,9 @@ Use alias to array
 
 Use alias to array
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UsageApi.new
@@ -28,11 +27,29 @@ opts = {
 }
 
 begin
-  #Use alias to array
+  # Use alias to array
   result = api_instance.array(opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling UsageApi->array: #{e}"
+  puts "Error when calling UsageApi->array: #{e}"
+end
+```
+
+#### Using the array_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(Object, Integer, Hash)> array_with_http_info(opts)
+
+```ruby
+begin
+  # Use alias to array
+  data, status_code, headers = api_instance.array_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => Object
+rescue Petstore::ApiError => e
+  puts "Error when calling UsageApi->array_with_http_info: #{e}"
 end
 ```
 
@@ -64,10 +81,9 @@ Use alias to map
 
 Use alias to map
 
-### Example
+### Examples
 
 ```ruby
-# load the gem
 require 'petstore'
 
 api_instance = Petstore::UsageApi.new
@@ -76,11 +92,29 @@ opts = {
 }
 
 begin
-  #Use alias to map
+  # Use alias to map
   result = api_instance.map(opts)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling UsageApi->map: #{e}"
+  puts "Error when calling UsageApi->map: #{e}"
+end
+```
+
+#### Using the map_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(Object, Integer, Hash)> map_with_http_info(opts)
+
+```ruby
+begin
+  # Use alias to map
+  data, status_code, headers = api_instance.map_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => Object
+rescue Petstore::ApiError => e
+  puts "Error when calling UsageApi->map_with_http_info: #{e}"
 end
 ```
 


### PR DESCRIPTION
Those methods are useful for us because we need to retrieve pagination information from the headers but they were not documented. This addresses that, no code change.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@cliffano (2017/07) @zlx (2017/09) @autopp (2019/02) @wing328 