### PR TITLE
[java] Generate "static final" instead "final static"

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
@@ -99,7 +99,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     // store a list of schema names defined in anyOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public {{classname}}() {
         super("anyOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/oneof_model.mustache
@@ -132,7 +132,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public {{classname}}() {
         super("oneOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/anyof_model.mustache
@@ -99,7 +99,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     // store a list of schema names defined in anyOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public {{classname}}() {
         super("anyOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/oneof_model.mustache
@@ -132,7 +132,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public {{classname}}() {
         super("oneOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/apiServiceFactory.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/apiServiceFactory.mustache
@@ -5,7 +5,7 @@ import {{package}}.impl.{{classname}}ServiceImpl;
 
 {{>generatedAnnotation}}
 public class {{classname}}ServiceFactory {
-    private final static {{classname}}Service service = new {{classname}}ServiceImpl();
+    private static final {{classname}}Service service = new {{classname}}ServiceImpl();
 
     public static {{classname}}Service get{{classname}}() {
         return service;

--- a/modules/openapi-generator/src/main/resources/JavaVertXServer/MainApiVerticle.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXServer/MainApiVerticle.mustache
@@ -19,7 +19,7 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 
 public class MainApiVerticle extends AbstractVerticle {
-    final static Logger LOGGER = LoggerFactory.getLogger(MainApiVerticle.class);
+    static final Logger LOGGER = LoggerFactory.getLogger(MainApiVerticle.class);
 
     private int serverPort = {{serverPort}};
     protected Router router;

--- a/modules/openapi-generator/src/main/resources/JavaVertXServer/apiVerticle.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXServer/apiVerticle.mustache
@@ -15,9 +15,9 @@ import java.util.List;
 import java.util.Map;
 
 public class {{classname}}Verticle extends AbstractVerticle {
-    final static Logger LOGGER = LoggerFactory.getLogger({{classname}}Verticle.class); 
+    static final Logger LOGGER = LoggerFactory.getLogger({{classname}}Verticle.class);
     
-    {{#operations}}{{#operation}}{{#vendorExtensions}}final static String {{x-serviceid-varname}} = "{{x-serviceid}}";
+    {{#operations}}{{#operation}}{{#vendorExtensions}}static final String {{x-serviceid-varname}} = "{{x-serviceid}}";
     {{/vendorExtensions}}{{/operation}}{{/operations}}
     final {{classname}} service;
 

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/apiServiceFactory.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/apiServiceFactory.mustache
@@ -4,7 +4,7 @@ import {{package}}.{{classname}}Service;
 import {{package}}.impl.{{classname}}ServiceImpl;
 
 public class {{classname}}ServiceFactory {
-    private final static {{classname}}Service service = new {{classname}}ServiceImpl();
+    private static final {{classname}}Service service = new {{classname}}ServiceImpl();
 
     public static {{classname}}Service get{{classname}}() {
         return service;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Fruit.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Fruit.java
@@ -164,7 +164,7 @@ public class Fruit extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public Fruit() {
         super("oneOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FruitReq.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FruitReq.java
@@ -166,7 +166,7 @@ public class FruitReq extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public FruitReq() {
         super("oneOf", Boolean.TRUE);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -124,7 +124,7 @@ public class GmFruit extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in anyOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public GmFruit() {
         super("anyOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Mammal.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Mammal.java
@@ -216,7 +216,7 @@ public class Mammal extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public Mammal() {
         super("oneOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableShape.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableShape.java
@@ -187,7 +187,7 @@ public class NullableShape extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public NullableShape() {
         super("oneOf", Boolean.TRUE);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pig.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pig.java
@@ -185,7 +185,7 @@ public class Pig extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public Pig() {
         super("oneOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Quadrilateral.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Quadrilateral.java
@@ -185,7 +185,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public Quadrilateral() {
         super("oneOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Shape.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Shape.java
@@ -185,7 +185,7 @@ public class Shape extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public Shape() {
         super("oneOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ShapeOrNull.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ShapeOrNull.java
@@ -187,7 +187,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public ShapeOrNull() {
         super("oneOf", Boolean.TRUE);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Triangle.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Triangle.java
@@ -216,7 +216,7 @@ public class Triangle extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public Triangle() {
         super("oneOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Fruit.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Fruit.java
@@ -164,7 +164,7 @@ public class Fruit extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public Fruit() {
         super("oneOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/FruitReq.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/FruitReq.java
@@ -166,7 +166,7 @@ public class FruitReq extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public FruitReq() {
         super("oneOf", Boolean.TRUE);

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -124,7 +124,7 @@ public class GmFruit extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in anyOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public GmFruit() {
         super("anyOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Mammal.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Mammal.java
@@ -212,7 +212,7 @@ public class Mammal extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public Mammal() {
         super("oneOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/NullableShape.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/NullableShape.java
@@ -183,7 +183,7 @@ public class NullableShape extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public NullableShape() {
         super("oneOf", Boolean.TRUE);

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pig.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pig.java
@@ -181,7 +181,7 @@ public class Pig extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public Pig() {
         super("oneOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Quadrilateral.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Quadrilateral.java
@@ -181,7 +181,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public Quadrilateral() {
         super("oneOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Shape.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Shape.java
@@ -181,7 +181,7 @@ public class Shape extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public Shape() {
         super("oneOf", Boolean.FALSE);

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ShapeOrNull.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ShapeOrNull.java
@@ -183,7 +183,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public ShapeOrNull() {
         super("oneOf", Boolean.TRUE);

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Triangle.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Triangle.java
@@ -212,7 +212,7 @@ public class Triangle extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public final static Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
 
     public Triangle() {
         super("oneOf", Boolean.FALSE);

--- a/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
+++ b/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
@@ -4,7 +4,7 @@ import org.openapitools.api.AnotherFakeApiService;
 import org.openapitools.api.impl.AnotherFakeApiServiceImpl;
 
 public class AnotherFakeApiServiceFactory {
-    private final static AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
+    private static final AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
 
     public static AnotherFakeApiService getAnotherFakeApi() {
         return service;

--- a/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
+++ b/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
@@ -4,7 +4,7 @@ import org.openapitools.api.FakeApiService;
 import org.openapitools.api.impl.FakeApiServiceImpl;
 
 public class FakeApiServiceFactory {
-    private final static FakeApiService service = new FakeApiServiceImpl();
+    private static final FakeApiService service = new FakeApiServiceImpl();
 
     public static FakeApiService getFakeApi() {
         return service;

--- a/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/factories/FakeClassnameTestApiServiceFactory.java
+++ b/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/factories/FakeClassnameTestApiServiceFactory.java
@@ -4,7 +4,7 @@ import org.openapitools.api.FakeClassnameTestApiService;
 import org.openapitools.api.impl.FakeClassnameTestApiServiceImpl;
 
 public class FakeClassnameTestApiServiceFactory {
-    private final static FakeClassnameTestApiService service = new FakeClassnameTestApiServiceImpl();
+    private static final FakeClassnameTestApiService service = new FakeClassnameTestApiServiceImpl();
 
     public static FakeClassnameTestApiService getFakeClassnameTestApi() {
         return service;

--- a/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
+++ b/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
@@ -4,7 +4,7 @@ import org.openapitools.api.PetApiService;
 import org.openapitools.api.impl.PetApiServiceImpl;
 
 public class PetApiServiceFactory {
-    private final static PetApiService service = new PetApiServiceImpl();
+    private static final PetApiService service = new PetApiServiceImpl();
 
     public static PetApiService getPetApi() {
         return service;

--- a/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
+++ b/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
@@ -4,7 +4,7 @@ import org.openapitools.api.StoreApiService;
 import org.openapitools.api.impl.StoreApiServiceImpl;
 
 public class StoreApiServiceFactory {
-    private final static StoreApiService service = new StoreApiServiceImpl();
+    private static final StoreApiService service = new StoreApiServiceImpl();
 
     public static StoreApiService getStoreApi() {
         return service;

--- a/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
+++ b/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
@@ -4,7 +4,7 @@ import org.openapitools.api.UserApiService;
 import org.openapitools.api.impl.UserApiServiceImpl;
 
 public class UserApiServiceFactory {
-    private final static UserApiService service = new UserApiServiceImpl();
+    private static final UserApiService service = new UserApiServiceImpl();
 
     public static UserApiService getUserApi() {
         return service;

--- a/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.AnotherFakeApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class AnotherFakeApiServiceFactory {
-    private final static AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
+    private static final AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
 
     public static AnotherFakeApiService getAnotherFakeApi() {
         return service;

--- a/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FakeApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FakeApiServiceFactory {
-    private final static FakeApiService service = new FakeApiServiceImpl();
+    private static final FakeApiService service = new FakeApiServiceImpl();
 
     public static FakeApiService getFakeApi() {
         return service;

--- a/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/factories/FakeClassnameTestApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/factories/FakeClassnameTestApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FakeClassnameTestApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FakeClassnameTestApiServiceFactory {
-    private final static FakeClassnameTestApiService service = new FakeClassnameTestApiServiceImpl();
+    private static final FakeClassnameTestApiService service = new FakeClassnameTestApiServiceImpl();
 
     public static FakeClassnameTestApiService getFakeClassnameTestApi() {
         return service;

--- a/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.PetApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class PetApiServiceFactory {
-    private final static PetApiService service = new PetApiServiceImpl();
+    private static final PetApiService service = new PetApiServiceImpl();
 
     public static PetApiService getPetApi() {
         return service;

--- a/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.StoreApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class StoreApiServiceFactory {
-    private final static StoreApiService service = new StoreApiServiceImpl();
+    private static final StoreApiService service = new StoreApiServiceImpl();
 
     public static StoreApiService getStoreApi() {
         return service;

--- a/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.UserApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class UserApiServiceFactory {
-    private final static UserApiService service = new UserApiServiceImpl();
+    private static final UserApiService service = new UserApiServiceImpl();
 
     public static UserApiService getUserApi() {
         return service;

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.AnotherFakeApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class AnotherFakeApiServiceFactory {
-    private final static AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
+    private static final AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
 
     public static AnotherFakeApiService getAnotherFakeApi() {
         return service;

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FakeApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FakeApiServiceFactory {
-    private final static FakeApiService service = new FakeApiServiceImpl();
+    private static final FakeApiService service = new FakeApiServiceImpl();
 
     public static FakeApiService getFakeApi() {
         return service;

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/FakeClassnameTestApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/FakeClassnameTestApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FakeClassnameTestApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FakeClassnameTestApiServiceFactory {
-    private final static FakeClassnameTestApiService service = new FakeClassnameTestApiServiceImpl();
+    private static final FakeClassnameTestApiService service = new FakeClassnameTestApiServiceImpl();
 
     public static FakeClassnameTestApiService getFakeClassnameTestApi() {
         return service;

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/FooApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/FooApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FooApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FooApiServiceFactory {
-    private final static FooApiService service = new FooApiServiceImpl();
+    private static final FooApiService service = new FooApiServiceImpl();
 
     public static FooApiService getFooApi() {
         return service;

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.PetApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class PetApiServiceFactory {
-    private final static PetApiService service = new PetApiServiceImpl();
+    private static final PetApiService service = new PetApiServiceImpl();
 
     public static PetApiService getPetApi() {
         return service;

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.StoreApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class StoreApiServiceFactory {
-    private final static StoreApiService service = new StoreApiServiceImpl();
+    private static final StoreApiService service = new StoreApiServiceImpl();
 
     public static StoreApiService getStoreApi() {
         return service;

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.UserApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class UserApiServiceFactory {
-    private final static UserApiService service = new UserApiServiceImpl();
+    private static final UserApiService service = new UserApiServiceImpl();
 
     public static UserApiService getUserApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.AnotherFakeApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class AnotherFakeApiServiceFactory {
-    private final static AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
+    private static final AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
 
     public static AnotherFakeApiService getAnotherFakeApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FakeApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FakeApiServiceFactory {
-    private final static FakeApiService service = new FakeApiServiceImpl();
+    private static final FakeApiService service = new FakeApiServiceImpl();
 
     public static FakeApiService getFakeApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/factories/FakeClassnameTags123ApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/factories/FakeClassnameTags123ApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FakeClassnameTags123ApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FakeClassnameTags123ApiServiceFactory {
-    private final static FakeClassnameTags123ApiService service = new FakeClassnameTags123ApiServiceImpl();
+    private static final FakeClassnameTags123ApiService service = new FakeClassnameTags123ApiServiceImpl();
 
     public static FakeClassnameTags123ApiService getFakeClassnameTags123Api() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.PetApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class PetApiServiceFactory {
-    private final static PetApiService service = new PetApiServiceImpl();
+    private static final PetApiService service = new PetApiServiceImpl();
 
     public static PetApiService getPetApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.StoreApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class StoreApiServiceFactory {
-    private final static StoreApiService service = new StoreApiServiceImpl();
+    private static final StoreApiService service = new StoreApiServiceImpl();
 
     public static StoreApiService getStoreApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.UserApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class UserApiServiceFactory {
-    private final static UserApiService service = new UserApiServiceImpl();
+    private static final UserApiService service = new UserApiServiceImpl();
 
     public static UserApiService getUserApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.AnotherFakeApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class AnotherFakeApiServiceFactory {
-    private final static AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
+    private static final AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
 
     public static AnotherFakeApiService getAnotherFakeApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FakeApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FakeApiServiceFactory {
-    private final static FakeApiService service = new FakeApiServiceImpl();
+    private static final FakeApiService service = new FakeApiServiceImpl();
 
     public static FakeApiService getFakeApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/factories/FakeClassnameTestApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/factories/FakeClassnameTestApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FakeClassnameTestApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FakeClassnameTestApiServiceFactory {
-    private final static FakeClassnameTestApiService service = new FakeClassnameTestApiServiceImpl();
+    private static final FakeClassnameTestApiService service = new FakeClassnameTestApiServiceImpl();
 
     public static FakeClassnameTestApiService getFakeClassnameTestApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.PetApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class PetApiServiceFactory {
-    private final static PetApiService service = new PetApiServiceImpl();
+    private static final PetApiService service = new PetApiServiceImpl();
 
     public static PetApiService getPetApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.StoreApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class StoreApiServiceFactory {
-    private final static StoreApiService service = new StoreApiServiceImpl();
+    private static final StoreApiService service = new StoreApiServiceImpl();
 
     public static StoreApiService getStoreApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.UserApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class UserApiServiceFactory {
-    private final static UserApiService service = new UserApiServiceImpl();
+    private static final UserApiService service = new UserApiServiceImpl();
 
     public static UserApiService getUserApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.AnotherFakeApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class AnotherFakeApiServiceFactory {
-    private final static AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
+    private static final AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
 
     public static AnotherFakeApiService getAnotherFakeApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FakeApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FakeApiServiceFactory {
-    private final static FakeApiService service = new FakeApiServiceImpl();
+    private static final FakeApiService service = new FakeApiServiceImpl();
 
     public static FakeApiService getFakeApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/factories/FakeClassnameTags123ApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/factories/FakeClassnameTags123ApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FakeClassnameTags123ApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FakeClassnameTags123ApiServiceFactory {
-    private final static FakeClassnameTags123ApiService service = new FakeClassnameTags123ApiServiceImpl();
+    private static final FakeClassnameTags123ApiService service = new FakeClassnameTags123ApiServiceImpl();
 
     public static FakeClassnameTags123ApiService getFakeClassnameTags123Api() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.PetApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class PetApiServiceFactory {
-    private final static PetApiService service = new PetApiServiceImpl();
+    private static final PetApiService service = new PetApiServiceImpl();
 
     public static PetApiService getPetApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.StoreApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class StoreApiServiceFactory {
-    private final static StoreApiService service = new StoreApiServiceImpl();
+    private static final StoreApiService service = new StoreApiServiceImpl();
 
     public static StoreApiService getStoreApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.UserApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class UserApiServiceFactory {
-    private final static UserApiService service = new UserApiServiceImpl();
+    private static final UserApiService service = new UserApiServiceImpl();
 
     public static UserApiService getUserApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/factories/AnotherFakeApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.AnotherFakeApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class AnotherFakeApiServiceFactory {
-    private final static AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
+    private static final AnotherFakeApiService service = new AnotherFakeApiServiceImpl();
 
     public static AnotherFakeApiService getAnotherFakeApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/factories/FakeApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FakeApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FakeApiServiceFactory {
-    private final static FakeApiService service = new FakeApiServiceImpl();
+    private static final FakeApiService service = new FakeApiServiceImpl();
 
     public static FakeApiService getFakeApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/factories/FakeClassnameTestApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/factories/FakeClassnameTestApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.FakeClassnameTestApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class FakeClassnameTestApiServiceFactory {
-    private final static FakeClassnameTestApiService service = new FakeClassnameTestApiServiceImpl();
+    private static final FakeClassnameTestApiService service = new FakeClassnameTestApiServiceImpl();
 
     public static FakeClassnameTestApiService getFakeClassnameTestApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/factories/PetApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.PetApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class PetApiServiceFactory {
-    private final static PetApiService service = new PetApiServiceImpl();
+    private static final PetApiService service = new PetApiServiceImpl();
 
     public static PetApiService getPetApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/factories/StoreApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.StoreApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class StoreApiServiceFactory {
-    private final static StoreApiService service = new StoreApiServiceImpl();
+    private static final StoreApiService service = new StoreApiServiceImpl();
 
     public static StoreApiService getStoreApi() {
         return service;

--- a/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/factories/UserApiServiceFactory.java
@@ -5,7 +5,7 @@ import org.openapitools.api.impl.UserApiServiceImpl;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJerseyServerCodegen")
 public class UserApiServiceFactory {
-    private final static UserApiService service = new UserApiServiceImpl();
+    private static final UserApiService service = new UserApiServiceImpl();
 
     public static UserApiService getUserApi() {
         return service;


### PR DESCRIPTION
Simple change, to follow general consensus, generated java code will have "static final" not "final static".

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
