### PR TITLE
[dart] Use raw strings for json/header parameter names

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -56,7 +56,7 @@ class {{classname}} {
             {{/isFile}}
         {{/isMultipart}}
         {{^isMultipart}}
-            formData['{{baseName}}'] = parameterToString(_serializers, {{paramName}});
+            formData[r'{{baseName}}'] = parameterToString(_serializers, {{paramName}});
         {{/isMultipart}}
         {{/formParams}}
         bodyData = FormData.fromMap(formData);

--- a/modules/openapi-generator/src/main/resources/dart2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api.mustache
@@ -85,11 +85,11 @@ class {{{classname}}} {
 
       {{#headerParams}}
         {{#required}}
-    headerParams['{{{baseName}}}'] = parameterToString({{{paramName}}});
+    headerParams[r'{{{baseName}}}'] = parameterToString({{{paramName}}});
         {{/required}}
         {{^required}}
     if ({{{paramName}}} != null) {
-      headerParams['{{{baseName}}}'] = parameterToString({{{paramName}}});
+      headerParams[r'{{{baseName}}}'] = parameterToString({{{paramName}}});
     }
         {{/required}}
       {{/headerParams}}
@@ -109,13 +109,13 @@ class {{{classname}}} {
       {{^isFile}}
       if ({{{paramName}}} != null) {
         hasFields = true;
-        mp.fields['{{{baseName}}}'] = parameterToString({{{paramName}}});
+        mp.fields[r'{{{baseName}}}'] = parameterToString({{{paramName}}});
       }
       {{/isFile}}
       {{#isFile}}
       if ({{{paramName}}} != null) {
         hasFields = true;
-        mp.fields['{{{baseName}}}'] = {{{paramName}}}.field;
+        mp.fields[r'{{{baseName}}}'] = {{{paramName}}}.field;
         mp.files.add({{{paramName}}});
       }
       {{/isFile}}
@@ -127,7 +127,7 @@ class {{{classname}}} {
       {{#formParams}}
       {{^isFile}}
       if ({{{paramName}}} != null) {
-        formParams['{{{baseName}}}'] = parameterToString({{{paramName}}});
+        formParams[r'{{{baseName}}}'] = parameterToString({{{paramName}}});
       }
       {{/isFile}}
       {{/formParams}}

--- a/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
@@ -7,17 +7,17 @@ class ApiClient {
   {{#authMethods}}
   {{#isBasic}}
   {{#isBasicBasic}}
-    _authentications['{{{name}}}'] = HttpBasicAuth();
+    _authentications[r'{{{name}}}'] = HttpBasicAuth();
   {{/isBasicBasic}}
   {{#isBasicBearer}}
-    _authentications['{{{name}}}'] = HttpBearerAuth();
+    _authentications[r'{{{name}}}'] = HttpBearerAuth();
   {{/isBasicBearer}}
   {{/isBasic}}
   {{#isApiKey}}
-    _authentications['{{{name}}}'] = ApiKeyAuth({{#isKeyInCookie}}'cookie'{{/isKeyInCookie}}{{^isKeyInCookie}}{{#isKeyInHeader}}'header'{{/isKeyInHeader}}{{^isKeyInHeader}}'query'{{/isKeyInHeader}}{{/isKeyInCookie}}, '{{{keyParamName}}}');
+    _authentications[r'{{{name}}}'] = ApiKeyAuth({{#isKeyInCookie}}'cookie'{{/isKeyInCookie}}{{^isKeyInCookie}}{{#isKeyInHeader}}'header'{{/isKeyInHeader}}{{^isKeyInHeader}}'query'{{/isKeyInHeader}}{{/isKeyInCookie}}, '{{{keyParamName}}}');
   {{/isApiKey}}
   {{#isOAuth}}
-    _authentications['{{{name}}}'] = OAuth();
+    _authentications[r'{{{name}}}'] = OAuth();
   {{/isOAuth}}
   {{/authMethods}}
   {{/hasAuthMethods}}

--- a/modules/openapi-generator/src/main/resources/dart2/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/class.mustache
@@ -55,27 +55,27 @@ class {{{classname}}} {
     if ({{{name}}} != null) {
     {{#isDateTime}}
       {{#pattern}}
-      json['{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
+      json[r'{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
         ? {{{name}}}.millisecondsSinceEpoch
         : {{{name}}}.toUtc().toIso8601String();
       {{/pattern}}
       {{^pattern}}
-      json['{{{baseName}}}'] = {{{name}}}.toUtc().toIso8601String();
+      json[r'{{{baseName}}}'] = {{{name}}}.toUtc().toIso8601String();
       {{/pattern}}
     {{/isDateTime}}
     {{#isDate}}
       {{#pattern}}
-      json['{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
+      json[r'{{{baseName}}}'] = _dateEpochMarker == '{{{pattern}}}'
         ? {{{name}}}.millisecondsSinceEpoch
         : _dateFormatter.format({{{name}}}.toUtc());
       {{/pattern}}
       {{^pattern}}
-      json['{{{baseName}}}'] = _dateFormatter.format({{{name}}}.toUtc());
+      json[r'{{{baseName}}}'] = _dateFormatter.format({{{name}}}.toUtc());
       {{/pattern}}
     {{/isDate}}
     {{^isDateTime}}
       {{^isDate}}
-      json['{{{baseName}}}'] = {{{name}}};
+      json[r'{{{baseName}}}'] = {{{name}}};
       {{/isDate}}
     {{/isDateTime}}
     }
@@ -90,27 +90,27 @@ class {{{classname}}} {
     : {{{classname}}}(
   {{#vars}}
   {{#isDateTime}}
-        {{{name}}}: json['{{{baseName}}}'] == null
+        {{{name}}}: json[r'{{{baseName}}}'] == null
           ? null
     {{#pattern}}
           : _dateEpochMarker == '{{{pattern}}}'
-            ? DateTime.fromMillisecondsSinceEpoch(json['{{{baseName}}}'] as int, isUtc: true)
-            : DateTime.parse(json['{{{baseName}}}']),
+            ? DateTime.fromMillisecondsSinceEpoch(json[r'{{{baseName}}}'] as int, isUtc: true)
+            : DateTime.parse(json[r'{{{baseName}}}']),
 	{{/pattern}}
     {{^pattern}}
-          : DateTime.parse(json['{{{baseName}}}']),
+          : DateTime.parse(json[r'{{{baseName}}}']),
 	{{/pattern}}
   {{/isDateTime}}
   {{#isDate}}
-        {{{name}}}: json['{{{baseName}}}'] == null
+        {{{name}}}: json[r'{{{baseName}}}'] == null
           ? null
     {{#pattern}}
           : _dateEpochMarker == '{{{pattern}}}'
-            ? DateTime.fromMillisecondsSinceEpoch(json['{{{baseName}}}'] as int, isUtc: true)
-            : DateTime.parse(json['{{{baseName}}}']),
+            ? DateTime.fromMillisecondsSinceEpoch(json[r'{{{baseName}}}'] as int, isUtc: true)
+            : DateTime.parse(json[r'{{{baseName}}}']),
 	{{/pattern}}
     {{^pattern}}
-          : DateTime.parse(json['{{{baseName}}}']),
+          : DateTime.parse(json[r'{{{baseName}}}']),
 	{{/pattern}}
   {{/isDate}}
   {{^isDateTime}}
@@ -118,11 +118,11 @@ class {{{classname}}} {
     {{#complexType}}
       {{#isArray}}
         {{#items.isArray}}
-        {{{name}}}: json['{{{baseName}}}'] == null
+        {{{name}}}: json[r'{{{baseName}}}'] == null
           ? null
-          : (json['{{{baseName}}}'] as List).map(
+          : (json[r'{{{baseName}}}'] as List).map(
       {{#items.complexType}}
-              {{items.complexType}}.listFromJson(json['{{{baseName}}}'])
+              {{items.complexType}}.listFromJson(json[r'{{{baseName}}}'])
       {{/items.complexType}}
       {{^items.complexType}}
               (e) => e == null ? null : (e as List).cast<{{items.items.dataType}}>()
@@ -130,25 +130,25 @@ class {{{classname}}} {
             ).toList(growable: false),
         {{/items.isArray}}
         {{^items.isArray}}
-        {{{name}}}: {{{complexType}}}.listFromJson(json['{{{baseName}}}']),
+        {{{name}}}: {{{complexType}}}.listFromJson(json[r'{{{baseName}}}']),
         {{/items.isArray}}
       {{/isArray}}
       {{^isArray}}
         {{#isMap}}
           {{#items.isArray}}
-        {{{name}}}: json['{{{baseName}}}'] == null
+        {{{name}}}: json[r'{{{baseName}}}'] == null
           ? null
               {{#items.complexType}}
-          : {{items.complexType}}.mapListFromJson(json['{{{baseName}}}']),
+          : {{items.complexType}}.mapListFromJson(json[r'{{{baseName}}}']),
               {{/items.complexType}}
               {{^items.complexType}}
-          : (json['{{{baseName}}}'] as Map).cast<String, List>(),
+          : (json[r'{{{baseName}}}'] as Map).cast<String, List>(),
   	          {{/items.complexType}}
           {{/items.isArray}}
           {{^items.isArray}}
-        {{{name}}}: json['{{{baseName}}}'] == null
+        {{{name}}}: json[r'{{{baseName}}}'] == null
           ? null
-          : {{{complexType}}}.mapFromJson(json['{{{baseName}}}']),
+          : {{{complexType}}}.mapFromJson(json[r'{{{baseName}}}']),
           {{/items.isArray}}
         {{/isMap}}
         {{^isMap}}
@@ -156,7 +156,7 @@ class {{{classname}}} {
         {{{name}}}: null, // No support for decoding binary content from JSON
             {{/isBinary}}
             {{^isBinary}}
-        {{{name}}}: {{{complexType}}}.fromJson(json['{{{baseName}}}']),
+        {{{name}}}: {{{complexType}}}.fromJson(json[r'{{{baseName}}}']),
             {{/isBinary}}
         {{/isMap}}
       {{/isArray}}
@@ -164,32 +164,32 @@ class {{{classname}}} {
     {{^complexType}}
       {{#isArray}}
         {{#isEnum}}
-        {{{name}}}: {{{classname}}}{{{items.datatypeWithEnum}}}.listFromJson(json['{{{baseName}}}']),
+        {{{name}}}: {{{classname}}}{{{items.datatypeWithEnum}}}.listFromJson(json[r'{{{baseName}}}']),
         {{/isEnum}}
         {{^isEnum}}
-        {{{name}}}: json['{{{baseName}}}'] == null
+        {{{name}}}: json[r'{{{baseName}}}'] == null
           ? null
-          : (json['{{{baseName}}}'] as List).cast<{{{items.datatype}}}>(),
+          : (json[r'{{{baseName}}}'] as List).cast<{{{items.datatype}}}>(),
         {{/isEnum}}
       {{/isArray}}
       {{^isArray}}
         {{#isMap}}
-        {{{name}}}: json['{{{baseName}}}'] == null ?
+        {{{name}}}: json[r'{{{baseName}}}'] == null ?
           null :
-          (json['{{{baseName}}}'] as Map).cast<String, {{{items.datatype}}}>(),
+          (json[r'{{{baseName}}}'] as Map).cast<String, {{{items.datatype}}}>(),
         {{/isMap}}
         {{^isMap}}
           {{#isNumber}}
-        {{{name}}}: json['{{{baseName}}}'] == null ?
+        {{{name}}}: json[r'{{{baseName}}}'] == null ?
           null :
-          json['{{{baseName}}}'].toDouble(),
+          json[r'{{{baseName}}}'].toDouble(),
           {{/isNumber}}
           {{^isNumber}}
     {{^isEnum}}
-        {{{name}}}: json['{{{baseName}}}'],
+        {{{name}}}: json[r'{{{baseName}}}'],
     {{/isEnum}}
     {{#isEnum}}
-        {{{name}}}: {{{classname}}}{{{enumName}}}.fromJson(json['{{{baseName}}}']),
+        {{{name}}}: {{{classname}}}{{{enumName}}}.fromJson(json[r'{{{baseName}}}']),
     {{/isEnum}}
           {{/isNumber}}
         {{/isMap}}

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -296,8 +296,8 @@ class PetApi {
         List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
         Map<String, dynamic> formData = {};
-            formData['name'] = parameterToString(_serializers, name);
-            formData['status'] = parameterToString(_serializers, status);
+            formData[r'name'] = parameterToString(_serializers, name);
+            formData[r'status'] = parameterToString(_serializers, status);
         bodyData = FormData.fromMap(formData);
 
 

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
@@ -104,7 +104,7 @@ class PetApi {
     final formParams = <String, String>{};
 
     if (apiKey != null) {
-      headerParams['api_key'] = parameterToString(apiKey);
+      headerParams[r'api_key'] = parameterToString(apiKey);
     }
 
     final contentTypes = <String>[];
@@ -485,21 +485,21 @@ class PetApi {
       final mp = MultipartRequest(null, null);
       if (name != null) {
         hasFields = true;
-        mp.fields['name'] = parameterToString(name);
+        mp.fields[r'name'] = parameterToString(name);
       }
       if (status != null) {
         hasFields = true;
-        mp.fields['status'] = parameterToString(status);
+        mp.fields[r'status'] = parameterToString(status);
       }
       if (hasFields) {
         postBody = mp;
       }
     } else {
       if (name != null) {
-        formParams['name'] = parameterToString(name);
+        formParams[r'name'] = parameterToString(name);
       }
       if (status != null) {
-        formParams['status'] = parameterToString(status);
+        formParams[r'status'] = parameterToString(status);
       }
     }
 
@@ -575,11 +575,11 @@ class PetApi {
       final mp = MultipartRequest(null, null);
       if (additionalMetadata != null) {
         hasFields = true;
-        mp.fields['additionalMetadata'] = parameterToString(additionalMetadata);
+        mp.fields[r'additionalMetadata'] = parameterToString(additionalMetadata);
       }
       if (file != null) {
         hasFields = true;
-        mp.fields['file'] = file.field;
+        mp.fields[r'file'] = file.field;
         mp.files.add(file);
       }
       if (hasFields) {
@@ -587,7 +587,7 @@ class PetApi {
       }
     } else {
       if (additionalMetadata != null) {
-        formParams['additionalMetadata'] = parameterToString(additionalMetadata);
+        formParams[r'additionalMetadata'] = parameterToString(additionalMetadata);
       }
     }
 

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
@@ -12,8 +12,8 @@ part of openapi.api;
 class ApiClient {
   ApiClient({this.basePath = 'http://petstore.swagger.io/v2'}) {
     // Setup authentications (key: authentication name, value: authentication).
-    _authentications['api_key'] = ApiKeyAuth('header', 'api_key');
-    _authentications['petstore_auth'] = OAuth();
+    _authentications[r'api_key'] = ApiKeyAuth('header', 'api_key');
+    _authentications[r'petstore_auth'] = OAuth();
   }
 
   final String basePath;

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
@@ -44,13 +44,13 @@ class ApiResponse {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (code != null) {
-      json['code'] = code;
+      json[r'code'] = code;
     }
     if (type != null) {
-      json['type'] = type;
+      json[r'type'] = type;
     }
     if (message != null) {
-      json['message'] = message;
+      json[r'message'] = message;
     }
     return json;
   }
@@ -60,9 +60,9 @@ class ApiResponse {
   static ApiResponse fromJson(Map<String, dynamic> json) => json == null
     ? null
     : ApiResponse(
-        code: json['code'],
-        type: json['type'],
-        message: json['message'],
+        code: json[r'code'],
+        type: json[r'type'],
+        message: json[r'message'],
     );
 
   static List<ApiResponse> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
@@ -38,10 +38,10 @@ class Category {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class Category {
   static Category fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Category(
-        id: json['id'],
-        name: json['name'],
+        id: json[r'id'],
+        name: json[r'name'],
     );
 
   static List<Category> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -62,22 +62,22 @@ class Order {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (petId != null) {
-      json['petId'] = petId;
+      json[r'petId'] = petId;
     }
     if (quantity != null) {
-      json['quantity'] = quantity;
+      json[r'quantity'] = quantity;
     }
     if (shipDate != null) {
-      json['shipDate'] = shipDate.toUtc().toIso8601String();
+      json[r'shipDate'] = shipDate.toUtc().toIso8601String();
     }
     if (status != null) {
-      json['status'] = status;
+      json[r'status'] = status;
     }
     if (complete != null) {
-      json['complete'] = complete;
+      json[r'complete'] = complete;
     }
     return json;
   }
@@ -87,14 +87,14 @@ class Order {
   static Order fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Order(
-        id: json['id'],
-        petId: json['petId'],
-        quantity: json['quantity'],
-        shipDate: json['shipDate'] == null
+        id: json[r'id'],
+        petId: json[r'petId'],
+        quantity: json[r'quantity'],
+        shipDate: json[r'shipDate'] == null
           ? null
-          : DateTime.parse(json['shipDate']),
-        status: OrderStatusEnum.fromJson(json['status']),
-        complete: json['complete'],
+          : DateTime.parse(json[r'shipDate']),
+        status: OrderStatusEnum.fromJson(json[r'status']),
+        complete: json[r'complete'],
     );
 
   static List<Order> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -62,22 +62,22 @@ class Pet {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (category != null) {
-      json['category'] = category;
+      json[r'category'] = category;
     }
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     if (photoUrls != null) {
-      json['photoUrls'] = photoUrls;
+      json[r'photoUrls'] = photoUrls;
     }
     if (tags != null) {
-      json['tags'] = tags;
+      json[r'tags'] = tags;
     }
     if (status != null) {
-      json['status'] = status;
+      json[r'status'] = status;
     }
     return json;
   }
@@ -87,14 +87,14 @@ class Pet {
   static Pet fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Pet(
-        id: json['id'],
-        category: Category.fromJson(json['category']),
-        name: json['name'],
-        photoUrls: json['photoUrls'] == null
+        id: json[r'id'],
+        category: Category.fromJson(json[r'category']),
+        name: json[r'name'],
+        photoUrls: json[r'photoUrls'] == null
           ? null
-          : (json['photoUrls'] as List).cast<String>(),
-        tags: Tag.listFromJson(json['tags']),
-        status: PetStatusEnum.fromJson(json['status']),
+          : (json[r'photoUrls'] as List).cast<String>(),
+        tags: Tag.listFromJson(json[r'tags']),
+        status: PetStatusEnum.fromJson(json[r'status']),
     );
 
   static List<Pet> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
@@ -38,10 +38,10 @@ class Tag {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class Tag {
   static Tag fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Tag(
-        id: json['id'],
-        name: json['name'],
+        id: json[r'id'],
+        name: json[r'name'],
     );
 
   static List<Tag> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
@@ -74,28 +74,28 @@ class User {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (username != null) {
-      json['username'] = username;
+      json[r'username'] = username;
     }
     if (firstName != null) {
-      json['firstName'] = firstName;
+      json[r'firstName'] = firstName;
     }
     if (lastName != null) {
-      json['lastName'] = lastName;
+      json[r'lastName'] = lastName;
     }
     if (email != null) {
-      json['email'] = email;
+      json[r'email'] = email;
     }
     if (password != null) {
-      json['password'] = password;
+      json[r'password'] = password;
     }
     if (phone != null) {
-      json['phone'] = phone;
+      json[r'phone'] = phone;
     }
     if (userStatus != null) {
-      json['userStatus'] = userStatus;
+      json[r'userStatus'] = userStatus;
     }
     return json;
   }
@@ -105,14 +105,14 @@ class User {
   static User fromJson(Map<String, dynamic> json) => json == null
     ? null
     : User(
-        id: json['id'],
-        username: json['username'],
-        firstName: json['firstName'],
-        lastName: json['lastName'],
-        email: json['email'],
-        password: json['password'],
-        phone: json['phone'],
-        userStatus: json['userStatus'],
+        id: json[r'id'],
+        username: json[r'username'],
+        firstName: json[r'firstName'],
+        lastName: json[r'lastName'],
+        email: json[r'email'],
+        password: json[r'password'],
+        phone: json[r'phone'],
+        userStatus: json[r'userStatus'],
     );
 
   static List<User> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -324,8 +324,8 @@ class PetApi {
         List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
         Map<String, dynamic> formData = {};
-            formData['name'] = parameterToString(_serializers, name);
-            formData['status'] = parameterToString(_serializers, status);
+            formData[r'name'] = parameterToString(_serializers, name);
+            formData[r'status'] = parameterToString(_serializers, status);
         bodyData = FormData.fromMap(formData);
 
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -463,20 +463,20 @@ class FakeApi {
         List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
         Map<String, dynamic> formData = {};
-            formData['integer'] = parameterToString(_serializers, integer);
-            formData['int32'] = parameterToString(_serializers, int32);
-            formData['int64'] = parameterToString(_serializers, int64);
-            formData['number'] = parameterToString(_serializers, number);
-            formData['float'] = parameterToString(_serializers, float);
-            formData['double'] = parameterToString(_serializers, double);
-            formData['string'] = parameterToString(_serializers, string);
-            formData['pattern_without_delimiter'] = parameterToString(_serializers, patternWithoutDelimiter);
-            formData['byte'] = parameterToString(_serializers, byte);
-            formData['binary'] = parameterToString(_serializers, binary);
-            formData['date'] = parameterToString(_serializers, date);
-            formData['dateTime'] = parameterToString(_serializers, dateTime);
-            formData['password'] = parameterToString(_serializers, password);
-            formData['callback'] = parameterToString(_serializers, callback);
+            formData[r'integer'] = parameterToString(_serializers, integer);
+            formData[r'int32'] = parameterToString(_serializers, int32);
+            formData[r'int64'] = parameterToString(_serializers, int64);
+            formData[r'number'] = parameterToString(_serializers, number);
+            formData[r'float'] = parameterToString(_serializers, float);
+            formData[r'double'] = parameterToString(_serializers, double);
+            formData[r'string'] = parameterToString(_serializers, string);
+            formData[r'pattern_without_delimiter'] = parameterToString(_serializers, patternWithoutDelimiter);
+            formData[r'byte'] = parameterToString(_serializers, byte);
+            formData[r'binary'] = parameterToString(_serializers, binary);
+            formData[r'date'] = parameterToString(_serializers, date);
+            formData[r'dateTime'] = parameterToString(_serializers, dateTime);
+            formData[r'password'] = parameterToString(_serializers, password);
+            formData[r'callback'] = parameterToString(_serializers, callback);
         bodyData = FormData.fromMap(formData);
 
 
@@ -520,8 +520,8 @@ class FakeApi {
         List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
         Map<String, dynamic> formData = {};
-            formData['enum_form_string_array'] = parameterToString(_serializers, enumFormStringArray);
-            formData['enum_form_string'] = parameterToString(_serializers, enumFormString);
+            formData[r'enum_form_string_array'] = parameterToString(_serializers, enumFormStringArray);
+            formData[r'enum_form_string'] = parameterToString(_serializers, enumFormString);
         bodyData = FormData.fromMap(formData);
 
 
@@ -638,8 +638,8 @@ class FakeApi {
         List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
         Map<String, dynamic> formData = {};
-            formData['param'] = parameterToString(_serializers, param);
-            formData['param2'] = parameterToString(_serializers, param2);
+            formData[r'param'] = parameterToString(_serializers, param);
+            formData[r'param2'] = parameterToString(_serializers, param2);
         bodyData = FormData.fromMap(formData);
 
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -296,8 +296,8 @@ class PetApi {
         List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
         Map<String, dynamic> formData = {};
-            formData['name'] = parameterToString(_serializers, name);
-            formData['status'] = parameterToString(_serializers, status);
+            formData[r'name'] = parameterToString(_serializers, name);
+            formData[r'status'] = parameterToString(_serializers, status);
         bodyData = FormData.fromMap(formData);
 
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
@@ -111,7 +111,7 @@ class PetApi {
     final formParams = <String, String>{};
 
     if (apiKey != null) {
-      headerParams['api_key'] = parameterToString(apiKey);
+      headerParams[r'api_key'] = parameterToString(apiKey);
     }
 
     final contentTypes = <String>[];
@@ -499,21 +499,21 @@ class PetApi {
       final mp = MultipartRequest(null, null);
       if (name != null) {
         hasFields = true;
-        mp.fields['name'] = parameterToString(name);
+        mp.fields[r'name'] = parameterToString(name);
       }
       if (status != null) {
         hasFields = true;
-        mp.fields['status'] = parameterToString(status);
+        mp.fields[r'status'] = parameterToString(status);
       }
       if (hasFields) {
         postBody = mp;
       }
     } else {
       if (name != null) {
-        formParams['name'] = parameterToString(name);
+        formParams[r'name'] = parameterToString(name);
       }
       if (status != null) {
-        formParams['status'] = parameterToString(status);
+        formParams[r'status'] = parameterToString(status);
       }
     }
 
@@ -589,11 +589,11 @@ class PetApi {
       final mp = MultipartRequest(null, null);
       if (additionalMetadata != null) {
         hasFields = true;
-        mp.fields['additionalMetadata'] = parameterToString(additionalMetadata);
+        mp.fields[r'additionalMetadata'] = parameterToString(additionalMetadata);
       }
       if (file != null) {
         hasFields = true;
-        mp.fields['file'] = file.field;
+        mp.fields[r'file'] = file.field;
         mp.files.add(file);
       }
       if (hasFields) {
@@ -601,7 +601,7 @@ class PetApi {
       }
     } else {
       if (additionalMetadata != null) {
-        formParams['additionalMetadata'] = parameterToString(additionalMetadata);
+        formParams[r'additionalMetadata'] = parameterToString(additionalMetadata);
       }
     }
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
@@ -12,8 +12,8 @@ part of openapi.api;
 class ApiClient {
   ApiClient({this.basePath = 'http://petstore.swagger.io/v2'}) {
     // Setup authentications (key: authentication name, value: authentication).
-    _authentications['api_key'] = ApiKeyAuth('header', 'api_key');
-    _authentications['petstore_auth'] = OAuth();
+    _authentications[r'api_key'] = ApiKeyAuth('header', 'api_key');
+    _authentications[r'petstore_auth'] = OAuth();
   }
 
   final String basePath;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
@@ -44,13 +44,13 @@ class ApiResponse {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (code != null) {
-      json['code'] = code;
+      json[r'code'] = code;
     }
     if (type != null) {
-      json['type'] = type;
+      json[r'type'] = type;
     }
     if (message != null) {
-      json['message'] = message;
+      json[r'message'] = message;
     }
     return json;
   }
@@ -60,9 +60,9 @@ class ApiResponse {
   static ApiResponse fromJson(Map<String, dynamic> json) => json == null
     ? null
     : ApiResponse(
-        code: json['code'],
-        type: json['type'],
-        message: json['message'],
+        code: json[r'code'],
+        type: json[r'type'],
+        message: json[r'message'],
     );
 
   static List<ApiResponse> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
@@ -38,10 +38,10 @@ class Category {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class Category {
   static Category fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Category(
-        id: json['id'],
-        name: json['name'],
+        id: json[r'id'],
+        name: json[r'name'],
     );
 
   static List<Category> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/inline_object.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/inline_object.dart
@@ -38,10 +38,10 @@ class InlineObject {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     if (status != null) {
-      json['status'] = status;
+      json[r'status'] = status;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class InlineObject {
   static InlineObject fromJson(Map<String, dynamic> json) => json == null
     ? null
     : InlineObject(
-        name: json['name'],
-        status: json['status'],
+        name: json[r'name'],
+        status: json[r'status'],
     );
 
   static List<InlineObject> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/inline_object1.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/inline_object1.dart
@@ -38,10 +38,10 @@ class InlineObject1 {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (additionalMetadata != null) {
-      json['additionalMetadata'] = additionalMetadata;
+      json[r'additionalMetadata'] = additionalMetadata;
     }
     if (file != null) {
-      json['file'] = file;
+      json[r'file'] = file;
     }
     return json;
   }
@@ -51,7 +51,7 @@ class InlineObject1 {
   static InlineObject1 fromJson(Map<String, dynamic> json) => json == null
     ? null
     : InlineObject1(
-        additionalMetadata: json['additionalMetadata'],
+        additionalMetadata: json[r'additionalMetadata'],
         file: null, // No support for decoding binary content from JSON
     );
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -62,22 +62,22 @@ class Order {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (petId != null) {
-      json['petId'] = petId;
+      json[r'petId'] = petId;
     }
     if (quantity != null) {
-      json['quantity'] = quantity;
+      json[r'quantity'] = quantity;
     }
     if (shipDate != null) {
-      json['shipDate'] = shipDate.toUtc().toIso8601String();
+      json[r'shipDate'] = shipDate.toUtc().toIso8601String();
     }
     if (status != null) {
-      json['status'] = status;
+      json[r'status'] = status;
     }
     if (complete != null) {
-      json['complete'] = complete;
+      json[r'complete'] = complete;
     }
     return json;
   }
@@ -87,14 +87,14 @@ class Order {
   static Order fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Order(
-        id: json['id'],
-        petId: json['petId'],
-        quantity: json['quantity'],
-        shipDate: json['shipDate'] == null
+        id: json[r'id'],
+        petId: json[r'petId'],
+        quantity: json[r'quantity'],
+        shipDate: json[r'shipDate'] == null
           ? null
-          : DateTime.parse(json['shipDate']),
-        status: OrderStatusEnum.fromJson(json['status']),
-        complete: json['complete'],
+          : DateTime.parse(json[r'shipDate']),
+        status: OrderStatusEnum.fromJson(json[r'status']),
+        complete: json[r'complete'],
     );
 
   static List<Order> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -62,22 +62,22 @@ class Pet {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (category != null) {
-      json['category'] = category;
+      json[r'category'] = category;
     }
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     if (photoUrls != null) {
-      json['photoUrls'] = photoUrls;
+      json[r'photoUrls'] = photoUrls;
     }
     if (tags != null) {
-      json['tags'] = tags;
+      json[r'tags'] = tags;
     }
     if (status != null) {
-      json['status'] = status;
+      json[r'status'] = status;
     }
     return json;
   }
@@ -87,14 +87,14 @@ class Pet {
   static Pet fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Pet(
-        id: json['id'],
-        category: Category.fromJson(json['category']),
-        name: json['name'],
-        photoUrls: json['photoUrls'] == null
+        id: json[r'id'],
+        category: Category.fromJson(json[r'category']),
+        name: json[r'name'],
+        photoUrls: json[r'photoUrls'] == null
           ? null
-          : (json['photoUrls'] as List).cast<String>(),
-        tags: Tag.listFromJson(json['tags']),
-        status: PetStatusEnum.fromJson(json['status']),
+          : (json[r'photoUrls'] as List).cast<String>(),
+        tags: Tag.listFromJson(json[r'tags']),
+        status: PetStatusEnum.fromJson(json[r'status']),
     );
 
   static List<Pet> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
@@ -38,10 +38,10 @@ class Tag {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class Tag {
   static Tag fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Tag(
-        id: json['id'],
-        name: json['name'],
+        id: json[r'id'],
+        name: json[r'name'],
     );
 
   static List<Tag> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
@@ -74,28 +74,28 @@ class User {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (username != null) {
-      json['username'] = username;
+      json[r'username'] = username;
     }
     if (firstName != null) {
-      json['firstName'] = firstName;
+      json[r'firstName'] = firstName;
     }
     if (lastName != null) {
-      json['lastName'] = lastName;
+      json[r'lastName'] = lastName;
     }
     if (email != null) {
-      json['email'] = email;
+      json[r'email'] = email;
     }
     if (password != null) {
-      json['password'] = password;
+      json[r'password'] = password;
     }
     if (phone != null) {
-      json['phone'] = phone;
+      json[r'phone'] = phone;
     }
     if (userStatus != null) {
-      json['userStatus'] = userStatus;
+      json[r'userStatus'] = userStatus;
     }
     return json;
   }
@@ -105,14 +105,14 @@ class User {
   static User fromJson(Map<String, dynamic> json) => json == null
     ? null
     : User(
-        id: json['id'],
-        username: json['username'],
-        firstName: json['firstName'],
-        lastName: json['lastName'],
-        email: json['email'],
-        password: json['password'],
-        phone: json['phone'],
-        userStatus: json['userStatus'],
+        id: json[r'id'],
+        username: json[r'username'],
+        firstName: json[r'firstName'],
+        lastName: json[r'lastName'],
+        email: json[r'email'],
+        password: json[r'password'],
+        phone: json[r'phone'],
+        userStatus: json[r'userStatus'],
     );
 
   static List<User> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -103,7 +103,7 @@ class FakeApi {
     }
 
     if (header1 != null) {
-      headerParams['header_1'] = parameterToString(header1);
+      headerParams[r'header_1'] = parameterToString(header1);
     }
 
     final contentTypes = <String>['application/json', 'application/xml'];
@@ -705,103 +705,103 @@ class FakeApi {
       final mp = MultipartRequest(null, null);
       if (integer != null) {
         hasFields = true;
-        mp.fields['integer'] = parameterToString(integer);
+        mp.fields[r'integer'] = parameterToString(integer);
       }
       if (int32 != null) {
         hasFields = true;
-        mp.fields['int32'] = parameterToString(int32);
+        mp.fields[r'int32'] = parameterToString(int32);
       }
       if (int64 != null) {
         hasFields = true;
-        mp.fields['int64'] = parameterToString(int64);
+        mp.fields[r'int64'] = parameterToString(int64);
       }
       if (number != null) {
         hasFields = true;
-        mp.fields['number'] = parameterToString(number);
+        mp.fields[r'number'] = parameterToString(number);
       }
       if (float != null) {
         hasFields = true;
-        mp.fields['float'] = parameterToString(float);
+        mp.fields[r'float'] = parameterToString(float);
       }
       if (double != null) {
         hasFields = true;
-        mp.fields['double'] = parameterToString(double);
+        mp.fields[r'double'] = parameterToString(double);
       }
       if (string != null) {
         hasFields = true;
-        mp.fields['string'] = parameterToString(string);
+        mp.fields[r'string'] = parameterToString(string);
       }
       if (patternWithoutDelimiter != null) {
         hasFields = true;
-        mp.fields['pattern_without_delimiter'] = parameterToString(patternWithoutDelimiter);
+        mp.fields[r'pattern_without_delimiter'] = parameterToString(patternWithoutDelimiter);
       }
       if (byte != null) {
         hasFields = true;
-        mp.fields['byte'] = parameterToString(byte);
+        mp.fields[r'byte'] = parameterToString(byte);
       }
       if (binary != null) {
         hasFields = true;
-        mp.fields['binary'] = binary.field;
+        mp.fields[r'binary'] = binary.field;
         mp.files.add(binary);
       }
       if (date != null) {
         hasFields = true;
-        mp.fields['date'] = parameterToString(date);
+        mp.fields[r'date'] = parameterToString(date);
       }
       if (dateTime != null) {
         hasFields = true;
-        mp.fields['dateTime'] = parameterToString(dateTime);
+        mp.fields[r'dateTime'] = parameterToString(dateTime);
       }
       if (password != null) {
         hasFields = true;
-        mp.fields['password'] = parameterToString(password);
+        mp.fields[r'password'] = parameterToString(password);
       }
       if (callback != null) {
         hasFields = true;
-        mp.fields['callback'] = parameterToString(callback);
+        mp.fields[r'callback'] = parameterToString(callback);
       }
       if (hasFields) {
         postBody = mp;
       }
     } else {
       if (integer != null) {
-        formParams['integer'] = parameterToString(integer);
+        formParams[r'integer'] = parameterToString(integer);
       }
       if (int32 != null) {
-        formParams['int32'] = parameterToString(int32);
+        formParams[r'int32'] = parameterToString(int32);
       }
       if (int64 != null) {
-        formParams['int64'] = parameterToString(int64);
+        formParams[r'int64'] = parameterToString(int64);
       }
       if (number != null) {
-        formParams['number'] = parameterToString(number);
+        formParams[r'number'] = parameterToString(number);
       }
       if (float != null) {
-        formParams['float'] = parameterToString(float);
+        formParams[r'float'] = parameterToString(float);
       }
       if (double != null) {
-        formParams['double'] = parameterToString(double);
+        formParams[r'double'] = parameterToString(double);
       }
       if (string != null) {
-        formParams['string'] = parameterToString(string);
+        formParams[r'string'] = parameterToString(string);
       }
       if (patternWithoutDelimiter != null) {
-        formParams['pattern_without_delimiter'] = parameterToString(patternWithoutDelimiter);
+        formParams[r'pattern_without_delimiter'] = parameterToString(patternWithoutDelimiter);
       }
       if (byte != null) {
-        formParams['byte'] = parameterToString(byte);
+        formParams[r'byte'] = parameterToString(byte);
       }
       if (date != null) {
-        formParams['date'] = parameterToString(date);
+        formParams[r'date'] = parameterToString(date);
       }
       if (dateTime != null) {
-        formParams['dateTime'] = parameterToString(dateTime);
+        formParams[r'dateTime'] = parameterToString(dateTime);
       }
       if (password != null) {
-        formParams['password'] = parameterToString(password);
+        formParams[r'password'] = parameterToString(password);
       }
       if (callback != null) {
-        formParams['callback'] = parameterToString(callback);
+        formParams[r'callback'] = parameterToString(callback);
       }
     }
 
@@ -927,10 +927,10 @@ class FakeApi {
     }
 
     if (enumHeaderStringArray != null) {
-      headerParams['enum_header_string_array'] = parameterToString(enumHeaderStringArray);
+      headerParams[r'enum_header_string_array'] = parameterToString(enumHeaderStringArray);
     }
     if (enumHeaderString != null) {
-      headerParams['enum_header_string'] = parameterToString(enumHeaderString);
+      headerParams[r'enum_header_string'] = parameterToString(enumHeaderString);
     }
 
     final contentTypes = <String>['application/x-www-form-urlencoded'];
@@ -945,21 +945,21 @@ class FakeApi {
       final mp = MultipartRequest(null, null);
       if (enumFormStringArray != null) {
         hasFields = true;
-        mp.fields['enum_form_string_array'] = parameterToString(enumFormStringArray);
+        mp.fields[r'enum_form_string_array'] = parameterToString(enumFormStringArray);
       }
       if (enumFormString != null) {
         hasFields = true;
-        mp.fields['enum_form_string'] = parameterToString(enumFormString);
+        mp.fields[r'enum_form_string'] = parameterToString(enumFormString);
       }
       if (hasFields) {
         postBody = mp;
       }
     } else {
       if (enumFormStringArray != null) {
-        formParams['enum_form_string_array'] = parameterToString(enumFormStringArray);
+        formParams[r'enum_form_string_array'] = parameterToString(enumFormStringArray);
       }
       if (enumFormString != null) {
-        formParams['enum_form_string'] = parameterToString(enumFormString);
+        formParams[r'enum_form_string'] = parameterToString(enumFormString);
       }
     }
 
@@ -1065,9 +1065,9 @@ class FakeApi {
       queryParams.addAll(_convertParametersForCollectionFormat('', 'int64_group', int64Group));
     }
 
-    headerParams['required_boolean_group'] = parameterToString(requiredBooleanGroup);
+    headerParams[r'required_boolean_group'] = parameterToString(requiredBooleanGroup);
     if (booleanGroup != null) {
-      headerParams['boolean_group'] = parameterToString(booleanGroup);
+      headerParams[r'boolean_group'] = parameterToString(booleanGroup);
     }
 
     final contentTypes = <String>[];
@@ -1231,21 +1231,21 @@ class FakeApi {
       final mp = MultipartRequest(null, null);
       if (param != null) {
         hasFields = true;
-        mp.fields['param'] = parameterToString(param);
+        mp.fields[r'param'] = parameterToString(param);
       }
       if (param2 != null) {
         hasFields = true;
-        mp.fields['param2'] = parameterToString(param2);
+        mp.fields[r'param2'] = parameterToString(param2);
       }
       if (hasFields) {
         postBody = mp;
       }
     } else {
       if (param != null) {
-        formParams['param'] = parameterToString(param);
+        formParams[r'param'] = parameterToString(param);
       }
       if (param2 != null) {
-        formParams['param2'] = parameterToString(param2);
+        formParams[r'param2'] = parameterToString(param2);
       }
     }
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -104,7 +104,7 @@ class PetApi {
     final formParams = <String, String>{};
 
     if (apiKey != null) {
-      headerParams['api_key'] = parameterToString(apiKey);
+      headerParams[r'api_key'] = parameterToString(apiKey);
     }
 
     final contentTypes = <String>[];
@@ -485,21 +485,21 @@ class PetApi {
       final mp = MultipartRequest(null, null);
       if (name != null) {
         hasFields = true;
-        mp.fields['name'] = parameterToString(name);
+        mp.fields[r'name'] = parameterToString(name);
       }
       if (status != null) {
         hasFields = true;
-        mp.fields['status'] = parameterToString(status);
+        mp.fields[r'status'] = parameterToString(status);
       }
       if (hasFields) {
         postBody = mp;
       }
     } else {
       if (name != null) {
-        formParams['name'] = parameterToString(name);
+        formParams[r'name'] = parameterToString(name);
       }
       if (status != null) {
-        formParams['status'] = parameterToString(status);
+        formParams[r'status'] = parameterToString(status);
       }
     }
 
@@ -575,11 +575,11 @@ class PetApi {
       final mp = MultipartRequest(null, null);
       if (additionalMetadata != null) {
         hasFields = true;
-        mp.fields['additionalMetadata'] = parameterToString(additionalMetadata);
+        mp.fields[r'additionalMetadata'] = parameterToString(additionalMetadata);
       }
       if (file != null) {
         hasFields = true;
-        mp.fields['file'] = file.field;
+        mp.fields[r'file'] = file.field;
         mp.files.add(file);
       }
       if (hasFields) {
@@ -587,7 +587,7 @@ class PetApi {
       }
     } else {
       if (additionalMetadata != null) {
-        formParams['additionalMetadata'] = parameterToString(additionalMetadata);
+        formParams[r'additionalMetadata'] = parameterToString(additionalMetadata);
       }
     }
 
@@ -673,11 +673,11 @@ class PetApi {
       final mp = MultipartRequest(null, null);
       if (additionalMetadata != null) {
         hasFields = true;
-        mp.fields['additionalMetadata'] = parameterToString(additionalMetadata);
+        mp.fields[r'additionalMetadata'] = parameterToString(additionalMetadata);
       }
       if (requiredFile != null) {
         hasFields = true;
-        mp.fields['requiredFile'] = requiredFile.field;
+        mp.fields[r'requiredFile'] = requiredFile.field;
         mp.files.add(requiredFile);
       }
       if (hasFields) {
@@ -685,7 +685,7 @@ class PetApi {
       }
     } else {
       if (additionalMetadata != null) {
-        formParams['additionalMetadata'] = parameterToString(additionalMetadata);
+        formParams[r'additionalMetadata'] = parameterToString(additionalMetadata);
       }
     }
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
@@ -12,11 +12,11 @@ part of openapi.api;
 class ApiClient {
   ApiClient({this.basePath = 'http://petstore.swagger.io:80/v2'}) {
     // Setup authentications (key: authentication name, value: authentication).
-    _authentications['api_key'] = ApiKeyAuth('header', 'api_key');
-    _authentications['api_key_query'] = ApiKeyAuth('query', 'api_key_query');
-    _authentications['bearer_test'] = HttpBearerAuth();
-    _authentications['http_basic_test'] = HttpBasicAuth();
-    _authentications['petstore_auth'] = OAuth();
+    _authentications[r'api_key'] = ApiKeyAuth('header', 'api_key');
+    _authentications[r'api_key_query'] = ApiKeyAuth('query', 'api_key_query');
+    _authentications[r'bearer_test'] = HttpBearerAuth();
+    _authentications[r'http_basic_test'] = HttpBasicAuth();
+    _authentications[r'petstore_auth'] = OAuth();
   }
 
   final String basePath;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
@@ -38,10 +38,10 @@ class AdditionalPropertiesClass {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (mapProperty != null) {
-      json['map_property'] = mapProperty;
+      json[r'map_property'] = mapProperty;
     }
     if (mapOfMapProperty != null) {
-      json['map_of_map_property'] = mapOfMapProperty;
+      json[r'map_of_map_property'] = mapOfMapProperty;
     }
     return json;
   }
@@ -51,12 +51,12 @@ class AdditionalPropertiesClass {
   static AdditionalPropertiesClass fromJson(Map<String, dynamic> json) => json == null
     ? null
     : AdditionalPropertiesClass(
-        mapProperty: json['map_property'] == null ?
+        mapProperty: json[r'map_property'] == null ?
           null :
-          (json['map_property'] as Map).cast<String, String>(),
-        mapOfMapProperty: json['map_of_map_property'] == null
+          (json[r'map_property'] as Map).cast<String, String>(),
+        mapOfMapProperty: json[r'map_of_map_property'] == null
           ? null
-          : Map.mapFromJson(json['map_of_map_property']),
+          : Map.mapFromJson(json[r'map_of_map_property']),
     );
 
   static List<AdditionalPropertiesClass> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/animal.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/animal.dart
@@ -38,10 +38,10 @@ class Animal {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (className != null) {
-      json['className'] = className;
+      json[r'className'] = className;
     }
     if (color != null) {
-      json['color'] = color;
+      json[r'color'] = color;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class Animal {
   static Animal fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Animal(
-        className: json['className'],
-        color: json['color'],
+        className: json[r'className'],
+        color: json[r'color'],
     );
 
   static List<Animal> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
@@ -44,13 +44,13 @@ class ApiResponse {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (code != null) {
-      json['code'] = code;
+      json[r'code'] = code;
     }
     if (type != null) {
-      json['type'] = type;
+      json[r'type'] = type;
     }
     if (message != null) {
-      json['message'] = message;
+      json[r'message'] = message;
     }
     return json;
   }
@@ -60,9 +60,9 @@ class ApiResponse {
   static ApiResponse fromJson(Map<String, dynamic> json) => json == null
     ? null
     : ApiResponse(
-        code: json['code'],
-        type: json['type'],
-        message: json['message'],
+        code: json[r'code'],
+        type: json[r'type'],
+        message: json[r'message'],
     );
 
   static List<ApiResponse> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
@@ -32,7 +32,7 @@ class ArrayOfArrayOfNumberOnly {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (arrayArrayNumber != null) {
-      json['ArrayArrayNumber'] = arrayArrayNumber;
+      json[r'ArrayArrayNumber'] = arrayArrayNumber;
     }
     return json;
   }
@@ -42,9 +42,9 @@ class ArrayOfArrayOfNumberOnly {
   static ArrayOfArrayOfNumberOnly fromJson(Map<String, dynamic> json) => json == null
     ? null
     : ArrayOfArrayOfNumberOnly(
-        arrayArrayNumber: json['ArrayArrayNumber'] == null
+        arrayArrayNumber: json[r'ArrayArrayNumber'] == null
           ? null
-          : (json['ArrayArrayNumber'] as List).map(
+          : (json[r'ArrayArrayNumber'] as List).map(
               (e) => e == null ? null : (e as List).cast<num>()
             ).toList(growable: false),
     );

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
@@ -32,7 +32,7 @@ class ArrayOfNumberOnly {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (arrayNumber != null) {
-      json['ArrayNumber'] = arrayNumber;
+      json[r'ArrayNumber'] = arrayNumber;
     }
     return json;
   }
@@ -42,9 +42,9 @@ class ArrayOfNumberOnly {
   static ArrayOfNumberOnly fromJson(Map<String, dynamic> json) => json == null
     ? null
     : ArrayOfNumberOnly(
-        arrayNumber: json['ArrayNumber'] == null
+        arrayNumber: json[r'ArrayNumber'] == null
           ? null
-          : (json['ArrayNumber'] as List).cast<num>(),
+          : (json[r'ArrayNumber'] as List).cast<num>(),
     );
 
   static List<ArrayOfNumberOnly> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
@@ -44,13 +44,13 @@ class ArrayTest {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (arrayOfString != null) {
-      json['array_of_string'] = arrayOfString;
+      json[r'array_of_string'] = arrayOfString;
     }
     if (arrayArrayOfInteger != null) {
-      json['array_array_of_integer'] = arrayArrayOfInteger;
+      json[r'array_array_of_integer'] = arrayArrayOfInteger;
     }
     if (arrayArrayOfModel != null) {
-      json['array_array_of_model'] = arrayArrayOfModel;
+      json[r'array_array_of_model'] = arrayArrayOfModel;
     }
     return json;
   }
@@ -60,18 +60,18 @@ class ArrayTest {
   static ArrayTest fromJson(Map<String, dynamic> json) => json == null
     ? null
     : ArrayTest(
-        arrayOfString: json['array_of_string'] == null
+        arrayOfString: json[r'array_of_string'] == null
           ? null
-          : (json['array_of_string'] as List).cast<String>(),
-        arrayArrayOfInteger: json['array_array_of_integer'] == null
+          : (json[r'array_of_string'] as List).cast<String>(),
+        arrayArrayOfInteger: json[r'array_array_of_integer'] == null
           ? null
-          : (json['array_array_of_integer'] as List).map(
+          : (json[r'array_array_of_integer'] as List).map(
               (e) => e == null ? null : (e as List).cast<int>()
             ).toList(growable: false),
-        arrayArrayOfModel: json['array_array_of_model'] == null
+        arrayArrayOfModel: json[r'array_array_of_model'] == null
           ? null
-          : (json['array_array_of_model'] as List).map(
-              ReadOnlyFirst.listFromJson(json['array_array_of_model'])
+          : (json[r'array_array_of_model'] as List).map(
+              ReadOnlyFirst.listFromJson(json[r'array_array_of_model'])
             ).toList(growable: false),
     );
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
@@ -62,22 +62,22 @@ class Capitalization {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (smallCamel != null) {
-      json['smallCamel'] = smallCamel;
+      json[r'smallCamel'] = smallCamel;
     }
     if (capitalCamel != null) {
-      json['CapitalCamel'] = capitalCamel;
+      json[r'CapitalCamel'] = capitalCamel;
     }
     if (smallSnake != null) {
-      json['small_Snake'] = smallSnake;
+      json[r'small_Snake'] = smallSnake;
     }
     if (capitalSnake != null) {
-      json['Capital_Snake'] = capitalSnake;
+      json[r'Capital_Snake'] = capitalSnake;
     }
     if (sCAETHFlowPoints != null) {
-      json['SCA_ETH_Flow_Points'] = sCAETHFlowPoints;
+      json[r'SCA_ETH_Flow_Points'] = sCAETHFlowPoints;
     }
     if (ATT_NAME != null) {
-      json['ATT_NAME'] = ATT_NAME;
+      json[r'ATT_NAME'] = ATT_NAME;
     }
     return json;
   }
@@ -87,12 +87,12 @@ class Capitalization {
   static Capitalization fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Capitalization(
-        smallCamel: json['smallCamel'],
-        capitalCamel: json['CapitalCamel'],
-        smallSnake: json['small_Snake'],
-        capitalSnake: json['Capital_Snake'],
-        sCAETHFlowPoints: json['SCA_ETH_Flow_Points'],
-        ATT_NAME: json['ATT_NAME'],
+        smallCamel: json[r'smallCamel'],
+        capitalCamel: json[r'CapitalCamel'],
+        smallSnake: json[r'small_Snake'],
+        capitalSnake: json[r'Capital_Snake'],
+        sCAETHFlowPoints: json[r'SCA_ETH_Flow_Points'],
+        ATT_NAME: json[r'ATT_NAME'],
     );
 
   static List<Capitalization> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
@@ -44,13 +44,13 @@ class Cat {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (className != null) {
-      json['className'] = className;
+      json[r'className'] = className;
     }
     if (color != null) {
-      json['color'] = color;
+      json[r'color'] = color;
     }
     if (declawed != null) {
-      json['declawed'] = declawed;
+      json[r'declawed'] = declawed;
     }
     return json;
   }
@@ -60,9 +60,9 @@ class Cat {
   static Cat fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Cat(
-        className: json['className'],
-        color: json['color'],
-        declawed: json['declawed'],
+        className: json[r'className'],
+        color: json[r'color'],
+        declawed: json[r'declawed'],
     );
 
   static List<Cat> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat_all_of.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat_all_of.dart
@@ -32,7 +32,7 @@ class CatAllOf {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (declawed != null) {
-      json['declawed'] = declawed;
+      json[r'declawed'] = declawed;
     }
     return json;
   }
@@ -42,7 +42,7 @@ class CatAllOf {
   static CatAllOf fromJson(Map<String, dynamic> json) => json == null
     ? null
     : CatAllOf(
-        declawed: json['declawed'],
+        declawed: json[r'declawed'],
     );
 
   static List<CatAllOf> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
@@ -38,10 +38,10 @@ class Category {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class Category {
   static Category fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Category(
-        id: json['id'],
-        name: json['name'],
+        id: json[r'id'],
+        name: json[r'name'],
     );
 
   static List<Category> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
@@ -32,7 +32,7 @@ class ClassModel {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (class_ != null) {
-      json['_class'] = class_;
+      json[r'_class'] = class_;
     }
     return json;
   }
@@ -42,7 +42,7 @@ class ClassModel {
   static ClassModel fromJson(Map<String, dynamic> json) => json == null
     ? null
     : ClassModel(
-        class_: json['_class'],
+        class_: json[r'_class'],
     );
 
   static List<ClassModel> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/client.dart
@@ -32,7 +32,7 @@ class Client {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (client != null) {
-      json['client'] = client;
+      json[r'client'] = client;
     }
     return json;
   }
@@ -42,7 +42,7 @@ class Client {
   static Client fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Client(
-        client: json['client'],
+        client: json[r'client'],
     );
 
   static List<Client> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
@@ -44,13 +44,13 @@ class Dog {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (className != null) {
-      json['className'] = className;
+      json[r'className'] = className;
     }
     if (color != null) {
-      json['color'] = color;
+      json[r'color'] = color;
     }
     if (breed != null) {
-      json['breed'] = breed;
+      json[r'breed'] = breed;
     }
     return json;
   }
@@ -60,9 +60,9 @@ class Dog {
   static Dog fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Dog(
-        className: json['className'],
-        color: json['color'],
-        breed: json['breed'],
+        className: json[r'className'],
+        color: json[r'color'],
+        breed: json[r'breed'],
     );
 
   static List<Dog> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog_all_of.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog_all_of.dart
@@ -32,7 +32,7 @@ class DogAllOf {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (breed != null) {
-      json['breed'] = breed;
+      json[r'breed'] = breed;
     }
     return json;
   }
@@ -42,7 +42,7 @@ class DogAllOf {
   static DogAllOf fromJson(Map<String, dynamic> json) => json == null
     ? null
     : DogAllOf(
-        breed: json['breed'],
+        breed: json[r'breed'],
     );
 
   static List<DogAllOf> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -38,10 +38,10 @@ class EnumArrays {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (justSymbol != null) {
-      json['just_symbol'] = justSymbol;
+      json[r'just_symbol'] = justSymbol;
     }
     if (arrayEnum != null) {
-      json['array_enum'] = arrayEnum;
+      json[r'array_enum'] = arrayEnum;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class EnumArrays {
   static EnumArrays fromJson(Map<String, dynamic> json) => json == null
     ? null
     : EnumArrays(
-        justSymbol: EnumArraysJustSymbolEnum.fromJson(json['just_symbol']),
-        arrayEnum: EnumArraysArrayEnumEnum.listFromJson(json['array_enum']),
+        justSymbol: EnumArraysJustSymbolEnum.fromJson(json[r'just_symbol']),
+        arrayEnum: EnumArraysArrayEnumEnum.listFromJson(json[r'array_enum']),
     );
 
   static List<EnumArrays> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -74,28 +74,28 @@ class EnumTest {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (enumString != null) {
-      json['enum_string'] = enumString;
+      json[r'enum_string'] = enumString;
     }
     if (enumStringRequired != null) {
-      json['enum_string_required'] = enumStringRequired;
+      json[r'enum_string_required'] = enumStringRequired;
     }
     if (enumInteger != null) {
-      json['enum_integer'] = enumInteger;
+      json[r'enum_integer'] = enumInteger;
     }
     if (enumNumber != null) {
-      json['enum_number'] = enumNumber;
+      json[r'enum_number'] = enumNumber;
     }
     if (outerEnum != null) {
-      json['outerEnum'] = outerEnum;
+      json[r'outerEnum'] = outerEnum;
     }
     if (outerEnumInteger != null) {
-      json['outerEnumInteger'] = outerEnumInteger;
+      json[r'outerEnumInteger'] = outerEnumInteger;
     }
     if (outerEnumDefaultValue != null) {
-      json['outerEnumDefaultValue'] = outerEnumDefaultValue;
+      json[r'outerEnumDefaultValue'] = outerEnumDefaultValue;
     }
     if (outerEnumIntegerDefaultValue != null) {
-      json['outerEnumIntegerDefaultValue'] = outerEnumIntegerDefaultValue;
+      json[r'outerEnumIntegerDefaultValue'] = outerEnumIntegerDefaultValue;
     }
     return json;
   }
@@ -105,14 +105,14 @@ class EnumTest {
   static EnumTest fromJson(Map<String, dynamic> json) => json == null
     ? null
     : EnumTest(
-        enumString: EnumTestEnumStringEnum.fromJson(json['enum_string']),
-        enumStringRequired: EnumTestEnumStringRequiredEnum.fromJson(json['enum_string_required']),
-        enumInteger: EnumTestEnumIntegerEnum.fromJson(json['enum_integer']),
-        enumNumber: EnumTestEnumNumberEnum.fromJson(json['enum_number']),
-        outerEnum: OuterEnum.fromJson(json['outerEnum']),
-        outerEnumInteger: OuterEnumInteger.fromJson(json['outerEnumInteger']),
-        outerEnumDefaultValue: OuterEnumDefaultValue.fromJson(json['outerEnumDefaultValue']),
-        outerEnumIntegerDefaultValue: OuterEnumIntegerDefaultValue.fromJson(json['outerEnumIntegerDefaultValue']),
+        enumString: EnumTestEnumStringEnum.fromJson(json[r'enum_string']),
+        enumStringRequired: EnumTestEnumStringRequiredEnum.fromJson(json[r'enum_string_required']),
+        enumInteger: EnumTestEnumIntegerEnum.fromJson(json[r'enum_integer']),
+        enumNumber: EnumTestEnumNumberEnum.fromJson(json[r'enum_number']),
+        outerEnum: OuterEnum.fromJson(json[r'outerEnum']),
+        outerEnumInteger: OuterEnumInteger.fromJson(json[r'outerEnumInteger']),
+        outerEnumDefaultValue: OuterEnumDefaultValue.fromJson(json[r'outerEnumDefaultValue']),
+        outerEnumIntegerDefaultValue: OuterEnumIntegerDefaultValue.fromJson(json[r'outerEnumIntegerDefaultValue']),
     );
 
   static List<EnumTest> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file.dart
@@ -32,7 +32,7 @@ class File {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (sourceURI != null) {
-      json['sourceURI'] = sourceURI;
+      json[r'sourceURI'] = sourceURI;
     }
     return json;
   }
@@ -42,7 +42,7 @@ class File {
   static File fromJson(Map<String, dynamic> json) => json == null
     ? null
     : File(
-        sourceURI: json['sourceURI'],
+        sourceURI: json[r'sourceURI'],
     );
 
   static List<File> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
@@ -38,10 +38,10 @@ class FileSchemaTestClass {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (file != null) {
-      json['file'] = file;
+      json[r'file'] = file;
     }
     if (files != null) {
-      json['files'] = files;
+      json[r'files'] = files;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class FileSchemaTestClass {
   static FileSchemaTestClass fromJson(Map<String, dynamic> json) => json == null
     ? null
     : FileSchemaTestClass(
-        file: MultipartFile.fromJson(json['file']),
-        files: MultipartFile.listFromJson(json['files']),
+        file: MultipartFile.fromJson(json[r'file']),
+        files: MultipartFile.listFromJson(json[r'files']),
     );
 
   static List<FileSchemaTestClass> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo.dart
@@ -32,7 +32,7 @@ class Foo {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (bar != null) {
-      json['bar'] = bar;
+      json[r'bar'] = bar;
     }
     return json;
   }
@@ -42,7 +42,7 @@ class Foo {
   static Foo fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Foo(
-        bar: json['bar'],
+        bar: json[r'bar'],
     );
 
   static List<Foo> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
@@ -132,52 +132,52 @@ class FormatTest {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (integer != null) {
-      json['integer'] = integer;
+      json[r'integer'] = integer;
     }
     if (int32 != null) {
-      json['int32'] = int32;
+      json[r'int32'] = int32;
     }
     if (int64 != null) {
-      json['int64'] = int64;
+      json[r'int64'] = int64;
     }
     if (number != null) {
-      json['number'] = number;
+      json[r'number'] = number;
     }
     if (float != null) {
-      json['float'] = float;
+      json[r'float'] = float;
     }
     if (double != null) {
-      json['double'] = double;
+      json[r'double'] = double;
     }
     if (decimal != null) {
-      json['decimal'] = decimal;
+      json[r'decimal'] = decimal;
     }
     if (string != null) {
-      json['string'] = string;
+      json[r'string'] = string;
     }
     if (byte != null) {
-      json['byte'] = byte;
+      json[r'byte'] = byte;
     }
     if (binary != null) {
-      json['binary'] = binary;
+      json[r'binary'] = binary;
     }
     if (date != null) {
-      json['date'] = _dateFormatter.format(date.toUtc());
+      json[r'date'] = _dateFormatter.format(date.toUtc());
     }
     if (dateTime != null) {
-      json['dateTime'] = dateTime.toUtc().toIso8601String();
+      json[r'dateTime'] = dateTime.toUtc().toIso8601String();
     }
     if (uuid != null) {
-      json['uuid'] = uuid;
+      json[r'uuid'] = uuid;
     }
     if (password != null) {
-      json['password'] = password;
+      json[r'password'] = password;
     }
     if (patternWithDigits != null) {
-      json['pattern_with_digits'] = patternWithDigits;
+      json[r'pattern_with_digits'] = patternWithDigits;
     }
     if (patternWithDigitsAndDelimiter != null) {
-      json['pattern_with_digits_and_delimiter'] = patternWithDigitsAndDelimiter;
+      json[r'pattern_with_digits_and_delimiter'] = patternWithDigitsAndDelimiter;
     }
     return json;
   }
@@ -187,28 +187,28 @@ class FormatTest {
   static FormatTest fromJson(Map<String, dynamic> json) => json == null
     ? null
     : FormatTest(
-        integer: json['integer'],
-        int32: json['int32'],
-        int64: json['int64'],
-        number: json['number'] == null ?
+        integer: json[r'integer'],
+        int32: json[r'int32'],
+        int64: json[r'int64'],
+        number: json[r'number'] == null ?
           null :
-          json['number'].toDouble(),
-        float: json['float'],
-        double: json['double'],
-        decimal: json['decimal'],
-        string: json['string'],
-        byte: json['byte'],
+          json[r'number'].toDouble(),
+        float: json[r'float'],
+        double: json[r'double'],
+        decimal: json[r'decimal'],
+        string: json[r'string'],
+        byte: json[r'byte'],
         binary: null, // No support for decoding binary content from JSON
-        date: json['date'] == null
+        date: json[r'date'] == null
           ? null
-          : DateTime.parse(json['date']),
-        dateTime: json['dateTime'] == null
+          : DateTime.parse(json[r'date']),
+        dateTime: json[r'dateTime'] == null
           ? null
-          : DateTime.parse(json['dateTime']),
-        uuid: json['uuid'],
-        password: json['password'],
-        patternWithDigits: json['pattern_with_digits'],
-        patternWithDigitsAndDelimiter: json['pattern_with_digits_and_delimiter'],
+          : DateTime.parse(json[r'dateTime']),
+        uuid: json[r'uuid'],
+        password: json[r'password'],
+        patternWithDigits: json[r'pattern_with_digits'],
+        patternWithDigitsAndDelimiter: json[r'pattern_with_digits_and_delimiter'],
     );
 
   static List<FormatTest> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
@@ -38,10 +38,10 @@ class HasOnlyReadOnly {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (bar != null) {
-      json['bar'] = bar;
+      json[r'bar'] = bar;
     }
     if (foo != null) {
-      json['foo'] = foo;
+      json[r'foo'] = foo;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class HasOnlyReadOnly {
   static HasOnlyReadOnly fromJson(Map<String, dynamic> json) => json == null
     ? null
     : HasOnlyReadOnly(
-        bar: json['bar'],
-        foo: json['foo'],
+        bar: json[r'bar'],
+        foo: json[r'foo'],
     );
 
   static List<HasOnlyReadOnly> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
@@ -32,7 +32,7 @@ class HealthCheckResult {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (nullableMessage != null) {
-      json['NullableMessage'] = nullableMessage;
+      json[r'NullableMessage'] = nullableMessage;
     }
     return json;
   }
@@ -42,7 +42,7 @@ class HealthCheckResult {
   static HealthCheckResult fromJson(Map<String, dynamic> json) => json == null
     ? null
     : HealthCheckResult(
-        nullableMessage: json['NullableMessage'],
+        nullableMessage: json[r'NullableMessage'],
     );
 
   static List<HealthCheckResult> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object.dart
@@ -38,10 +38,10 @@ class InlineObject {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     if (status != null) {
-      json['status'] = status;
+      json[r'status'] = status;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class InlineObject {
   static InlineObject fromJson(Map<String, dynamic> json) => json == null
     ? null
     : InlineObject(
-        name: json['name'],
-        status: json['status'],
+        name: json[r'name'],
+        status: json[r'status'],
     );
 
   static List<InlineObject> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object1.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object1.dart
@@ -38,10 +38,10 @@ class InlineObject1 {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (additionalMetadata != null) {
-      json['additionalMetadata'] = additionalMetadata;
+      json[r'additionalMetadata'] = additionalMetadata;
     }
     if (file != null) {
-      json['file'] = file;
+      json[r'file'] = file;
     }
     return json;
   }
@@ -51,7 +51,7 @@ class InlineObject1 {
   static InlineObject1 fromJson(Map<String, dynamic> json) => json == null
     ? null
     : InlineObject1(
-        additionalMetadata: json['additionalMetadata'],
+        additionalMetadata: json[r'additionalMetadata'],
         file: null, // No support for decoding binary content from JSON
     );
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object2.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object2.dart
@@ -38,10 +38,10 @@ class InlineObject2 {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (enumFormStringArray != null) {
-      json['enum_form_string_array'] = enumFormStringArray;
+      json[r'enum_form_string_array'] = enumFormStringArray;
     }
     if (enumFormString != null) {
-      json['enum_form_string'] = enumFormString;
+      json[r'enum_form_string'] = enumFormString;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class InlineObject2 {
   static InlineObject2 fromJson(Map<String, dynamic> json) => json == null
     ? null
     : InlineObject2(
-        enumFormStringArray: InlineObject2EnumFormStringArrayEnum.listFromJson(json['enum_form_string_array']),
-        enumFormString: InlineObject2EnumFormStringEnum.fromJson(json['enum_form_string']),
+        enumFormStringArray: InlineObject2EnumFormStringArrayEnum.listFromJson(json[r'enum_form_string_array']),
+        enumFormString: InlineObject2EnumFormStringEnum.fromJson(json[r'enum_form_string']),
     );
 
   static List<InlineObject2> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object3.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object3.dart
@@ -119,46 +119,46 @@ class InlineObject3 {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (integer != null) {
-      json['integer'] = integer;
+      json[r'integer'] = integer;
     }
     if (int32 != null) {
-      json['int32'] = int32;
+      json[r'int32'] = int32;
     }
     if (int64 != null) {
-      json['int64'] = int64;
+      json[r'int64'] = int64;
     }
     if (number != null) {
-      json['number'] = number;
+      json[r'number'] = number;
     }
     if (float != null) {
-      json['float'] = float;
+      json[r'float'] = float;
     }
     if (double != null) {
-      json['double'] = double;
+      json[r'double'] = double;
     }
     if (string != null) {
-      json['string'] = string;
+      json[r'string'] = string;
     }
     if (patternWithoutDelimiter != null) {
-      json['pattern_without_delimiter'] = patternWithoutDelimiter;
+      json[r'pattern_without_delimiter'] = patternWithoutDelimiter;
     }
     if (byte != null) {
-      json['byte'] = byte;
+      json[r'byte'] = byte;
     }
     if (binary != null) {
-      json['binary'] = binary;
+      json[r'binary'] = binary;
     }
     if (date != null) {
-      json['date'] = _dateFormatter.format(date.toUtc());
+      json[r'date'] = _dateFormatter.format(date.toUtc());
     }
     if (dateTime != null) {
-      json['dateTime'] = dateTime.toUtc().toIso8601String();
+      json[r'dateTime'] = dateTime.toUtc().toIso8601String();
     }
     if (password != null) {
-      json['password'] = password;
+      json[r'password'] = password;
     }
     if (callback != null) {
-      json['callback'] = callback;
+      json[r'callback'] = callback;
     }
     return json;
   }
@@ -168,26 +168,26 @@ class InlineObject3 {
   static InlineObject3 fromJson(Map<String, dynamic> json) => json == null
     ? null
     : InlineObject3(
-        integer: json['integer'],
-        int32: json['int32'],
-        int64: json['int64'],
-        number: json['number'] == null ?
+        integer: json[r'integer'],
+        int32: json[r'int32'],
+        int64: json[r'int64'],
+        number: json[r'number'] == null ?
           null :
-          json['number'].toDouble(),
-        float: json['float'],
-        double: json['double'],
-        string: json['string'],
-        patternWithoutDelimiter: json['pattern_without_delimiter'],
-        byte: json['byte'],
+          json[r'number'].toDouble(),
+        float: json[r'float'],
+        double: json[r'double'],
+        string: json[r'string'],
+        patternWithoutDelimiter: json[r'pattern_without_delimiter'],
+        byte: json[r'byte'],
         binary: null, // No support for decoding binary content from JSON
-        date: json['date'] == null
+        date: json[r'date'] == null
           ? null
-          : DateTime.parse(json['date']),
-        dateTime: json['dateTime'] == null
+          : DateTime.parse(json[r'date']),
+        dateTime: json[r'dateTime'] == null
           ? null
-          : DateTime.parse(json['dateTime']),
-        password: json['password'],
-        callback: json['callback'],
+          : DateTime.parse(json[r'dateTime']),
+        password: json[r'password'],
+        callback: json[r'callback'],
     );
 
   static List<InlineObject3> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object4.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object4.dart
@@ -38,10 +38,10 @@ class InlineObject4 {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (param != null) {
-      json['param'] = param;
+      json[r'param'] = param;
     }
     if (param2 != null) {
-      json['param2'] = param2;
+      json[r'param2'] = param2;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class InlineObject4 {
   static InlineObject4 fromJson(Map<String, dynamic> json) => json == null
     ? null
     : InlineObject4(
-        param: json['param'],
-        param2: json['param2'],
+        param: json[r'param'],
+        param2: json[r'param2'],
     );
 
   static List<InlineObject4> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object5.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object5.dart
@@ -38,10 +38,10 @@ class InlineObject5 {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (additionalMetadata != null) {
-      json['additionalMetadata'] = additionalMetadata;
+      json[r'additionalMetadata'] = additionalMetadata;
     }
     if (requiredFile != null) {
-      json['requiredFile'] = requiredFile;
+      json[r'requiredFile'] = requiredFile;
     }
     return json;
   }
@@ -51,7 +51,7 @@ class InlineObject5 {
   static InlineObject5 fromJson(Map<String, dynamic> json) => json == null
     ? null
     : InlineObject5(
-        additionalMetadata: json['additionalMetadata'],
+        additionalMetadata: json[r'additionalMetadata'],
         requiredFile: null, // No support for decoding binary content from JSON
     );
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_response_default.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_response_default.dart
@@ -32,7 +32,7 @@ class InlineResponseDefault {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (string != null) {
-      json['string'] = string;
+      json[r'string'] = string;
     }
     return json;
   }
@@ -42,7 +42,7 @@ class InlineResponseDefault {
   static InlineResponseDefault fromJson(Map<String, dynamic> json) => json == null
     ? null
     : InlineResponseDefault(
-        string: Foo.fromJson(json['string']),
+        string: Foo.fromJson(json[r'string']),
     );
 
   static List<InlineResponseDefault> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
@@ -50,16 +50,16 @@ class MapTest {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (mapMapOfString != null) {
-      json['map_map_of_string'] = mapMapOfString;
+      json[r'map_map_of_string'] = mapMapOfString;
     }
     if (mapOfEnumString != null) {
-      json['map_of_enum_string'] = mapOfEnumString;
+      json[r'map_of_enum_string'] = mapOfEnumString;
     }
     if (directMap != null) {
-      json['direct_map'] = directMap;
+      json[r'direct_map'] = directMap;
     }
     if (indirectMap != null) {
-      json['indirect_map'] = indirectMap;
+      json[r'indirect_map'] = indirectMap;
     }
     return json;
   }
@@ -69,18 +69,18 @@ class MapTest {
   static MapTest fromJson(Map<String, dynamic> json) => json == null
     ? null
     : MapTest(
-        mapMapOfString: json['map_map_of_string'] == null
+        mapMapOfString: json[r'map_map_of_string'] == null
           ? null
-          : Map.mapFromJson(json['map_map_of_string']),
-        mapOfEnumString: json['map_of_enum_string'] == null ?
+          : Map.mapFromJson(json[r'map_map_of_string']),
+        mapOfEnumString: json[r'map_of_enum_string'] == null ?
           null :
-          (json['map_of_enum_string'] as Map).cast<String, String>(),
-        directMap: json['direct_map'] == null ?
+          (json[r'map_of_enum_string'] as Map).cast<String, String>(),
+        directMap: json[r'direct_map'] == null ?
           null :
-          (json['direct_map'] as Map).cast<String, bool>(),
-        indirectMap: json['indirect_map'] == null ?
+          (json[r'direct_map'] as Map).cast<String, bool>(),
+        indirectMap: json[r'indirect_map'] == null ?
           null :
-          (json['indirect_map'] as Map).cast<String, bool>(),
+          (json[r'indirect_map'] as Map).cast<String, bool>(),
     );
 
   static List<MapTest> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
@@ -44,13 +44,13 @@ class MixedPropertiesAndAdditionalPropertiesClass {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (uuid != null) {
-      json['uuid'] = uuid;
+      json[r'uuid'] = uuid;
     }
     if (dateTime != null) {
-      json['dateTime'] = dateTime.toUtc().toIso8601String();
+      json[r'dateTime'] = dateTime.toUtc().toIso8601String();
     }
     if (map != null) {
-      json['map'] = map;
+      json[r'map'] = map;
     }
     return json;
   }
@@ -60,13 +60,13 @@ class MixedPropertiesAndAdditionalPropertiesClass {
   static MixedPropertiesAndAdditionalPropertiesClass fromJson(Map<String, dynamic> json) => json == null
     ? null
     : MixedPropertiesAndAdditionalPropertiesClass(
-        uuid: json['uuid'],
-        dateTime: json['dateTime'] == null
+        uuid: json[r'uuid'],
+        dateTime: json[r'dateTime'] == null
           ? null
-          : DateTime.parse(json['dateTime']),
-        map: json['map'] == null
+          : DateTime.parse(json[r'dateTime']),
+        map: json[r'map'] == null
           ? null
-          : Animal.mapFromJson(json['map']),
+          : Animal.mapFromJson(json[r'map']),
     );
 
   static List<MixedPropertiesAndAdditionalPropertiesClass> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
@@ -38,10 +38,10 @@ class Model200Response {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     if (class_ != null) {
-      json['class'] = class_;
+      json[r'class'] = class_;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class Model200Response {
   static Model200Response fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Model200Response(
-        name: json['name'],
-        class_: json['class'],
+        name: json[r'name'],
+        class_: json[r'class'],
     );
 
   static List<Model200Response> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
@@ -32,7 +32,7 @@ class ModelReturn {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (return_ != null) {
-      json['return'] = return_;
+      json[r'return'] = return_;
     }
     return json;
   }
@@ -42,7 +42,7 @@ class ModelReturn {
   static ModelReturn fromJson(Map<String, dynamic> json) => json == null
     ? null
     : ModelReturn(
-        return_: json['return'],
+        return_: json[r'return'],
     );
 
   static List<ModelReturn> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
@@ -50,16 +50,16 @@ class Name {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     if (snakeCase != null) {
-      json['snake_case'] = snakeCase;
+      json[r'snake_case'] = snakeCase;
     }
     if (property != null) {
-      json['property'] = property;
+      json[r'property'] = property;
     }
     if (n123number != null) {
-      json['123Number'] = n123number;
+      json[r'123Number'] = n123number;
     }
     return json;
   }
@@ -69,10 +69,10 @@ class Name {
   static Name fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Name(
-        name: json['name'],
-        snakeCase: json['snake_case'],
-        property: json['property'],
-        n123number: json['123Number'],
+        name: json[r'name'],
+        snakeCase: json[r'snake_case'],
+        property: json[r'property'],
+        n123number: json[r'123Number'],
     );
 
   static List<Name> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -98,40 +98,40 @@ class NullableClass {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (integerProp != null) {
-      json['integer_prop'] = integerProp;
+      json[r'integer_prop'] = integerProp;
     }
     if (numberProp != null) {
-      json['number_prop'] = numberProp;
+      json[r'number_prop'] = numberProp;
     }
     if (booleanProp != null) {
-      json['boolean_prop'] = booleanProp;
+      json[r'boolean_prop'] = booleanProp;
     }
     if (stringProp != null) {
-      json['string_prop'] = stringProp;
+      json[r'string_prop'] = stringProp;
     }
     if (dateProp != null) {
-      json['date_prop'] = _dateFormatter.format(dateProp.toUtc());
+      json[r'date_prop'] = _dateFormatter.format(dateProp.toUtc());
     }
     if (datetimeProp != null) {
-      json['datetime_prop'] = datetimeProp.toUtc().toIso8601String();
+      json[r'datetime_prop'] = datetimeProp.toUtc().toIso8601String();
     }
     if (arrayNullableProp != null) {
-      json['array_nullable_prop'] = arrayNullableProp;
+      json[r'array_nullable_prop'] = arrayNullableProp;
     }
     if (arrayAndItemsNullableProp != null) {
-      json['array_and_items_nullable_prop'] = arrayAndItemsNullableProp;
+      json[r'array_and_items_nullable_prop'] = arrayAndItemsNullableProp;
     }
     if (arrayItemsNullable != null) {
-      json['array_items_nullable'] = arrayItemsNullable;
+      json[r'array_items_nullable'] = arrayItemsNullable;
     }
     if (objectNullableProp != null) {
-      json['object_nullable_prop'] = objectNullableProp;
+      json[r'object_nullable_prop'] = objectNullableProp;
     }
     if (objectAndItemsNullableProp != null) {
-      json['object_and_items_nullable_prop'] = objectAndItemsNullableProp;
+      json[r'object_and_items_nullable_prop'] = objectAndItemsNullableProp;
     }
     if (objectItemsNullable != null) {
-      json['object_items_nullable'] = objectItemsNullable;
+      json[r'object_items_nullable'] = objectItemsNullable;
     }
     return json;
   }
@@ -141,30 +141,30 @@ class NullableClass {
   static NullableClass fromJson(Map<String, dynamic> json) => json == null
     ? null
     : NullableClass(
-        integerProp: json['integer_prop'],
-        numberProp: json['number_prop'] == null ?
+        integerProp: json[r'integer_prop'],
+        numberProp: json[r'number_prop'] == null ?
           null :
-          json['number_prop'].toDouble(),
-        booleanProp: json['boolean_prop'],
-        stringProp: json['string_prop'],
-        dateProp: json['date_prop'] == null
+          json[r'number_prop'].toDouble(),
+        booleanProp: json[r'boolean_prop'],
+        stringProp: json[r'string_prop'],
+        dateProp: json[r'date_prop'] == null
           ? null
-          : DateTime.parse(json['date_prop']),
-        datetimeProp: json['datetime_prop'] == null
+          : DateTime.parse(json[r'date_prop']),
+        datetimeProp: json[r'datetime_prop'] == null
           ? null
-          : DateTime.parse(json['datetime_prop']),
-        arrayNullableProp: Object.listFromJson(json['array_nullable_prop']),
-        arrayAndItemsNullableProp: Object.listFromJson(json['array_and_items_nullable_prop']),
-        arrayItemsNullable: Object.listFromJson(json['array_items_nullable']),
-        objectNullableProp: json['object_nullable_prop'] == null
+          : DateTime.parse(json[r'datetime_prop']),
+        arrayNullableProp: Object.listFromJson(json[r'array_nullable_prop']),
+        arrayAndItemsNullableProp: Object.listFromJson(json[r'array_and_items_nullable_prop']),
+        arrayItemsNullable: Object.listFromJson(json[r'array_items_nullable']),
+        objectNullableProp: json[r'object_nullable_prop'] == null
           ? null
-          : Object.mapFromJson(json['object_nullable_prop']),
-        objectAndItemsNullableProp: json['object_and_items_nullable_prop'] == null
+          : Object.mapFromJson(json[r'object_nullable_prop']),
+        objectAndItemsNullableProp: json[r'object_and_items_nullable_prop'] == null
           ? null
-          : Object.mapFromJson(json['object_and_items_nullable_prop']),
-        objectItemsNullable: json['object_items_nullable'] == null
+          : Object.mapFromJson(json[r'object_and_items_nullable_prop']),
+        objectItemsNullable: json[r'object_items_nullable'] == null
           ? null
-          : Object.mapFromJson(json['object_items_nullable']),
+          : Object.mapFromJson(json[r'object_items_nullable']),
     );
 
   static List<NullableClass> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
@@ -32,7 +32,7 @@ class NumberOnly {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (justNumber != null) {
-      json['JustNumber'] = justNumber;
+      json[r'JustNumber'] = justNumber;
     }
     return json;
   }
@@ -42,9 +42,9 @@ class NumberOnly {
   static NumberOnly fromJson(Map<String, dynamic> json) => json == null
     ? null
     : NumberOnly(
-        justNumber: json['JustNumber'] == null ?
+        justNumber: json[r'JustNumber'] == null ?
           null :
-          json['JustNumber'].toDouble(),
+          json[r'JustNumber'].toDouble(),
     );
 
   static List<NumberOnly> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
@@ -62,22 +62,22 @@ class Order {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (petId != null) {
-      json['petId'] = petId;
+      json[r'petId'] = petId;
     }
     if (quantity != null) {
-      json['quantity'] = quantity;
+      json[r'quantity'] = quantity;
     }
     if (shipDate != null) {
-      json['shipDate'] = shipDate.toUtc().toIso8601String();
+      json[r'shipDate'] = shipDate.toUtc().toIso8601String();
     }
     if (status != null) {
-      json['status'] = status;
+      json[r'status'] = status;
     }
     if (complete != null) {
-      json['complete'] = complete;
+      json[r'complete'] = complete;
     }
     return json;
   }
@@ -87,14 +87,14 @@ class Order {
   static Order fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Order(
-        id: json['id'],
-        petId: json['petId'],
-        quantity: json['quantity'],
-        shipDate: json['shipDate'] == null
+        id: json[r'id'],
+        petId: json[r'petId'],
+        quantity: json[r'quantity'],
+        shipDate: json[r'shipDate'] == null
           ? null
-          : DateTime.parse(json['shipDate']),
-        status: OrderStatusEnum.fromJson(json['status']),
-        complete: json['complete'],
+          : DateTime.parse(json[r'shipDate']),
+        status: OrderStatusEnum.fromJson(json[r'status']),
+        complete: json[r'complete'],
     );
 
   static List<Order> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
@@ -44,13 +44,13 @@ class OuterComposite {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (myNumber != null) {
-      json['my_number'] = myNumber;
+      json[r'my_number'] = myNumber;
     }
     if (myString != null) {
-      json['my_string'] = myString;
+      json[r'my_string'] = myString;
     }
     if (myBoolean != null) {
-      json['my_boolean'] = myBoolean;
+      json[r'my_boolean'] = myBoolean;
     }
     return json;
   }
@@ -60,11 +60,11 @@ class OuterComposite {
   static OuterComposite fromJson(Map<String, dynamic> json) => json == null
     ? null
     : OuterComposite(
-        myNumber: json['my_number'] == null ?
+        myNumber: json[r'my_number'] == null ?
           null :
-          json['my_number'].toDouble(),
-        myString: json['my_string'],
-        myBoolean: json['my_boolean'],
+          json[r'my_number'].toDouble(),
+        myString: json[r'my_string'],
+        myBoolean: json[r'my_boolean'],
     );
 
   static List<OuterComposite> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
@@ -62,22 +62,22 @@ class Pet {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (category != null) {
-      json['category'] = category;
+      json[r'category'] = category;
     }
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     if (photoUrls != null) {
-      json['photoUrls'] = photoUrls;
+      json[r'photoUrls'] = photoUrls;
     }
     if (tags != null) {
-      json['tags'] = tags;
+      json[r'tags'] = tags;
     }
     if (status != null) {
-      json['status'] = status;
+      json[r'status'] = status;
     }
     return json;
   }
@@ -87,14 +87,14 @@ class Pet {
   static Pet fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Pet(
-        id: json['id'],
-        category: Category.fromJson(json['category']),
-        name: json['name'],
-        photoUrls: json['photoUrls'] == null
+        id: json[r'id'],
+        category: Category.fromJson(json[r'category']),
+        name: json[r'name'],
+        photoUrls: json[r'photoUrls'] == null
           ? null
-          : (json['photoUrls'] as List).cast<String>(),
-        tags: Tag.listFromJson(json['tags']),
-        status: PetStatusEnum.fromJson(json['status']),
+          : (json[r'photoUrls'] as List).cast<String>(),
+        tags: Tag.listFromJson(json[r'tags']),
+        status: PetStatusEnum.fromJson(json[r'status']),
     );
 
   static List<Pet> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
@@ -38,10 +38,10 @@ class ReadOnlyFirst {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (bar != null) {
-      json['bar'] = bar;
+      json[r'bar'] = bar;
     }
     if (baz != null) {
-      json['baz'] = baz;
+      json[r'baz'] = baz;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class ReadOnlyFirst {
   static ReadOnlyFirst fromJson(Map<String, dynamic> json) => json == null
     ? null
     : ReadOnlyFirst(
-        bar: json['bar'],
-        baz: json['baz'],
+        bar: json[r'bar'],
+        baz: json[r'baz'],
     );
 
   static List<ReadOnlyFirst> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
@@ -32,7 +32,7 @@ class SpecialModelName {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if ($special[propertyName] != null) {
-      json['$special[property.name]'] = $special[propertyName];
+      json[r'$special[property.name]'] = $special[propertyName];
     }
     return json;
   }
@@ -42,7 +42,7 @@ class SpecialModelName {
   static SpecialModelName fromJson(Map<String, dynamic> json) => json == null
     ? null
     : SpecialModelName(
-        $special[propertyName]: json['$special[property.name]'],
+        $special[propertyName]: json[r'$special[property.name]'],
     );
 
   static List<SpecialModelName> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
@@ -38,10 +38,10 @@ class Tag {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (name != null) {
-      json['name'] = name;
+      json[r'name'] = name;
     }
     return json;
   }
@@ -51,8 +51,8 @@ class Tag {
   static Tag fromJson(Map<String, dynamic> json) => json == null
     ? null
     : Tag(
-        id: json['id'],
-        name: json['name'],
+        id: json[r'id'],
+        name: json[r'name'],
     );
 
   static List<Tag> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
@@ -74,28 +74,28 @@ class User {
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     if (id != null) {
-      json['id'] = id;
+      json[r'id'] = id;
     }
     if (username != null) {
-      json['username'] = username;
+      json[r'username'] = username;
     }
     if (firstName != null) {
-      json['firstName'] = firstName;
+      json[r'firstName'] = firstName;
     }
     if (lastName != null) {
-      json['lastName'] = lastName;
+      json[r'lastName'] = lastName;
     }
     if (email != null) {
-      json['email'] = email;
+      json[r'email'] = email;
     }
     if (password != null) {
-      json['password'] = password;
+      json[r'password'] = password;
     }
     if (phone != null) {
-      json['phone'] = phone;
+      json[r'phone'] = phone;
     }
     if (userStatus != null) {
-      json['userStatus'] = userStatus;
+      json[r'userStatus'] = userStatus;
     }
     return json;
   }
@@ -105,14 +105,14 @@ class User {
   static User fromJson(Map<String, dynamic> json) => json == null
     ? null
     : User(
-        id: json['id'],
-        username: json['username'],
-        firstName: json['firstName'],
-        lastName: json['lastName'],
-        email: json['email'],
-        password: json['password'],
-        phone: json['phone'],
-        userStatus: json['userStatus'],
+        id: json[r'id'],
+        username: json[r'username'],
+        firstName: json[r'firstName'],
+        lastName: json[r'lastName'],
+        email: json[r'email'],
+        password: json[r'password'],
+        phone: json[r'phone'],
+        userStatus: json[r'userStatus'],
     );
 
   static List<User> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>


### PR DESCRIPTION
This should fix all problems related to unescaped characters in strings that are assumed to be raw - e.g. `json['$special[property.name]']` -> `json[r'$special[property.name]']`.


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09) @josh-burton  (2019/12) @amondnet (2019/12) @agilob 