### PR TITLE
Fixed the query string for HttpSigning core vs dotnet47

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/HttpSigningConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/HttpSigningConfiguration.mustache
@@ -123,7 +123,8 @@ namespace {{packageName}}.Client
             var httpValues = HttpUtility.ParseQueryString(String.Empty);
             foreach (var parameter in requestOptions.QueryParameters)
             {
-                if (parameter.Value.Count > 1)
+#if (NETCOREAPP)
+				if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
@@ -132,13 +133,25 @@ namespace {{packageName}}.Client
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
-
-                }
+					httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+				}
+#else
+				if (parameter.Value.Count > 1)
+					{ // array
+						foreach (var value in parameter.Value)
+						{
+							httpValues.Add(parameter.Key + "[]", value);
+						}
+					}
+					else
+					{
+						httpValues.Add(parameter.Key, parameter.Value[0]);
+					}
+#endif
             }
             var uriBuilder = new UriBuilder(string.Concat(basePath, path));
-            uriBuilder.Query = httpValues.ToString();
-
+			uriBuilder.Query = httpValues.ToString().Replace("+", "%20");
+            
             var dateTime = DateTime.Now;
             String Digest = String.Empty;
 

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/HttpSigningConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/HttpSigningConfiguration.mustache
@@ -124,7 +124,7 @@ namespace {{packageName}}.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-				if (parameter.Value.Count > 1)
+                if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
@@ -133,24 +133,24 @@ namespace {{packageName}}.Client
                 }
                 else
                 {
-					httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
-				}
+                httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                }
 #else
-				if (parameter.Value.Count > 1)
-					{ // array
-						foreach (var value in parameter.Value)
-						{
-							httpValues.Add(parameter.Key + "[]", value);
-						}
-					}
-					else
-					{
-						httpValues.Add(parameter.Key, parameter.Value[0]);
-					}
+                if (parameter.Value.Count > 1)
+                    { // array
+                    foreach (var value in parameter.Value)
+                    {
+                        httpValues.Add(parameter.Key + "[]", value);
+                    }
+                    }
+                    else
+                    {
+                        httpValues.Add(parameter.Key, parameter.Value[0]);
+                    }
 #endif
             }
             var uriBuilder = new UriBuilder(string.Concat(basePath, path));
-			uriBuilder.Query = httpValues.ToString().Replace("+", "%20");
+            uriBuilder.Query = httpValues.ToString().Replace("+", "%20");
             
             var dateTime = DateTime.Now;
             String Digest = String.Empty;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -123,7 +123,8 @@ namespace Org.OpenAPITools.Client
             var httpValues = HttpUtility.ParseQueryString(String.Empty);
             foreach (var parameter in requestOptions.QueryParameters)
             {
-                if (parameter.Value.Count > 1)
+#if (NETCOREAPP)
+				if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
@@ -132,13 +133,25 @@ namespace Org.OpenAPITools.Client
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
-
-                }
+					httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+				}
+#else
+				if (parameter.Value.Count > 1)
+					{ // array
+						foreach (var value in parameter.Value)
+						{
+							httpValues.Add(parameter.Key + "[]", value);
+						}
+					}
+					else
+					{
+						httpValues.Add(parameter.Key, parameter.Value[0]);
+					}
+#endif
             }
             var uriBuilder = new UriBuilder(string.Concat(basePath, path));
-            uriBuilder.Query = httpValues.ToString();
-
+			uriBuilder.Query = httpValues.ToString().Replace("+", "%20");
+            
             var dateTime = DateTime.Now;
             String Digest = String.Empty;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-				if (parameter.Value.Count > 1)
+                if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
@@ -133,24 +133,24 @@ namespace Org.OpenAPITools.Client
                 }
                 else
                 {
-					httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
-				}
+                httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                }
 #else
-				if (parameter.Value.Count > 1)
-					{ // array
-						foreach (var value in parameter.Value)
-						{
-							httpValues.Add(parameter.Key + "[]", value);
-						}
-					}
-					else
-					{
-						httpValues.Add(parameter.Key, parameter.Value[0]);
-					}
+                if (parameter.Value.Count > 1)
+                    { // array
+                    foreach (var value in parameter.Value)
+                    {
+                        httpValues.Add(parameter.Key + "[]", value);
+                    }
+                    }
+                    else
+                    {
+                        httpValues.Add(parameter.Key, parameter.Value[0]);
+                    }
 #endif
             }
             var uriBuilder = new UriBuilder(string.Concat(basePath, path));
