### PR TITLE
[C][Client] Fix coredump when releasing the memory of an incompleted model

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -214,59 +214,92 @@ void {{classname}}_free({{classname}}_t *{{classname}}) {
     {{^isPrimitiveType}}
     {{#isModel}}
     {{^isEnum}}
-    {{{complexType}}}_free({{{classname}}}->{{{name}}});
+    if ({{{classname}}}->{{{name}}}) {
+        {{{complexType}}}_free({{{classname}}}->{{{name}}});
+        {{classname}}->{{name}} = NULL;
+    }
     {{/isEnum}}
     {{/isModel}}
     {{#isUuid}}
-    free({{{classname}}}->{{{name}}});
+    if ({{{classname}}}->{{{name}}}) {
+        free({{{classname}}}->{{{name}}});
+        {{classname}}->{{name}} = NULL;
+    }
     {{/isUuid}}
     {{#isEmail}}
-    free({{{classname}}}->{{{name}}});
+    if ({{{classname}}}->{{{name}}}) {
+        free({{{classname}}}->{{{name}}});
+        {{classname}}->{{name}} = NULL;
+    }
     {{/isEmail}}
     {{#isFreeFormObject}}
-    object_free({{{classname}}}->{{{name}}});
+    if ({{{classname}}}->{{{name}}}) {
+        object_free({{{classname}}}->{{{name}}});
+        {{classname}}->{{name}} = NULL;
+    }
     {{/isFreeFormObject}}
     {{/isPrimitiveType}}
     {{#isPrimitiveType}}
     {{^isEnum}}
     {{#isString}}
-    free({{{classname}}}->{{{name}}});
+    if ({{{classname}}}->{{{name}}}) {
+        free({{{classname}}}->{{{name}}});
+        {{classname}}->{{name}} = NULL;
+    }
     {{/isString}}
     {{/isEnum}}
     {{#isBinary}}
-    free({{{classname}}}->{{{name}}}->data);
+    if ({{{classname}}}->{{{name}}}) {
+        free({{{classname}}}->{{{name}}}->data);
+        {{classname}}->{{name}} = NULL;
+    }
     {{/isBinary}}
     {{#isDate}}
-    free({{{classname}}}->{{{name}}});
+    if ({{{classname}}}->{{{name}}}) {
+        free({{{classname}}}->{{{name}}});
+        {{classname}}->{{name}} = NULL;
+    }
     {{/isDate}}
     {{#isDateTime}}
-    free({{{classname}}}->{{{name}}});
+    if ({{{classname}}}->{{{name}}}) {
+        free({{{classname}}}->{{{name}}});
+        {{classname}}->{{name}} = NULL;
+    }
     {{/isDateTime}}
     {{/isPrimitiveType}}
     {{/isContainer}}
     {{#isContainer}}
     {{#isArray}}
     {{#isPrimitiveType}}
-    list_ForEach(listEntry, {{classname}}->{{name}}) {
-        free(listEntry->data);
+    if ({{{classname}}}->{{{name}}}) {
+        list_ForEach(listEntry, {{classname}}->{{name}}) {
+            free(listEntry->data);
+        }
+        list_free({{classname}}->{{name}});
+        {{classname}}->{{name}} = NULL;
     }
-    list_free({{classname}}->{{name}});
     {{/isPrimitiveType}}
     {{^isPrimitiveType}}
-    list_ForEach(listEntry, {{classname}}->{{name}}) {
-        {{complexType}}_free(listEntry->data);
+    if ({{{classname}}}->{{{name}}}) {
+        list_ForEach(listEntry, {{classname}}->{{name}}) {
+            {{complexType}}_free(listEntry->data);
+        }
+        list_free({{classname}}->{{name}});
+        {{classname}}->{{name}} = NULL;
     }
-    list_free({{classname}}->{{name}});
     {{/isPrimitiveType}}
     {{/isArray}}
     {{#isMap}}
-    list_ForEach(listEntry, {{classname}}->{{name}}) {
-        keyValuePair_t *localKeyValue = (keyValuePair_t*) listEntry->data;
-        free (localKeyValue->key);
-        free (localKeyValue->value);
-        keyValuePair_free(localKeyValue);
+    if ({{{classname}}}->{{{name}}}) {
+        list_ForEach(listEntry, {{classname}}->{{name}}) {
+            keyValuePair_t *localKeyValue = (keyValuePair_t*) listEntry->data;
+            free (localKeyValue->key);
+            free (localKeyValue->value);
+            keyValuePair_free(localKeyValue);
+        }
+        list_free({{classname}}->{{name}});
+        {{classname}}->{{name}} = NULL;
     }
-    list_free({{classname}}->{{name}});
     {{/isMap}}
     {{/isContainer}}
     {{/vars}}

--- a/samples/client/petstore/c/model/api_response.c
+++ b/samples/client/petstore/c/model/api_response.c
@@ -27,8 +27,14 @@ void api_response_free(api_response_t *api_response) {
         return ;
     }
     listEntry_t *listEntry;
-    free(api_response->type);
-    free(api_response->message);
+    if (api_response->type) {
+        free(api_response->type);
+        api_response->type = NULL;
+    }
+    if (api_response->message) {
+        free(api_response->message);
+        api_response->message = NULL;
+    }
     free(api_response);
 }
 

--- a/samples/client/petstore/c/model/category.c
+++ b/samples/client/petstore/c/model/category.c
@@ -25,7 +25,10 @@ void category_free(category_t *category) {
         return ;
     }
     listEntry_t *listEntry;
-    free(category->name);
+    if (category->name) {
+        free(category->name);
+        category->name = NULL;
+    }
     free(category);
 }
 

--- a/samples/client/petstore/c/model/order.c
+++ b/samples/client/petstore/c/model/order.c
@@ -50,7 +50,10 @@ void order_free(order_t *order) {
         return ;
     }
     listEntry_t *listEntry;
-    free(order->ship_date);
+    if (order->ship_date) {
+        free(order->ship_date);
+        order->ship_date = NULL;
+    }
     free(order);
 }
 

--- a/samples/client/petstore/c/model/pet.c
+++ b/samples/client/petstore/c/model/pet.c
@@ -50,16 +50,28 @@ void pet_free(pet_t *pet) {
         return ;
     }
     listEntry_t *listEntry;
-    category_free(pet->category);
-    free(pet->name);
-    list_ForEach(listEntry, pet->photo_urls) {
-        free(listEntry->data);
+    if (pet->category) {
+        category_free(pet->category);
+        pet->category = NULL;
     }
-    list_free(pet->photo_urls);
-    list_ForEach(listEntry, pet->tags) {
-        tag_free(listEntry->data);
+    if (pet->name) {
+        free(pet->name);
+        pet->name = NULL;
     }
-    list_free(pet->tags);
+    if (pet->photo_urls) {
+        list_ForEach(listEntry, pet->photo_urls) {
+            free(listEntry->data);
+        }
+        list_free(pet->photo_urls);
+        pet->photo_urls = NULL;
+    }
+    if (pet->tags) {
+        list_ForEach(listEntry, pet->tags) {
+            tag_free(listEntry->data);
+        }
+        list_free(pet->tags);
+        pet->tags = NULL;
+    }
     free(pet);
 }
 

--- a/samples/client/petstore/c/model/tag.c
+++ b/samples/client/petstore/c/model/tag.c
@@ -25,7 +25,10 @@ void tag_free(tag_t *tag) {
         return ;
     }
     listEntry_t *listEntry;
-    free(tag->name);
+    if (tag->name) {
+        free(tag->name);
+        tag->name = NULL;
+    }
     free(tag);
 }
 

--- a/samples/client/petstore/c/model/user.c
+++ b/samples/client/petstore/c/model/user.c
@@ -37,12 +37,30 @@ void user_free(user_t *user) {
         return ;
     }
     listEntry_t *listEntry;
-    free(user->username);
-    free(user->first_name);
-    free(user->last_name);
-    free(user->email);
-    free(user->password);
-    free(user->phone);
+    if (user->username) {
+        free(user->username);
+        user->username = NULL;
+    }
+    if (user->first_name) {
+        free(user->first_name);
+        user->first_name = NULL;
+    }
+    if (user->last_name) {
+        free(user->last_name);
+        user->last_name = NULL;
+    }
+    if (user->email) {
+        free(user->email);
+        user->email = NULL;
+    }
+    if (user->password) {
+        free(user->password);
+        user->password = NULL;
+    }
+    if (user->phone) {
+        free(user->phone);
+        user->phone = NULL;
+    }
     free(user);
 }
 


### PR DESCRIPTION
Sometimes, the model is not created completely due to some error (e.g. JSON string of a data field of the model cannot be parsed). Only a part of model is created.

At this time, we need check whether the pointer pointing to the data field is valid to avoid core-dump before releasing its memory.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant @michelealbano