### PR TITLE
[Python][Client] Default to system CA instead of certifi

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-legacy/README_onlypackage.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/README_onlypackage.mustache
@@ -25,9 +25,8 @@ This python library package is generated without supporting files like setup.py 
 
 To be able to use it, you will need these dependencies in your own package that uses this library:
 
-* urllib3 >= 1.15
+* urllib3 >= 1.25.3
 * six >= 1.10
-* certifi
 * python-dateutil
 {{#asyncio}}
 * aiohttp

--- a/modules/openapi-generator/src/main/resources/python-legacy/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/asyncio/rest.mustache
@@ -9,7 +9,6 @@ import re
 import ssl
 
 import aiohttp
-import certifi
 # python 2 and python 3 compatibility library
 from six.moves.urllib.parse import urlencode
 
@@ -43,14 +42,7 @@ class RESTClientObject(object):
         if maxsize is None:
             maxsize = configuration.connection_pool_maxsize
 
-        # ca_certs
-        if configuration.ssl_ca_cert:
-            ca_certs = configuration.ssl_ca_cert
-        else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
-
-        ssl_context = ssl.create_default_context(cafile=ca_certs)
+        ssl_context = ssl.create_default_context(cafile=configuration.ssl_ca_cert)
         if configuration.cert_file:
             ssl_context.load_cert_chain(
                 configuration.cert_file, keyfile=configuration.key_file

--- a/modules/openapi-generator/src/main/resources/python-legacy/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/configuration.mustache
@@ -76,6 +76,8 @@ class Configuration(object):
     :param server_operation_variables: Mapping from operation ID to a mapping with
       string values to replace variables in templated server configuration.
       The validation of enums is performed for variables with defined enum values before.
+    :param ssl_ca_cert: str - the path to a file of concatenated CA certificates 
+      in PEM format 
 
 {{#hasAuthMethods}}
     :Example:
@@ -174,6 +176,7 @@ conf = {{{packageName}}}.Configuration(
 {{/hasHttpSignatureMethods}}
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ssl_ca_cert=None,
                  ):
         """Constructor
         """
@@ -258,7 +261,7 @@ conf = {{{packageName}}}.Configuration(
            Set this to false to skip verifying SSL certificate when calling API
            from https server.
         """
-        self.ssl_ca_cert = None
+        self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
         """
         self.cert_file = None

--- a/modules/openapi-generator/src/main/resources/python-legacy/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/requirements.mustache
@@ -1,6 +1,5 @@
-certifi >= 14.05.14
 future; python_version<="2.7"
 six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 1.25.3

--- a/modules/openapi-generator/src/main/resources/python-legacy/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/rest.mustache
@@ -10,7 +10,6 @@ import logging
 import re
 import ssl
 
-import certifi
 # python 2 and python 3 compatibility library
 import six
 from six.moves.urllib.parse import urlencode
@@ -54,13 +53,6 @@ class RESTClientObject(object):
         else:
             cert_reqs = ssl.CERT_NONE
 
-        # ca_certs
-        if configuration.ssl_ca_cert:
-            ca_certs = configuration.ssl_ca_cert
-        else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
-
         addition_pool_args = {}
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
@@ -83,7 +75,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
@@ -95,7 +87,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 **addition_pool_args

--- a/modules/openapi-generator/src/main/resources/python-legacy/setup.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/setup.mustache
@@ -16,7 +16,7 @@ VERSION = "{{packageVersion}}"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = ["urllib3 >= 1.25.3", "six >= 1.10", "python-dateutil"]
 {{#asyncio}}
 REQUIRES.append("aiohttp >= 3.0.0")
 {{/asyncio}}

--- a/modules/openapi-generator/src/main/resources/python/README_onlypackage.mustache
+++ b/modules/openapi-generator/src/main/resources/python/README_onlypackage.mustache
@@ -25,8 +25,7 @@ This python library package is generated without supporting files like setup.py 
 
 To be able to use it, you will need these dependencies in your own package that uses this library:
 
-* urllib3 >= 1.15
-* certifi
+* urllib3 >= 1.25.3
 * python-dateutil
 {{#asyncio}}
 * aiohttp

--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -9,7 +9,6 @@ import re
 import ssl
 
 import aiohttp
-import certifi
 # python 2 and python 3 compatibility library
 from six.moves.urllib.parse import urlencode
 
@@ -43,14 +42,7 @@ class RESTClientObject(object):
         if maxsize is None:
             maxsize = configuration.connection_pool_maxsize
 
-        # ca_certs
-        if configuration.ssl_ca_cert:
-            ca_certs = configuration.ssl_ca_cert
-        else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
-
-        ssl_context = ssl.create_default_context(cafile=ca_certs)
+        ssl_context = ssl.create_default_context(cafile=configuration.ssl_ca_cert)
         if configuration.cert_file:
             ssl_context.load_cert_chain(
                 configuration.cert_file, keyfile=configuration.key_file

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -73,6 +73,8 @@ class Configuration(object):
     :param server_operation_variables: Mapping from operation ID to a mapping with
       string values to replace variables in templated server configuration.
       The validation of enums is performed for variables with defined enum values before.
+    :param ssl_ca_cert: str - the path to a file of concatenated CA certificates 
+      in PEM format
 
 {{#hasAuthMethods}}
     :Example:
@@ -171,6 +173,7 @@ conf = {{{packageName}}}.Configuration(
 {{/hasHttpSignatureMethods}}
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ssl_ca_cert=None,
                  ):
         """Constructor
         """
@@ -255,7 +258,7 @@ conf = {{{packageName}}}.Configuration(
            Set this to false to skip verifying SSL certificate when calling API
            from https server.
         """
-        self.ssl_ca_cert = None
+        self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
         """
         self.cert_file = None

--- a/modules/openapi-generator/src/main/resources/python/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/requirements.mustache
@@ -1,5 +1,4 @@
 nulltype
-certifi >= 14.05.14
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 1.25.3

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -9,7 +9,6 @@ import re
 import ssl
 from urllib.parse import urlencode
 
-import certifi
 import urllib3
 
 from {{packageName}}.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError
@@ -50,13 +49,6 @@ class RESTClientObject(object):
         else:
             cert_reqs = ssl.CERT_NONE
 
-        # ca_certs
-        if configuration.ssl_ca_cert:
-            ca_certs = configuration.ssl_ca_cert
-        else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
-
         addition_pool_args = {}
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
@@ -79,7 +71,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
@@ -91,7 +83,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 **addition_pool_args

--- a/modules/openapi-generator/src/main/resources/python/setup.mustache
+++ b/modules/openapi-generator/src/main/resources/python/setup.mustache
@@ -17,8 +17,7 @@ VERSION = "{{packageVersion}}"
 # http://pypi.python.org/pypi/setuptools
 
 REQUIRES = [
-  "urllib3 >= 1.15",
-  "certifi",
+  "urllib3 >= 1.25.3",
   "python-dateutil",
   "nulltype",
 {{#asyncio}}

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -77,6 +77,8 @@ class Configuration(object):
     :param server_operation_variables: Mapping from operation ID to a mapping with
       string values to replace variables in templated server configuration.
       The validation of enums is performed for variables with defined enum values before.
+    :param ssl_ca_cert: str - the path to a file of concatenated CA certificates 
+      in PEM format 
 
     :Example:
 
@@ -125,6 +127,7 @@ conf = petstore_api.Configuration(
                  disabled_client_side_validations="",
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ssl_ca_cert=None,
                  ):
         """Constructor
         """
@@ -193,7 +196,7 @@ conf = petstore_api.Configuration(
            Set this to false to skip verifying SSL certificate when calling API
            from https server.
         """
-        self.ssl_ca_cert = None
+        self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
         """
         self.cert_file = None

--- a/samples/client/petstore/python-asyncio/petstore_api/rest.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/rest.py
@@ -17,7 +17,6 @@ import re
 import ssl
 
 import aiohttp
-import certifi
 # python 2 and python 3 compatibility library
 from six.moves.urllib.parse import urlencode
 
@@ -51,14 +50,7 @@ class RESTClientObject(object):
         if maxsize is None:
             maxsize = configuration.connection_pool_maxsize
 
-        # ca_certs
-        if configuration.ssl_ca_cert:
-            ca_certs = configuration.ssl_ca_cert
-        else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
-
-        ssl_context = ssl.create_default_context(cafile=ca_certs)
+        ssl_context = ssl.create_default_context(cafile=configuration.ssl_ca_cert)
         if configuration.cert_file:
             ssl_context.load_cert_chain(
                 configuration.cert_file, keyfile=configuration.key_file

--- a/samples/client/petstore/python-asyncio/requirements.txt
+++ b/samples/client/petstore/python-asyncio/requirements.txt
@@ -1,6 +1,5 @@
-certifi >= 14.05.14
 future; python_version<="2.7"
 six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 1.25.3

--- a/samples/client/petstore/python-asyncio/setup.py
+++ b/samples/client/petstore/python-asyncio/setup.py
@@ -21,7 +21,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = ["urllib3 >= 1.25.3", "six >= 1.10", "python-dateutil"]
 REQUIRES.append("aiohttp >= 3.0.0")
 
 setup(

--- a/samples/client/petstore/python-legacy/petstore_api/configuration.py
+++ b/samples/client/petstore/python-legacy/petstore_api/configuration.py
@@ -78,6 +78,8 @@ class Configuration(object):
     :param server_operation_variables: Mapping from operation ID to a mapping with
       string values to replace variables in templated server configuration.
       The validation of enums is performed for variables with defined enum values before.
+    :param ssl_ca_cert: str - the path to a file of concatenated CA certificates 
+      in PEM format 
 
     :Example:
 
@@ -126,6 +128,7 @@ conf = petstore_api.Configuration(
                  disabled_client_side_validations="",
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ssl_ca_cert=None,
                  ):
         """Constructor
         """
@@ -194,7 +197,7 @@ conf = petstore_api.Configuration(
            Set this to false to skip verifying SSL certificate when calling API
            from https server.
         """
-        self.ssl_ca_cert = None
+        self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
         """
         self.cert_file = None

--- a/samples/client/petstore/python-legacy/petstore_api/rest.py
+++ b/samples/client/petstore/python-legacy/petstore_api/rest.py
@@ -18,7 +18,6 @@ import logging
 import re
 import ssl
 
-import certifi
 # python 2 and python 3 compatibility library
 import six
 from six.moves.urllib.parse import urlencode
@@ -62,13 +61,6 @@ class RESTClientObject(object):
         else:
             cert_reqs = ssl.CERT_NONE
 
-        # ca_certs
-        if configuration.ssl_ca_cert:
-            ca_certs = configuration.ssl_ca_cert
-        else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
-
         addition_pool_args = {}
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
@@ -91,7 +83,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
@@ -103,7 +95,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 **addition_pool_args

--- a/samples/client/petstore/python-legacy/requirements.txt
+++ b/samples/client/petstore/python-legacy/requirements.txt
@@ -1,6 +1,5 @@
-certifi >= 14.05.14
 future; python_version<="2.7"
 six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 1.25.3

--- a/samples/client/petstore/python-legacy/setup.py
+++ b/samples/client/petstore/python-legacy/setup.py
@@ -21,7 +21,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = ["urllib3 >= 1.25.3", "six >= 1.10", "python-dateutil"]
 
 setup(
     name=NAME,

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -78,6 +78,8 @@ class Configuration(object):
     :param server_operation_variables: Mapping from operation ID to a mapping with
       string values to replace variables in templated server configuration.
       The validation of enums is performed for variables with defined enum values before.
+    :param ssl_ca_cert: str - the path to a file of concatenated CA certificates 
+      in PEM format 
 
     :Example:
 
@@ -126,6 +128,7 @@ conf = petstore_api.Configuration(
                  disabled_client_side_validations="",
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ssl_ca_cert=None,
                  ):
         """Constructor
         """
@@ -194,7 +197,7 @@ conf = petstore_api.Configuration(
            Set this to false to skip verifying SSL certificate when calling API
            from https server.
         """
-        self.ssl_ca_cert = None
+        self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
         """
         self.cert_file = None

--- a/samples/client/petstore/python-tornado/requirements.txt
+++ b/samples/client/petstore/python-tornado/requirements.txt
@@ -1,6 +1,5 @@
-certifi >= 14.05.14
 future; python_version<="2.7"
 six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 1.25.3

--- a/samples/client/petstore/python-tornado/setup.py
+++ b/samples/client/petstore/python-tornado/setup.py
@@ -21,7 +21,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = ["urllib3 >= 1.25.3", "six >= 1.10", "python-dateutil"]
 REQUIRES.append("tornado>=4.2,<5")
 
 setup(

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -75,6 +75,8 @@ class Configuration(object):
     :param server_operation_variables: Mapping from operation ID to a mapping with
       string values to replace variables in templated server configuration.
       The validation of enums is performed for variables with defined enum values before.
+    :param ssl_ca_cert: str - the path to a file of concatenated CA certificates 
+      in PEM format
 
     :Example:
 
@@ -123,6 +125,7 @@ conf = petstore_api.Configuration(
                  disabled_client_side_validations="",
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ssl_ca_cert=None,
                  ):
         """Constructor
         """
@@ -191,7 +194,7 @@ conf = petstore_api.Configuration(
            Set this to false to skip verifying SSL certificate when calling API
            from https server.
         """
-        self.ssl_ca_cert = None
+        self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
         """
         self.cert_file = None

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -17,7 +17,6 @@ import re
 import ssl
 from urllib.parse import urlencode
 
-import certifi
 import urllib3
 
 from petstore_api.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError
@@ -58,13 +57,6 @@ class RESTClientObject(object):
         else:
             cert_reqs = ssl.CERT_NONE
 
-        # ca_certs
-        if configuration.ssl_ca_cert:
-            ca_certs = configuration.ssl_ca_cert
-        else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
-
         addition_pool_args = {}
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
@@ -87,7 +79,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
@@ -99,7 +91,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 **addition_pool_args

--- a/samples/client/petstore/python/requirements.txt
+++ b/samples/client/petstore/python/requirements.txt
@@ -1,5 +1,4 @@
 nulltype
-certifi >= 14.05.14
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 1.25.3

--- a/samples/client/petstore/python/setup.py
+++ b/samples/client/petstore/python/setup.py
@@ -22,8 +22,7 @@ VERSION = "1.0.0"
 # http://pypi.python.org/pypi/setuptools
 
 REQUIRES = [
-  "urllib3 >= 1.15",
-  "certifi",
+  "urllib3 >= 1.25.3",
   "python-dateutil",
   "nulltype",
 ]

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/requirements.txt
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/requirements.txt
@@ -1,5 +1,4 @@
 nulltype
-certifi >= 14.05.14
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 1.25.3

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/setup.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/setup.py
@@ -22,8 +22,7 @@ VERSION = "1.0.0"
 # http://pypi.python.org/pypi/setuptools
 
 REQUIRES = [
-  "urllib3 >= 1.15",
-  "certifi",
+  "urllib3 >= 1.25.3",
   "python-dateutil",
   "nulltype",
 ]

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/configuration.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/configuration.py
@@ -75,6 +75,8 @@ class Configuration(object):
     :param server_operation_variables: Mapping from operation ID to a mapping with
       string values to replace variables in templated server configuration.
       The validation of enums is performed for variables with defined enum values before.
+    :param ssl_ca_cert: str - the path to a file of concatenated CA certificates 
+      in PEM format
 
     :Example:
 
@@ -107,6 +109,7 @@ conf = x_auth_id_alias.Configuration(
                  disabled_client_side_validations="",
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ssl_ca_cert=None,
                  ):
         """Constructor
         """
@@ -172,7 +175,7 @@ conf = x_auth_id_alias.Configuration(
            Set this to false to skip verifying SSL certificate when calling API
            from https server.
         """
-        self.ssl_ca_cert = None
+        self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
         """
         self.cert_file = None

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/rest.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/rest.py
@@ -17,7 +17,6 @@ import re
 import ssl
 from urllib.parse import urlencode
 
-import certifi
 import urllib3
 
 from x_auth_id_alias.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError
@@ -58,13 +57,6 @@ class RESTClientObject(object):
         else:
             cert_reqs = ssl.CERT_NONE
 
-        # ca_certs
-        if configuration.ssl_ca_cert:
-            ca_certs = configuration.ssl_ca_cert
-        else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
-
         addition_pool_args = {}
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
@@ -87,7 +79,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
@@ -99,7 +91,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 **addition_pool_args

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/configuration.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/configuration.py
@@ -75,6 +75,8 @@ class Configuration(object):
     :param server_operation_variables: Mapping from operation ID to a mapping with
       string values to replace variables in templated server configuration.
       The validation of enums is performed for variables with defined enum values before.
+    :param ssl_ca_cert: str - the path to a file of concatenated CA certificates 
+      in PEM format
 
     """
 
@@ -87,6 +89,7 @@ class Configuration(object):
                  disabled_client_side_validations="",
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ssl_ca_cert=None,
                  ):
         """Constructor
         """
@@ -152,7 +155,7 @@ class Configuration(object):
            Set this to false to skip verifying SSL certificate when calling API
            from https server.
         """
-        self.ssl_ca_cert = None
+        self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
         """
         self.cert_file = None

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/rest.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/rest.py
@@ -17,7 +17,6 @@ import re
 import ssl
 from urllib.parse import urlencode
 
-import certifi
 import urllib3
 
 from dynamic_servers.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError
@@ -58,13 +57,6 @@ class RESTClientObject(object):
         else:
             cert_reqs = ssl.CERT_NONE
 
-        # ca_certs
-        if configuration.ssl_ca_cert:
-            ca_certs = configuration.ssl_ca_cert
-        else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
-
         addition_pool_args = {}
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
@@ -87,7 +79,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
@@ -99,7 +91,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 **addition_pool_args

--- a/samples/openapi3/client/features/dynamic-servers/python/requirements.txt
+++ b/samples/openapi3/client/features/dynamic-servers/python/requirements.txt
@@ -1,5 +1,4 @@
 nulltype
-certifi >= 14.05.14
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 1.25.3

--- a/samples/openapi3/client/features/dynamic-servers/python/setup.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/setup.py
@@ -22,8 +22,7 @@ VERSION = "1.0.0"
 # http://pypi.python.org/pypi/setuptools
 
 REQUIRES = [
-  "urllib3 >= 1.15",
-  "certifi",
+  "urllib3 >= 1.25.3",
   "python-dateutil",
   "nulltype",
 ]

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/configuration.py
@@ -80,6 +80,8 @@ class Configuration(object):
     :param server_operation_variables: Mapping from operation ID to a mapping with
       string values to replace variables in templated server configuration.
       The validation of enums is performed for variables with defined enum values before.
+    :param ssl_ca_cert: str - the path to a file of concatenated CA certificates 
+      in PEM format 
 
     :Example:
 
@@ -168,6 +170,7 @@ conf = petstore_api.Configuration(
                  signing_info=None,
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ssl_ca_cert=None,
                  ):
         """Constructor
         """
@@ -241,7 +244,7 @@ conf = petstore_api.Configuration(
            Set this to false to skip verifying SSL certificate when calling API
            from https server.
         """
-        self.ssl_ca_cert = None
+        self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
         """
         self.cert_file = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/rest.py
@@ -18,7 +18,6 @@ import logging
 import re
 import ssl
 
-import certifi
 # python 2 and python 3 compatibility library
 import six
 from six.moves.urllib.parse import urlencode
@@ -62,13 +61,6 @@ class RESTClientObject(object):
         else:
             cert_reqs = ssl.CERT_NONE
 
-        # ca_certs
-        if configuration.ssl_ca_cert:
-            ca_certs = configuration.ssl_ca_cert
-        else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
-
         addition_pool_args = {}
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
@@ -91,7 +83,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
@@ -103,7 +95,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 **addition_pool_args

--- a/samples/openapi3/client/petstore/python-legacy/requirements.txt
+++ b/samples/openapi3/client/petstore/python-legacy/requirements.txt
@@ -1,6 +1,5 @@
-certifi >= 14.05.14
 future; python_version<="2.7"
 six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 1.25.3

--- a/samples/openapi3/client/petstore/python-legacy/setup.py
+++ b/samples/openapi3/client/petstore/python-legacy/setup.py
@@ -21,7 +21,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+REQUIRES = ["urllib3 >= 1.25.3", "six >= 1.10", "python-dateutil"]
 
 setup(
     name=NAME,

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -77,6 +77,8 @@ class Configuration(object):
     :param server_operation_variables: Mapping from operation ID to a mapping with
       string values to replace variables in templated server configuration.
       The validation of enums is performed for variables with defined enum values before.
+    :param ssl_ca_cert: str - the path to a file of concatenated CA certificates 
+      in PEM format
 
     :Example:
 
@@ -165,6 +167,7 @@ conf = petstore_api.Configuration(
                  signing_info=None,
                  server_index=None, server_variables=None,
                  server_operation_index=None, server_operation_variables=None,
+                 ssl_ca_cert=None,
                  ):
         """Constructor
         """
@@ -238,7 +241,7 @@ conf = petstore_api.Configuration(
            Set this to false to skip verifying SSL certificate when calling API
            from https server.
         """
-        self.ssl_ca_cert = None
+        self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
         """
         self.cert_file = None

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -17,7 +17,6 @@ import re
 import ssl
 from urllib.parse import urlencode
 
-import certifi
 import urllib3
 
 from petstore_api.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError
@@ -58,13 +57,6 @@ class RESTClientObject(object):
         else:
             cert_reqs = ssl.CERT_NONE
 
-        # ca_certs
-        if configuration.ssl_ca_cert:
-            ca_certs = configuration.ssl_ca_cert
-        else:
-            # if not set certificate file, use Mozilla's root certificates.
-            ca_certs = certifi.where()
-
         addition_pool_args = {}
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
@@ -87,7 +79,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 proxy_url=configuration.proxy,
@@ -99,7 +91,7 @@ class RESTClientObject(object):
                 num_pools=pools_size,
                 maxsize=maxsize,
                 cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
+                ca_certs=configuration.ssl_ca_cert,
                 cert_file=configuration.cert_file,
                 key_file=configuration.key_file,
                 **addition_pool_args

--- a/samples/openapi3/client/petstore/python/requirements.txt
+++ b/samples/openapi3/client/petstore/python/requirements.txt
@@ -1,5 +1,4 @@
 nulltype
-certifi >= 14.05.14
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.15.1
+urllib3 >= 1.25.3

--- a/samples/openapi3/client/petstore/python/setup.py
+++ b/samples/openapi3/client/petstore/python/setup.py
@@ -22,8 +22,7 @@ VERSION = "1.0.0"
 # http://pypi.python.org/pypi/setuptools
 
 REQUIRES = [
-  "urllib3 >= 1.15",
-  "certifi",
+  "urllib3 >= 1.25.3",
   "python-dateutil",
   "nulltype",
   "pem>=19.3.0",


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Resolves #6506 

Gets the Python client to use the system Certificate Authority bundle by default for verifying ssl connections (like the Python standard library does, as described in [PEP 476](https://www.python.org/dev/peps/pep-0476/#trust-database)) instead of relying on the external certifi python package for the default.  See https://github.com/OpenAPITools/openapi-generator/issues/6506 for the reasons for this change.

For the urllib3 python client this is achieved by passing `configuration.ssl_ca_cert` directly to urllib3.PoolManager or urllib3.ProxyManager’s `ca_certs` argument.  Then `ca_certs` be `None` by default and in this case urllib3 (from version 1.25.3) will load the system CA certificates, as described [here](https://github.com/urllib3/urllib3/blob/master/CHANGES.rst#1253-2019-05-23).

I have done the same with the asyncio python client since the `ssl.create_default_context` will also use the system’s default CA certificates if `cafile`, `capath` and `cadata` are all `None`, as documented [here](https://docs.python.org/3.8/library/ssl.html#ssl.create_default_context).

I have additionally:
- Removed `certifi` as a dependency
- Required `urllib3 >= 1.25.3`

These changes would be breaking for anyone relying on the certifi certificates, although I imagine most people’s system default CA certificates are adequate and in this case the change would not be noticed.  Any user still wanting to use the certifi certificates could continue to do so by setting `configuration.ssl_ca_cert=certifi.where()`.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @Jyhess @arun-nalla @spacether