### PR TITLE
[dart][dart-dio] Use built_value collection types without string replacement

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -35,7 +35,6 @@ import java.util.*;
 
 import io.swagger.v3.oas.models.media.Schema;
 
-import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
 public class DartDioClientCodegen extends DartClientCodegen {
@@ -65,9 +64,15 @@ public class DartDioClientCodegen extends DartClientCodegen {
         dateLibrary.setEnum(dateOptions);
         cliOptions.add(dateLibrary);
 
+        typeMapping.put("Array", "BuiltList");
+        typeMapping.put("array", "BuiltList");
+        typeMapping.put("List", "BuiltList");
+        typeMapping.put("set", "BuiltSet");
+        typeMapping.put("map", "BuiltMap");
         typeMapping.put("file", "Uint8List");
         typeMapping.put("binary", "Uint8List");
-        typeMapping.put("AnyType", "Object");
+        typeMapping.put("object", "JsonObject");
+        typeMapping.put("AnyType", "JsonObject");
 
         importMapping.put("BuiltList", "package:built_collection/built_collection.dart");
         importMapping.put("BuiltSet", "package:built_collection/built_collection.dart");
@@ -247,7 +252,7 @@ public class DartDioClientCodegen extends DartClientCodegen {
             for (String modelImport : cm.imports) {
                 if (importMapping().containsKey(modelImport)) {
                     final String value = importMapping().get(modelImport);
-                    if (!Objects.equals(value, "dart:core")) {
+                    if (needToImport(value)) {
                         modelImports.add(value);
                     }
                 } else {
@@ -264,29 +269,9 @@ public class DartDioClientCodegen extends DartClientCodegen {
 
     @Override
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
+        super.postProcessModelProperty(model, property);
         if (nullableFields) {
             property.isNullable = true;
-        }
-
-        property.setDatatype(property.getDataType()
-                .replaceAll("\\bList\\b", "BuiltList")
-                .replaceAll("\\bMap\\b", "BuiltMap")
-                .replaceAll("\\bObject\\b", "JsonObject")
-        );
-        property.setBaseType(property.getBaseType()
-                .replaceAll("\\bList\\b", "BuiltList")
-                .replaceAll("\\bMap\\b", "BuiltMap")
-                .replaceAll("\\bObject\\b", "JsonObject")
-        );
-
-        if (property.dataType.contains("BuiltList")) {
-            model.imports.add("BuiltList");
-        }
-        if (property.dataType.contains("BuiltMap")) {
-            model.imports.add("BuiltMap");
-        }
-        if (property.dataType.contains("JsonObject")) {
-            model.imports.add("JsonObject");
         }
 
         if (property.isEnum) {
@@ -340,7 +325,7 @@ public class DartDioClientCodegen extends DartClientCodegen {
             for (String item : op.imports) {
                 if (importMapping().containsKey(item)) {
                     final String value = importMapping().get(item);
-                    if (!Objects.equals(value, "dart:core")) {
+                    if (needToImport(value)) {
                         fullImports.add(value);
                     }
                 } else {

--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 {{#operations}}
@@ -64,13 +63,13 @@ class {{classname}} {
 
         {{#bodyParam}}
             {{#isArray}}
-            final type = const FullType(BuiltList, const [const FullType({{baseType}})]);
-            var serializedBody = _serializers.serialize(BuiltList<{{baseType}}>.from({{paramName}}), specifiedType: type);
+            const type = FullType(BuiltList, [FullType({{baseType}})]);
+            final serializedBody = _serializers.serialize({{paramName}}, specifiedType: type);
             {{/isArray}}
             {{^isArray}}
-            var serializedBody = _serializers.serialize({{paramName}});
+            final serializedBody = _serializers.serialize({{paramName}});
             {{/isArray}}
-            var json{{paramName}} = json.encode(serializedBody);
+            final json{{paramName}} = json.encode(serializedBody);
             bodyData = json{{paramName}};
         {{/bodyParam}}
 
@@ -94,30 +93,25 @@ class {{classname}} {
             onReceiveProgress: onReceiveProgress,
             ){{#returnType}}.then((response) {
 
-        {{#returnTypeIsPrimitive}}
-            var data = response.data as {{{returnType}}};
-        {{/returnTypeIsPrimitive}}
-        {{^returnTypeIsPrimitive}}
         {{#isResponseFile}}
             final data = response.data;
         {{/isResponseFile}}
         {{^isResponseFile}}
-        {{#isArray}}
-            final FullType type = const FullType(BuiltList, const [const FullType({{returnBaseType}})]);
-            final BuiltList<{{returnBaseType}}> dataList = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
-            final data = dataList.toList();
-        {{/isArray}}
-        {{^isArray}}
-        {{#isMap}}
-            final serializer = _serializers.serializerForType(Map);
-        {{/isMap}}
-        {{^isMap}}
-            final serializer = _serializers.serializerForType({{{returnType}}});
-        {{/isMap}}
-            final data = _serializers.deserializeWith<{{{returnType}}}>(serializer, response.data is String ? jsonDecode(response.data) : response.data);
-        {{/isArray}}
-        {{/isResponseFile}}
+        {{#returnSimpleType}}
+        {{#returnTypeIsPrimitive}}
+            final data = response.data as {{{returnType}}};
         {{/returnTypeIsPrimitive}}
+        {{^returnTypeIsPrimitive}}
+            final serializer = _serializers.serializerForType({{{returnType}}});
+            final data = _serializers.deserializeWith<{{{returnType}}}>(serializer, response.data is String ? jsonDecode(response.data) : response.data);
+        {{/returnTypeIsPrimitive}}
+        {{/returnSimpleType}}
+        {{^returnSimpleType}}
+            const collectionType = {{#isMap}}BuiltMap{{/isMap}}{{^isMap}}BuiltList{{/isMap}};
+            const type = FullType(collectionType, [{{#isMap}}FullType(String), {{/isMap}}FullType({{{returnBaseType}}})]);
+            final {{{returnType}}} data = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
+        {{/returnSimpleType}}
+        {{/isResponseFile}}
 
             return Response<{{{returnType}}}>(
                 data: data,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/doc/PetApi.md
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/doc/PetApi.md
@@ -106,7 +106,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **findPetsByStatus**
-> List<Pet> findPetsByStatus(status)
+> BuiltList<Pet> findPetsByStatus(status)
 
 Finds Pets by status
 
@@ -119,7 +119,7 @@ import 'package:openapi/api.dart';
 //defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
 
 var api_instance = new PetApi();
-var status = []; // List<String> | Status values that need to be considered for filter
+var status = []; // BuiltList<String> | Status values that need to be considered for filter
 
 try { 
     var result = api_instance.findPetsByStatus(status);
@@ -133,11 +133,11 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**List&lt;String&gt;**](String.md)| Status values that need to be considered for filter | [default to const []]
+ **status** | [**BuiltList&lt;String&gt;**](String.md)| Status values that need to be considered for filter | [default to const []]
 
 ### Return type
 
-[**List<Pet>**](Pet.md)
+[**BuiltList<Pet>**](Pet.md)
 
 ### Authorization
 
@@ -151,7 +151,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **findPetsByTags**
-> List<Pet> findPetsByTags(tags)
+> BuiltList<Pet> findPetsByTags(tags)
 
 Finds Pets by tags
 
@@ -164,7 +164,7 @@ import 'package:openapi/api.dart';
 //defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
 
 var api_instance = new PetApi();
-var tags = []; // List<String> | Tags to filter by
+var tags = []; // BuiltList<String> | Tags to filter by
 
 try { 
     var result = api_instance.findPetsByTags(tags);
@@ -178,11 +178,11 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **tags** | [**List&lt;String&gt;**](String.md)| Tags to filter by | [default to const []]
+ **tags** | [**BuiltList&lt;String&gt;**](String.md)| Tags to filter by | [default to const []]
 
 ### Return type
 
-[**List<Pet>**](Pet.md)
+[**BuiltList<Pet>**](Pet.md)
 
 ### Authorization
 

--- a/samples/client/petstore/dart-dio/petstore_client_lib/doc/StoreApi.md
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/doc/StoreApi.md
@@ -58,7 +58,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **getInventory**
-> Map<String, int> getInventory()
+> BuiltMap<String, int> getInventory()
 
 Returns pet inventories by status
 
@@ -87,7 +87,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-**Map<String, int>**
+**BuiltMap<String, int>**
 
 ### Authorization
 

--- a/samples/client/petstore/dart-dio/petstore_client_lib/doc/UserApi.md
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/doc/UserApi.md
@@ -71,7 +71,7 @@ Creates list of users with given input array
 import 'package:openapi/api.dart';
 
 var api_instance = new UserApi();
-var body = [new List&lt;User&gt;()]; // List<User> | List of user object
+var body = [new BuiltList&lt;User&gt;()]; // BuiltList<User> | List of user object
 
 try { 
     api_instance.createUsersWithArrayInput(body);
@@ -84,7 +84,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | [**List&lt;User&gt;**](User.md)| List of user object | 
+ **body** | [**BuiltList&lt;User&gt;**](User.md)| List of user object | 
 
 ### Return type
 
@@ -111,7 +111,7 @@ Creates list of users with given input array
 import 'package:openapi/api.dart';
 
 var api_instance = new UserApi();
-var body = [new List&lt;User&gt;()]; // List<User> | List of user object
+var body = [new BuiltList&lt;User&gt;()]; // BuiltList<User> | List of user object
 
 try { 
     api_instance.createUsersWithListInput(body);
@@ -124,7 +124,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | [**List&lt;User&gt;**](User.md)| List of user object | 
+ **body** | [**BuiltList&lt;User&gt;**](User.md)| List of user object | 
 
 ### Return type
 

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -2,12 +2,12 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/pet.dart';
 import 'package:openapi/model/api_response.dart';
 import 'dart:typed_data';
+import 'package:built_collection/built_collection.dart';
 import 'package:openapi/api_util.dart';
 
 class PetApi {
@@ -33,8 +33,8 @@ class PetApi {
         List<String> contentTypes = ["application/json","application/xml"];
 
 
-            var serializedBody = _serializers.serialize(body);
-            var jsonbody = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(body);
+            final jsonbody = json.encode(serializedBody);
             bodyData = jsonbody;
 
             return _dio.request(
@@ -93,7 +93,7 @@ class PetApi {
         /// Finds Pets by status
         ///
         /// Multiple status values can be provided with comma separated strings
-        Future<Response<List<Pet>>>findPetsByStatus(List<String> status,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response<BuiltList<Pet>>>findPetsByStatus(BuiltList<String> status,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet/findByStatus";
 
@@ -126,11 +126,11 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            final FullType type = const FullType(BuiltList, const [const FullType(Pet)]);
-            final BuiltList<Pet> dataList = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
-            final data = dataList.toList();
+            const collectionType = BuiltList;
+            const type = FullType(collectionType, [FullType(Pet)]);
+            final BuiltList<Pet> data = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
 
-            return Response<List<Pet>>(
+            return Response<BuiltList<Pet>>(
                 data: data,
                 headers: response.headers,
                 request: response.request,
@@ -144,7 +144,7 @@ class PetApi {
         /// Finds Pets by tags
         ///
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-        Future<Response<List<Pet>>>findPetsByTags(List<String> tags,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response<BuiltList<Pet>>>findPetsByTags(BuiltList<String> tags,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet/findByTags";
 
@@ -177,11 +177,11 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            final FullType type = const FullType(BuiltList, const [const FullType(Pet)]);
-            final BuiltList<Pet> dataList = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
-            final data = dataList.toList();
+            const collectionType = BuiltList;
+            const type = FullType(collectionType, [FullType(Pet)]);
+            final BuiltList<Pet> data = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
 
-            return Response<List<Pet>>(
+            return Response<BuiltList<Pet>>(
                 data: data,
                 headers: response.headers,
                 request: response.request,
@@ -258,8 +258,8 @@ class PetApi {
         List<String> contentTypes = ["application/json","application/xml"];
 
 
-            var serializedBody = _serializers.serialize(body);
-            var jsonbody = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(body);
+            final jsonbody = json.encode(serializedBody);
             bodyData = jsonbody;
 
             return _dio.request(

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/order.dart';
+import 'package:built_collection/built_collection.dart';
 
 class StoreApi {
     final Dio _dio;
@@ -51,7 +51,7 @@ class StoreApi {
         /// Returns pet inventories by status
         ///
         /// Returns a map of status codes to quantities
-        Future<Response<Map<String, int>>>getInventory({ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response<BuiltMap<String, int>>>getInventory({ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/store/inventory";
 
@@ -83,9 +83,11 @@ class StoreApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            var data = response.data as Map<String, int>;
+            const collectionType = BuiltMap;
+            const type = FullType(collectionType, [FullType(String), FullType(int)]);
+            final BuiltMap<String, int> data = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
 
-            return Response<Map<String, int>>(
+            return Response<BuiltMap<String, int>>(
                 data: data,
                 headers: response.headers,
                 request: response.request,
@@ -162,8 +164,8 @@ class StoreApi {
         List<String> contentTypes = [];
 
 
-            var serializedBody = _serializers.serialize(body);
-            var jsonbody = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(body);
+            final jsonbody = json.encode(serializedBody);
             bodyData = jsonbody;
 
             return _dio.request(

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/user.dart';
+import 'package:built_collection/built_collection.dart';
 
 class UserApi {
     final Dio _dio;
@@ -30,8 +30,8 @@ class UserApi {
         List<String> contentTypes = [];
 
 
-            var serializedBody = _serializers.serialize(body);
-            var jsonbody = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(body);
+            final jsonbody = json.encode(serializedBody);
             bodyData = jsonbody;
 
             return _dio.request(
@@ -54,7 +54,7 @@ class UserApi {
         /// Creates list of users with given input array
         ///
         /// 
-        Future<Response>createUsersWithArrayInput(List<User> body,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response>createUsersWithArrayInput(BuiltList<User> body,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/createWithArray";
 
@@ -68,9 +68,9 @@ class UserApi {
         List<String> contentTypes = [];
 
 
-            final type = const FullType(BuiltList, const [const FullType(User)]);
-            var serializedBody = _serializers.serialize(BuiltList<User>.from(body), specifiedType: type);
-            var jsonbody = json.encode(serializedBody);
+            const type = FullType(BuiltList, [FullType(User)]);
+            final serializedBody = _serializers.serialize(body, specifiedType: type);
+            final jsonbody = json.encode(serializedBody);
             bodyData = jsonbody;
 
             return _dio.request(
@@ -93,7 +93,7 @@ class UserApi {
         /// Creates list of users with given input array
         ///
         /// 
-        Future<Response>createUsersWithListInput(List<User> body,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response>createUsersWithListInput(BuiltList<User> body,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/createWithList";
 
@@ -107,9 +107,9 @@ class UserApi {
         List<String> contentTypes = [];
 
 
-            final type = const FullType(BuiltList, const [const FullType(User)]);
-            var serializedBody = _serializers.serialize(BuiltList<User>.from(body), specifiedType: type);
-            var jsonbody = json.encode(serializedBody);
+            const type = FullType(BuiltList, [FullType(User)]);
+            final serializedBody = _serializers.serialize(body, specifiedType: type);
+            final jsonbody = json.encode(serializedBody);
             bodyData = jsonbody;
 
             return _dio.request(
@@ -250,7 +250,7 @@ class UserApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            var data = response.data as String;
+            final data = response.data as String;
 
             return Response<String>(
                 data: data,
@@ -315,8 +315,8 @@ class UserApi {
         List<String> contentTypes = [];
 
 
-            var serializedBody = _serializers.serialize(body);
-            var jsonbody = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(body);
+            final jsonbody = json.encode(serializedBody);
             bodyData = jsonbody;
 
             return _dio.request(

--- a/samples/client/petstore/dart-dio/petstore_client_lib/test/pet_api_test.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/test/pet_api_test.dart
@@ -26,7 +26,7 @@ void main() {
     //
     // Multiple status values can be provided with comma separated strings
     //
-    //Future<List<Pet>> findPetsByStatus(List<String> status) async
+    //Future<BuiltList<Pet>> findPetsByStatus(BuiltList<String> status) async
     test('test findPetsByStatus', () async {
       // TODO
     });
@@ -35,7 +35,7 @@ void main() {
     //
     // Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
     //
-    //Future<List<Pet>> findPetsByTags(List<String> tags) async
+    //Future<BuiltList<Pet>> findPetsByTags(BuiltList<String> tags) async
     test('test findPetsByTags', () async {
       // TODO
     });

--- a/samples/client/petstore/dart-dio/petstore_client_lib/test/store_api_test.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/test/store_api_test.dart
@@ -21,7 +21,7 @@ void main() {
     //
     // Returns a map of status codes to quantities
     //
-    //Future<Map<String, int>> getInventory() async
+    //Future<BuiltMap<String, int>> getInventory() async
     test('test getInventory', () async {
       // TODO
     });

--- a/samples/client/petstore/dart-dio/petstore_client_lib/test/user_api_test.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/test/user_api_test.dart
@@ -19,14 +19,14 @@ void main() {
 
     // Creates list of users with given input array
     //
-    //Future createUsersWithArrayInput(List<User> body) async
+    //Future createUsersWithArrayInput(BuiltList<User> body) async
     test('test createUsersWithArrayInput', () async {
       // TODO
     });
 
     // Creates list of users with given input array
     //
-    //Future createUsersWithListInput(List<User> body) async
+    //Future createUsersWithListInput(BuiltList<User> body) async
     test('test createUsersWithListInput', () async {
       // TODO
     });

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/PetApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/PetApi.md
@@ -107,7 +107,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **findPetsByStatus**
-> List<Pet> findPetsByStatus(status)
+> BuiltList<Pet> findPetsByStatus(status)
 
 Finds Pets by status
 
@@ -120,7 +120,7 @@ import 'package:openapi/api.dart';
 //defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
 
 var api_instance = new PetApi();
-var status = []; // List<String> | Status values that need to be considered for filter
+var status = []; // BuiltList<String> | Status values that need to be considered for filter
 
 try { 
     var result = api_instance.findPetsByStatus(status);
@@ -134,11 +134,11 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**List&lt;String&gt;**](String.md)| Status values that need to be considered for filter | [default to const []]
+ **status** | [**BuiltList&lt;String&gt;**](String.md)| Status values that need to be considered for filter | [default to const []]
 
 ### Return type
 
-[**List<Pet>**](Pet.md)
+[**BuiltList<Pet>**](Pet.md)
 
 ### Authorization
 
@@ -152,7 +152,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **findPetsByTags**
-> List<Pet> findPetsByTags(tags)
+> BuiltList<Pet> findPetsByTags(tags)
 
 Finds Pets by tags
 
@@ -165,7 +165,7 @@ import 'package:openapi/api.dart';
 //defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
 
 var api_instance = new PetApi();
-var tags = []; // List<String> | Tags to filter by
+var tags = []; // BuiltList<String> | Tags to filter by
 
 try { 
     var result = api_instance.findPetsByTags(tags);
@@ -179,11 +179,11 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **tags** | [**List&lt;String&gt;**](String.md)| Tags to filter by | [default to const []]
+ **tags** | [**BuiltList&lt;String&gt;**](String.md)| Tags to filter by | [default to const []]
 
 ### Return type
 
-[**List<Pet>**](Pet.md)
+[**BuiltList<Pet>**](Pet.md)
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/StoreApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/StoreApi.md
@@ -58,7 +58,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **getInventory**
-> Map<String, int> getInventory()
+> BuiltMap<String, int> getInventory()
 
 Returns pet inventories by status
 
@@ -87,7 +87,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-**Map<String, int>**
+**BuiltMap<String, int>**
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/UserApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/UserApi.md
@@ -79,7 +79,7 @@ import 'package:openapi/api.dart';
 //defaultApiClient.getAuthentication<ApiKeyAuth>('api_key').apiKeyPrefix = 'Bearer';
 
 var api_instance = new UserApi();
-var user = [new List&lt;User&gt;()]; // List<User> | List of user object
+var user = [new BuiltList&lt;User&gt;()]; // BuiltList<User> | List of user object
 
 try { 
     api_instance.createUsersWithArrayInput(user);
@@ -92,7 +92,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **user** | [**List&lt;User&gt;**](User.md)| List of user object | 
+ **user** | [**BuiltList&lt;User&gt;**](User.md)| List of user object | 
 
 ### Return type
 
@@ -123,7 +123,7 @@ import 'package:openapi/api.dart';
 //defaultApiClient.getAuthentication<ApiKeyAuth>('api_key').apiKeyPrefix = 'Bearer';
 
 var api_instance = new UserApi();
-var user = [new List&lt;User&gt;()]; // List<User> | List of user object
+var user = [new BuiltList&lt;User&gt;()]; // BuiltList<User> | List of user object
 
 try { 
     api_instance.createUsersWithListInput(user);
@@ -136,7 +136,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **user** | [**List&lt;User&gt;**](User.md)| List of user object | 
+ **user** | [**BuiltList&lt;User&gt;**](User.md)| List of user object | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -2,12 +2,12 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/pet.dart';
 import 'package:openapi/model/api_response.dart';
 import 'dart:typed_data';
+import 'package:built_collection/built_collection.dart';
 import 'package:openapi/api_util.dart';
 
 class PetApi {
@@ -33,8 +33,8 @@ class PetApi {
         List<String> contentTypes = ["application/json","application/xml"];
 
 
-            var serializedBody = _serializers.serialize(pet);
-            var jsonpet = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(pet);
+            final jsonpet = json.encode(serializedBody);
             bodyData = jsonpet;
 
             return _dio.request(
@@ -107,7 +107,7 @@ class PetApi {
         /// Finds Pets by status
         ///
         /// Multiple status values can be provided with comma separated strings
-        Future<Response<List<Pet>>>findPetsByStatus(List<String> status,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response<BuiltList<Pet>>>findPetsByStatus(BuiltList<String> status,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet/findByStatus";
 
@@ -140,11 +140,11 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            final FullType type = const FullType(BuiltList, const [const FullType(Pet)]);
-            final BuiltList<Pet> dataList = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
-            final data = dataList.toList();
+            const collectionType = BuiltList;
+            const type = FullType(collectionType, [FullType(Pet)]);
+            final BuiltList<Pet> data = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
 
-            return Response<List<Pet>>(
+            return Response<BuiltList<Pet>>(
                 data: data,
                 headers: response.headers,
                 request: response.request,
@@ -158,7 +158,7 @@ class PetApi {
         /// Finds Pets by tags
         ///
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-        Future<Response<List<Pet>>>findPetsByTags(List<String> tags,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response<BuiltList<Pet>>>findPetsByTags(BuiltList<String> tags,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet/findByTags";
 
@@ -191,11 +191,11 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            final FullType type = const FullType(BuiltList, const [const FullType(Pet)]);
-            final BuiltList<Pet> dataList = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
-            final data = dataList.toList();
+            const collectionType = BuiltList;
+            const type = FullType(collectionType, [FullType(Pet)]);
+            final BuiltList<Pet> data = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
 
-            return Response<List<Pet>>(
+            return Response<BuiltList<Pet>>(
                 data: data,
                 headers: response.headers,
                 request: response.request,
@@ -272,8 +272,8 @@ class PetApi {
         List<String> contentTypes = ["application/json","application/xml"];
 
 
-            var serializedBody = _serializers.serialize(pet);
-            var jsonpet = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(pet);
+            final jsonpet = json.encode(serializedBody);
             bodyData = jsonpet;
 
             return _dio.request(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/order.dart';
+import 'package:built_collection/built_collection.dart';
 
 class StoreApi {
     final Dio _dio;
@@ -51,7 +51,7 @@ class StoreApi {
         /// Returns pet inventories by status
         ///
         /// Returns a map of status codes to quantities
-        Future<Response<Map<String, int>>>getInventory({ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response<BuiltMap<String, int>>>getInventory({ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/store/inventory";
 
@@ -83,9 +83,11 @@ class StoreApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            var data = response.data as Map<String, int>;
+            const collectionType = BuiltMap;
+            const type = FullType(collectionType, [FullType(String), FullType(int)]);
+            final BuiltMap<String, int> data = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
 
-            return Response<Map<String, int>>(
+            return Response<BuiltMap<String, int>>(
                 data: data,
                 headers: response.headers,
                 request: response.request,
@@ -162,8 +164,8 @@ class StoreApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(order);
-            var jsonorder = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(order);
+            final jsonorder = json.encode(serializedBody);
             bodyData = jsonorder;
 
             return _dio.request(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/user.dart';
+import 'package:built_collection/built_collection.dart';
 
 class UserApi {
     final Dio _dio;
@@ -30,8 +30,8 @@ class UserApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(user);
-            var jsonuser = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(user);
+            final jsonuser = json.encode(serializedBody);
             bodyData = jsonuser;
 
             return _dio.request(
@@ -54,7 +54,7 @@ class UserApi {
         /// Creates list of users with given input array
         ///
         /// 
-        Future<Response>createUsersWithArrayInput(List<User> user,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response>createUsersWithArrayInput(BuiltList<User> user,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/createWithArray";
 
@@ -68,9 +68,9 @@ class UserApi {
         List<String> contentTypes = ["application/json"];
 
 
-            final type = const FullType(BuiltList, const [const FullType(User)]);
-            var serializedBody = _serializers.serialize(BuiltList<User>.from(user), specifiedType: type);
-            var jsonuser = json.encode(serializedBody);
+            const type = FullType(BuiltList, [FullType(User)]);
+            final serializedBody = _serializers.serialize(user, specifiedType: type);
+            final jsonuser = json.encode(serializedBody);
             bodyData = jsonuser;
 
             return _dio.request(
@@ -93,7 +93,7 @@ class UserApi {
         /// Creates list of users with given input array
         ///
         /// 
-        Future<Response>createUsersWithListInput(List<User> user,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response>createUsersWithListInput(BuiltList<User> user,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/createWithList";
 
@@ -107,9 +107,9 @@ class UserApi {
         List<String> contentTypes = ["application/json"];
 
 
-            final type = const FullType(BuiltList, const [const FullType(User)]);
-            var serializedBody = _serializers.serialize(BuiltList<User>.from(user), specifiedType: type);
-            var jsonuser = json.encode(serializedBody);
+            const type = FullType(BuiltList, [FullType(User)]);
+            final serializedBody = _serializers.serialize(user, specifiedType: type);
+            final jsonuser = json.encode(serializedBody);
             bodyData = jsonuser;
 
             return _dio.request(
@@ -250,7 +250,7 @@ class UserApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            var data = response.data as String;
+            final data = response.data as String;
 
             return Response<String>(
                 data: data,
@@ -315,8 +315,8 @@ class UserApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(user);
-            var jsonuser = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(user);
+            final jsonuser = json.encode(serializedBody);
             bodyData = jsonuser;
 
             return _dio.request(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/test/pet_api_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/test/pet_api_test.dart
@@ -26,7 +26,7 @@ void main() {
     //
     // Multiple status values can be provided with comma separated strings
     //
-    //Future<List<Pet>> findPetsByStatus(List<String> status) async
+    //Future<BuiltList<Pet>> findPetsByStatus(BuiltList<String> status) async
     test('test findPetsByStatus', () async {
       // TODO
     });
@@ -35,7 +35,7 @@ void main() {
     //
     // Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
     //
-    //Future<List<Pet>> findPetsByTags(List<String> tags) async
+    //Future<BuiltList<Pet>> findPetsByTags(BuiltList<String> tags) async
     test('test findPetsByTags', () async {
       // TODO
     });

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/test/store_api_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/test/store_api_test.dart
@@ -21,7 +21,7 @@ void main() {
     //
     // Returns a map of status codes to quantities
     //
-    //Future<Map<String, int>> getInventory() async
+    //Future<BuiltMap<String, int>> getInventory() async
     test('test getInventory', () async {
       // TODO
     });

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/test/user_api_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/test/user_api_test.dart
@@ -19,14 +19,14 @@ void main() {
 
     // Creates list of users with given input array
     //
-    //Future createUsersWithArrayInput(List<User> user) async
+    //Future createUsersWithArrayInput(BuiltList<User> user) async
     test('test createUsersWithArrayInput', () async {
       // TODO
     });
 
     // Creates list of users with given input array
     //
-    //Future createUsersWithListInput(List<User> user) async
+    //Future createUsersWithListInput(BuiltList<User> user) async
     test('test createUsersWithListInput', () async {
       // TODO
     });

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/AdditionalPropertiesClass.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/AdditionalPropertiesClass.md
@@ -9,7 +9,7 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **mapProperty** | **BuiltMap&lt;String, String&gt;** |  | [optional] [default to const {}]
-**mapOfMapProperty** | [**BuiltMap&lt;String, BuiltMap&lt;String, String&gt;&gt;**](Map.md) |  | [optional] [default to const {}]
+**mapOfMapProperty** | [**BuiltMap&lt;String, BuiltMap&lt;String, String&gt;&gt;**](BuiltMap.md) |  | [optional] [default to const {}]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ArrayOfArrayOfNumberOnly.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ArrayOfArrayOfNumberOnly.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**arrayArrayNumber** | [**BuiltList&lt;BuiltList&lt;num&gt;&gt;**](List.md) |  | [optional] [default to const []]
+**arrayArrayNumber** | [**BuiltList&lt;BuiltList&lt;num&gt;&gt;**](BuiltList.md) |  | [optional] [default to const []]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ArrayTest.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ArrayTest.md
@@ -9,8 +9,8 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **arrayOfString** | **BuiltList&lt;String&gt;** |  | [optional] [default to const []]
-**arrayArrayOfInteger** | [**BuiltList&lt;BuiltList&lt;int&gt;&gt;**](List.md) |  | [optional] [default to const []]
-**arrayArrayOfModel** | [**BuiltList&lt;BuiltList&lt;ReadOnlyFirst&gt;&gt;**](List.md) |  | [optional] [default to const []]
+**arrayArrayOfInteger** | [**BuiltList&lt;BuiltList&lt;int&gt;&gt;**](BuiltList.md) |  | [optional] [default to const []]
+**arrayArrayOfModel** | [**BuiltList&lt;BuiltList&lt;ReadOnlyFirst&gt;&gt;**](BuiltList.md) |  | [optional] [default to const []]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FakeApi.md
@@ -492,13 +492,13 @@ To test enum parameters
 import 'package:openapi/api.dart';
 
 var api_instance = new FakeApi();
-var enumHeaderStringArray = []; // List<String> | Header parameter enum test (string array)
+var enumHeaderStringArray = []; // BuiltList<String> | Header parameter enum test (string array)
 var enumHeaderString = enumHeaderString_example; // String | Header parameter enum test (string)
-var enumQueryStringArray = []; // List<String> | Query parameter enum test (string array)
+var enumQueryStringArray = []; // BuiltList<String> | Query parameter enum test (string array)
 var enumQueryString = enumQueryString_example; // String | Query parameter enum test (string)
 var enumQueryInteger = 56; // int | Query parameter enum test (double)
 var enumQueryDouble = 1.2; // double | Query parameter enum test (double)
-var enumFormStringArray = [enumFormStringArray_example]; // List<String> | Form parameter enum test (string array)
+var enumFormStringArray = [enumFormStringArray_example]; // BuiltList<String> | Form parameter enum test (string array)
 var enumFormString = enumFormString_example; // String | Form parameter enum test (string)
 
 try { 
@@ -512,13 +512,13 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **enumHeaderStringArray** | [**List&lt;String&gt;**](String.md)| Header parameter enum test (string array) | [optional] [default to const []]
+ **enumHeaderStringArray** | [**BuiltList&lt;String&gt;**](String.md)| Header parameter enum test (string array) | [optional] [default to const []]
  **enumHeaderString** | **String**| Header parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
- **enumQueryStringArray** | [**List&lt;String&gt;**](String.md)| Query parameter enum test (string array) | [optional] [default to const []]
+ **enumQueryStringArray** | [**BuiltList&lt;String&gt;**](String.md)| Query parameter enum test (string array) | [optional] [default to const []]
  **enumQueryString** | **String**| Query parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
  **enumQueryInteger** | **int**| Query parameter enum test (double) | [optional] [default to null]
  **enumQueryDouble** | **double**| Query parameter enum test (double) | [optional] [default to null]
- **enumFormStringArray** | [**List&lt;String&gt;**](String.md)| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;]
+ **enumFormStringArray** | [**BuiltList&lt;String&gt;**](String.md)| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;]
  **enumFormString** | **String**| Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
 
 ### Return type
@@ -601,7 +601,7 @@ test inline additionalProperties
 import 'package:openapi/api.dart';
 
 var api_instance = new FakeApi();
-var requestBody = new Map&lt;String, String&gt;(); // Map<String, String> | request body
+var requestBody = new BuiltMap&lt;String, String&gt;(); // BuiltMap<String, String> | request body
 
 try { 
     api_instance.testInlineAdditionalProperties(requestBody);
@@ -614,7 +614,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **requestBody** | [**Map&lt;String, String&gt;**](String.md)| request body | 
+ **requestBody** | [**BuiltMap&lt;String, String&gt;**](String.md)| request body | 
 
 ### Return type
 
@@ -685,11 +685,11 @@ To test the collection format in query parameters
 import 'package:openapi/api.dart';
 
 var api_instance = new FakeApi();
-var pipe = []; // List<String> | 
-var ioutil = []; // List<String> | 
-var http = []; // List<String> | 
-var url = []; // List<String> | 
-var context = []; // List<String> | 
+var pipe = []; // BuiltList<String> | 
+var ioutil = []; // BuiltList<String> | 
+var http = []; // BuiltList<String> | 
+var url = []; // BuiltList<String> | 
+var context = []; // BuiltList<String> | 
 
 try { 
     api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
@@ -702,11 +702,11 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **pipe** | [**List&lt;String&gt;**](String.md)|  | [default to const []]
- **ioutil** | [**List&lt;String&gt;**](String.md)|  | [default to const []]
- **http** | [**List&lt;String&gt;**](String.md)|  | [default to const []]
- **url** | [**List&lt;String&gt;**](String.md)|  | [default to const []]
- **context** | [**List&lt;String&gt;**](String.md)|  | [default to const []]
+ **pipe** | [**BuiltList&lt;String&gt;**](String.md)|  | [default to const []]
+ **ioutil** | [**BuiltList&lt;String&gt;**](String.md)|  | [default to const []]
+ **http** | [**BuiltList&lt;String&gt;**](String.md)|  | [default to const []]
+ **url** | [**BuiltList&lt;String&gt;**](String.md)|  | [default to const []]
+ **context** | [**BuiltList&lt;String&gt;**](String.md)|  | [default to const []]
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/MapTest.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/MapTest.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**mapMapOfString** | [**BuiltMap&lt;String, BuiltMap&lt;String, String&gt;&gt;**](Map.md) |  | [optional] [default to const {}]
+**mapMapOfString** | [**BuiltMap&lt;String, BuiltMap&lt;String, String&gt;&gt;**](BuiltMap.md) |  | [optional] [default to const {}]
 **mapOfEnumString** | **BuiltMap&lt;String, String&gt;** |  | [optional] [default to const {}]
 **directMap** | **BuiltMap&lt;String, bool&gt;** |  | [optional] [default to const {}]
 **indirectMap** | **BuiltMap&lt;String, bool&gt;** |  | [optional] [default to const {}]

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/NullableClass.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/NullableClass.md
@@ -14,12 +14,12 @@ Name | Type | Description | Notes
 **stringProp** | **String** |  | [optional] [default to null]
 **dateProp** | [**DateTime**](DateTime.md) |  | [optional] [default to null]
 **datetimeProp** | [**DateTime**](DateTime.md) |  | [optional] [default to null]
-**arrayNullableProp** | [**BuiltList&lt;JsonObject&gt;**](Object.md) |  | [optional] [default to const []]
-**arrayAndItemsNullableProp** | [**BuiltList&lt;JsonObject&gt;**](Object.md) |  | [optional] [default to const []]
-**arrayItemsNullable** | [**BuiltList&lt;JsonObject&gt;**](Object.md) |  | [optional] [default to const []]
-**objectNullableProp** | [**BuiltMap&lt;String, JsonObject&gt;**](Object.md) |  | [optional] [default to const {}]
-**objectAndItemsNullableProp** | [**BuiltMap&lt;String, JsonObject&gt;**](Object.md) |  | [optional] [default to const {}]
-**objectItemsNullable** | [**BuiltMap&lt;String, JsonObject&gt;**](Object.md) |  | [optional] [default to const {}]
+**arrayNullableProp** | [**BuiltList&lt;JsonObject&gt;**](JsonObject.md) |  | [optional] [default to const []]
+**arrayAndItemsNullableProp** | [**BuiltList&lt;JsonObject&gt;**](JsonObject.md) |  | [optional] [default to const []]
+**arrayItemsNullable** | [**BuiltList&lt;JsonObject&gt;**](JsonObject.md) |  | [optional] [default to const []]
+**objectNullableProp** | [**BuiltMap&lt;String, JsonObject&gt;**](JsonObject.md) |  | [optional] [default to const {}]
+**objectAndItemsNullableProp** | [**BuiltMap&lt;String, JsonObject&gt;**](JsonObject.md) |  | [optional] [default to const {}]
+**objectItemsNullable** | [**BuiltMap&lt;String, JsonObject&gt;**](JsonObject.md) |  | [optional] [default to const {}]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/PetApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/PetApi.md
@@ -107,7 +107,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **findPetsByStatus**
-> List<Pet> findPetsByStatus(status)
+> BuiltList<Pet> findPetsByStatus(status)
 
 Finds Pets by status
 
@@ -120,7 +120,7 @@ import 'package:openapi/api.dart';
 //defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
 
 var api_instance = new PetApi();
-var status = []; // List<String> | Status values that need to be considered for filter
+var status = []; // BuiltList<String> | Status values that need to be considered for filter
 
 try { 
     var result = api_instance.findPetsByStatus(status);
@@ -134,11 +134,11 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**List&lt;String&gt;**](String.md)| Status values that need to be considered for filter | [default to const []]
+ **status** | [**BuiltList&lt;String&gt;**](String.md)| Status values that need to be considered for filter | [default to const []]
 
 ### Return type
 
-[**List<Pet>**](Pet.md)
+[**BuiltList<Pet>**](Pet.md)
 
 ### Authorization
 
@@ -152,7 +152,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **findPetsByTags**
-> List<Pet> findPetsByTags(tags)
+> BuiltList<Pet> findPetsByTags(tags)
 
 Finds Pets by tags
 
@@ -165,7 +165,7 @@ import 'package:openapi/api.dart';
 //defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
 
 var api_instance = new PetApi();
-var tags = []; // List<String> | Tags to filter by
+var tags = []; // BuiltList<String> | Tags to filter by
 
 try { 
     var result = api_instance.findPetsByTags(tags);
@@ -179,11 +179,11 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **tags** | [**List&lt;String&gt;**](String.md)| Tags to filter by | [default to const []]
+ **tags** | [**BuiltList&lt;String&gt;**](String.md)| Tags to filter by | [default to const []]
 
 ### Return type
 
-[**List<Pet>**](Pet.md)
+[**BuiltList<Pet>**](Pet.md)
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/StoreApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/StoreApi.md
@@ -58,7 +58,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **getInventory**
-> Map<String, int> getInventory()
+> BuiltMap<String, int> getInventory()
 
 Returns pet inventories by status
 
@@ -87,7 +87,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-**Map<String, int>**
+**BuiltMap<String, int>**
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/UserApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/UserApi.md
@@ -71,7 +71,7 @@ Creates list of users with given input array
 import 'package:openapi/api.dart';
 
 var api_instance = new UserApi();
-var user = [new List&lt;User&gt;()]; // List<User> | List of user object
+var user = [new BuiltList&lt;User&gt;()]; // BuiltList<User> | List of user object
 
 try { 
     api_instance.createUsersWithArrayInput(user);
@@ -84,7 +84,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **user** | [**List&lt;User&gt;**](User.md)| List of user object | 
+ **user** | [**BuiltList&lt;User&gt;**](User.md)| List of user object | 
 
 ### Return type
 
@@ -111,7 +111,7 @@ Creates list of users with given input array
 import 'package:openapi/api.dart';
 
 var api_instance = new UserApi();
-var user = [new List&lt;User&gt;()]; // List<User> | List of user object
+var user = [new BuiltList&lt;User&gt;()]; // BuiltList<User> | List of user object
 
 try { 
     api_instance.createUsersWithListInput(user);
@@ -124,7 +124,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **user** | [**List&lt;User&gt;**](User.md)| List of user object | 
+ **user** | [**BuiltList&lt;User&gt;**](User.md)| List of user object | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/client.dart';
@@ -30,8 +29,8 @@ class AnotherFakeApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(client);
-            var jsonclient = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(client);
+            final jsonclient = json.encode(serializedBody);
             bodyData = jsonclient;
 
             return _dio.request(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/default_api.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/inline_response_default.dart';

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/client.dart';
@@ -12,6 +11,7 @@ import 'package:openapi/model/user.dart';
 import 'package:openapi/model/health_check_result.dart';
 import 'package:openapi/model/pet.dart';
 import 'dart:typed_data';
+import 'package:built_collection/built_collection.dart';
 import 'package:openapi/api_util.dart';
 
 class FakeApi {
@@ -88,8 +88,8 @@ class FakeApi {
         List<String> contentTypes = ["application/json","application/xml"];
 
 
-            var serializedBody = _serializers.serialize(pet);
-            var jsonpet = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(pet);
+            final jsonpet = json.encode(serializedBody);
             bodyData = jsonpet;
 
             return _dio.request(
@@ -126,8 +126,8 @@ class FakeApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(body);
-            var jsonbody = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(body);
+            final jsonbody = json.encode(serializedBody);
             bodyData = jsonbody;
 
             return _dio.request(
@@ -147,7 +147,7 @@ class FakeApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            var data = response.data as bool;
+            final data = response.data as bool;
 
             return Response<bool>(
                 data: data,
@@ -177,8 +177,8 @@ class FakeApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(outerComposite);
-            var jsonouterComposite = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(outerComposite);
+            final jsonouterComposite = json.encode(serializedBody);
             bodyData = jsonouterComposite;
 
             return _dio.request(
@@ -229,8 +229,8 @@ class FakeApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(body);
-            var jsonbody = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(body);
+            final jsonbody = json.encode(serializedBody);
             bodyData = jsonbody;
 
             return _dio.request(
@@ -250,7 +250,7 @@ class FakeApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            var data = response.data as num;
+            final data = response.data as num;
 
             return Response<num>(
                 data: data,
@@ -280,8 +280,8 @@ class FakeApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(body);
-            var jsonbody = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(body);
+            final jsonbody = json.encode(serializedBody);
             bodyData = jsonbody;
 
             return _dio.request(
@@ -301,7 +301,7 @@ class FakeApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            var data = response.data as String;
+            final data = response.data as String;
 
             return Response<String>(
                 data: data,
@@ -331,8 +331,8 @@ class FakeApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(fileSchemaTestClass);
-            var jsonfileSchemaTestClass = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(fileSchemaTestClass);
+            final jsonfileSchemaTestClass = json.encode(serializedBody);
             bodyData = jsonfileSchemaTestClass;
 
             return _dio.request(
@@ -370,8 +370,8 @@ class FakeApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(user);
-            var jsonuser = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(user);
+            final jsonuser = json.encode(serializedBody);
             bodyData = jsonuser;
 
             return _dio.request(
@@ -408,8 +408,8 @@ class FakeApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(client);
-            var jsonclient = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(client);
+            final jsonclient = json.encode(serializedBody);
             bodyData = jsonclient;
 
             return _dio.request(
@@ -497,7 +497,7 @@ class FakeApi {
         /// To test enum parameters
         ///
         /// To test enum parameters
-        Future<Response>testEnumParameters({ List<String> enumHeaderStringArray,String enumHeaderString,List<String> enumQueryStringArray,String enumQueryString,int enumQueryInteger,double enumQueryDouble,List<String> enumFormStringArray,String enumFormString,CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response>testEnumParameters({ BuiltList<String> enumHeaderStringArray,String enumHeaderString,BuiltList<String> enumQueryStringArray,String enumQueryString,int enumQueryInteger,double enumQueryDouble,BuiltList<String> enumFormStringArray,String enumFormString,CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/fake";
 
@@ -583,7 +583,7 @@ class FakeApi {
         /// test inline additionalProperties
         ///
         /// 
-        Future<Response>testInlineAdditionalProperties(Map<String, String> requestBody,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response>testInlineAdditionalProperties(BuiltMap<String, String> requestBody,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/fake/inline-additionalProperties";
 
@@ -597,8 +597,8 @@ class FakeApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(requestBody);
-            var jsonrequestBody = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(requestBody);
+            final jsonrequestBody = json.encode(serializedBody);
             bodyData = jsonrequestBody;
 
             return _dio.request(
@@ -660,7 +660,7 @@ class FakeApi {
         /// 
         ///
         /// To test the collection format in query parameters
-        Future<Response>testQueryParameterCollectionFormat(List<String> pipe,List<String> ioutil,List<String> http,List<String> url,List<String> context,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response>testQueryParameterCollectionFormat(BuiltList<String> pipe,BuiltList<String> ioutil,BuiltList<String> http,BuiltList<String> url,BuiltList<String> context,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/fake/test-query-paramters";
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/client.dart';
@@ -30,8 +29,8 @@ class FakeClassnameTags123Api {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(client);
-            var jsonclient = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(client);
+            final jsonclient = json.encode(serializedBody);
             bodyData = jsonclient;
 
             return _dio.request(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -2,12 +2,12 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/pet.dart';
 import 'package:openapi/model/api_response.dart';
 import 'dart:typed_data';
+import 'package:built_collection/built_collection.dart';
 import 'package:openapi/api_util.dart';
 
 class PetApi {
@@ -33,8 +33,8 @@ class PetApi {
         List<String> contentTypes = ["application/json","application/xml"];
 
 
-            var serializedBody = _serializers.serialize(pet);
-            var jsonpet = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(pet);
+            final jsonpet = json.encode(serializedBody);
             bodyData = jsonpet;
 
             return _dio.request(
@@ -93,7 +93,7 @@ class PetApi {
         /// Finds Pets by status
         ///
         /// Multiple status values can be provided with comma separated strings
-        Future<Response<List<Pet>>>findPetsByStatus(List<String> status,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response<BuiltList<Pet>>>findPetsByStatus(BuiltList<String> status,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet/findByStatus";
 
@@ -126,11 +126,11 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            final FullType type = const FullType(BuiltList, const [const FullType(Pet)]);
-            final BuiltList<Pet> dataList = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
-            final data = dataList.toList();
+            const collectionType = BuiltList;
+            const type = FullType(collectionType, [FullType(Pet)]);
+            final BuiltList<Pet> data = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
 
-            return Response<List<Pet>>(
+            return Response<BuiltList<Pet>>(
                 data: data,
                 headers: response.headers,
                 request: response.request,
@@ -144,7 +144,7 @@ class PetApi {
         /// Finds Pets by tags
         ///
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-        Future<Response<List<Pet>>>findPetsByTags(List<String> tags,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response<BuiltList<Pet>>>findPetsByTags(BuiltList<String> tags,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/pet/findByTags";
 
@@ -177,11 +177,11 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            final FullType type = const FullType(BuiltList, const [const FullType(Pet)]);
-            final BuiltList<Pet> dataList = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
-            final data = dataList.toList();
+            const collectionType = BuiltList;
+            const type = FullType(collectionType, [FullType(Pet)]);
+            final BuiltList<Pet> data = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
 
-            return Response<List<Pet>>(
+            return Response<BuiltList<Pet>>(
                 data: data,
                 headers: response.headers,
                 request: response.request,
@@ -258,8 +258,8 @@ class PetApi {
         List<String> contentTypes = ["application/json","application/xml"];
 
 
-            var serializedBody = _serializers.serialize(pet);
-            var jsonpet = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(pet);
+            final jsonpet = json.encode(serializedBody);
             bodyData = jsonpet;
 
             return _dio.request(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/order.dart';
+import 'package:built_collection/built_collection.dart';
 
 class StoreApi {
     final Dio _dio;
@@ -51,7 +51,7 @@ class StoreApi {
         /// Returns pet inventories by status
         ///
         /// Returns a map of status codes to quantities
-        Future<Response<Map<String, int>>>getInventory({ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response<BuiltMap<String, int>>>getInventory({ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/store/inventory";
 
@@ -83,9 +83,11 @@ class StoreApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            var data = response.data as Map<String, int>;
+            const collectionType = BuiltMap;
+            const type = FullType(collectionType, [FullType(String), FullType(int)]);
+            final BuiltMap<String, int> data = _serializers.deserialize(response.data is String ? jsonDecode(response.data) : response.data, specifiedType: type);
 
-            return Response<Map<String, int>>(
+            return Response<BuiltMap<String, int>>(
                 data: data,
                 headers: response.headers,
                 request: response.request,
@@ -162,8 +164,8 @@ class StoreApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(order);
-            var jsonorder = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(order);
+            final jsonorder = json.encode(serializedBody);
             bodyData = jsonorder;
 
             return _dio.request(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 
 import 'package:openapi/model/user.dart';
+import 'package:built_collection/built_collection.dart';
 
 class UserApi {
     final Dio _dio;
@@ -30,8 +30,8 @@ class UserApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(user);
-            var jsonuser = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(user);
+            final jsonuser = json.encode(serializedBody);
             bodyData = jsonuser;
 
             return _dio.request(
@@ -54,7 +54,7 @@ class UserApi {
         /// Creates list of users with given input array
         ///
         /// 
-        Future<Response>createUsersWithArrayInput(List<User> user,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response>createUsersWithArrayInput(BuiltList<User> user,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/createWithArray";
 
@@ -68,9 +68,9 @@ class UserApi {
         List<String> contentTypes = ["application/json"];
 
 
-            final type = const FullType(BuiltList, const [const FullType(User)]);
-            var serializedBody = _serializers.serialize(BuiltList<User>.from(user), specifiedType: type);
-            var jsonuser = json.encode(serializedBody);
+            const type = FullType(BuiltList, [FullType(User)]);
+            final serializedBody = _serializers.serialize(user, specifiedType: type);
+            final jsonuser = json.encode(serializedBody);
             bodyData = jsonuser;
 
             return _dio.request(
@@ -93,7 +93,7 @@ class UserApi {
         /// Creates list of users with given input array
         ///
         /// 
-        Future<Response>createUsersWithListInput(List<User> user,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
+        Future<Response>createUsersWithListInput(BuiltList<User> user,{ CancelToken cancelToken, Map<String, String> headers, ProgressCallback onSendProgress, ProgressCallback onReceiveProgress,}) async {
 
         String _path = "/user/createWithList";
 
@@ -107,9 +107,9 @@ class UserApi {
         List<String> contentTypes = ["application/json"];
 
 
-            final type = const FullType(BuiltList, const [const FullType(User)]);
-            var serializedBody = _serializers.serialize(BuiltList<User>.from(user), specifiedType: type);
-            var jsonuser = json.encode(serializedBody);
+            const type = FullType(BuiltList, [FullType(User)]);
+            final serializedBody = _serializers.serialize(user, specifiedType: type);
+            final jsonuser = json.encode(serializedBody);
             bodyData = jsonuser;
 
             return _dio.request(
@@ -250,7 +250,7 @@ class UserApi {
             onReceiveProgress: onReceiveProgress,
             ).then((response) {
 
-            var data = response.data as String;
+            final data = response.data as String;
 
             return Response<String>(
                 data: data,
@@ -315,8 +315,8 @@ class UserApi {
         List<String> contentTypes = ["application/json"];
 
 
-            var serializedBody = _serializers.serialize(user);
-            var jsonuser = json.encode(serializedBody);
+            final serializedBody = _serializers.serialize(user);
+            final jsonuser = json.encode(serializedBody);
             bodyData = jsonuser;
 
             return _dio.request(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/test/fake_api_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/test/fake_api_test.dart
@@ -84,7 +84,7 @@ void main() {
     //
     // To test enum parameters
     //
-    //Future testEnumParameters({ List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, int enumQueryInteger, double enumQueryDouble, List<String> enumFormStringArray, String enumFormString }) async
+    //Future testEnumParameters({ BuiltList<String> enumHeaderStringArray, String enumHeaderString, BuiltList<String> enumQueryStringArray, String enumQueryString, int enumQueryInteger, double enumQueryDouble, BuiltList<String> enumFormStringArray, String enumFormString }) async
     test('test testEnumParameters', () async {
       // TODO
     });
@@ -100,7 +100,7 @@ void main() {
 
     // test inline additionalProperties
     //
-    //Future testInlineAdditionalProperties(Map<String, String> requestBody) async
+    //Future testInlineAdditionalProperties(BuiltMap<String, String> requestBody) async
     test('test testInlineAdditionalProperties', () async {
       // TODO
     });
@@ -114,7 +114,7 @@ void main() {
 
     // To test the collection format in query parameters
     //
-    //Future testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) async
+    //Future testQueryParameterCollectionFormat(BuiltList<String> pipe, BuiltList<String> ioutil, BuiltList<String> http, BuiltList<String> url, BuiltList<String> context) async
     test('test testQueryParameterCollectionFormat', () async {
       // TODO
     });

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/test/pet_api_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/test/pet_api_test.dart
@@ -26,7 +26,7 @@ void main() {
     //
     // Multiple status values can be provided with comma separated strings
     //
-    //Future<List<Pet>> findPetsByStatus(List<String> status) async
+    //Future<BuiltList<Pet>> findPetsByStatus(BuiltList<String> status) async
     test('test findPetsByStatus', () async {
       // TODO
     });
@@ -35,7 +35,7 @@ void main() {
     //
     // Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
     //
-    //Future<List<Pet>> findPetsByTags(List<String> tags) async
+    //Future<BuiltList<Pet>> findPetsByTags(BuiltList<String> tags) async
     test('test findPetsByTags', () async {
       // TODO
     });

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/test/store_api_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/test/store_api_test.dart
@@ -21,7 +21,7 @@ void main() {
     //
     // Returns a map of status codes to quantities
     //
-    //Future<Map<String, int>> getInventory() async
+    //Future<BuiltMap<String, int>> getInventory() async
     test('test getInventory', () async {
       // TODO
     });

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/test/user_api_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/test/user_api_test.dart
@@ -19,14 +19,14 @@ void main() {
 
     // Creates list of users with given input array
     //
-    //Future createUsersWithArrayInput(List<User> user) async
+    //Future createUsersWithArrayInput(BuiltList<User> user) async
     test('test createUsersWithArrayInput', () async {
       // TODO
     });
 
     // Creates list of users with given input array
     //
-    //Future createUsersWithListInput(List<User> user) async
+    //Future createUsersWithListInput(BuiltList<User> user) async
     test('test createUsersWithListInput', () async {
       // TODO
     });


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Do not use String replacement for built_value collection types. 
This fixes https://github.com/OpenAPITools/openapi-generator/issues/4865 but also changes return/parameter types and would be a breaking change.
I think this is the correct thing to do but the changed parameter types may reduce usability in cases of list body/parameters.

@josh-burton Did you intentionally prevent the return/parameter types from being built_value types? What is your opinion on this?

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)