### PR TITLE
[dart-dio] Fix x-www-form-urlencoded body not working

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -40,25 +40,28 @@ class {{classname}} {
         List<String> contentTypes = [{{#consumes}}"{{{mediaType}}}"{{^-last}},{{/-last}}{{/consumes}}];
 
         {{#hasFormParams}}
-        Map<String, dynamic> formData = {};
-        {{#formParams}}
+        final Map<String, dynamic> formData = {};
         {{#isMultipart}}
-            {{^isFile}}
-                if ({{paramName}} != null) {
-                    formData[r'{{baseName}}'] = parameterToString(_serializers, {{paramName}});
-                }
-            {{/isFile}}
-            {{#isFile}}
-                if ({{paramName}} != null) {
-                    formData[r'{{baseName}}'] = MultipartFile.fromBytes({{paramName}}, filename: r'{{baseName}}');
-                }
-            {{/isFile}}
-        {{/isMultipart}}
-        {{^isMultipart}}
+        {{#formParams}}
+        {{^isFile}}
+        if ({{paramName}} != null) {
             formData[r'{{baseName}}'] = parameterToString(_serializers, {{paramName}});
-        {{/isMultipart}}
+        }
+        {{/isFile}}
+        {{#isFile}}
+        if ({{paramName}} != null) {
+            formData[r'{{baseName}}'] = MultipartFile.fromBytes({{paramName}}, filename: r'{{baseName}}');
+        }
+        {{/isFile}}
         {{/formParams}}
         bodyData = FormData.fromMap(formData);
+        {{/isMultipart}}
+        {{^isMultipart}}
+        {{#formParams}}
+        formData['{{baseName}}'] = parameterToString(_serializers, {{paramName}});
+        {{/formParams}}
+        bodyData = formData;
+        {{/isMultipart}}
         {{/hasFormParams}}
 
         {{#bodyParam}}

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -295,10 +295,10 @@ class PetApi {
 
         List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
-        Map<String, dynamic> formData = {};
-            formData[r'name'] = parameterToString(_serializers, name);
-            formData[r'status'] = parameterToString(_serializers, status);
-        bodyData = FormData.fromMap(formData);
+        final Map<String, dynamic> formData = {};
+        formData['name'] = parameterToString(_serializers, name);
+        formData['status'] = parameterToString(_serializers, status);
+        bodyData = formData;
 
 
             return _dio.request(
@@ -334,13 +334,13 @@ class PetApi {
 
         List<String> contentTypes = ["multipart/form-data"];
 
-        Map<String, dynamic> formData = {};
-                if (additionalMetadata != null) {
-                    formData[r'additionalMetadata'] = parameterToString(_serializers, additionalMetadata);
-                }
-                if (file != null) {
-                    formData[r'file'] = MultipartFile.fromBytes(file, filename: r'file');
-                }
+        final Map<String, dynamic> formData = {};
+        if (additionalMetadata != null) {
+            formData[r'additionalMetadata'] = parameterToString(_serializers, additionalMetadata);
+        }
+        if (file != null) {
+            formData[r'file'] = MultipartFile.fromBytes(file, filename: r'file');
+        }
         bodyData = FormData.fromMap(formData);
 
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -323,10 +323,10 @@ class PetApi {
 
         List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
-        Map<String, dynamic> formData = {};
-            formData[r'name'] = parameterToString(_serializers, name);
-            formData[r'status'] = parameterToString(_serializers, status);
-        bodyData = FormData.fromMap(formData);
+        final Map<String, dynamic> formData = {};
+        formData['name'] = parameterToString(_serializers, name);
+        formData['status'] = parameterToString(_serializers, status);
+        bodyData = formData;
 
 
             return _dio.request(
@@ -362,13 +362,13 @@ class PetApi {
 
         List<String> contentTypes = ["multipart/form-data"];
 
-        Map<String, dynamic> formData = {};
-                if (additionalMetadata != null) {
-                    formData[r'additionalMetadata'] = parameterToString(_serializers, additionalMetadata);
-                }
-                if (file != null) {
-                    formData[r'file'] = MultipartFile.fromBytes(file, filename: r'file');
-                }
+        final Map<String, dynamic> formData = {};
+        if (additionalMetadata != null) {
+            formData[r'additionalMetadata'] = parameterToString(_serializers, additionalMetadata);
+        }
+        if (file != null) {
+            formData[r'file'] = MultipartFile.fromBytes(file, filename: r'file');
+        }
         bodyData = FormData.fromMap(formData);
 
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -459,22 +459,22 @@ class FakeApi {
 
         List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
-        Map<String, dynamic> formData = {};
-            formData[r'integer'] = parameterToString(_serializers, integer);
-            formData[r'int32'] = parameterToString(_serializers, int32);
-            formData[r'int64'] = parameterToString(_serializers, int64);
-            formData[r'number'] = parameterToString(_serializers, number);
-            formData[r'float'] = parameterToString(_serializers, float);
-            formData[r'double'] = parameterToString(_serializers, double_);
-            formData[r'string'] = parameterToString(_serializers, string);
-            formData[r'pattern_without_delimiter'] = parameterToString(_serializers, patternWithoutDelimiter);
-            formData[r'byte'] = parameterToString(_serializers, byte);
-            formData[r'binary'] = parameterToString(_serializers, binary);
-            formData[r'date'] = parameterToString(_serializers, date);
-            formData[r'dateTime'] = parameterToString(_serializers, dateTime);
-            formData[r'password'] = parameterToString(_serializers, password);
-            formData[r'callback'] = parameterToString(_serializers, callback);
-        bodyData = FormData.fromMap(formData);
+        final Map<String, dynamic> formData = {};
+        formData['integer'] = parameterToString(_serializers, integer);
+        formData['int32'] = parameterToString(_serializers, int32);
+        formData['int64'] = parameterToString(_serializers, int64);
+        formData['number'] = parameterToString(_serializers, number);
+        formData['float'] = parameterToString(_serializers, float);
+        formData['double'] = parameterToString(_serializers, double_);
+        formData['string'] = parameterToString(_serializers, string);
+        formData['pattern_without_delimiter'] = parameterToString(_serializers, patternWithoutDelimiter);
+        formData['byte'] = parameterToString(_serializers, byte);
+        formData['binary'] = parameterToString(_serializers, binary);
+        formData['date'] = parameterToString(_serializers, date);
+        formData['dateTime'] = parameterToString(_serializers, dateTime);
+        formData['password'] = parameterToString(_serializers, password);
+        formData['callback'] = parameterToString(_serializers, callback);
+        bodyData = formData;
 
 
             return _dio.request(
@@ -516,10 +516,10 @@ class FakeApi {
 
         List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
-        Map<String, dynamic> formData = {};
-            formData[r'enum_form_string_array'] = parameterToString(_serializers, enumFormStringArray);
-            formData[r'enum_form_string'] = parameterToString(_serializers, enumFormString);
-        bodyData = FormData.fromMap(formData);
+        final Map<String, dynamic> formData = {};
+        formData['enum_form_string_array'] = parameterToString(_serializers, enumFormStringArray);
+        formData['enum_form_string'] = parameterToString(_serializers, enumFormString);
+        bodyData = formData;
 
 
             return _dio.request(
@@ -634,10 +634,10 @@ class FakeApi {
 
         List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
-        Map<String, dynamic> formData = {};
-            formData[r'param'] = parameterToString(_serializers, param);
-            formData[r'param2'] = parameterToString(_serializers, param2);
-        bodyData = FormData.fromMap(formData);
+        final Map<String, dynamic> formData = {};
+        formData['param'] = parameterToString(_serializers, param);
+        formData['param2'] = parameterToString(_serializers, param2);
+        bodyData = formData;
 
 
             return _dio.request(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -295,10 +295,10 @@ class PetApi {
 
         List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
-        Map<String, dynamic> formData = {};
-            formData[r'name'] = parameterToString(_serializers, name);
-            formData[r'status'] = parameterToString(_serializers, status);
-        bodyData = FormData.fromMap(formData);
+        final Map<String, dynamic> formData = {};
+        formData['name'] = parameterToString(_serializers, name);
+        formData['status'] = parameterToString(_serializers, status);
+        bodyData = formData;
 
 
             return _dio.request(
@@ -334,13 +334,13 @@ class PetApi {
 
         List<String> contentTypes = ["multipart/form-data"];
 
-        Map<String, dynamic> formData = {};
-                if (additionalMetadata != null) {
-                    formData[r'additionalMetadata'] = parameterToString(_serializers, additionalMetadata);
-                }
-                if (file != null) {
-                    formData[r'file'] = MultipartFile.fromBytes(file, filename: r'file');
-                }
+        final Map<String, dynamic> formData = {};
+        if (additionalMetadata != null) {
+            formData[r'additionalMetadata'] = parameterToString(_serializers, additionalMetadata);
+        }
+        if (file != null) {
+            formData[r'file'] = MultipartFile.fromBytes(file, filename: r'file');
+        }
         bodyData = FormData.fromMap(formData);
 
 
@@ -391,13 +391,13 @@ class PetApi {
 
         List<String> contentTypes = ["multipart/form-data"];
 
-        Map<String, dynamic> formData = {};
-                if (additionalMetadata != null) {
-                    formData[r'additionalMetadata'] = parameterToString(_serializers, additionalMetadata);
-                }
-                if (requiredFile != null) {
-                    formData[r'requiredFile'] = MultipartFile.fromBytes(requiredFile, filename: r'requiredFile');
-                }
+        final Map<String, dynamic> formData = {};
+        if (additionalMetadata != null) {
+            formData[r'additionalMetadata'] = parameterToString(_serializers, additionalMetadata);
+        }
+        if (requiredFile != null) {
+            formData[r'requiredFile'] = MultipartFile.fromBytes(requiredFile, filename: r'requiredFile');
+        }
         bodyData = FormData.fromMap(formData);
 
 


### PR DESCRIPTION
* only use `FormData.fromMap()` for multipart content, `FormData` does not work with `x-www-form-urlencoded`
* use a basic map for `x-www-form-urlencoded` content
* fix formatting

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)
--


