### PR TITLE
[dart][dart-dio] Enum improvements

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -16,7 +16,9 @@
 
 package org.openapitools.codegen.languages;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import com.samskivert.mustache.Mustache;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
@@ -105,6 +107,18 @@ public class DartDioClientCodegen extends DartClientCodegen {
     @Override
     protected boolean isReservedWord(String word) {
         return super.isReservedWord(word) || reservedBuiltValueWords.contains(word);
+    }
+
+    @Override
+    protected ImmutableMap.Builder<String, Mustache.Lambda> addMustacheLambdas() {
+        return super.addMustacheLambdas()
+                .put("escapeBuiltValueEnum", (fragment, writer) -> {
+                    // Raw strings don't work correctly in built_value enum strings.
+                    // Dollar signs need to be escaped in to make them work.
+                    // @BuiltValueEnumConst(wireName: r'$') produces '$' in generated code.
+                    // @BuiltValueEnumConst(wireName: r'\$') produces '\$' in generated code.
+                    writer.write(fragment.execute().replace("$", "\\$"));
+                });
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/dart-dio/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/enum.mustache
@@ -11,7 +11,7 @@ class {{classname}} extends EnumClass {
       {{#description}}
   /// {{{description}}}
       {{/description}}
-  @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{^isInteger}}wireName: {{{value}}}{{/isInteger}})
+  @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{^isInteger}}wireName: r{{#lambda.escapeBuiltValueEnum}}{{{value}}}{{/lambda.escapeBuiltValueEnum}}{{/isInteger}})
   static const {{classname}} {{name}} = _${{name}};
     {{/enumVars}}
   {{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/dart-dio/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/enum_inline.mustache
@@ -5,7 +5,7 @@ class {{classname}}{{nameInCamelCase}} extends EnumClass {
       {{#description}}
   /// {{{description}}}
       {{/description}}
-  @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{^isInteger}}wireName: {{{value}}}{{/isInteger}})
+  @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{^isInteger}}wireName: r{{#lambda.escapeBuiltValueEnum}}{{{value}}}{{/lambda.escapeBuiltValueEnum}}{{/isInteger}})
   static const {{classname}}{{nameInCamelCase}} {{name}} = _${{#lambda.camelcase}}{{classname}}{{nameInCamelCase}}{{/lambda.camelcase}}_{{name}};
     {{/enumVars}}
   {{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/dart2/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/enum.mustache
@@ -4,29 +4,23 @@ class {{{classname}}} {
   const {{{classname}}}._(this.value);
 
   /// The underlying value of this enum member.
-  {{#isEnum}}
-  final String value;
-  {{/isEnum}}
-  {{^isEnum}}
   final {{{dataType}}} value;
-  {{/isEnum}}
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is {{{classname}}} && other.value == value ||
-      other is {{#isEnum}}String{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}} && other == value;
+      other is {{{classname}}} && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
 
   @override
-  String toString() => {{#isString}}value{{/isString}}{{^isString}}value.toString(){{/isString}};
+  String toString() => value{{^isString}}.toString(){{/isString}};
 
-  {{#isEnum}}String{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}} toJson() => value;
+  {{{dataType}}} toJson() => value;
 
   {{#allowableValues}}
     {{#enumVars}}
-  static const {{{name}}} = {{{classname}}}._({{{value}}});
+  static const {{{name}}} = {{{classname}}}._({{#isString}}r{{/isString}}{{{value}}});
     {{/enumVars}}
   {{/allowableValues}}
 
@@ -57,7 +51,7 @@ class {{{classname}}}TypeTransformer {
 
   factory {{{classname}}}TypeTransformer() => _instance ??= {{{classname}}}TypeTransformer._();
 
-  {{#isEnum}}String{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}} encode({{{classname}}} data) => data.value;
+  {{{dataType}}} encode({{{classname}}} data) => data.value;
 
   /// Decodes a [dynamic value][data] to a {{{classname}}}.
   ///
@@ -71,7 +65,7 @@ class {{{classname}}}TypeTransformer {
     switch (data) {
       {{#allowableValues}}
         {{#enumVars}}
-      case {{{value}}}: return {{{classname}}}.{{{name}}};
+      case {{#isString}}r{{/isString}}{{{value}}}: return {{{classname}}}.{{{name}}};
         {{/enumVars}}
       {{/allowableValues}}
       default:

--- a/modules/openapi-generator/src/main/resources/dart2/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/enum_inline.mustache
@@ -4,29 +4,23 @@ class {{{classname}}}{{{enumName}}} {
   const {{{classname}}}{{{enumName}}}._(this.value);
 
   /// The underlying value of this enum member.
-  {{#isEnum}}
-  final String value;
-  {{/isEnum}}
-  {{^isEnum}}
   final {{{dataType}}} value;
-  {{/isEnum}}
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is {{{classname}}}{{{enumName}}} && other.value == value ||
-      other is {{#isEnum}}String{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}} && other == value;
+      other is {{{classname}}}{{{enumName}}} && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
 
   @override
-  String toString() => {{#isString}}value{{/isString}}{{^isString}}value.toString(){{/isString}};
+  String toString() => value{{^isString}}.toString(){{/isString}};
 
-  {{#isEnum}}String{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}} toJson() => value;
+  {{{dataType}}} toJson() => value;
 
   {{#allowableValues}}
     {{#enumVars}}
-  static const {{{name}}} = {{{classname}}}{{{enumName}}}._({{{value}}});
+  static const {{{name}}} = {{{classname}}}{{{enumName}}}._({{#isString}}r{{/isString}}{{{value}}});
     {{/enumVars}}
   {{/allowableValues}}
 
@@ -57,7 +51,7 @@ class {{{classname}}}{{{enumName}}}TypeTransformer {
 
   factory {{{classname}}}{{{enumName}}}TypeTransformer() => _instance ??= {{{classname}}}{{{enumName}}}TypeTransformer._();
 
-  {{#isEnum}}String{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}} encode({{{classname}}}{{{enumName}}} data) => data.value;
+  {{{dataType}}} encode({{{classname}}}{{{enumName}}} data) => data.value;
 
   /// Decodes a [dynamic value][data] to a {{{classname}}}{{{enumName}}}.
   ///
@@ -71,7 +65,7 @@ class {{{classname}}}{{{enumName}}}TypeTransformer {
     switch (data) {
       {{#allowableValues}}
         {{#enumVars}}
-      case {{{value}}}: return {{{classname}}}{{{enumName}}}.{{{name}}};
+      case {{#isString}}r{{/isString}}{{{value}}}: return {{{classname}}}{{{enumName}}}.{{{name}}};
         {{/enumVars}}
       {{/allowableValues}}
       default:

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
@@ -42,13 +42,13 @@ abstract class Order implements Built<Order, OrderBuilder> {
 class OrderStatus extends EnumClass {
 
   /// Order Status
-  @BuiltValueEnumConst(wireName: 'placed')
+  @BuiltValueEnumConst(wireName: r'placed')
   static const OrderStatus placed = _$orderStatus_placed;
   /// Order Status
-  @BuiltValueEnumConst(wireName: 'approved')
+  @BuiltValueEnumConst(wireName: r'approved')
   static const OrderStatus approved = _$orderStatus_approved;
   /// Order Status
-  @BuiltValueEnumConst(wireName: 'delivered')
+  @BuiltValueEnumConst(wireName: r'delivered')
   static const OrderStatus delivered = _$orderStatus_delivered;
 
   static Serializer<OrderStatus> get serializer => _$orderStatusSerializer;

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
@@ -44,13 +44,13 @@ abstract class Pet implements Built<Pet, PetBuilder> {
 class PetStatus extends EnumClass {
 
   /// pet status in the store
-  @BuiltValueEnumConst(wireName: 'available')
+  @BuiltValueEnumConst(wireName: r'available')
   static const PetStatus available = _$petStatus_available;
   /// pet status in the store
-  @BuiltValueEnumConst(wireName: 'pending')
+  @BuiltValueEnumConst(wireName: r'pending')
   static const PetStatus pending = _$petStatus_pending;
   /// pet status in the store
-  @BuiltValueEnumConst(wireName: 'sold')
+  @BuiltValueEnumConst(wireName: r'sold')
   static const PetStatus sold = _$petStatus_sold;
 
   static Serializer<PetStatus> get serializer => _$petStatusSerializer;

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -132,8 +132,7 @@ class OrderStatusEnum {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is OrderStatusEnum && other.value == value ||
-      other is String && other == value;
+      other is OrderStatusEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -143,9 +142,9 @@ class OrderStatusEnum {
 
   String toJson() => value;
 
-  static const placed = OrderStatusEnum._('placed');
-  static const approved = OrderStatusEnum._('approved');
-  static const delivered = OrderStatusEnum._('delivered');
+  static const placed = OrderStatusEnum._(r'placed');
+  static const approved = OrderStatusEnum._(r'approved');
+  static const delivered = OrderStatusEnum._(r'delivered');
 
   /// List of all possible values in this [enum][OrderStatusEnum].
   static const values = <OrderStatusEnum>[
@@ -184,9 +183,9 @@ class OrderStatusEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   OrderStatusEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case 'placed': return OrderStatusEnum.placed;
-      case 'approved': return OrderStatusEnum.approved;
-      case 'delivered': return OrderStatusEnum.delivered;
+      case r'placed': return OrderStatusEnum.placed;
+      case r'approved': return OrderStatusEnum.approved;
+      case r'delivered': return OrderStatusEnum.delivered;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -132,8 +132,7 @@ class PetStatusEnum {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is PetStatusEnum && other.value == value ||
-      other is String && other == value;
+      other is PetStatusEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -143,9 +142,9 @@ class PetStatusEnum {
 
   String toJson() => value;
 
-  static const available = PetStatusEnum._('available');
-  static const pending = PetStatusEnum._('pending');
-  static const sold = PetStatusEnum._('sold');
+  static const available = PetStatusEnum._(r'available');
+  static const pending = PetStatusEnum._(r'pending');
+  static const sold = PetStatusEnum._(r'sold');
 
   /// List of all possible values in this [enum][PetStatusEnum].
   static const values = <PetStatusEnum>[
@@ -184,9 +183,9 @@ class PetStatusEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   PetStatusEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case 'available': return PetStatusEnum.available;
-      case 'pending': return PetStatusEnum.pending;
-      case 'sold': return PetStatusEnum.sold;
+      case r'available': return PetStatusEnum.available;
+      case r'pending': return PetStatusEnum.pending;
+      case r'sold': return PetStatusEnum.sold;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
@@ -42,13 +42,13 @@ abstract class Order implements Built<Order, OrderBuilder> {
 class OrderStatus extends EnumClass {
 
   /// Order Status
-  @BuiltValueEnumConst(wireName: 'placed')
+  @BuiltValueEnumConst(wireName: r'placed')
   static const OrderStatus placed = _$orderStatus_placed;
   /// Order Status
-  @BuiltValueEnumConst(wireName: 'approved')
+  @BuiltValueEnumConst(wireName: r'approved')
   static const OrderStatus approved = _$orderStatus_approved;
   /// Order Status
-  @BuiltValueEnumConst(wireName: 'delivered')
+  @BuiltValueEnumConst(wireName: r'delivered')
   static const OrderStatus delivered = _$orderStatus_delivered;
 
   static Serializer<OrderStatus> get serializer => _$orderStatusSerializer;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
@@ -44,13 +44,13 @@ abstract class Pet implements Built<Pet, PetBuilder> {
 class PetStatus extends EnumClass {
 
   /// pet status in the store
-  @BuiltValueEnumConst(wireName: 'available')
+  @BuiltValueEnumConst(wireName: r'available')
   static const PetStatus available = _$petStatus_available;
   /// pet status in the store
-  @BuiltValueEnumConst(wireName: 'pending')
+  @BuiltValueEnumConst(wireName: r'pending')
   static const PetStatus pending = _$petStatus_pending;
   /// pet status in the store
-  @BuiltValueEnumConst(wireName: 'sold')
+  @BuiltValueEnumConst(wireName: r'sold')
   static const PetStatus sold = _$petStatus_sold;
 
   static Serializer<PetStatus> get serializer => _$petStatusSerializer;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -26,9 +26,9 @@ abstract class EnumArrays implements Built<EnumArrays, EnumArraysBuilder> {
 
 class EnumArraysJustSymbol extends EnumClass {
 
-  @BuiltValueEnumConst(wireName: '>=')
+  @BuiltValueEnumConst(wireName: r'>=')
   static const EnumArraysJustSymbol greaterThanEqual = _$enumArraysJustSymbol_greaterThanEqual;
-  @BuiltValueEnumConst(wireName: '$')
+  @BuiltValueEnumConst(wireName: r'\$')
   static const EnumArraysJustSymbol dollar = _$enumArraysJustSymbol_dollar;
 
   static Serializer<EnumArraysJustSymbol> get serializer => _$enumArraysJustSymbolSerializer;
@@ -42,9 +42,9 @@ class EnumArraysJustSymbol extends EnumClass {
 
 class EnumArraysArrayEnum extends EnumClass {
 
-  @BuiltValueEnumConst(wireName: 'fish')
+  @BuiltValueEnumConst(wireName: r'fish')
   static const EnumArraysArrayEnum fish = _$enumArraysArrayEnum_fish;
-  @BuiltValueEnumConst(wireName: 'crab')
+  @BuiltValueEnumConst(wireName: r'crab')
   static const EnumArraysArrayEnum crab = _$enumArraysArrayEnum_crab;
 
   static Serializer<EnumArraysArrayEnum> get serializer => _$enumArraysArrayEnumSerializer;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -60,11 +60,11 @@ abstract class EnumTest implements Built<EnumTest, EnumTestBuilder> {
 
 class EnumTestEnumString extends EnumClass {
 
-  @BuiltValueEnumConst(wireName: 'UPPER')
+  @BuiltValueEnumConst(wireName: r'UPPER')
   static const EnumTestEnumString UPPER = _$enumTestEnumString_UPPER;
-  @BuiltValueEnumConst(wireName: 'lower')
+  @BuiltValueEnumConst(wireName: r'lower')
   static const EnumTestEnumString lower = _$enumTestEnumString_lower;
-  @BuiltValueEnumConst(wireName: '')
+  @BuiltValueEnumConst(wireName: r'')
   static const EnumTestEnumString empty = _$enumTestEnumString_empty;
 
   static Serializer<EnumTestEnumString> get serializer => _$enumTestEnumStringSerializer;
@@ -78,11 +78,11 @@ class EnumTestEnumString extends EnumClass {
 
 class EnumTestEnumStringRequired extends EnumClass {
 
-  @BuiltValueEnumConst(wireName: 'UPPER')
+  @BuiltValueEnumConst(wireName: r'UPPER')
   static const EnumTestEnumStringRequired UPPER = _$enumTestEnumStringRequired_UPPER;
-  @BuiltValueEnumConst(wireName: 'lower')
+  @BuiltValueEnumConst(wireName: r'lower')
   static const EnumTestEnumStringRequired lower = _$enumTestEnumStringRequired_lower;
-  @BuiltValueEnumConst(wireName: '')
+  @BuiltValueEnumConst(wireName: r'')
   static const EnumTestEnumStringRequired empty = _$enumTestEnumStringRequired_empty;
 
   static Serializer<EnumTestEnumStringRequired> get serializer => _$enumTestEnumStringRequiredSerializer;
@@ -112,9 +112,9 @@ class EnumTestEnumInteger extends EnumClass {
 
 class EnumTestEnumNumber extends EnumClass {
 
-  @BuiltValueEnumConst(wireName: '1.1')
+  @BuiltValueEnumConst(wireName: r'1.1')
   static const EnumTestEnumNumber number1Period1 = _$enumTestEnumNumber_number1Period1;
-  @BuiltValueEnumConst(wireName: '-1.2')
+  @BuiltValueEnumConst(wireName: r'-1.2')
   static const EnumTestEnumNumber numberNegative1Period2 = _$enumTestEnumNumber_numberNegative1Period2;
 
   static Serializer<EnumTestEnumNumber> get serializer => _$enumTestEnumNumberSerializer;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object2.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object2.dart
@@ -27,10 +27,10 @@ abstract class InlineObject2 implements Built<InlineObject2, InlineObject2Builde
 class InlineObject2EnumFormStringArray extends EnumClass {
 
   /// Form parameter enum test (string array)
-  @BuiltValueEnumConst(wireName: '>')
+  @BuiltValueEnumConst(wireName: r'>')
   static const InlineObject2EnumFormStringArray greaterThan = _$inlineObject2EnumFormStringArray_greaterThan;
   /// Form parameter enum test (string array)
-  @BuiltValueEnumConst(wireName: '$')
+  @BuiltValueEnumConst(wireName: r'\$')
   static const InlineObject2EnumFormStringArray dollar = _$inlineObject2EnumFormStringArray_dollar;
 
   static Serializer<InlineObject2EnumFormStringArray> get serializer => _$inlineObject2EnumFormStringArraySerializer;
@@ -45,13 +45,13 @@ class InlineObject2EnumFormStringArray extends EnumClass {
 class InlineObject2EnumFormString extends EnumClass {
 
   /// Form parameter enum test (string)
-  @BuiltValueEnumConst(wireName: '_abc')
+  @BuiltValueEnumConst(wireName: r'_abc')
   static const InlineObject2EnumFormString abc = _$inlineObject2EnumFormString_abc;
   /// Form parameter enum test (string)
-  @BuiltValueEnumConst(wireName: '-efg')
+  @BuiltValueEnumConst(wireName: r'-efg')
   static const InlineObject2EnumFormString efg = _$inlineObject2EnumFormString_efg;
   /// Form parameter enum test (string)
-  @BuiltValueEnumConst(wireName: '(xyz)')
+  @BuiltValueEnumConst(wireName: r'(xyz)')
   static const InlineObject2EnumFormString leftParenthesisXyzRightParenthesis = _$inlineObject2EnumFormString_leftParenthesisXyzRightParenthesis;
 
   static Serializer<InlineObject2EnumFormString> get serializer => _$inlineObject2EnumFormStringSerializer;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/map_test.dart
@@ -33,9 +33,9 @@ abstract class MapTest implements Built<MapTest, MapTestBuilder> {
 
 class MapTestMapOfEnumString extends EnumClass {
 
-  @BuiltValueEnumConst(wireName: 'UPPER')
+  @BuiltValueEnumConst(wireName: r'UPPER')
   static const MapTestMapOfEnumString UPPER = _$mapTestMapOfEnumString_UPPER;
-  @BuiltValueEnumConst(wireName: 'lower')
+  @BuiltValueEnumConst(wireName: r'lower')
   static const MapTestMapOfEnumString lower = _$mapTestMapOfEnumString_lower;
 
   static Serializer<MapTestMapOfEnumString> get serializer => _$mapTestMapOfEnumStringSerializer;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_enum_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_enum_class.dart
@@ -6,11 +6,11 @@ part 'model_enum_class.g.dart';
 
 class ModelEnumClass extends EnumClass {
 
-  @BuiltValueEnumConst(wireName: '_abc')
+  @BuiltValueEnumConst(wireName: r'_abc')
   static const ModelEnumClass abc = _$abc;
-  @BuiltValueEnumConst(wireName: '-efg')
+  @BuiltValueEnumConst(wireName: r'-efg')
   static const ModelEnumClass efg = _$efg;
-  @BuiltValueEnumConst(wireName: '(xyz)')
+  @BuiltValueEnumConst(wireName: r'(xyz)')
   static const ModelEnumClass leftParenthesisXyzRightParenthesis = _$leftParenthesisXyzRightParenthesis;
 
   static Serializer<ModelEnumClass> get serializer => _$modelEnumClassSerializer;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/order.dart
@@ -42,13 +42,13 @@ abstract class Order implements Built<Order, OrderBuilder> {
 class OrderStatus extends EnumClass {
 
   /// Order Status
-  @BuiltValueEnumConst(wireName: 'placed')
+  @BuiltValueEnumConst(wireName: r'placed')
   static const OrderStatus placed = _$orderStatus_placed;
   /// Order Status
-  @BuiltValueEnumConst(wireName: 'approved')
+  @BuiltValueEnumConst(wireName: r'approved')
   static const OrderStatus approved = _$orderStatus_approved;
   /// Order Status
-  @BuiltValueEnumConst(wireName: 'delivered')
+  @BuiltValueEnumConst(wireName: r'delivered')
   static const OrderStatus delivered = _$orderStatus_delivered;
 
   static Serializer<OrderStatus> get serializer => _$orderStatusSerializer;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/outer_enum.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/outer_enum.dart
@@ -6,11 +6,11 @@ part 'outer_enum.g.dart';
 
 class OuterEnum extends EnumClass {
 
-  @BuiltValueEnumConst(wireName: 'placed')
+  @BuiltValueEnumConst(wireName: r'placed')
   static const OuterEnum placed = _$placed;
-  @BuiltValueEnumConst(wireName: 'approved')
+  @BuiltValueEnumConst(wireName: r'approved')
   static const OuterEnum approved = _$approved;
-  @BuiltValueEnumConst(wireName: 'delivered')
+  @BuiltValueEnumConst(wireName: r'delivered')
   static const OuterEnum delivered = _$delivered;
 
   static Serializer<OuterEnum> get serializer => _$outerEnumSerializer;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/outer_enum_default_value.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/outer_enum_default_value.dart
@@ -6,11 +6,11 @@ part 'outer_enum_default_value.g.dart';
 
 class OuterEnumDefaultValue extends EnumClass {
 
-  @BuiltValueEnumConst(wireName: 'placed')
+  @BuiltValueEnumConst(wireName: r'placed')
   static const OuterEnumDefaultValue placed = _$placed;
-  @BuiltValueEnumConst(wireName: 'approved')
+  @BuiltValueEnumConst(wireName: r'approved')
   static const OuterEnumDefaultValue approved = _$approved;
-  @BuiltValueEnumConst(wireName: 'delivered')
+  @BuiltValueEnumConst(wireName: r'delivered')
   static const OuterEnumDefaultValue delivered = _$delivered;
 
   static Serializer<OuterEnumDefaultValue> get serializer => _$outerEnumDefaultValueSerializer;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/pet.dart
@@ -44,13 +44,13 @@ abstract class Pet implements Built<Pet, PetBuilder> {
 class PetStatus extends EnumClass {
 
   /// pet status in the store
-  @BuiltValueEnumConst(wireName: 'available')
+  @BuiltValueEnumConst(wireName: r'available')
   static const PetStatus available = _$petStatus_available;
   /// pet status in the store
-  @BuiltValueEnumConst(wireName: 'pending')
+  @BuiltValueEnumConst(wireName: r'pending')
   static const PetStatus pending = _$petStatus_pending;
   /// pet status in the store
-  @BuiltValueEnumConst(wireName: 'sold')
+  @BuiltValueEnumConst(wireName: r'sold')
   static const PetStatus sold = _$petStatus_sold;
 
   static Serializer<PetStatus> get serializer => _$petStatusSerializer;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -132,8 +132,7 @@ class OrderStatusEnum {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is OrderStatusEnum && other.value == value ||
-      other is String && other == value;
+      other is OrderStatusEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -143,9 +142,9 @@ class OrderStatusEnum {
 
   String toJson() => value;
 
-  static const placed = OrderStatusEnum._('placed');
-  static const approved = OrderStatusEnum._('approved');
-  static const delivered = OrderStatusEnum._('delivered');
+  static const placed = OrderStatusEnum._(r'placed');
+  static const approved = OrderStatusEnum._(r'approved');
+  static const delivered = OrderStatusEnum._(r'delivered');
 
   /// List of all possible values in this [enum][OrderStatusEnum].
   static const values = <OrderStatusEnum>[
@@ -184,9 +183,9 @@ class OrderStatusEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   OrderStatusEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case 'placed': return OrderStatusEnum.placed;
-      case 'approved': return OrderStatusEnum.approved;
-      case 'delivered': return OrderStatusEnum.delivered;
+      case r'placed': return OrderStatusEnum.placed;
+      case r'approved': return OrderStatusEnum.approved;
+      case r'delivered': return OrderStatusEnum.delivered;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -132,8 +132,7 @@ class PetStatusEnum {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is PetStatusEnum && other.value == value ||
-      other is String && other == value;
+      other is PetStatusEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -143,9 +142,9 @@ class PetStatusEnum {
 
   String toJson() => value;
 
-  static const available = PetStatusEnum._('available');
-  static const pending = PetStatusEnum._('pending');
-  static const sold = PetStatusEnum._('sold');
+  static const available = PetStatusEnum._(r'available');
+  static const pending = PetStatusEnum._(r'pending');
+  static const sold = PetStatusEnum._(r'sold');
 
   /// List of all possible values in this [enum][PetStatusEnum].
   static const values = <PetStatusEnum>[
@@ -184,9 +183,9 @@ class PetStatusEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   PetStatusEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case 'available': return PetStatusEnum.available;
-      case 'pending': return PetStatusEnum.pending;
-      case 'sold': return PetStatusEnum.sold;
+      case r'available': return PetStatusEnum.available;
+      case r'pending': return PetStatusEnum.pending;
+      case r'sold': return PetStatusEnum.sold;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -90,8 +90,7 @@ class EnumArraysJustSymbolEnum {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is EnumArraysJustSymbolEnum && other.value == value ||
-      other is String && other == value;
+      other is EnumArraysJustSymbolEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -101,8 +100,8 @@ class EnumArraysJustSymbolEnum {
 
   String toJson() => value;
 
-  static const greaterThanEqual = EnumArraysJustSymbolEnum._('>=');
-  static const dollar = EnumArraysJustSymbolEnum._('$');
+  static const greaterThanEqual = EnumArraysJustSymbolEnum._(r'>=');
+  static const dollar = EnumArraysJustSymbolEnum._(r'$');
 
   /// List of all possible values in this [enum][EnumArraysJustSymbolEnum].
   static const values = <EnumArraysJustSymbolEnum>[
@@ -140,8 +139,8 @@ class EnumArraysJustSymbolEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   EnumArraysJustSymbolEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case '>=': return EnumArraysJustSymbolEnum.greaterThanEqual;
-      case '$': return EnumArraysJustSymbolEnum.dollar;
+      case r'>=': return EnumArraysJustSymbolEnum.greaterThanEqual;
+      case r'$': return EnumArraysJustSymbolEnum.dollar;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');
@@ -160,12 +159,11 @@ class EnumArraysArrayEnumEnum {
   const EnumArraysArrayEnumEnum._(this.value);
 
   /// The underlying value of this enum member.
-  final String value;
+  final List<String> value;
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is EnumArraysArrayEnumEnum && other.value == value ||
-      other is String && other == value;
+      other is EnumArraysArrayEnumEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -173,10 +171,10 @@ class EnumArraysArrayEnumEnum {
   @override
   String toString() => value.toString();
 
-  String toJson() => value;
+  List<String> toJson() => value;
 
-  static const fish = EnumArraysArrayEnumEnum._('fish');
-  static const crab = EnumArraysArrayEnumEnum._('crab');
+  static const fish = EnumArraysArrayEnumEnum._(r'fish');
+  static const crab = EnumArraysArrayEnumEnum._(r'crab');
 
   /// List of all possible values in this [enum][EnumArraysArrayEnumEnum].
   static const values = <EnumArraysArrayEnumEnum>[
@@ -202,7 +200,7 @@ class EnumArraysArrayEnumEnumTypeTransformer {
 
   factory EnumArraysArrayEnumEnumTypeTransformer() => _instance ??= EnumArraysArrayEnumEnumTypeTransformer._();
 
-  String encode(EnumArraysArrayEnumEnum data) => data.value;
+  List<String> encode(EnumArraysArrayEnumEnum data) => data.value;
 
   /// Decodes a [dynamic value][data] to a EnumArraysArrayEnumEnum.
   ///
@@ -214,8 +212,8 @@ class EnumArraysArrayEnumEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   EnumArraysArrayEnumEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case 'fish': return EnumArraysArrayEnumEnum.fish;
-      case 'crab': return EnumArraysArrayEnumEnum.crab;
+      case r'fish': return EnumArraysArrayEnumEnum.fish;
+      case r'crab': return EnumArraysArrayEnumEnum.crab;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_class.dart
@@ -19,8 +19,7 @@ class EnumClass {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is EnumClass && other.value == value ||
-      other is String && other == value;
+      other is EnumClass && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -30,9 +29,9 @@ class EnumClass {
 
   String toJson() => value;
 
-  static const abc = EnumClass._('_abc');
-  static const efg = EnumClass._('-efg');
-  static const leftParenthesisXyzRightParenthesis = EnumClass._('(xyz)');
+  static const abc = EnumClass._(r'_abc');
+  static const efg = EnumClass._(r'-efg');
+  static const leftParenthesisXyzRightParenthesis = EnumClass._(r'(xyz)');
 
   /// List of all possible values in this [enum][EnumClass].
   static const values = <EnumClass>[
@@ -71,9 +70,9 @@ class EnumClassTypeTransformer {
   /// and users are still using an old app with the old code.
   EnumClass decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case '_abc': return EnumClass.abc;
-      case '-efg': return EnumClass.efg;
-      case '(xyz)': return EnumClass.leftParenthesisXyzRightParenthesis;
+      case r'_abc': return EnumClass.abc;
+      case r'-efg': return EnumClass.efg;
+      case r'(xyz)': return EnumClass.leftParenthesisXyzRightParenthesis;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -150,8 +150,7 @@ class EnumTestEnumStringEnum {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is EnumTestEnumStringEnum && other.value == value ||
-      other is String && other == value;
+      other is EnumTestEnumStringEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -161,9 +160,9 @@ class EnumTestEnumStringEnum {
 
   String toJson() => value;
 
-  static const UPPER = EnumTestEnumStringEnum._('UPPER');
-  static const lower = EnumTestEnumStringEnum._('lower');
-  static const empty = EnumTestEnumStringEnum._('');
+  static const UPPER = EnumTestEnumStringEnum._(r'UPPER');
+  static const lower = EnumTestEnumStringEnum._(r'lower');
+  static const empty = EnumTestEnumStringEnum._(r'');
 
   /// List of all possible values in this [enum][EnumTestEnumStringEnum].
   static const values = <EnumTestEnumStringEnum>[
@@ -202,9 +201,9 @@ class EnumTestEnumStringEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   EnumTestEnumStringEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case 'UPPER': return EnumTestEnumStringEnum.UPPER;
-      case 'lower': return EnumTestEnumStringEnum.lower;
-      case '': return EnumTestEnumStringEnum.empty;
+      case r'UPPER': return EnumTestEnumStringEnum.UPPER;
+      case r'lower': return EnumTestEnumStringEnum.lower;
+      case r'': return EnumTestEnumStringEnum.empty;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');
@@ -227,8 +226,7 @@ class EnumTestEnumStringRequiredEnum {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is EnumTestEnumStringRequiredEnum && other.value == value ||
-      other is String && other == value;
+      other is EnumTestEnumStringRequiredEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -238,9 +236,9 @@ class EnumTestEnumStringRequiredEnum {
 
   String toJson() => value;
 
-  static const UPPER = EnumTestEnumStringRequiredEnum._('UPPER');
-  static const lower = EnumTestEnumStringRequiredEnum._('lower');
-  static const empty = EnumTestEnumStringRequiredEnum._('');
+  static const UPPER = EnumTestEnumStringRequiredEnum._(r'UPPER');
+  static const lower = EnumTestEnumStringRequiredEnum._(r'lower');
+  static const empty = EnumTestEnumStringRequiredEnum._(r'');
 
   /// List of all possible values in this [enum][EnumTestEnumStringRequiredEnum].
   static const values = <EnumTestEnumStringRequiredEnum>[
@@ -279,9 +277,9 @@ class EnumTestEnumStringRequiredEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   EnumTestEnumStringRequiredEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case 'UPPER': return EnumTestEnumStringRequiredEnum.UPPER;
-      case 'lower': return EnumTestEnumStringRequiredEnum.lower;
-      case '': return EnumTestEnumStringRequiredEnum.empty;
+      case r'UPPER': return EnumTestEnumStringRequiredEnum.UPPER;
+      case r'lower': return EnumTestEnumStringRequiredEnum.lower;
+      case r'': return EnumTestEnumStringRequiredEnum.empty;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');
@@ -300,12 +298,11 @@ class EnumTestEnumIntegerEnum {
   const EnumTestEnumIntegerEnum._(this.value);
 
   /// The underlying value of this enum member.
-  final String value;
+  final int value;
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is EnumTestEnumIntegerEnum && other.value == value ||
-      other is String && other == value;
+      other is EnumTestEnumIntegerEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -313,7 +310,7 @@ class EnumTestEnumIntegerEnum {
   @override
   String toString() => value.toString();
 
-  String toJson() => value;
+  int toJson() => value;
 
   static const number1 = EnumTestEnumIntegerEnum._(1);
   static const numberNegative1 = EnumTestEnumIntegerEnum._(-1);
@@ -342,7 +339,7 @@ class EnumTestEnumIntegerEnumTypeTransformer {
 
   factory EnumTestEnumIntegerEnumTypeTransformer() => _instance ??= EnumTestEnumIntegerEnumTypeTransformer._();
 
-  String encode(EnumTestEnumIntegerEnum data) => data.value;
+  int encode(EnumTestEnumIntegerEnum data) => data.value;
 
   /// Decodes a [dynamic value][data] to a EnumTestEnumIntegerEnum.
   ///
@@ -374,12 +371,11 @@ class EnumTestEnumNumberEnum {
   const EnumTestEnumNumberEnum._(this.value);
 
   /// The underlying value of this enum member.
-  final String value;
+  final double value;
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is EnumTestEnumNumberEnum && other.value == value ||
-      other is String && other == value;
+      other is EnumTestEnumNumberEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -387,7 +383,7 @@ class EnumTestEnumNumberEnum {
   @override
   String toString() => value.toString();
 
-  String toJson() => value;
+  double toJson() => value;
 
   static const number1Period1 = EnumTestEnumNumberEnum._('1.1');
   static const numberNegative1Period2 = EnumTestEnumNumberEnum._('-1.2');
@@ -416,7 +412,7 @@ class EnumTestEnumNumberEnumTypeTransformer {
 
   factory EnumTestEnumNumberEnumTypeTransformer() => _instance ??= EnumTestEnumNumberEnumTypeTransformer._();
 
-  String encode(EnumTestEnumNumberEnum data) => data.value;
+  double encode(EnumTestEnumNumberEnum data) => data.value;
 
   /// Decodes a [dynamic value][data] to a EnumTestEnumNumberEnum.
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object2.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object2.dart
@@ -86,12 +86,11 @@ class InlineObject2EnumFormStringArrayEnum {
   const InlineObject2EnumFormStringArrayEnum._(this.value);
 
   /// The underlying value of this enum member.
-  final String value;
+  final List<String> value;
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is InlineObject2EnumFormStringArrayEnum && other.value == value ||
-      other is String && other == value;
+      other is InlineObject2EnumFormStringArrayEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -99,10 +98,10 @@ class InlineObject2EnumFormStringArrayEnum {
   @override
   String toString() => value.toString();
 
-  String toJson() => value;
+  List<String> toJson() => value;
 
-  static const greaterThan = InlineObject2EnumFormStringArrayEnum._('>');
-  static const dollar = InlineObject2EnumFormStringArrayEnum._('$');
+  static const greaterThan = InlineObject2EnumFormStringArrayEnum._(r'>');
+  static const dollar = InlineObject2EnumFormStringArrayEnum._(r'$');
 
   /// List of all possible values in this [enum][InlineObject2EnumFormStringArrayEnum].
   static const values = <InlineObject2EnumFormStringArrayEnum>[
@@ -128,7 +127,7 @@ class InlineObject2EnumFormStringArrayEnumTypeTransformer {
 
   factory InlineObject2EnumFormStringArrayEnumTypeTransformer() => _instance ??= InlineObject2EnumFormStringArrayEnumTypeTransformer._();
 
-  String encode(InlineObject2EnumFormStringArrayEnum data) => data.value;
+  List<String> encode(InlineObject2EnumFormStringArrayEnum data) => data.value;
 
   /// Decodes a [dynamic value][data] to a InlineObject2EnumFormStringArrayEnum.
   ///
@@ -140,8 +139,8 @@ class InlineObject2EnumFormStringArrayEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   InlineObject2EnumFormStringArrayEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case '>': return InlineObject2EnumFormStringArrayEnum.greaterThan;
-      case '$': return InlineObject2EnumFormStringArrayEnum.dollar;
+      case r'>': return InlineObject2EnumFormStringArrayEnum.greaterThan;
+      case r'$': return InlineObject2EnumFormStringArrayEnum.dollar;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');
@@ -164,8 +163,7 @@ class InlineObject2EnumFormStringEnum {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is InlineObject2EnumFormStringEnum && other.value == value ||
-      other is String && other == value;
+      other is InlineObject2EnumFormStringEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -175,9 +173,9 @@ class InlineObject2EnumFormStringEnum {
 
   String toJson() => value;
 
-  static const abc = InlineObject2EnumFormStringEnum._('_abc');
-  static const efg = InlineObject2EnumFormStringEnum._('-efg');
-  static const leftParenthesisXyzRightParenthesis = InlineObject2EnumFormStringEnum._('(xyz)');
+  static const abc = InlineObject2EnumFormStringEnum._(r'_abc');
+  static const efg = InlineObject2EnumFormStringEnum._(r'-efg');
+  static const leftParenthesisXyzRightParenthesis = InlineObject2EnumFormStringEnum._(r'(xyz)');
 
   /// List of all possible values in this [enum][InlineObject2EnumFormStringEnum].
   static const values = <InlineObject2EnumFormStringEnum>[
@@ -216,9 +214,9 @@ class InlineObject2EnumFormStringEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   InlineObject2EnumFormStringEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case '_abc': return InlineObject2EnumFormStringEnum.abc;
-      case '-efg': return InlineObject2EnumFormStringEnum.efg;
-      case '(xyz)': return InlineObject2EnumFormStringEnum.leftParenthesisXyzRightParenthesis;
+      case r'_abc': return InlineObject2EnumFormStringEnum.abc;
+      case r'-efg': return InlineObject2EnumFormStringEnum.efg;
+      case r'(xyz)': return InlineObject2EnumFormStringEnum.leftParenthesisXyzRightParenthesis;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
@@ -114,12 +114,11 @@ class MapTestMapOfEnumStringEnum {
   const MapTestMapOfEnumStringEnum._(this.value);
 
   /// The underlying value of this enum member.
-  final String value;
+  final Map<String, String> value;
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is MapTestMapOfEnumStringEnum && other.value == value ||
-      other is String && other == value;
+      other is MapTestMapOfEnumStringEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -127,10 +126,10 @@ class MapTestMapOfEnumStringEnum {
   @override
   String toString() => value.toString();
 
-  String toJson() => value;
+  Map<String, String> toJson() => value;
 
-  static const UPPER = MapTestMapOfEnumStringEnum._('UPPER');
-  static const lower = MapTestMapOfEnumStringEnum._('lower');
+  static const UPPER = MapTestMapOfEnumStringEnum._(r'UPPER');
+  static const lower = MapTestMapOfEnumStringEnum._(r'lower');
 
   /// List of all possible values in this [enum][MapTestMapOfEnumStringEnum].
   static const values = <MapTestMapOfEnumStringEnum>[
@@ -156,7 +155,7 @@ class MapTestMapOfEnumStringEnumTypeTransformer {
 
   factory MapTestMapOfEnumStringEnumTypeTransformer() => _instance ??= MapTestMapOfEnumStringEnumTypeTransformer._();
 
-  String encode(MapTestMapOfEnumStringEnum data) => data.value;
+  Map<String, String> encode(MapTestMapOfEnumStringEnum data) => data.value;
 
   /// Decodes a [dynamic value][data] to a MapTestMapOfEnumStringEnum.
   ///
@@ -168,8 +167,8 @@ class MapTestMapOfEnumStringEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   MapTestMapOfEnumStringEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case 'UPPER': return MapTestMapOfEnumStringEnum.UPPER;
-      case 'lower': return MapTestMapOfEnumStringEnum.lower;
+      case r'UPPER': return MapTestMapOfEnumStringEnum.UPPER;
+      case r'lower': return MapTestMapOfEnumStringEnum.lower;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
@@ -132,8 +132,7 @@ class OrderStatusEnum {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is OrderStatusEnum && other.value == value ||
-      other is String && other == value;
+      other is OrderStatusEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -143,9 +142,9 @@ class OrderStatusEnum {
 
   String toJson() => value;
 
-  static const placed = OrderStatusEnum._('placed');
-  static const approved = OrderStatusEnum._('approved');
-  static const delivered = OrderStatusEnum._('delivered');
+  static const placed = OrderStatusEnum._(r'placed');
+  static const approved = OrderStatusEnum._(r'approved');
+  static const delivered = OrderStatusEnum._(r'delivered');
 
   /// List of all possible values in this [enum][OrderStatusEnum].
   static const values = <OrderStatusEnum>[
@@ -184,9 +183,9 @@ class OrderStatusEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   OrderStatusEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case 'placed': return OrderStatusEnum.placed;
-      case 'approved': return OrderStatusEnum.approved;
-      case 'delivered': return OrderStatusEnum.delivered;
+      case r'placed': return OrderStatusEnum.placed;
+      case r'approved': return OrderStatusEnum.approved;
+      case r'delivered': return OrderStatusEnum.delivered;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum.dart
@@ -19,8 +19,7 @@ class OuterEnum {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is OuterEnum && other.value == value ||
-      other is String && other == value;
+      other is OuterEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -30,9 +29,9 @@ class OuterEnum {
 
   String toJson() => value;
 
-  static const placed = OuterEnum._('placed');
-  static const approved = OuterEnum._('approved');
-  static const delivered = OuterEnum._('delivered');
+  static const placed = OuterEnum._(r'placed');
+  static const approved = OuterEnum._(r'approved');
+  static const delivered = OuterEnum._(r'delivered');
 
   /// List of all possible values in this [enum][OuterEnum].
   static const values = <OuterEnum>[
@@ -71,9 +70,9 @@ class OuterEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   OuterEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case 'placed': return OuterEnum.placed;
-      case 'approved': return OuterEnum.approved;
-      case 'delivered': return OuterEnum.delivered;
+      case r'placed': return OuterEnum.placed;
+      case r'approved': return OuterEnum.approved;
+      case r'delivered': return OuterEnum.delivered;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_default_value.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_default_value.dart
@@ -19,8 +19,7 @@ class OuterEnumDefaultValue {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is OuterEnumDefaultValue && other.value == value ||
-      other is String && other == value;
+      other is OuterEnumDefaultValue && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -30,9 +29,9 @@ class OuterEnumDefaultValue {
 
   String toJson() => value;
 
-  static const placed = OuterEnumDefaultValue._('placed');
-  static const approved = OuterEnumDefaultValue._('approved');
-  static const delivered = OuterEnumDefaultValue._('delivered');
+  static const placed = OuterEnumDefaultValue._(r'placed');
+  static const approved = OuterEnumDefaultValue._(r'approved');
+  static const delivered = OuterEnumDefaultValue._(r'delivered');
 
   /// List of all possible values in this [enum][OuterEnumDefaultValue].
   static const values = <OuterEnumDefaultValue>[
@@ -71,9 +70,9 @@ class OuterEnumDefaultValueTypeTransformer {
   /// and users are still using an old app with the old code.
   OuterEnumDefaultValue decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case 'placed': return OuterEnumDefaultValue.placed;
-      case 'approved': return OuterEnumDefaultValue.approved;
-      case 'delivered': return OuterEnumDefaultValue.delivered;
+      case r'placed': return OuterEnumDefaultValue.placed;
+      case r'approved': return OuterEnumDefaultValue.approved;
+      case r'delivered': return OuterEnumDefaultValue.delivered;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer.dart
@@ -15,12 +15,11 @@ class OuterEnumInteger {
   const OuterEnumInteger._(this.value);
 
   /// The underlying value of this enum member.
-  final String value;
+  final int value;
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is OuterEnumInteger && other.value == value ||
-      other is String && other == value;
+      other is OuterEnumInteger && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -28,7 +27,7 @@ class OuterEnumInteger {
   @override
   String toString() => value.toString();
 
-  String toJson() => value;
+  int toJson() => value;
 
   static const number0 = OuterEnumInteger._(0);
   static const number1 = OuterEnumInteger._(1);
@@ -59,7 +58,7 @@ class OuterEnumIntegerTypeTransformer {
 
   factory OuterEnumIntegerTypeTransformer() => _instance ??= OuterEnumIntegerTypeTransformer._();
 
-  String encode(OuterEnumInteger data) => data.value;
+  int encode(OuterEnumInteger data) => data.value;
 
   /// Decodes a [dynamic value][data] to a OuterEnumInteger.
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer_default_value.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer_default_value.dart
@@ -15,12 +15,11 @@ class OuterEnumIntegerDefaultValue {
   const OuterEnumIntegerDefaultValue._(this.value);
 
   /// The underlying value of this enum member.
-  final String value;
+  final int value;
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is OuterEnumIntegerDefaultValue && other.value == value ||
-      other is String && other == value;
+      other is OuterEnumIntegerDefaultValue && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -28,7 +27,7 @@ class OuterEnumIntegerDefaultValue {
   @override
   String toString() => value.toString();
 
-  String toJson() => value;
+  int toJson() => value;
 
   static const number0 = OuterEnumIntegerDefaultValue._(0);
   static const number1 = OuterEnumIntegerDefaultValue._(1);
@@ -59,7 +58,7 @@ class OuterEnumIntegerDefaultValueTypeTransformer {
 
   factory OuterEnumIntegerDefaultValueTypeTransformer() => _instance ??= OuterEnumIntegerDefaultValueTypeTransformer._();
 
-  String encode(OuterEnumIntegerDefaultValue data) => data.value;
+  int encode(OuterEnumIntegerDefaultValue data) => data.value;
 
   /// Decodes a [dynamic value][data] to a OuterEnumIntegerDefaultValue.
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
@@ -132,8 +132,7 @@ class PetStatusEnum {
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is PetStatusEnum && other.value == value ||
-      other is String && other == value;
+      other is PetStatusEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
@@ -143,9 +142,9 @@ class PetStatusEnum {
 
   String toJson() => value;
 
-  static const available = PetStatusEnum._('available');
-  static const pending = PetStatusEnum._('pending');
-  static const sold = PetStatusEnum._('sold');
+  static const available = PetStatusEnum._(r'available');
+  static const pending = PetStatusEnum._(r'pending');
+  static const sold = PetStatusEnum._(r'sold');
 
   /// List of all possible values in this [enum][PetStatusEnum].
   static const values = <PetStatusEnum>[
@@ -184,9 +183,9 @@ class PetStatusEnumTypeTransformer {
   /// and users are still using an old app with the old code.
   PetStatusEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case 'available': return PetStatusEnum.available;
-      case 'pending': return PetStatusEnum.pending;
-      case 'sold': return PetStatusEnum.sold;
+      case r'available': return PetStatusEnum.available;
+      case r'pending': return PetStatusEnum.pending;
+      case r'sold': return PetStatusEnum.sold;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
* use raw strings for enum value where possible
* special handling for dart-dio as raw string don't work as expected with the built_value generator
* use the correct datatype in dart enum templates

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12)
FYI @agilob 

@noordawod I reverted some of your changes to the enum templates. As far as I can tell `isEnum` is always true in enum templates.
