### PR TITLE
Include description directly in python docstrings

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -74,7 +74,7 @@ class {{classname}}(object):
 {{/requiredParams}}
 
             Keyword Args:{{#optionalParams}}
-                {{paramName}} ({{dataType}}):{{#description}} {{description}}.{{/description}} [optional]{{#defaultValue}} if omitted the server will use the default value of {{{defaultValue}}}{{/defaultValue}}{{/optionalParams}}
+                {{paramName}} ({{dataType}}):{{#description}} {{{description}}}.{{/description}} [optional]{{#defaultValue}} if omitted the server will use the default value of {{{defaultValue}}}{{/defaultValue}}{{/optionalParams}}
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -64,12 +64,12 @@ class {{classname}}(object):
 {{/requiredParams}}
 {{#requiredParams}}
 {{^defaultValue}}
-                {{paramName}} ({{dataType}}):{{#description}} {{description}}{{/description}}
+                {{paramName}} ({{dataType}}):{{#description}} {{{description}}}{{/description}}
 {{/defaultValue}}
 {{/requiredParams}}
 {{#requiredParams}}
 {{#defaultValue}}
-                {{paramName}} ({{dataType}}):{{#description}} {{description}}.{{/description}} defaults to {{{defaultValue}}}, must be one of [{{{defaultValue}}}]
+                {{paramName}} ({{dataType}}):{{#description}} {{{description}}}.{{/description}} defaults to {{{defaultValue}}}, must be one of [{{{defaultValue}}}]
 {{/defaultValue}}
 {{/requiredParams}}
 

--- a/modules/openapi-generator/src/main/resources/python/model_templates/method_init_shared.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/method_init_shared.mustache
@@ -7,7 +7,7 @@
         Args:
 {{/-first}}
 {{^defaultValue}}
-            {{name}} ({{{dataType}}}):{{#description}} {{description}}{{/description}}
+            {{name}} ({{{dataType}}}):{{#description}} {{{description}}}{{/description}}
 {{/defaultValue}}
 {{#-last}}
 
@@ -16,12 +16,12 @@
         Keyword Args:
 {{#requiredVars}}
 {{#defaultValue}}
-            {{name}} ({{{dataType}}}):{{#description}} {{description}}.{{/description}} defaults to {{{defaultValue}}}{{#allowableValues}}, must be one of [{{#enumVars}}{{{value}}}, {{/enumVars}}]{{/allowableValues}}  # noqa: E501
+            {{name}} ({{{dataType}}}):{{#description}} {{{description}}}.{{/description}} defaults to {{{defaultValue}}}{{#allowableValues}}, must be one of [{{#enumVars}}{{{value}}}, {{/enumVars}}]{{/allowableValues}}  # noqa: E501
 {{/defaultValue}}
 {{/requiredVars}}
 {{> model_templates/docstring_init_required_kwargs }}
 {{#optionalVars}}
-            {{name}} ({{{dataType}}}):{{#description}} {{description}}.{{/description}} [optional]{{#defaultValue}} if omitted the server will use the default value of {{{defaultValue}}}{{/defaultValue}}  # noqa: E501
+            {{name}} ({{{dataType}}}):{{#description}} {{{description}}}.{{/description}} [optional]{{#defaultValue}} if omitted the server will use the default value of {{{defaultValue}}}{{/defaultValue}}  # noqa: E501
 {{/optionalVars}}
         """
 

--- a/modules/openapi-generator/src/main/resources/python/model_templates/method_init_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/method_init_simple.mustache
@@ -14,10 +14,10 @@
         Note that value can be passed either in args or in kwargs, but not in both.
 
         Args:
-            args[0] ({{{dataType}}}):{{#description}} {{description}}.{{/description}}{{#defaultValue}} if omitted defaults to {{{defaultValue}}}{{/defaultValue}}{{#allowableValues}}, must be one of [{{#enumVars}}{{{value}}}, {{/enumVars}}]{{/allowableValues}}  # noqa: E501
+            args[0] ({{{dataType}}}):{{#description}} {{{description}}}.{{/description}}{{#defaultValue}} if omitted defaults to {{{defaultValue}}}{{/defaultValue}}{{#allowableValues}}, must be one of [{{#enumVars}}{{{value}}}, {{/enumVars}}]{{/allowableValues}}  # noqa: E501
 
         Keyword Args:
-            value ({{{dataType}}}):{{#description}} {{description}}.{{/description}}{{#defaultValue}} if omitted defaults to {{{defaultValue}}}{{/defaultValue}}{{#allowableValues}}, must be one of [{{#enumVars}}{{{value}}}, {{/enumVars}}]{{/allowableValues}}  # noqa: E501
+            value ({{{dataType}}}):{{#description}} {{{description}}}.{{/description}}{{#defaultValue}} if omitted defaults to {{{defaultValue}}}{{/defaultValue}}{{#allowableValues}}, must be one of [{{#enumVars}}{{{value}}}, {{/enumVars}}]{{/allowableValues}}  # noqa: E501
 {{> model_templates/docstring_init_required_kwargs }}
         """
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/additional_properties_class.py
@@ -152,7 +152,7 @@ class AdditionalPropertiesClass(ModelNormal):
             map_with_undeclared_properties_anytype_1 ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): [optional]  # noqa: E501
             map_with_undeclared_properties_anytype_2 ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): [optional]  # noqa: E501
             map_with_undeclared_properties_anytype_3 ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): [optional]  # noqa: E501
-            empty_map (bool, date, datetime, dict, float, int, list, str): an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.. [optional]  # noqa: E501
+            empty_map (bool, date, datetime, dict, float, int, list, str): an object with no declared properties and no undeclared properties, hence it's an empty map.. [optional]  # noqa: E501
             map_with_undeclared_properties_string ({str: (str,)}): [optional]  # noqa: E501
         """
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/format_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/format_test.py
@@ -222,7 +222,7 @@ class FormatTest(ModelNormal):
             uuid (str): [optional]  # noqa: E501
             uuid_no_example (str): [optional]  # noqa: E501
             pattern_with_digits (str): A string that is a 10 digit number. Can have leading zeros.. [optional]  # noqa: E501
-            pattern_with_digits_and_delimiter (str): A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.. [optional]  # noqa: E501
+            pattern_with_digits_and_delimiter (str): A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/user.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/user.py
@@ -162,10 +162,10 @@ class User(ModelNormal):
             password (str): [optional]  # noqa: E501
             phone (str): [optional]  # noqa: E501
             user_status (int): User Status. [optional]  # noqa: E501
-            object_with_no_declared_props ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.. [optional]  # noqa: E501
-            object_with_no_declared_props_nullable ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}, none_type): test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.. [optional]  # noqa: E501
-            any_type_prop (bool, date, datetime, dict, float, int, list, str, none_type): test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389. [optional]  # noqa: E501
-            any_type_prop_nullable (bool, date, datetime, dict, float, int, list, str, none_type): test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.. [optional]  # noqa: E501
+            object_with_no_declared_props ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): test code generation for objects Value must be a map of strings to values. It cannot be the 'null' value.. [optional]  # noqa: E501
+            object_with_no_declared_props_nullable ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}, none_type): test code generation for nullable objects. Value must be a map of strings to values or the 'null' value.. [optional]  # noqa: E501
+            any_type_prop (bool, date, datetime, dict, float, int, list, str, none_type): test code generation for any type Here the 'type' attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389. [optional]  # noqa: E501
+            any_type_prop_nullable (bool, date, datetime, dict, float, int, list, str, none_type): test code generation for any type Here the 'type' attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The 'nullable' attribute does not change the allowed values.. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

mustache escaping the description make them render weirdly, including sometimes
unsupported characters in python.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.