-			uriBuilder.Query = httpValues.ToString().Replace("+", "%20");
+            uriBuilder.Query = httpValues.ToString().Replace("+", "%20");
             
             var dateTime = DateTime.Now;
             String Digest = String.Empty;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -123,7 +123,8 @@ namespace Org.OpenAPITools.Client
             var httpValues = HttpUtility.ParseQueryString(String.Empty);
             foreach (var parameter in requestOptions.QueryParameters)
             {
-                if (parameter.Value.Count > 1)
+#if (NETCOREAPP)
+				if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
@@ -132,13 +133,25 @@ namespace Org.OpenAPITools.Client
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
-
-                }
+					httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+				}
+#else
+				if (parameter.Value.Count > 1)
+					{ // array
+						foreach (var value in parameter.Value)
+						{
+							httpValues.Add(parameter.Key + "[]", value);
+						}
+					}
+					else
+					{
+						httpValues.Add(parameter.Key, parameter.Value[0]);
+					}
+#endif
             }
             var uriBuilder = new UriBuilder(string.Concat(basePath, path));
-            uriBuilder.Query = httpValues.ToString();
-
+			uriBuilder.Query = httpValues.ToString().Replace("+", "%20");
+            
             var dateTime = DateTime.Now;
             String Digest = String.Empty;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-				if (parameter.Value.Count > 1)
+                if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
@@ -133,24 +133,24 @@ namespace Org.OpenAPITools.Client
                 }
                 else
                 {
-					httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
-				}
+                httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                }
 #else
-				if (parameter.Value.Count > 1)
-					{ // array
-						foreach (var value in parameter.Value)
-						{
-							httpValues.Add(parameter.Key + "[]", value);
-						}
-					}
-					else
-					{
-						httpValues.Add(parameter.Key, parameter.Value[0]);
-					}
+                if (parameter.Value.Count > 1)
+                    { // array
+                    foreach (var value in parameter.Value)
+                    {
+                        httpValues.Add(parameter.Key + "[]", value);
+                    }
+                    }
+                    else
+                    {
+                        httpValues.Add(parameter.Key, parameter.Value[0]);
+                    }
 #endif
             }
             var uriBuilder = new UriBuilder(string.Concat(basePath, path));
-			uriBuilder.Query = httpValues.ToString().Replace("+", "%20");
+            uriBuilder.Query = httpValues.ToString().Replace("+", "%20");
             
             var dateTime = DateTime.Now;
             String Digest = String.Empty;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -123,7 +123,8 @@ namespace Org.OpenAPITools.Client
             var httpValues = HttpUtility.ParseQueryString(String.Empty);
             foreach (var parameter in requestOptions.QueryParameters)
             {
-                if (parameter.Value.Count > 1)
+#if (NETCOREAPP)
+				if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
@@ -132,13 +133,25 @@ namespace Org.OpenAPITools.Client
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
-
-                }
+					httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+				}
+#else
+				if (parameter.Value.Count > 1)
+					{ // array
+						foreach (var value in parameter.Value)
+						{
+							httpValues.Add(parameter.Key + "[]", value);
+						}
+					}
+					else
+					{
+						httpValues.Add(parameter.Key, parameter.Value[0]);
+					}
+#endif
             }
             var uriBuilder = new UriBuilder(string.Concat(basePath, path));
-            uriBuilder.Query = httpValues.ToString();
-
+			uriBuilder.Query = httpValues.ToString().Replace("+", "%20");
+            
             var dateTime = DateTime.Now;
             String Digest = String.Empty;
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
-				if (parameter.Value.Count > 1)
+                if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
@@ -133,24 +133,24 @@ namespace Org.OpenAPITools.Client
                 }
                 else
                 {
-					httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
-				}
+                httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                }
 #else
-				if (parameter.Value.Count > 1)
-					{ // array
-						foreach (var value in parameter.Value)
-						{
-							httpValues.Add(parameter.Key + "[]", value);
-						}
-					}
-					else
-					{
-						httpValues.Add(parameter.Key, parameter.Value[0]);
-					}
+                if (parameter.Value.Count > 1)
+                    { // array
+                    foreach (var value in parameter.Value)
+                    {
+                        httpValues.Add(parameter.Key + "[]", value);
+                    }
+                    }
+                    else
+                    {
+                        httpValues.Add(parameter.Key, parameter.Value[0]);
+                    }
 #endif
             }
             var uriBuilder = new UriBuilder(string.Concat(basePath, path));
-			uriBuilder.Query = httpValues.ToString().Replace("+", "%20");
+            uriBuilder.Query = httpValues.ToString().Replace("+", "%20");
             
             var dateTime = DateTime.Now;
             String Digest = String.Empty;


### PR DESCRIPTION
Query string for HttpSigning has issue due peculiar behavior of HttpUtility ParseQueryString for dotnet core and dotnet47. 
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@wing328 