### PR TITLE
[Go][Server] Use the correct parameter name

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -35,60 +35,60 @@ func (c *{{classname}}Controller) Routes() Routes {
 func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Request) { {{#hasFormParams}}
 	err := r.ParseForm()
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/hasFormParams}}{{#hasPathParams}}
 	params := mux.Vars(r){{/hasPathParams}}{{#hasQueryParams}}
 	query := r.URL.Query(){{/hasQueryParams}}{{#allParams}}{{#isPathParam}}{{#isLong}}
-	{{paramName}}, err := parseInt64Parameter(params["{{paramName}}"])
+	{{paramName}}, err := parseInt64Parameter(params["{{baseName}}"])
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}{{/isLong}}{{#isInteger}}
-	{{paramName}}, err := parseInt32Parameter(params["{{paramName}}"])
+	{{paramName}}, err := parseInt32Parameter(params["{{baseName}}"])
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/isInteger}}{{^isLong}}{{^isInteger}}
-	{{paramName}} := params["{{paramName}}"]{{/isInteger}}{{/isLong}}{{/isPathParam}}{{#isQueryParam}}{{#isLong}}
-	{{paramName}}, err := parseInt64Parameter(query.Get("{{paramName}}"))
+	{{paramName}} := params["{{baseName}}"]{{/isInteger}}{{/isLong}}{{/isPathParam}}{{#isQueryParam}}{{#isLong}}
+	{{paramName}}, err := parseInt64Parameter(query.Get("{{baseName}}"))
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/isLong}}{{#isInteger}}
-	{{paramName}}, err := parseInt32Parameter(query.Get("{{paramName}}"))
+	{{paramName}}, err := parseInt32Parameter(query.Get("{{baseName}}"))
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/isInteger}}{{^isLong}}{{^isInteger}}
-	{{paramName}} := {{#isArray}}strings.Split({{/isArray}}query.Get("{{paramName}}"){{#isArray}}, ","){{/isArray}}{{/isInteger}}{{/isLong}}{{/isQueryParam}}{{#isFormParam}}{{#isFile}}
-	{{#isArray}}{{paramName}}, err := ReadFormFilesToTempFiles(r, "{{paramName}}"){{/isArray}}{{^isArray}}{{paramName}}, err := ReadFormFileToTempFile(r, "{{paramName}}"){{/isArray}}
+	{{paramName}} := {{#isArray}}strings.Split({{/isArray}}query.Get("{{baseName}}"){{#isArray}}, ","){{/isArray}}{{/isInteger}}{{/isLong}}{{/isQueryParam}}{{#isFormParam}}{{#isFile}}
+	{{#isArray}}{{paramName}}, err := ReadFormFilesToTempFiles(r, "{{baseName}}"){{/isArray}}{{^isArray}}{{paramName}}, err := ReadFormFileToTempFile(r, "{{baseName}}"){{/isArray}}
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/isFile}}{{#isLong}}
-	{{paramName}}, err := parseInt64Parameter( r.FormValue("{{paramName}}"))
+	{{paramName}}, err := parseInt64Parameter( r.FormValue("{{baseName}}"))
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/isLong}}{{#isInteger}}
-	{{paramName}}, err := parseInt32Parameter( r.FormValue("{{paramName}}"))
+	{{paramName}}, err := parseInt32Parameter( r.FormValue("{{baseName}}"))
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/isInteger}}{{^isFile}}{{^isLong}}
-	{{paramName}} := r.FormValue("{{paramName}}"){{/isLong}}{{/isFile}}{{/isFormParam}}{{#isHeaderParam}}
-	{{paramName}} := r.Header.Get("{{paramName}}"){{/isHeaderParam}}{{#isBodyParam}}
+	{{paramName}} := r.FormValue("{{baseName}}"){{/isLong}}{{/isFile}}{{/isFormParam}}{{#isHeaderParam}}
+	{{paramName}} := r.Header.Get("{{baseName}}"){{/isHeaderParam}}{{#isBodyParam}}
 	{{paramName}} := &{{dataType}}{}
 	if err := json.NewDecoder(r.Body).Decode(&{{paramName}}); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	{{/isBodyParam}}{{/allParams}}

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -85,7 +85,7 @@ func (c *PetApiController) Routes() Routes {
 func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) { 
 	pet := &Pet{}
 	if err := json.NewDecoder(r.Body).Decode(&pet); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
@@ -105,10 +105,10 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	petId, err := parseInt64Parameter(params["petId"])
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	apiKey := r.Header.Get("apiKey")
+	apiKey := r.Header.Get("api_key")
 	result, err := c.service.DeletePet(r.Context(), petId, apiKey)
 	//If an error occured, encode the error with the status code
 	if err != nil {
@@ -155,7 +155,7 @@ func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	petId, err := parseInt64Parameter(params["petId"])
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	result, err := c.service.GetPetById(r.Context(), petId)
@@ -173,7 +173,7 @@ func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
 func (c *PetApiController) UpdatePet(w http.ResponseWriter, r *http.Request) { 
 	pet := &Pet{}
 	if err := json.NewDecoder(r.Body).Decode(&pet); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
@@ -192,14 +192,14 @@ func (c *PetApiController) UpdatePet(w http.ResponseWriter, r *http.Request) {
 func (c *PetApiController) UpdatePetWithForm(w http.ResponseWriter, r *http.Request) { 
 	err := r.ParseForm()
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
 	params := mux.Vars(r)
 	petId, err := parseInt64Parameter(params["petId"])
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	name := r.FormValue("name")
@@ -219,20 +219,20 @@ func (c *PetApiController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) { 
 	err := r.ParseForm()
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
 	params := mux.Vars(r)
 	petId, err := parseInt64Parameter(params["petId"])
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	additionalMetadata := r.FormValue("additionalMetadata")
 	file, err := ReadFormFileToTempFile(r, "file")
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -90,7 +90,7 @@ func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request
 	params := mux.Vars(r)
 	orderId, err := parseInt64Parameter(params["orderId"])
 	if err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	result, err := c.service.GetOrderById(r.Context(), orderId)
@@ -108,7 +108,7 @@ func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request
 func (c *StoreApiController) PlaceOrder(w http.ResponseWriter, r *http.Request) { 
 	order := &Order{}
 	if err := json.NewDecoder(r.Body).Decode(&order); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -85,7 +85,7 @@ func (c *UserApiController) Routes() Routes {
 func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) { 
 	user := &User{}
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
@@ -104,7 +104,7 @@ func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
 func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *http.Request) { 
 	user := &[]User{}
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
@@ -123,7 +123,7 @@ func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *http.Request) { 
 	user := &[]User{}
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	
@@ -203,7 +203,7 @@ func (c *UserApiController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	username := params["username"]
 	user := &User{}
 	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	


### PR DESCRIPTION
Implementing two minor changes:

1. When extracting the parameter value use `baseName` instead of `paramName`. The two variables usually are not different, but there is a difference in case the path parameter name includes a special character like a `-`. For example in:
`/api/resource/{resource-id}`
`baseName` is equal to `resource-id`, while `paramName` is eqaul to `resourceId`. Using the latter is incorrect.
2. When failing to parse a parameter, like for example when the code expects an integer and parsing the integer fails, I would think it is more appropriate to return StatusBadParam isntead of StatusServerInternalError, because the failure was caused by the client sending invalid data and not because of an issue on the server.

@antihax @grokify @kemokemo @bkabrda
