### PR TITLE
[Go] Fix for 'Invalid code for files array in multipart/form-data request'…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
@@ -228,7 +228,7 @@ public class GoServerCodegen extends AbstractGoCodegen {
         for (CodegenOperation operation : operations) {
             for (CodegenParameter param : operation.allParams) {
                 // import "os" if the operation uses files
-                if (!addedOSImport && "*os.File".equals(param.dataType)) {
+                if (!addedOSImport && ("*os.File".equals(param.dataType) || ("[]*os.File".equals(param.dataType)))) {
                     imports.add(createMapping("import", "os"));
                     addedOSImport = true;
                 }

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -66,7 +66,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	}
 	{{/isInteger}}{{^isLong}}{{^isInteger}}
 	{{paramName}} := {{#isArray}}strings.Split({{/isArray}}query.Get("{{paramName}}"){{#isArray}}, ","){{/isArray}}{{/isInteger}}{{/isLong}}{{/isQueryParam}}{{#isFormParam}}{{#isFile}}
-	{{paramName}}, err := ReadFormFileToTempFile(r, "{{paramName}}")
+    {{#isArray}}{{paramName}}, err := ReadFormFilesToTempFiles(r, "{{paramName}}"){{/isArray}}{{^isArray}}{{paramName}}, err := ReadFormFileToTempFile(r, "{{paramName}}"){{/isArray}}
 	if err != nil {
 		w.WriteHeader(500)
 		return

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -66,7 +66,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	}
 	{{/isInteger}}{{^isLong}}{{^isInteger}}
 	{{paramName}} := {{#isArray}}strings.Split({{/isArray}}query.Get("{{paramName}}"){{#isArray}}, ","){{/isArray}}{{/isInteger}}{{/isLong}}{{/isQueryParam}}{{#isFormParam}}{{#isFile}}
-    {{#isArray}}{{paramName}}, err := ReadFormFilesToTempFiles(r, "{{paramName}}"){{/isArray}}{{^isArray}}{{paramName}}, err := ReadFormFileToTempFile(r, "{{paramName}}"){{/isArray}}
+	{{#isArray}}{{paramName}}, err := ReadFormFilesToTempFiles(r, "{{paramName}}"){{/isArray}}{{^isArray}}{{paramName}}, err := ReadFormFileToTempFile(r, "{{paramName}}"){{/isArray}}
 	if err != nil {
 		w.WriteHeader(500)
 		return

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-    {{#featureCORS}}
+	{{#featureCORS}}
 	"github.com/gorilla/handlers"
-    {{/featureCORS}}
+	{{/featureCORS}}
 	"github.com/gorilla/mux"
 )
 
@@ -37,9 +37,9 @@ func NewRouter(routers ...Router) *mux.Router {
 			var handler http.Handler
 			handler = route.HandlerFunc
 			handler = Logger(handler, route.Name)
-            {{#featureCORS}}
+			{{#featureCORS}}
 			handler = handlers.CORS()(handler)
-            {{/featureCORS}}
+			{{/featureCORS}}
 
 			router.
 				Methods(route.Method).
@@ -66,58 +66,58 @@ func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file
 func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
-    _, fileHeader, err := r.FormFile(key)
-    if err != nil {
-        return nil, err
-    }
+	_, fileHeader, err := r.FormFile(key)
+	if err != nil {
+		return nil, err
+	}
 
-    return readFileHeaderToTempFile(fileHeader)
+	return readFileHeaderToTempFile(fileHeader)
 }
 
 // ReadFormFilesToTempFiles reads files array data from a request form and writes it to a temporary files
 func ReadFormFilesToTempFiles(r *http.Request, key string) ([]*os.File, error) {
-    if err := r.ParseMultipartForm(32 << 20); err != nil {
-        return nil, err
-    }
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		return nil, err
+	}
 
-    files := make([]*os.File, 0, len(r.MultipartForm.File[key]))
+	files := make([]*os.File, 0, len(r.MultipartForm.File[key]))
 
-    for _, fileHeader := range r.MultipartForm.File[key] {
-        file, err := readFileHeaderToTempFile(fileHeader)
-        if err != nil {
-            return nil, err
-        }
+	for _, fileHeader := range r.MultipartForm.File[key] {
+		file, err := readFileHeaderToTempFile(fileHeader)
+		if err != nil {
+			return nil, err
+		}
 
-        files = append(files, file)
-    }
+		files = append(files, file)
+	}
 
-    return files, nil
+	return files, nil
 }
 
 // readFileHeaderToTempFile reads multipart.FileHeader and writes it to a temporary file
 func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error) {
-    formFile, err := fileHeader.Open()
-    if err != nil {
-        return nil, err
-    }
+	formFile, err := fileHeader.Open()
+	if err != nil {
+		return nil, err
+	}
 
-    defer formFile.Close()
+	defer formFile.Close()
 
-    fileBytes, err := ioutil.ReadAll(formFile)
-    if err != nil {
-        return nil, err
-    }
+	fileBytes, err := ioutil.ReadAll(formFile)
+	if err != nil {
+		return nil, err
+	}
 
-    file, err := ioutil.TempFile("", fileHeader.Filename)
-    if err != nil {
-        return nil, err
-    }
+	file, err := ioutil.TempFile("", fileHeader.Filename)
+	if err != nil {
+		return nil, err
+	}
 
-    defer file.Close()
+	defer file.Close()
 
-    file.Write(fileBytes)
+	file.Write(fileBytes)
 
-    return file, nil
+	return file, nil
 }
 
 

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -25,7 +25,7 @@ type Route struct {
 type Routes []Route
 
 // Router defines the required methods for retrieving api routes
-type Router interface { 
+type Router interface {
 	Routes() Routes
 }
 
@@ -66,27 +66,60 @@ func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file
 func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
-	r.ParseForm()
-	formFile, _, err := r.FormFile(key)
-	if err != nil {
-		return nil, err
-	}
+    _, fileHeader, err := r.FormFile(key)
+    if err != nil {
+        return nil, err
+    }
 
-	defer formFile.Close()
-	file, err := ioutil.TempFile("tmp", key)
-	if err != nil {
-		return nil, err
-	}
-
-	defer file.Close()
-	fileBytes, err := ioutil.ReadAll(formFile)
-	if err != nil {
-		return nil, err
-	}
-
-	file.Write(fileBytes)
-	return file, nil
+    return readFileHeaderToTempFile(fileHeader)
 }
+
+// ReadFormFilesToTempFiles reads files array data from a request form and writes it to a temporary files
+func ReadFormFilesToTempFiles(r *http.Request, key string) ([]*os.File, error) {
+    if err := r.ParseMultipartForm(32 << 20); err != nil {
+        return nil, err
+    }
+
+    files := make([]*os.File, 0, len(r.MultipartForm.File[key]))
+
+    for _, fileHeader := range r.MultipartForm.File[key] {
+        file, err := readFileHeaderToTempFile(fileHeader)
+        if err != nil {
+            return nil, err
+        }
+
+        files = append(files, file)
+    }
+
+    return files, nil
+}
+
+// readFileHeaderToTempFile reads multipart.FileHeader and writes it to a temporary file
+func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error) {
+    formFile, err := fileHeader.Open()
+    if err != nil {
+        return nil, err
+    }
+
+    defer formFile.Close()
+
+    fileBytes, err := ioutil.ReadAll(formFile)
+    if err != nil {
+        return nil, err
+    }
+
+    file, err := ioutil.TempFile("", fileHeader.Filename)
+    if err != nil {
+        return nil, err
+    }
+
+    defer file.Close()
+
+    file.Write(fileBytes)
+
+    return file, nil
+}
+
 
 // parseInt64Parameter parses a sting parameter to an int64
 func parseInt64Parameter(param string) (int64, error) {

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -230,7 +230,7 @@ func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	additionalMetadata := r.FormValue("additionalMetadata")
-    file, err := ReadFormFileToTempFile(r, "file")
+	file, err := ReadFormFileToTempFile(r, "file")
 	if err != nil {
 		w.WriteHeader(500)
 		return

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -230,7 +230,7 @@ func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	additionalMetadata := r.FormValue("additionalMetadata")
-	file, err := ReadFormFileToTempFile(r, "file")
+    file, err := ReadFormFileToTempFile(r, "file")
 	if err != nil {
 		w.WriteHeader(500)
 		return

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -68,58 +68,58 @@ func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file
 func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
-    _, fileHeader, err := r.FormFile(key)
-    if err != nil {
-        return nil, err
-    }
+	_, fileHeader, err := r.FormFile(key)
+	if err != nil {
+		return nil, err
+	}
 
-    return readFileHeaderToTempFile(fileHeader)
+	return readFileHeaderToTempFile(fileHeader)
 }
 
 // ReadFormFilesToTempFiles reads files array data from a request form and writes it to a temporary files
 func ReadFormFilesToTempFiles(r *http.Request, key string) ([]*os.File, error) {
-    if err := r.ParseMultipartForm(32 << 20); err != nil {
-        return nil, err
-    }
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		return nil, err
+	}
 
-    files := make([]*os.File, 0, len(r.MultipartForm.File[key]))
+	files := make([]*os.File, 0, len(r.MultipartForm.File[key]))
 
-    for _, fileHeader := range r.MultipartForm.File[key] {
-        file, err := readFileHeaderToTempFile(fileHeader)
-        if err != nil {
-            return nil, err
-        }
+	for _, fileHeader := range r.MultipartForm.File[key] {
+		file, err := readFileHeaderToTempFile(fileHeader)
+		if err != nil {
+			return nil, err
+		}
 
-        files = append(files, file)
-    }
+		files = append(files, file)
+	}
 
-    return files, nil
+	return files, nil
 }
 
 // readFileHeaderToTempFile reads multipart.FileHeader and writes it to a temporary file
 func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error) {
-    formFile, err := fileHeader.Open()
-    if err != nil {
-        return nil, err
-    }
+	formFile, err := fileHeader.Open()
+	if err != nil {
+		return nil, err
+	}
 
-    defer formFile.Close()
+	defer formFile.Close()
 
-    fileBytes, err := ioutil.ReadAll(formFile)
-    if err != nil {
-        return nil, err
-    }
+	fileBytes, err := ioutil.ReadAll(formFile)
+	if err != nil {
+		return nil, err
+	}
 
-    file, err := ioutil.TempFile("", fileHeader.Filename)
-    if err != nil {
-        return nil, err
-    }
+	file, err := ioutil.TempFile("", fileHeader.Filename)
+	if err != nil {
+		return nil, err
+	}
 
-    defer file.Close()
+	defer file.Close()
 
-    file.Write(fileBytes)
+	file.Write(fileBytes)
 
-    return file, nil
+	return file, nil
 }
 
 

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -30,7 +30,7 @@ type Route struct {
 type Routes []Route
 
 // Router defines the required methods for retrieving api routes
-type Router interface { 
+type Router interface {
 	Routes() Routes
 }
 
@@ -68,27 +68,60 @@ func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error
 
 // ReadFormFileToTempFile reads file data from a request form and writes it to a temporary file
 func ReadFormFileToTempFile(r *http.Request, key string) (*os.File, error) {
-	r.ParseForm()
-	formFile, _, err := r.FormFile(key)
-	if err != nil {
-		return nil, err
-	}
+    _, fileHeader, err := r.FormFile(key)
+    if err != nil {
+        return nil, err
+    }
 
-	defer formFile.Close()
-	file, err := ioutil.TempFile("tmp", key)
-	if err != nil {
-		return nil, err
-	}
-
-	defer file.Close()
-	fileBytes, err := ioutil.ReadAll(formFile)
-	if err != nil {
-		return nil, err
-	}
-
-	file.Write(fileBytes)
-	return file, nil
+    return readFileHeaderToTempFile(fileHeader)
 }
+
+// ReadFormFilesToTempFiles reads files array data from a request form and writes it to a temporary files
+func ReadFormFilesToTempFiles(r *http.Request, key string) ([]*os.File, error) {
+    if err := r.ParseMultipartForm(32 << 20); err != nil {
+        return nil, err
+    }
+
+    files := make([]*os.File, 0, len(r.MultipartForm.File[key]))
+
+    for _, fileHeader := range r.MultipartForm.File[key] {
+        file, err := readFileHeaderToTempFile(fileHeader)
+        if err != nil {
+            return nil, err
+        }
+
+        files = append(files, file)
+    }
+
+    return files, nil
+}
+
+// readFileHeaderToTempFile reads multipart.FileHeader and writes it to a temporary file
+func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error) {
+    formFile, err := fileHeader.Open()
+    if err != nil {
+        return nil, err
+    }
+
+    defer formFile.Close()
+
+    fileBytes, err := ioutil.ReadAll(formFile)
+    if err != nil {
+        return nil, err
+    }
+
+    file, err := ioutil.TempFile("", fileHeader.Filename)
+    if err != nil {
+        return nil, err
+    }
+
+    defer file.Close()
+
+    file.Write(fileBytes)
+
+    return file, nil
+}
+
 
 // parseInt64Parameter parses a sting parameter to an int64
 func parseInt64Parameter(param string) (int64, error) {


### PR DESCRIPTION
Fixes invalid code generation, when multipart/form-data requestBody contains array of files (OpenAPITools#8093).

In addition to existing `ReadFormFileToTempFile` function a new one introduced `ReadFormFilesToTempFiles` returning a slice of `*os.File`. 

To avoid code duplication, common part related to `FileHeader` reading and storing in temporary file moved to new `readFileHeaderToTempFile` function.

`controller-api.mustache` updated to invoke corresponding function, depending on either single or multiple files are in a request.

Condition verifying the `os` package import extended in `GoServerCodegen.java` with a slice of files type.

Replaced a temporary directory path `"tmp"` with `""` in `ioutil.TempFile` call to make `TempFile()` using the default `os.TempDir` directory. 

### Testing

Existing automated tests passed. No new tests added.

Built project locally, manually tested generated code with different specifications (single file, array of files, various file formats).

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

### Technical committee
@antihax @grokify @kemokemo @bkabrda

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
