### PR TITLE
[dart][dart-dio] More enum fixes for inner types

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
@@ -505,6 +505,25 @@ public class DartClientCodegen extends DefaultCodegen {
     }
 
     @Override
+    public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
+        super.postProcessModelProperty(model, property);
+        if (!model.isEnum && property.isEnum) {
+            // These are inner enums, enums which do not exist as models, just as properties.
+            // They are handled via the enum_inline template and and are generated in the
+            // same file as the containing class. To prevent name clashes the inline enum classes
+            // are prefix with the classname of the containing class in the template.
+            // Here the datatypeWithEnum template variable gets updated to match that scheme.
+            // Also taking into account potential collection types e.g. List<JustSymbolEnum> -> List<EnumArraysJustSymbolEnum>
+            if (property.items != null) {
+                // basically inner items e.g. map of maps etc.
+                property.setDatatypeWithEnum(property.datatypeWithEnum.replace(property.items.datatypeWithEnum, model.classname + property.items.datatypeWithEnum));
+            } else {
+                property.setDatatypeWithEnum(property.datatypeWithEnum.replace(property.enumName, model.classname + property.enumName));
+            }
+        }
+    }
+
+    @Override
     public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
         final CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
         for (CodegenResponse r : op.responses) {

--- a/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
@@ -11,7 +11,7 @@ abstract class {{classname}} implements Built<{{classname}}, {{classname}}Builde
     @nullable
     {{/isNullable}}
     @BuiltValueField(wireName: r'{{baseName}}')
-    {{#isEnum}}{{classname}}{{{nameInCamelCase}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}} get {{name}};
+    {{{datatypeWithEnum}}} get {{name}};
     {{#allowableValues}}
     {{#min}}// range from {{min}} to {{max}}{{/min}}//{{^min}} enum {{name}}Enum { {{#values}} {{.}}, {{/values}} };{{/min}}
     {{/allowableValues}}
@@ -31,8 +31,15 @@ abstract class {{classname}} implements Built<{{classname}}, {{classname}}Builde
 }}
 {{#vars}}
     {{#isEnum}}
+        {{^isContainer}}
 
 {{>enum_inline}}
+        {{/isContainer}}
+        {{#isContainer}}
+            {{#mostInnerItems}}
 
+{{>enum_inline}}
+            {{/mostInnerItems}}
+        {{/isContainer}}
     {{/isEnum}}
 {{/vars}}

--- a/modules/openapi-generator/src/main/resources/dart-dio/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/enum_inline.mustache
@@ -1,4 +1,4 @@
-class {{classname}}{{nameInCamelCase}} extends EnumClass {
+class {{{classname}}}{{{enumName}}} extends EnumClass {
 
   {{#allowableValues}}
     {{#enumVars}}
@@ -6,14 +6,14 @@ class {{classname}}{{nameInCamelCase}} extends EnumClass {
   /// {{{description}}}
       {{/description}}
   @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{^isInteger}}wireName: r{{#lambda.escapeBuiltValueEnum}}{{{value}}}{{/lambda.escapeBuiltValueEnum}}{{/isInteger}})
-  static const {{classname}}{{nameInCamelCase}} {{name}} = _${{#lambda.camelcase}}{{classname}}{{nameInCamelCase}}{{/lambda.camelcase}}_{{name}};
+  static const {{{classname}}}{{{enumName}}} {{name}} = _${{#lambda.camelcase}}{{{classname}}}{{{enumName}}}{{/lambda.camelcase}}_{{name}};
     {{/enumVars}}
   {{/allowableValues}}
 
-  static Serializer<{{classname}}{{nameInCamelCase}}> get serializer => _${{#lambda.camelcase}}{{classname}}{{nameInCamelCase}}{{/lambda.camelcase}}Serializer;
+  static Serializer<{{{classname}}}{{{enumName}}}> get serializer => _${{#lambda.camelcase}}{{{classname}}}{{{enumName}}}{{/lambda.camelcase}}Serializer;
 
-  const {{classname}}{{nameInCamelCase}}._(String name): super(name);
+  const {{{classname}}}{{{enumName}}}._(String name): super(name);
 
-  static BuiltSet<{{classname}}{{nameInCamelCase}}> get values => _${{#lambda.camelcase}}{{classname}}{{nameInCamelCase}}{{/lambda.camelcase}}Values;
-  static {{classname}}{{nameInCamelCase}} valueOf(String name) => _${{#lambda.camelcase}}{{classname}}{{nameInCamelCase}}{{/lambda.camelcase}}ValueOf(name);
+  static BuiltSet<{{{classname}}}{{{enumName}}}> get values => _${{#lambda.camelcase}}{{{classname}}}{{{enumName}}}{{/lambda.camelcase}}Values;
+  static {{{classname}}}{{{enumName}}} valueOf(String name) => _${{#lambda.camelcase}}{{{classname}}}{{{enumName}}}{{/lambda.camelcase}}ValueOf(name);
 }

--- a/modules/openapi-generator/src/main/resources/dart2/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/class.mustache
@@ -15,23 +15,8 @@ class {{{classname}}} {
     {{#maximum}}
   // maximum: {{{maximum}}}
     {{/maximum}}
-  {{{dataType}}} {{{name}}};
   {{/isEnum}}
-  {{#isEnum}}
-    {{#isContainer}}
-      {{#isArray}}
-  List<{{{classname}}}{{{enumName}}}> {{{name}}};
-      {{/isArray}}
-      {{#isMap}}
-  Map<String, dynamic> {{{name}}};
-      {{/isMap}}
-    {{/isContainer}}
-    {{^isContainer}}
-      {{#allowableValues}}
-  {{{classname}}}{{{enumName}}} {{{name}}}{{#required}}{{#defaultValue}} = {{{classname}}}{{{enumName}}}._({{{defaultValue}}}){{/defaultValue}}{{/required}};
-      {{/allowableValues}}
-    {{/isContainer}}
-  {{/isEnum}}
+  {{{datatypeWithEnum}}} {{{name}}};
 
   {{/vars}}
   @override
@@ -225,8 +210,16 @@ class {{{classname}}} {
   }
 }
 {{#vars}}
-{{#isEnum}}
+    {{#isEnum}}
+        {{^isContainer}}
 
 {{>enum_inline}}
-{{/isEnum}}
+        {{/isContainer}}
+        {{#isContainer}}
+            {{#mostInnerItems}}
+
+{{>enum_inline}}
+            {{/mostInnerItems}}
+        {{/isContainer}}
+    {{/isEnum}}
 {{/vars}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
@@ -419,7 +419,7 @@ public class DartModelTest {
         Assert.assertEquals(property1.baseName, "testStringEnum");
         Assert.assertEquals(property1.dataType, "String");
         Assert.assertEquals(property1.baseType, "String");
-        Assert.assertEquals(property1.datatypeWithEnum, "TestStringEnumEnum");
+        Assert.assertEquals(property1.datatypeWithEnum, "SampleTestStringEnumEnum");
         Assert.assertEquals(property1.name, "testStringEnum");
         Assert.assertTrue(property1.isEnum);
         Assert.assertEquals(property1.allowableValues.size(), 2);
@@ -439,7 +439,7 @@ public class DartModelTest {
         Assert.assertEquals(property2.baseName, "testIntEnum");
         Assert.assertEquals(property2.dataType, "int");
         Assert.assertEquals(property2.baseType, "int");
-        Assert.assertEquals(property2.datatypeWithEnum, "TestIntEnumEnum");
+        Assert.assertEquals(property2.datatypeWithEnum, "SampleTestIntEnumEnum");
         Assert.assertEquals(property2.name, "testIntEnum");
         Assert.assertTrue(property2.isEnum);
         Assert.assertEquals(property2.allowableValues.size(), 2);
@@ -482,7 +482,7 @@ public class DartModelTest {
         Assert.assertEquals(property1.baseName, "testIntEnum");
         Assert.assertEquals(property1.dataType, "int");
         Assert.assertEquals(property1.baseType, "int");
-        Assert.assertEquals(property1.datatypeWithEnum, "TestIntEnumEnum");
+        Assert.assertEquals(property1.datatypeWithEnum, "SampleTestIntEnumEnum");
         Assert.assertEquals(property1.name, "testIntEnum");
         Assert.assertTrue(property1.isEnum);
         Assert.assertEquals(property1.allowableValues.size(), 2);

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
@@ -25,7 +25,7 @@ abstract class Order implements Built<Order, OrderBuilder> {
     /* Order Status */
     @nullable
     @BuiltValueField(wireName: r'status')
-    OrderStatus get status;
+    OrderStatusEnum get status;
     // enum statusEnum {  placed,  approved,  delivered,  };
     
     @nullable
@@ -39,24 +39,23 @@ abstract class Order implements Built<Order, OrderBuilder> {
     static Serializer<Order> get serializer => _$orderSerializer;
 }
 
-class OrderStatus extends EnumClass {
+class OrderStatusEnum extends EnumClass {
 
   /// Order Status
   @BuiltValueEnumConst(wireName: r'placed')
-  static const OrderStatus placed = _$orderStatus_placed;
+  static const OrderStatusEnum placed = _$orderStatusEnum_placed;
   /// Order Status
   @BuiltValueEnumConst(wireName: r'approved')
-  static const OrderStatus approved = _$orderStatus_approved;
+  static const OrderStatusEnum approved = _$orderStatusEnum_approved;
   /// Order Status
   @BuiltValueEnumConst(wireName: r'delivered')
-  static const OrderStatus delivered = _$orderStatus_delivered;
+  static const OrderStatusEnum delivered = _$orderStatusEnum_delivered;
 
-  static Serializer<OrderStatus> get serializer => _$orderStatusSerializer;
+  static Serializer<OrderStatusEnum> get serializer => _$orderStatusEnumSerializer;
 
-  const OrderStatus._(String name): super(name);
+  const OrderStatusEnum._(String name): super(name);
 
-  static BuiltSet<OrderStatus> get values => _$orderStatusValues;
-  static OrderStatus valueOf(String name) => _$orderStatusValueOf(name);
+  static BuiltSet<OrderStatusEnum> get values => _$orderStatusEnumValues;
+  static OrderStatusEnum valueOf(String name) => _$orderStatusEnumValueOf(name);
 }
-
 

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
@@ -31,7 +31,7 @@ abstract class Pet implements Built<Pet, PetBuilder> {
     /* pet status in the store */
     @nullable
     @BuiltValueField(wireName: r'status')
-    PetStatus get status;
+    PetStatusEnum get status;
     // enum statusEnum {  available,  pending,  sold,  };
 
     // Boilerplate code needed to wire-up generated code
@@ -41,24 +41,23 @@ abstract class Pet implements Built<Pet, PetBuilder> {
     static Serializer<Pet> get serializer => _$petSerializer;
 }
 
-class PetStatus extends EnumClass {
+class PetStatusEnum extends EnumClass {
 
   /// pet status in the store
   @BuiltValueEnumConst(wireName: r'available')
-  static const PetStatus available = _$petStatus_available;
+  static const PetStatusEnum available = _$petStatusEnum_available;
   /// pet status in the store
   @BuiltValueEnumConst(wireName: r'pending')
-  static const PetStatus pending = _$petStatus_pending;
+  static const PetStatusEnum pending = _$petStatusEnum_pending;
   /// pet status in the store
   @BuiltValueEnumConst(wireName: r'sold')
-  static const PetStatus sold = _$petStatus_sold;
+  static const PetStatusEnum sold = _$petStatusEnum_sold;
 
-  static Serializer<PetStatus> get serializer => _$petStatusSerializer;
+  static Serializer<PetStatusEnum> get serializer => _$petStatusEnumSerializer;
 
-  const PetStatus._(String name): super(name);
+  const PetStatusEnum._(String name): super(name);
 
-  static BuiltSet<PetStatus> get values => _$petStatusValues;
-  static PetStatus valueOf(String name) => _$petStatusValueOf(name);
+  static BuiltSet<PetStatusEnum> get values => _$petStatusEnumValues;
+  static PetStatusEnum valueOf(String name) => _$petStatusEnumValueOf(name);
 }
-
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
@@ -25,7 +25,7 @@ abstract class Order implements Built<Order, OrderBuilder> {
     /* Order Status */
     @nullable
     @BuiltValueField(wireName: r'status')
-    OrderStatus get status;
+    OrderStatusEnum get status;
     // enum statusEnum {  placed,  approved,  delivered,  };
     
     @nullable
@@ -39,24 +39,23 @@ abstract class Order implements Built<Order, OrderBuilder> {
     static Serializer<Order> get serializer => _$orderSerializer;
 }
 
-class OrderStatus extends EnumClass {
+class OrderStatusEnum extends EnumClass {
 
   /// Order Status
   @BuiltValueEnumConst(wireName: r'placed')
-  static const OrderStatus placed = _$orderStatus_placed;
+  static const OrderStatusEnum placed = _$orderStatusEnum_placed;
   /// Order Status
   @BuiltValueEnumConst(wireName: r'approved')
-  static const OrderStatus approved = _$orderStatus_approved;
+  static const OrderStatusEnum approved = _$orderStatusEnum_approved;
   /// Order Status
   @BuiltValueEnumConst(wireName: r'delivered')
-  static const OrderStatus delivered = _$orderStatus_delivered;
+  static const OrderStatusEnum delivered = _$orderStatusEnum_delivered;
 
-  static Serializer<OrderStatus> get serializer => _$orderStatusSerializer;
+  static Serializer<OrderStatusEnum> get serializer => _$orderStatusEnumSerializer;
 
-  const OrderStatus._(String name): super(name);
+  const OrderStatusEnum._(String name): super(name);
 
-  static BuiltSet<OrderStatus> get values => _$orderStatusValues;
-  static OrderStatus valueOf(String name) => _$orderStatusValueOf(name);
+  static BuiltSet<OrderStatusEnum> get values => _$orderStatusEnumValues;
+  static OrderStatusEnum valueOf(String name) => _$orderStatusEnumValueOf(name);
 }
-
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
@@ -31,7 +31,7 @@ abstract class Pet implements Built<Pet, PetBuilder> {
     /* pet status in the store */
     @nullable
     @BuiltValueField(wireName: r'status')
-    PetStatus get status;
+    PetStatusEnum get status;
     // enum statusEnum {  available,  pending,  sold,  };
 
     // Boilerplate code needed to wire-up generated code
@@ -41,24 +41,23 @@ abstract class Pet implements Built<Pet, PetBuilder> {
     static Serializer<Pet> get serializer => _$petSerializer;
 }
 
-class PetStatus extends EnumClass {
+class PetStatusEnum extends EnumClass {
 
   /// pet status in the store
   @BuiltValueEnumConst(wireName: r'available')
-  static const PetStatus available = _$petStatus_available;
+  static const PetStatusEnum available = _$petStatusEnum_available;
   /// pet status in the store
   @BuiltValueEnumConst(wireName: r'pending')
-  static const PetStatus pending = _$petStatus_pending;
+  static const PetStatusEnum pending = _$petStatusEnum_pending;
   /// pet status in the store
   @BuiltValueEnumConst(wireName: r'sold')
-  static const PetStatus sold = _$petStatus_sold;
+  static const PetStatusEnum sold = _$petStatusEnum_sold;
 
-  static Serializer<PetStatus> get serializer => _$petStatusSerializer;
+  static Serializer<PetStatusEnum> get serializer => _$petStatusEnumSerializer;
 
-  const PetStatus._(String name): super(name);
+  const PetStatusEnum._(String name): super(name);
 
-  static BuiltSet<PetStatus> get values => _$petStatusValues;
-  static PetStatus valueOf(String name) => _$petStatusValueOf(name);
+  static BuiltSet<PetStatusEnum> get values => _$petStatusEnumValues;
+  static PetStatusEnum valueOf(String name) => _$petStatusEnumValueOf(name);
 }
-
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -9,12 +9,12 @@ abstract class EnumArrays implements Built<EnumArrays, EnumArraysBuilder> {
     
     @nullable
     @BuiltValueField(wireName: r'just_symbol')
-    EnumArraysJustSymbol get justSymbol;
+    EnumArraysJustSymbolEnum get justSymbol;
     // enum justSymbolEnum {  &gt;&#x3D;,  $,  };
     
     @nullable
     @BuiltValueField(wireName: r'array_enum')
-    EnumArraysArrayEnum get arrayEnum;
+    BuiltList<EnumArraysArrayEnumEnum> get arrayEnum;
     // enum arrayEnumEnum {  fish,  crab,  };
 
     // Boilerplate code needed to wire-up generated code
@@ -24,35 +24,33 @@ abstract class EnumArrays implements Built<EnumArrays, EnumArraysBuilder> {
     static Serializer<EnumArrays> get serializer => _$enumArraysSerializer;
 }
 
-class EnumArraysJustSymbol extends EnumClass {
+class EnumArraysJustSymbolEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: r'>=')
-  static const EnumArraysJustSymbol greaterThanEqual = _$enumArraysJustSymbol_greaterThanEqual;
+  static const EnumArraysJustSymbolEnum greaterThanEqual = _$enumArraysJustSymbolEnum_greaterThanEqual;
   @BuiltValueEnumConst(wireName: r'\$')
-  static const EnumArraysJustSymbol dollar = _$enumArraysJustSymbol_dollar;
+  static const EnumArraysJustSymbolEnum dollar = _$enumArraysJustSymbolEnum_dollar;
 
-  static Serializer<EnumArraysJustSymbol> get serializer => _$enumArraysJustSymbolSerializer;
+  static Serializer<EnumArraysJustSymbolEnum> get serializer => _$enumArraysJustSymbolEnumSerializer;
 
-  const EnumArraysJustSymbol._(String name): super(name);
+  const EnumArraysJustSymbolEnum._(String name): super(name);
 
-  static BuiltSet<EnumArraysJustSymbol> get values => _$enumArraysJustSymbolValues;
-  static EnumArraysJustSymbol valueOf(String name) => _$enumArraysJustSymbolValueOf(name);
+  static BuiltSet<EnumArraysJustSymbolEnum> get values => _$enumArraysJustSymbolEnumValues;
+  static EnumArraysJustSymbolEnum valueOf(String name) => _$enumArraysJustSymbolEnumValueOf(name);
 }
 
-
-class EnumArraysArrayEnum extends EnumClass {
+class EnumArraysArrayEnumEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: r'fish')
-  static const EnumArraysArrayEnum fish = _$enumArraysArrayEnum_fish;
+  static const EnumArraysArrayEnumEnum fish = _$enumArraysArrayEnumEnum_fish;
   @BuiltValueEnumConst(wireName: r'crab')
-  static const EnumArraysArrayEnum crab = _$enumArraysArrayEnum_crab;
+  static const EnumArraysArrayEnumEnum crab = _$enumArraysArrayEnumEnum_crab;
 
-  static Serializer<EnumArraysArrayEnum> get serializer => _$enumArraysArrayEnumSerializer;
+  static Serializer<EnumArraysArrayEnumEnum> get serializer => _$enumArraysArrayEnumEnumSerializer;
 
-  const EnumArraysArrayEnum._(String name): super(name);
+  const EnumArraysArrayEnumEnum._(String name): super(name);
 
-  static BuiltSet<EnumArraysArrayEnum> get values => _$enumArraysArrayEnumValues;
-  static EnumArraysArrayEnum valueOf(String name) => _$enumArraysArrayEnumValueOf(name);
+  static BuiltSet<EnumArraysArrayEnumEnum> get values => _$enumArraysArrayEnumEnumValues;
+  static EnumArraysArrayEnumEnum valueOf(String name) => _$enumArraysArrayEnumEnumValueOf(name);
 }
-
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -13,22 +13,22 @@ abstract class EnumTest implements Built<EnumTest, EnumTestBuilder> {
     
     @nullable
     @BuiltValueField(wireName: r'enum_string')
-    EnumTestEnumString get enumString;
+    EnumTestEnumStringEnum get enumString;
     // enum enumStringEnum {  UPPER,  lower,  ,  };
     
     @nullable
     @BuiltValueField(wireName: r'enum_string_required')
-    EnumTestEnumStringRequired get enumStringRequired;
+    EnumTestEnumStringRequiredEnum get enumStringRequired;
     // enum enumStringRequiredEnum {  UPPER,  lower,  ,  };
     
     @nullable
     @BuiltValueField(wireName: r'enum_integer')
-    EnumTestEnumInteger get enumInteger;
+    EnumTestEnumIntegerEnum get enumInteger;
     // enum enumIntegerEnum {  1,  -1,  };
     
     @nullable
     @BuiltValueField(wireName: r'enum_number')
-    EnumTestEnumNumber get enumNumber;
+    EnumTestEnumNumberEnum get enumNumber;
     // enum enumNumberEnum {  1.1,  -1.2,  };
     
     @nullable
@@ -58,71 +58,67 @@ abstract class EnumTest implements Built<EnumTest, EnumTestBuilder> {
     static Serializer<EnumTest> get serializer => _$enumTestSerializer;
 }
 
-class EnumTestEnumString extends EnumClass {
+class EnumTestEnumStringEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: r'UPPER')
-  static const EnumTestEnumString UPPER = _$enumTestEnumString_UPPER;
+  static const EnumTestEnumStringEnum UPPER = _$enumTestEnumStringEnum_UPPER;
   @BuiltValueEnumConst(wireName: r'lower')
-  static const EnumTestEnumString lower = _$enumTestEnumString_lower;
+  static const EnumTestEnumStringEnum lower = _$enumTestEnumStringEnum_lower;
   @BuiltValueEnumConst(wireName: r'')
-  static const EnumTestEnumString empty = _$enumTestEnumString_empty;
+  static const EnumTestEnumStringEnum empty = _$enumTestEnumStringEnum_empty;
 
-  static Serializer<EnumTestEnumString> get serializer => _$enumTestEnumStringSerializer;
+  static Serializer<EnumTestEnumStringEnum> get serializer => _$enumTestEnumStringEnumSerializer;
 
-  const EnumTestEnumString._(String name): super(name);
+  const EnumTestEnumStringEnum._(String name): super(name);
 
-  static BuiltSet<EnumTestEnumString> get values => _$enumTestEnumStringValues;
-  static EnumTestEnumString valueOf(String name) => _$enumTestEnumStringValueOf(name);
+  static BuiltSet<EnumTestEnumStringEnum> get values => _$enumTestEnumStringEnumValues;
+  static EnumTestEnumStringEnum valueOf(String name) => _$enumTestEnumStringEnumValueOf(name);
 }
 
-
-class EnumTestEnumStringRequired extends EnumClass {
+class EnumTestEnumStringRequiredEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: r'UPPER')
-  static const EnumTestEnumStringRequired UPPER = _$enumTestEnumStringRequired_UPPER;
+  static const EnumTestEnumStringRequiredEnum UPPER = _$enumTestEnumStringRequiredEnum_UPPER;
   @BuiltValueEnumConst(wireName: r'lower')
-  static const EnumTestEnumStringRequired lower = _$enumTestEnumStringRequired_lower;
+  static const EnumTestEnumStringRequiredEnum lower = _$enumTestEnumStringRequiredEnum_lower;
   @BuiltValueEnumConst(wireName: r'')
-  static const EnumTestEnumStringRequired empty = _$enumTestEnumStringRequired_empty;
+  static const EnumTestEnumStringRequiredEnum empty = _$enumTestEnumStringRequiredEnum_empty;
 
-  static Serializer<EnumTestEnumStringRequired> get serializer => _$enumTestEnumStringRequiredSerializer;
+  static Serializer<EnumTestEnumStringRequiredEnum> get serializer => _$enumTestEnumStringRequiredEnumSerializer;
 
-  const EnumTestEnumStringRequired._(String name): super(name);
+  const EnumTestEnumStringRequiredEnum._(String name): super(name);
 
-  static BuiltSet<EnumTestEnumStringRequired> get values => _$enumTestEnumStringRequiredValues;
-  static EnumTestEnumStringRequired valueOf(String name) => _$enumTestEnumStringRequiredValueOf(name);
+  static BuiltSet<EnumTestEnumStringRequiredEnum> get values => _$enumTestEnumStringRequiredEnumValues;
+  static EnumTestEnumStringRequiredEnum valueOf(String name) => _$enumTestEnumStringRequiredEnumValueOf(name);
 }
 
-
-class EnumTestEnumInteger extends EnumClass {
+class EnumTestEnumIntegerEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireNumber: 1)
-  static const EnumTestEnumInteger number1 = _$enumTestEnumInteger_number1;
+  static const EnumTestEnumIntegerEnum number1 = _$enumTestEnumIntegerEnum_number1;
   @BuiltValueEnumConst(wireNumber: -1)
-  static const EnumTestEnumInteger numberNegative1 = _$enumTestEnumInteger_numberNegative1;
+  static const EnumTestEnumIntegerEnum numberNegative1 = _$enumTestEnumIntegerEnum_numberNegative1;
 
-  static Serializer<EnumTestEnumInteger> get serializer => _$enumTestEnumIntegerSerializer;
+  static Serializer<EnumTestEnumIntegerEnum> get serializer => _$enumTestEnumIntegerEnumSerializer;
 
-  const EnumTestEnumInteger._(String name): super(name);
+  const EnumTestEnumIntegerEnum._(String name): super(name);
 
-  static BuiltSet<EnumTestEnumInteger> get values => _$enumTestEnumIntegerValues;
-  static EnumTestEnumInteger valueOf(String name) => _$enumTestEnumIntegerValueOf(name);
+  static BuiltSet<EnumTestEnumIntegerEnum> get values => _$enumTestEnumIntegerEnumValues;
+  static EnumTestEnumIntegerEnum valueOf(String name) => _$enumTestEnumIntegerEnumValueOf(name);
 }
 
-
-class EnumTestEnumNumber extends EnumClass {
+class EnumTestEnumNumberEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: r'1.1')
-  static const EnumTestEnumNumber number1Period1 = _$enumTestEnumNumber_number1Period1;
+  static const EnumTestEnumNumberEnum number1Period1 = _$enumTestEnumNumberEnum_number1Period1;
   @BuiltValueEnumConst(wireName: r'-1.2')
-  static const EnumTestEnumNumber numberNegative1Period2 = _$enumTestEnumNumber_numberNegative1Period2;
+  static const EnumTestEnumNumberEnum numberNegative1Period2 = _$enumTestEnumNumberEnum_numberNegative1Period2;
 
-  static Serializer<EnumTestEnumNumber> get serializer => _$enumTestEnumNumberSerializer;
+  static Serializer<EnumTestEnumNumberEnum> get serializer => _$enumTestEnumNumberEnumSerializer;
 
-  const EnumTestEnumNumber._(String name): super(name);
+  const EnumTestEnumNumberEnum._(String name): super(name);
 
-  static BuiltSet<EnumTestEnumNumber> get values => _$enumTestEnumNumberValues;
-  static EnumTestEnumNumber valueOf(String name) => _$enumTestEnumNumberValueOf(name);
+  static BuiltSet<EnumTestEnumNumberEnum> get values => _$enumTestEnumNumberEnumValues;
+  static EnumTestEnumNumberEnum valueOf(String name) => _$enumTestEnumNumberEnumValueOf(name);
 }
-
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object2.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object2.dart
@@ -9,12 +9,12 @@ abstract class InlineObject2 implements Built<InlineObject2, InlineObject2Builde
     /* Form parameter enum test (string array) */
     @nullable
     @BuiltValueField(wireName: r'enum_form_string_array')
-    InlineObject2EnumFormStringArray get enumFormStringArray;
+    BuiltList<InlineObject2EnumFormStringArrayEnum> get enumFormStringArray;
     // enum enumFormStringArrayEnum {  &gt;,  $,  };
     /* Form parameter enum test (string) */
     @nullable
     @BuiltValueField(wireName: r'enum_form_string')
-    InlineObject2EnumFormString get enumFormString;
+    InlineObject2EnumFormStringEnum get enumFormString;
     // enum enumFormStringEnum {  _abc,  -efg,  (xyz),  };
 
     // Boilerplate code needed to wire-up generated code
@@ -24,42 +24,38 @@ abstract class InlineObject2 implements Built<InlineObject2, InlineObject2Builde
     static Serializer<InlineObject2> get serializer => _$inlineObject2Serializer;
 }
 
-class InlineObject2EnumFormStringArray extends EnumClass {
+class InlineObject2EnumFormStringArrayEnum extends EnumClass {
 
-  /// Form parameter enum test (string array)
   @BuiltValueEnumConst(wireName: r'>')
-  static const InlineObject2EnumFormStringArray greaterThan = _$inlineObject2EnumFormStringArray_greaterThan;
-  /// Form parameter enum test (string array)
+  static const InlineObject2EnumFormStringArrayEnum greaterThan = _$inlineObject2EnumFormStringArrayEnum_greaterThan;
   @BuiltValueEnumConst(wireName: r'\$')
-  static const InlineObject2EnumFormStringArray dollar = _$inlineObject2EnumFormStringArray_dollar;
+  static const InlineObject2EnumFormStringArrayEnum dollar = _$inlineObject2EnumFormStringArrayEnum_dollar;
 
-  static Serializer<InlineObject2EnumFormStringArray> get serializer => _$inlineObject2EnumFormStringArraySerializer;
+  static Serializer<InlineObject2EnumFormStringArrayEnum> get serializer => _$inlineObject2EnumFormStringArrayEnumSerializer;
 
-  const InlineObject2EnumFormStringArray._(String name): super(name);
+  const InlineObject2EnumFormStringArrayEnum._(String name): super(name);
 
-  static BuiltSet<InlineObject2EnumFormStringArray> get values => _$inlineObject2EnumFormStringArrayValues;
-  static InlineObject2EnumFormStringArray valueOf(String name) => _$inlineObject2EnumFormStringArrayValueOf(name);
+  static BuiltSet<InlineObject2EnumFormStringArrayEnum> get values => _$inlineObject2EnumFormStringArrayEnumValues;
+  static InlineObject2EnumFormStringArrayEnum valueOf(String name) => _$inlineObject2EnumFormStringArrayEnumValueOf(name);
 }
 
-
-class InlineObject2EnumFormString extends EnumClass {
+class InlineObject2EnumFormStringEnum extends EnumClass {
 
   /// Form parameter enum test (string)
   @BuiltValueEnumConst(wireName: r'_abc')
-  static const InlineObject2EnumFormString abc = _$inlineObject2EnumFormString_abc;
+  static const InlineObject2EnumFormStringEnum abc = _$inlineObject2EnumFormStringEnum_abc;
   /// Form parameter enum test (string)
   @BuiltValueEnumConst(wireName: r'-efg')
-  static const InlineObject2EnumFormString efg = _$inlineObject2EnumFormString_efg;
+  static const InlineObject2EnumFormStringEnum efg = _$inlineObject2EnumFormStringEnum_efg;
   /// Form parameter enum test (string)
   @BuiltValueEnumConst(wireName: r'(xyz)')
-  static const InlineObject2EnumFormString leftParenthesisXyzRightParenthesis = _$inlineObject2EnumFormString_leftParenthesisXyzRightParenthesis;
+  static const InlineObject2EnumFormStringEnum leftParenthesisXyzRightParenthesis = _$inlineObject2EnumFormStringEnum_leftParenthesisXyzRightParenthesis;
 
-  static Serializer<InlineObject2EnumFormString> get serializer => _$inlineObject2EnumFormStringSerializer;
+  static Serializer<InlineObject2EnumFormStringEnum> get serializer => _$inlineObject2EnumFormStringEnumSerializer;
 
-  const InlineObject2EnumFormString._(String name): super(name);
+  const InlineObject2EnumFormStringEnum._(String name): super(name);
 
-  static BuiltSet<InlineObject2EnumFormString> get values => _$inlineObject2EnumFormStringValues;
-  static InlineObject2EnumFormString valueOf(String name) => _$inlineObject2EnumFormStringValueOf(name);
+  static BuiltSet<InlineObject2EnumFormStringEnum> get values => _$inlineObject2EnumFormStringEnumValues;
+  static InlineObject2EnumFormStringEnum valueOf(String name) => _$inlineObject2EnumFormStringEnumValueOf(name);
 }
-
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/map_test.dart
@@ -13,7 +13,7 @@ abstract class MapTest implements Built<MapTest, MapTestBuilder> {
     
     @nullable
     @BuiltValueField(wireName: r'map_of_enum_string')
-    MapTestMapOfEnumString get mapOfEnumString;
+    BuiltMap<String, MapTestInnerEnum> get mapOfEnumString;
     // enum mapOfEnumStringEnum {  UPPER,  lower,  };
     
     @nullable
@@ -31,19 +31,18 @@ abstract class MapTest implements Built<MapTest, MapTestBuilder> {
     static Serializer<MapTest> get serializer => _$mapTestSerializer;
 }
 
-class MapTestMapOfEnumString extends EnumClass {
+class MapTestInnerEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: r'UPPER')
-  static const MapTestMapOfEnumString UPPER = _$mapTestMapOfEnumString_UPPER;
+  static const MapTestInnerEnum UPPER = _$mapTestInnerEnum_UPPER;
   @BuiltValueEnumConst(wireName: r'lower')
-  static const MapTestMapOfEnumString lower = _$mapTestMapOfEnumString_lower;
+  static const MapTestInnerEnum lower = _$mapTestInnerEnum_lower;
 
-  static Serializer<MapTestMapOfEnumString> get serializer => _$mapTestMapOfEnumStringSerializer;
+  static Serializer<MapTestInnerEnum> get serializer => _$mapTestInnerEnumSerializer;
 
-  const MapTestMapOfEnumString._(String name): super(name);
+  const MapTestInnerEnum._(String name): super(name);
 
-  static BuiltSet<MapTestMapOfEnumString> get values => _$mapTestMapOfEnumStringValues;
-  static MapTestMapOfEnumString valueOf(String name) => _$mapTestMapOfEnumStringValueOf(name);
+  static BuiltSet<MapTestInnerEnum> get values => _$mapTestInnerEnumValues;
+  static MapTestInnerEnum valueOf(String name) => _$mapTestInnerEnumValueOf(name);
 }
-
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/order.dart
@@ -25,7 +25,7 @@ abstract class Order implements Built<Order, OrderBuilder> {
     /* Order Status */
     @nullable
     @BuiltValueField(wireName: r'status')
-    OrderStatus get status;
+    OrderStatusEnum get status;
     // enum statusEnum {  placed,  approved,  delivered,  };
     
     @nullable
@@ -39,24 +39,23 @@ abstract class Order implements Built<Order, OrderBuilder> {
     static Serializer<Order> get serializer => _$orderSerializer;
 }
 
-class OrderStatus extends EnumClass {
+class OrderStatusEnum extends EnumClass {
 
   /// Order Status
   @BuiltValueEnumConst(wireName: r'placed')
-  static const OrderStatus placed = _$orderStatus_placed;
+  static const OrderStatusEnum placed = _$orderStatusEnum_placed;
   /// Order Status
   @BuiltValueEnumConst(wireName: r'approved')
-  static const OrderStatus approved = _$orderStatus_approved;
+  static const OrderStatusEnum approved = _$orderStatusEnum_approved;
   /// Order Status
   @BuiltValueEnumConst(wireName: r'delivered')
-  static const OrderStatus delivered = _$orderStatus_delivered;
+  static const OrderStatusEnum delivered = _$orderStatusEnum_delivered;
 
-  static Serializer<OrderStatus> get serializer => _$orderStatusSerializer;
+  static Serializer<OrderStatusEnum> get serializer => _$orderStatusEnumSerializer;
 
-  const OrderStatus._(String name): super(name);
+  const OrderStatusEnum._(String name): super(name);
 
-  static BuiltSet<OrderStatus> get values => _$orderStatusValues;
-  static OrderStatus valueOf(String name) => _$orderStatusValueOf(name);
+  static BuiltSet<OrderStatusEnum> get values => _$orderStatusEnumValues;
+  static OrderStatusEnum valueOf(String name) => _$orderStatusEnumValueOf(name);
 }
-
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/pet.dart
@@ -31,7 +31,7 @@ abstract class Pet implements Built<Pet, PetBuilder> {
     /* pet status in the store */
     @nullable
     @BuiltValueField(wireName: r'status')
-    PetStatus get status;
+    PetStatusEnum get status;
     // enum statusEnum {  available,  pending,  sold,  };
 
     // Boilerplate code needed to wire-up generated code
@@ -41,24 +41,23 @@ abstract class Pet implements Built<Pet, PetBuilder> {
     static Serializer<Pet> get serializer => _$petSerializer;
 }
 
-class PetStatus extends EnumClass {
+class PetStatusEnum extends EnumClass {
 
   /// pet status in the store
   @BuiltValueEnumConst(wireName: r'available')
-  static const PetStatus available = _$petStatus_available;
+  static const PetStatusEnum available = _$petStatusEnum_available;
   /// pet status in the store
   @BuiltValueEnumConst(wireName: r'pending')
-  static const PetStatus pending = _$petStatus_pending;
+  static const PetStatusEnum pending = _$petStatusEnum_pending;
   /// pet status in the store
   @BuiltValueEnumConst(wireName: r'sold')
-  static const PetStatus sold = _$petStatus_sold;
+  static const PetStatusEnum sold = _$petStatusEnum_sold;
 
-  static Serializer<PetStatus> get serializer => _$petStatusSerializer;
+  static Serializer<PetStatusEnum> get serializer => _$petStatusEnumSerializer;
 
-  const PetStatus._(String name): super(name);
+  const PetStatusEnum._(String name): super(name);
 
-  static BuiltSet<PetStatus> get values => _$petStatusValues;
-  static PetStatus valueOf(String name) => _$petStatusValueOf(name);
+  static BuiltSet<PetStatusEnum> get values => _$petStatusEnumValues;
+  static PetStatusEnum valueOf(String name) => _$petStatusEnumValueOf(name);
 }
-
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -159,7 +159,7 @@ class EnumArraysArrayEnumEnum {
   const EnumArraysArrayEnumEnum._(this.value);
 
   /// The underlying value of this enum member.
-  final List<String> value;
+  final String value;
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
@@ -169,9 +169,9 @@ class EnumArraysArrayEnumEnum {
   int get hashCode => toString().hashCode;
 
   @override
-  String toString() => value.toString();
+  String toString() => value;
 
-  List<String> toJson() => value;
+  String toJson() => value;
 
   static const fish = EnumArraysArrayEnumEnum._(r'fish');
   static const crab = EnumArraysArrayEnumEnum._(r'crab');
@@ -193,14 +193,14 @@ class EnumArraysArrayEnumEnum {
           .toList(growable: true == growable);
 }
 
-/// Transformation class that can [encode] an instance of [EnumArraysArrayEnumEnum] to List<String>,
+/// Transformation class that can [encode] an instance of [EnumArraysArrayEnumEnum] to String,
 /// and [decode] dynamic data back to [EnumArraysArrayEnumEnum].
 class EnumArraysArrayEnumEnumTypeTransformer {
   const EnumArraysArrayEnumEnumTypeTransformer._();
 
   factory EnumArraysArrayEnumEnumTypeTransformer() => _instance ??= EnumArraysArrayEnumEnumTypeTransformer._();
 
-  List<String> encode(EnumArraysArrayEnumEnum data) => data.value;
+  String encode(EnumArraysArrayEnumEnum data) => data.value;
 
   /// Decodes a [dynamic value][data] to a EnumArraysArrayEnumEnum.
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object2.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/inline_object2.dart
@@ -80,13 +80,13 @@ class InlineObject2 {
   }
 }
 
-/// Form parameter enum test (string array)
+
 class InlineObject2EnumFormStringArrayEnum {
   /// Instantiate a new enum with the provided [value].
   const InlineObject2EnumFormStringArrayEnum._(this.value);
 
   /// The underlying value of this enum member.
-  final List<String> value;
+  final String value;
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
@@ -96,9 +96,9 @@ class InlineObject2EnumFormStringArrayEnum {
   int get hashCode => toString().hashCode;
 
   @override
-  String toString() => value.toString();
+  String toString() => value;
 
-  List<String> toJson() => value;
+  String toJson() => value;
 
   static const greaterThan = InlineObject2EnumFormStringArrayEnum._(r'>');
   static const dollar = InlineObject2EnumFormStringArrayEnum._(r'$');
@@ -120,14 +120,14 @@ class InlineObject2EnumFormStringArrayEnum {
           .toList(growable: true == growable);
 }
 
-/// Transformation class that can [encode] an instance of [InlineObject2EnumFormStringArrayEnum] to List<String>,
+/// Transformation class that can [encode] an instance of [InlineObject2EnumFormStringArrayEnum] to String,
 /// and [decode] dynamic data back to [InlineObject2EnumFormStringArrayEnum].
 class InlineObject2EnumFormStringArrayEnumTypeTransformer {
   const InlineObject2EnumFormStringArrayEnumTypeTransformer._();
 
   factory InlineObject2EnumFormStringArrayEnumTypeTransformer() => _instance ??= InlineObject2EnumFormStringArrayEnumTypeTransformer._();
 
-  List<String> encode(InlineObject2EnumFormStringArrayEnum data) => data.value;
+  String encode(InlineObject2EnumFormStringArrayEnum data) => data.value;
 
   /// Decodes a [dynamic value][data] to a InlineObject2EnumFormStringArrayEnum.
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
@@ -22,7 +22,7 @@ class MapTest {
   Map<String, Map<String, String>> mapMapOfString;
 
   
-  Map<String, dynamic> mapOfEnumString;
+  Map<String, MapTestInnerEnum> mapOfEnumString;
 
   
   Map<String, bool> directMap;
@@ -109,55 +109,55 @@ class MapTest {
 }
 
 
-class MapTestMapOfEnumStringEnum {
+class MapTestInnerEnum {
   /// Instantiate a new enum with the provided [value].
-  const MapTestMapOfEnumStringEnum._(this.value);
+  const MapTestInnerEnum._(this.value);
 
   /// The underlying value of this enum member.
-  final Map<String, String> value;
+  final String value;
 
   @override
   bool operator ==(Object other) => identical(this, other) ||
-      other is MapTestMapOfEnumStringEnum && other.value == value;
+      other is MapTestInnerEnum && other.value == value;
 
   @override
   int get hashCode => toString().hashCode;
 
   @override
-  String toString() => value.toString();
+  String toString() => value;
 
-  Map<String, String> toJson() => value;
+  String toJson() => value;
 
-  static const UPPER = MapTestMapOfEnumStringEnum._(r'UPPER');
-  static const lower = MapTestMapOfEnumStringEnum._(r'lower');
+  static const UPPER = MapTestInnerEnum._(r'UPPER');
+  static const lower = MapTestInnerEnum._(r'lower');
 
-  /// List of all possible values in this [enum][MapTestMapOfEnumStringEnum].
-  static const values = <MapTestMapOfEnumStringEnum>[
+  /// List of all possible values in this [enum][MapTestInnerEnum].
+  static const values = <MapTestInnerEnum>[
     UPPER,
     lower,
   ];
 
-  static MapTestMapOfEnumStringEnum fromJson(dynamic value) =>
-    MapTestMapOfEnumStringEnumTypeTransformer().decode(value);
+  static MapTestInnerEnum fromJson(dynamic value) =>
+    MapTestInnerEnumTypeTransformer().decode(value);
 
-  static List<MapTestMapOfEnumStringEnum> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
+  static List<MapTestInnerEnum> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
     json == null || json.isEmpty
-      ? true == emptyIsNull ? null : <MapTestMapOfEnumStringEnum>[]
+      ? true == emptyIsNull ? null : <MapTestInnerEnum>[]
       : json
-          .map((value) => MapTestMapOfEnumStringEnum.fromJson(value))
+          .map((value) => MapTestInnerEnum.fromJson(value))
           .toList(growable: true == growable);
 }
 
-/// Transformation class that can [encode] an instance of [MapTestMapOfEnumStringEnum] to Map<String, String>,
-/// and [decode] dynamic data back to [MapTestMapOfEnumStringEnum].
-class MapTestMapOfEnumStringEnumTypeTransformer {
-  const MapTestMapOfEnumStringEnumTypeTransformer._();
+/// Transformation class that can [encode] an instance of [MapTestInnerEnum] to String,
+/// and [decode] dynamic data back to [MapTestInnerEnum].
+class MapTestInnerEnumTypeTransformer {
+  const MapTestInnerEnumTypeTransformer._();
 
-  factory MapTestMapOfEnumStringEnumTypeTransformer() => _instance ??= MapTestMapOfEnumStringEnumTypeTransformer._();
+  factory MapTestInnerEnumTypeTransformer() => _instance ??= MapTestInnerEnumTypeTransformer._();
 
-  Map<String, String> encode(MapTestMapOfEnumStringEnum data) => data.value;
+  String encode(MapTestInnerEnum data) => data.value;
 
-  /// Decodes a [dynamic value][data] to a MapTestMapOfEnumStringEnum.
+  /// Decodes a [dynamic value][data] to a MapTestInnerEnum.
   ///
   /// If [allowNull] is true and the [dynamic value][data] cannot be decoded successfully,
   /// then null is returned. However, if [allowNull] is false and the [dynamic value][data]
@@ -165,10 +165,10 @@ class MapTestMapOfEnumStringEnumTypeTransformer {
   ///
   /// The [allowNull] is very handy when an API changes and a new enum value is added or removed,
   /// and users are still using an old app with the old code.
-  MapTestMapOfEnumStringEnum decode(dynamic data, {bool allowNull}) {
+  MapTestInnerEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case r'UPPER': return MapTestMapOfEnumStringEnum.UPPER;
-      case r'lower': return MapTestMapOfEnumStringEnum.lower;
+      case r'UPPER': return MapTestInnerEnum.UPPER;
+      case r'lower': return MapTestInnerEnum.lower;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');
@@ -177,7 +177,7 @@ class MapTestMapOfEnumStringEnumTypeTransformer {
     return null;
   }
 
-  /// Singleton [MapTestMapOfEnumStringEnumTypeTransformer] instance.
-  static MapTestMapOfEnumStringEnumTypeTransformer _instance;
+  /// Singleton [MapTestInnerEnumTypeTransformer] instance.
+  static MapTestInnerEnumTypeTransformer _instance;
 }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. --
* correctly generate enums from `mostInnerItems`
* use `datatypeWithEnum` which should always be he correct type
* dart generators prefix inner enums with the classname of the containing class, ensure datatypeWithEnum always matches
* use same `Enum` suffix in dart-dio like in the dart generator (this is a breaking change for dart-dio enum names)

Note:
The serialization code for maps of enums (and some maps in general) is still broken in the dart generator and not part of this PR.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)