### PR TITLE
[dart][dart-dio] Enum fixes specific to Dart DIO

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
@@ -21,7 +21,7 @@ abstract class {{classname}} implements Built<{{classname}}, {{classname}}Builde
     {{classname}}._();
 
     factory {{classname}}([updates({{classname}}Builder b)]) = _${{classname}};
-    static Serializer<{{classname}}> get serializer => _${{classVarName}}Serializer;
+    static Serializer<{{classname}}> get serializer => _${{#lambda.camelcase}}{{{classname}}}{{/lambda.camelcase}}Serializer;
 }
 {{!
     Generate an enum for any variables that are declared as inline enums

--- a/modules/openapi-generator/src/main/resources/dart-dio/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/enum.mustache
@@ -9,7 +9,7 @@ class {{classname}} extends EnumClass {
   {{#allowableValues}}
     {{#enumVars}}
       {{#description}}
-  /// {{description}}
+  /// {{{description}}}
       {{/description}}
   @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{^isInteger}}wireName: {{{value}}}{{/isInteger}})
   static const {{classname}} {{name}} = _${{name}};

--- a/modules/openapi-generator/src/main/resources/dart-dio/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/enum.mustache
@@ -16,7 +16,7 @@ class {{classname}} extends EnumClass {
     {{/enumVars}}
   {{/allowableValues}}
 
-  static Serializer<{{classname}}> get serializer => _${{classVarName}}Serializer;
+  static Serializer<{{classname}}> get serializer => _${{#lambda.camelcase}}{{{classname}}}{{/lambda.camelcase}}Serializer;
 
   const {{classname}}._(String name): super(name);
 

--- a/modules/openapi-generator/src/main/resources/dart-dio/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/enum_inline.mustache
@@ -3,10 +3,10 @@ class {{classname}}{{nameInCamelCase}} extends EnumClass {
   {{#allowableValues}}
     {{#enumVars}}
       {{#description}}
-  /// {{description}}
+  /// {{{description}}}
       {{/description}}
   @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{^isInteger}}wireName: {{{value}}}{{/isInteger}})
-  static const {{classname}}{{nameInCamelCase}} {{name}} = _${{name}};
+  static const {{classname}}{{nameInCamelCase}} {{name}} = _${{#lambda.camelcase}}{{classname}}{{nameInCamelCase}}{{/lambda.camelcase}}_{{name}};
     {{/enumVars}}
   {{/allowableValues}}
 

--- a/modules/openapi-generator/src/main/resources/dart-dio/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/enum_inline.mustache
@@ -10,10 +10,10 @@ class {{classname}}{{nameInCamelCase}} extends EnumClass {
     {{/enumVars}}
   {{/allowableValues}}
 
-  static Serializer<{{classname}}{{nameInCamelCase}}> get serializer => _${{classVarName}}{{nameInCamelCase}}Serializer;
+  static Serializer<{{classname}}{{nameInCamelCase}}> get serializer => _${{#lambda.camelcase}}{{classname}}{{nameInCamelCase}}{{/lambda.camelcase}}Serializer;
 
   const {{classname}}{{nameInCamelCase}}._(String name): super(name);
 
-  static BuiltSet<{{classname}}{{nameInCamelCase}}> get values => _${{classVarName}}{{nameInCamelCase}}Values;
-  static {{classname}}{{nameInCamelCase}} valueOf(String name) => _${{classVarName}}{{nameInCamelCase}}ValueOf(name);
+  static BuiltSet<{{classname}}{{nameInCamelCase}}> get values => _${{#lambda.camelcase}}{{classname}}{{nameInCamelCase}}{{/lambda.camelcase}}Values;
+  static {{classname}}{{nameInCamelCase}} valueOf(String name) => _${{#lambda.camelcase}}{{classname}}{{nameInCamelCase}}{{/lambda.camelcase}}ValueOf(name);
 }

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
@@ -43,13 +43,13 @@ class OrderStatus extends EnumClass {
 
   /// Order Status
   @BuiltValueEnumConst(wireName: 'placed')
-  static const OrderStatus placed = _$placed;
+  static const OrderStatus placed = _$orderStatus_placed;
   /// Order Status
   @BuiltValueEnumConst(wireName: 'approved')
-  static const OrderStatus approved = _$approved;
+  static const OrderStatus approved = _$orderStatus_approved;
   /// Order Status
   @BuiltValueEnumConst(wireName: 'delivered')
-  static const OrderStatus delivered = _$delivered;
+  static const OrderStatus delivered = _$orderStatus_delivered;
 
   static Serializer<OrderStatus> get serializer => _$orderStatusSerializer;
 

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
@@ -45,13 +45,13 @@ class PetStatus extends EnumClass {
 
   /// pet status in the store
   @BuiltValueEnumConst(wireName: 'available')
-  static const PetStatus available = _$available;
+  static const PetStatus available = _$petStatus_available;
   /// pet status in the store
   @BuiltValueEnumConst(wireName: 'pending')
-  static const PetStatus pending = _$pending;
+  static const PetStatus pending = _$petStatus_pending;
   /// pet status in the store
   @BuiltValueEnumConst(wireName: 'sold')
-  static const PetStatus sold = _$sold;
+  static const PetStatus sold = _$petStatus_sold;
 
   static Serializer<PetStatus> get serializer => _$petStatusSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
@@ -43,13 +43,13 @@ class OrderStatus extends EnumClass {
 
   /// Order Status
   @BuiltValueEnumConst(wireName: 'placed')
-  static const OrderStatus placed = _$placed;
+  static const OrderStatus placed = _$orderStatus_placed;
   /// Order Status
   @BuiltValueEnumConst(wireName: 'approved')
-  static const OrderStatus approved = _$approved;
+  static const OrderStatus approved = _$orderStatus_approved;
   /// Order Status
   @BuiltValueEnumConst(wireName: 'delivered')
-  static const OrderStatus delivered = _$delivered;
+  static const OrderStatus delivered = _$orderStatus_delivered;
 
   static Serializer<OrderStatus> get serializer => _$orderStatusSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
@@ -45,13 +45,13 @@ class PetStatus extends EnumClass {
 
   /// pet status in the store
   @BuiltValueEnumConst(wireName: 'available')
-  static const PetStatus available = _$available;
+  static const PetStatus available = _$petStatus_available;
   /// pet status in the store
   @BuiltValueEnumConst(wireName: 'pending')
-  static const PetStatus pending = _$pending;
+  static const PetStatus pending = _$petStatus_pending;
   /// pet status in the store
   @BuiltValueEnumConst(wireName: 'sold')
-  static const PetStatus sold = _$sold;
+  static const PetStatus sold = _$petStatus_sold;
 
   static Serializer<PetStatus> get serializer => _$petStatusSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -27,9 +27,9 @@ abstract class EnumArrays implements Built<EnumArrays, EnumArraysBuilder> {
 class EnumArraysJustSymbol extends EnumClass {
 
   @BuiltValueEnumConst(wireName: '>=')
-  static const EnumArraysJustSymbol &gt;&#x3D; = _$&gt;&#x3D;;
+  static const EnumArraysJustSymbol &gt;&#x3D; = _$enumArraysJustSymbol_&gt;&#x3D;;
   @BuiltValueEnumConst(wireName: '$')
-  static const EnumArraysJustSymbol $ = _$$;
+  static const EnumArraysJustSymbol $ = _$enumArraysJustSymbol_$;
 
   static Serializer<EnumArraysJustSymbol> get serializer => _$enumArraysJustSymbolSerializer;
 
@@ -43,9 +43,9 @@ class EnumArraysJustSymbol extends EnumClass {
 class EnumArraysArrayEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: 'fish')
-  static const EnumArraysArrayEnum fish = _$fish;
+  static const EnumArraysArrayEnum fish = _$enumArraysArrayEnum_fish;
   @BuiltValueEnumConst(wireName: 'crab')
-  static const EnumArraysArrayEnum crab = _$crab;
+  static const EnumArraysArrayEnum crab = _$enumArraysArrayEnum_crab;
 
   static Serializer<EnumArraysArrayEnum> get serializer => _$enumArraysArrayEnumSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -61,11 +61,11 @@ abstract class EnumTest implements Built<EnumTest, EnumTestBuilder> {
 class EnumTestEnumString extends EnumClass {
 
   @BuiltValueEnumConst(wireName: 'UPPER')
-  static const EnumTestEnumString uPPER = _$uPPER;
+  static const EnumTestEnumString uPPER = _$enumTestEnumString_uPPER;
   @BuiltValueEnumConst(wireName: 'lower')
-  static const EnumTestEnumString lower = _$lower;
+  static const EnumTestEnumString lower = _$enumTestEnumString_lower;
   @BuiltValueEnumConst(wireName: '')
-  static const EnumTestEnumString empty = _$empty;
+  static const EnumTestEnumString empty = _$enumTestEnumString_empty;
 
   static Serializer<EnumTestEnumString> get serializer => _$enumTestEnumStringSerializer;
 
@@ -79,11 +79,11 @@ class EnumTestEnumString extends EnumClass {
 class EnumTestEnumStringRequired extends EnumClass {
 
   @BuiltValueEnumConst(wireName: 'UPPER')
-  static const EnumTestEnumStringRequired uPPER = _$uPPER;
+  static const EnumTestEnumStringRequired uPPER = _$enumTestEnumStringRequired_uPPER;
   @BuiltValueEnumConst(wireName: 'lower')
-  static const EnumTestEnumStringRequired lower = _$lower;
+  static const EnumTestEnumStringRequired lower = _$enumTestEnumStringRequired_lower;
   @BuiltValueEnumConst(wireName: '')
-  static const EnumTestEnumStringRequired empty = _$empty;
+  static const EnumTestEnumStringRequired empty = _$enumTestEnumStringRequired_empty;
 
   static Serializer<EnumTestEnumStringRequired> get serializer => _$enumTestEnumStringRequiredSerializer;
 
@@ -97,9 +97,9 @@ class EnumTestEnumStringRequired extends EnumClass {
 class EnumTestEnumInteger extends EnumClass {
 
   @BuiltValueEnumConst(wireNumber: 1)
-  static const EnumTestEnumInteger number1 = _$number1;
+  static const EnumTestEnumInteger number1 = _$enumTestEnumInteger_number1;
   @BuiltValueEnumConst(wireNumber: -1)
-  static const EnumTestEnumInteger number1 = _$number1;
+  static const EnumTestEnumInteger number1 = _$enumTestEnumInteger_number1;
 
   static Serializer<EnumTestEnumInteger> get serializer => _$enumTestEnumIntegerSerializer;
 
@@ -113,9 +113,9 @@ class EnumTestEnumInteger extends EnumClass {
 class EnumTestEnumNumber extends EnumClass {
 
   @BuiltValueEnumConst(wireName: '1.1')
-  static const EnumTestEnumNumber 11_ = _$11_;
+  static const EnumTestEnumNumber 11_ = _$enumTestEnumNumber_11_;
   @BuiltValueEnumConst(wireName: '-1.2')
-  static const EnumTestEnumNumber 12_ = _$12_;
+  static const EnumTestEnumNumber 12_ = _$enumTestEnumNumber_12_;
 
   static Serializer<EnumTestEnumNumber> get serializer => _$enumTestEnumNumberSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object2.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object2.dart
@@ -28,10 +28,10 @@ class InlineObject2EnumFormStringArray extends EnumClass {
 
   /// Form parameter enum test (string array)
   @BuiltValueEnumConst(wireName: '>')
-  static const InlineObject2EnumFormStringArray &gt; = _$&gt;;
+  static const InlineObject2EnumFormStringArray &gt; = _$inlineObject2EnumFormStringArray_&gt;;
   /// Form parameter enum test (string array)
   @BuiltValueEnumConst(wireName: '$')
-  static const InlineObject2EnumFormStringArray $ = _$$;
+  static const InlineObject2EnumFormStringArray $ = _$inlineObject2EnumFormStringArray_$;
 
   static Serializer<InlineObject2EnumFormStringArray> get serializer => _$inlineObject2EnumFormStringArraySerializer;
 
@@ -46,13 +46,13 @@ class InlineObject2EnumFormString extends EnumClass {
 
   /// Form parameter enum test (string)
   @BuiltValueEnumConst(wireName: '_abc')
-  static const InlineObject2EnumFormString abc = _$abc;
+  static const InlineObject2EnumFormString abc = _$inlineObject2EnumFormString_abc;
   /// Form parameter enum test (string)
   @BuiltValueEnumConst(wireName: '-efg')
-  static const InlineObject2EnumFormString efg = _$efg;
+  static const InlineObject2EnumFormString efg = _$inlineObject2EnumFormString_efg;
   /// Form parameter enum test (string)
   @BuiltValueEnumConst(wireName: '(xyz)')
-  static const InlineObject2EnumFormString (xyz) = _$(xyz);
+  static const InlineObject2EnumFormString (xyz) = _$inlineObject2EnumFormString_(xyz);
 
   static Serializer<InlineObject2EnumFormString> get serializer => _$inlineObject2EnumFormStringSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/map_test.dart
@@ -34,9 +34,9 @@ abstract class MapTest implements Built<MapTest, MapTestBuilder> {
 class MapTestMapOfEnumString extends EnumClass {
 
   @BuiltValueEnumConst(wireName: 'UPPER')
-  static const MapTestMapOfEnumString uPPER = _$uPPER;
+  static const MapTestMapOfEnumString uPPER = _$mapTestMapOfEnumString_uPPER;
   @BuiltValueEnumConst(wireName: 'lower')
-  static const MapTestMapOfEnumString lower = _$lower;
+  static const MapTestMapOfEnumString lower = _$mapTestMapOfEnumString_lower;
 
   static Serializer<MapTestMapOfEnumString> get serializer => _$mapTestMapOfEnumStringSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model200_response.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model200_response.dart
@@ -18,6 +18,6 @@ abstract class Model200Response implements Built<Model200Response, Model200Respo
     Model200Response._();
 
     factory Model200Response([updates(Model200ResponseBuilder b)]) = _$Model200Response;
-    static Serializer<Model200Response> get serializer => _$n200responseSerializer;
+    static Serializer<Model200Response> get serializer => _$model200ResponseSerializer;
 }
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_enum_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_enum_class.dart
@@ -13,7 +13,7 @@ class ModelEnumClass extends EnumClass {
   @BuiltValueEnumConst(wireName: '(xyz)')
   static const ModelEnumClass (xyz) = _$(xyz);
 
-  static Serializer<ModelEnumClass> get serializer => _$enumClassSerializer;
+  static Serializer<ModelEnumClass> get serializer => _$modelEnumClassSerializer;
 
   const ModelEnumClass._(String name): super(name);
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_return.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_return.dart
@@ -14,6 +14,6 @@ abstract class ModelReturn implements Built<ModelReturn, ModelReturnBuilder> {
     ModelReturn._();
 
     factory ModelReturn([updates(ModelReturnBuilder b)]) = _$ModelReturn;
-    static Serializer<ModelReturn> get serializer => _$return_Serializer;
+    static Serializer<ModelReturn> get serializer => _$modelReturnSerializer;
 }
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/order.dart
@@ -43,13 +43,13 @@ class OrderStatus extends EnumClass {
 
   /// Order Status
   @BuiltValueEnumConst(wireName: 'placed')
-  static const OrderStatus placed = _$placed;
+  static const OrderStatus placed = _$orderStatus_placed;
   /// Order Status
   @BuiltValueEnumConst(wireName: 'approved')
-  static const OrderStatus approved = _$approved;
+  static const OrderStatus approved = _$orderStatus_approved;
   /// Order Status
   @BuiltValueEnumConst(wireName: 'delivered')
-  static const OrderStatus delivered = _$delivered;
+  static const OrderStatus delivered = _$orderStatus_delivered;
 
   static Serializer<OrderStatus> get serializer => _$orderStatusSerializer;
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/pet.dart
@@ -45,13 +45,13 @@ class PetStatus extends EnumClass {
 
   /// pet status in the store
   @BuiltValueEnumConst(wireName: 'available')
-  static const PetStatus available = _$available;
+  static const PetStatus available = _$petStatus_available;
   /// pet status in the store
   @BuiltValueEnumConst(wireName: 'pending')
-  static const PetStatus pending = _$pending;
+  static const PetStatus pending = _$petStatus_pending;
   /// pet status in the store
   @BuiltValueEnumConst(wireName: 'sold')
-  static const PetStatus sold = _$sold;
+  static const PetStatus sold = _$petStatus_sold;
 
   static Serializer<PetStatus> get serializer => _$petStatusSerializer;
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
* fix wrong escaped built_value serializer names
* prevent enum name collisions in inlined enums by prefixing the private built_value instances with the enum class name. This prevents clashes when multiple inline enums contain the same value - for example `EnumTest`.  No breaking changes here as all the changed fields/references are private and automatically re-generated with built_value.

There is still a lot wrong with enums but this is a small step.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
