### PR TITLE
[dart][dart-dio] Correctly type responses and futures

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -19,7 +19,7 @@ class {{classname}} {
     /// {{{summary}}}
     ///
     /// {{{notes}}}
-    Future<Response{{#returnType}}<{{{returnType}}}>{{/returnType}}>{{nickname}}({{^hasRequiredParams}}{ {{/hasRequiredParams}}{{#requiredParams}}
+    Future<Response<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>> {{nickname}}({{^hasRequiredParams}}{ {{/hasRequiredParams}}{{#requiredParams}}
         {{{dataType}}} {{paramName}},{{#-last}} { {{/-last}}{{/requiredParams}}{{#optionalParams}}
         {{{dataType}}} {{paramName}},{{/optionalParams}}
         CancelToken cancelToken,

--- a/modules/openapi-generator/src/main/resources/dart2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api.mustache
@@ -49,7 +49,7 @@ class {{{classname}}} {
   ///
     {{/-last}}
   {{/allParams}}
-  {{#returnType}}Future<Response> {{/returnType}}{{^returnType}}Future {{/returnType}}{{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}} {{{paramName}}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
+  Future<Response> {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}} {{{paramName}}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
   {{#hasParams}}
     // Verify required params are set.
     {{#allParams}}
@@ -175,7 +175,7 @@ class {{{classname}}} {
   ///
     {{/-last}}
   {{/allParams}}
-  {{#returnType}}Future<{{{returnType}}}> {{/returnType}}{{^returnType}}Future {{/returnType}}{{{nickname}}}({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}} {{{paramName}}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
+  Future<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {{{nickname}}}({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}} {{{paramName}}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
     final response = await {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{paramName}}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}} {{#allParams}}{{^required}}{{{paramName}}}: {{{paramName}}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}} {{/hasOptionalParams}});
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -18,7 +18,7 @@ class PetApi {
     /// Add a new pet to the store
     ///
     /// 
-    Future<Response>addPet(
+    Future<Response<void>> addPet(
         Pet body, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -69,7 +69,7 @@ class PetApi {
     /// Deletes a pet
     ///
     /// 
-    Future<Response>deletePet(
+    Future<Response<void>> deletePet(
         int petId, { 
         String apiKey,
         CancelToken cancelToken,
@@ -115,7 +115,7 @@ class PetApi {
     /// Finds Pets by status
     ///
     /// Multiple status values can be provided with comma separated strings
-    Future<Response<BuiltList<Pet>>>findPetsByStatus(
+    Future<Response<BuiltList<Pet>>> findPetsByStatus(
         BuiltList<String> status, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -174,7 +174,7 @@ class PetApi {
     /// Finds Pets by tags
     ///
     /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-    Future<Response<BuiltList<Pet>>>findPetsByTags(
+    Future<Response<BuiltList<Pet>>> findPetsByTags(
         BuiltList<String> tags, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -233,7 +233,7 @@ class PetApi {
     /// Find pet by ID
     ///
     /// Returns a single pet
-    Future<Response<Pet>>getPetById(
+    Future<Response<Pet>> getPetById(
         int petId, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -292,7 +292,7 @@ class PetApi {
     /// Update an existing pet
     ///
     /// 
-    Future<Response>updatePet(
+    Future<Response<void>> updatePet(
         Pet body, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -343,7 +343,7 @@ class PetApi {
     /// Updates a pet in the store with form data
     ///
     /// 
-    Future<Response>updatePetWithForm(
+    Future<Response<void>> updatePetWithForm(
         int petId, { 
         String name,
         String status,
@@ -396,7 +396,7 @@ class PetApi {
     /// uploads an image
     ///
     /// 
-    Future<Response<ApiResponse>>uploadFile(
+    Future<Response<ApiResponse>> uploadFile(
         int petId, { 
         String additionalMetadata,
         Uint8List file,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -15,7 +15,7 @@ class StoreApi {
     /// Delete purchase order by ID
     ///
     /// For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-    Future<Response>deleteOrder(
+    Future<Response<void>> deleteOrder(
         String orderId, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -54,7 +54,7 @@ class StoreApi {
     /// Returns pet inventories by status
     ///
     /// Returns a map of status codes to quantities
-    Future<Response<BuiltMap<String, int>>>getInventory({ 
+    Future<Response<BuiltMap<String, int>>> getInventory({ 
         CancelToken cancelToken,
         Map<String, String> headers,
         ProgressCallback onSendProgress,
@@ -113,7 +113,7 @@ class StoreApi {
     /// Find purchase order by ID
     ///
     /// For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-    Future<Response<Order>>getOrderById(
+    Future<Response<Order>> getOrderById(
         int orderId, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -165,7 +165,7 @@ class StoreApi {
     /// Place an order for a pet
     ///
     /// 
-    Future<Response<Order>>placeOrder(
+    Future<Response<Order>> placeOrder(
         Order body, { 
         CancelToken cancelToken,
         Map<String, String> headers,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -15,7 +15,7 @@ class UserApi {
     /// Create user
     ///
     /// This can only be done by the logged in user.
-    Future<Response>createUser(
+    Future<Response<void>> createUser(
         User body, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -58,7 +58,7 @@ class UserApi {
     /// Creates list of users with given input array
     ///
     /// 
-    Future<Response>createUsersWithArrayInput(
+    Future<Response<void>> createUsersWithArrayInput(
         BuiltList<User> body, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -102,7 +102,7 @@ class UserApi {
     /// Creates list of users with given input array
     ///
     /// 
-    Future<Response>createUsersWithListInput(
+    Future<Response<void>> createUsersWithListInput(
         BuiltList<User> body, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -146,7 +146,7 @@ class UserApi {
     /// Delete user
     ///
     /// This can only be done by the logged in user.
-    Future<Response>deleteUser(
+    Future<Response<void>> deleteUser(
         String username, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -185,7 +185,7 @@ class UserApi {
     /// Get user by user name
     ///
     /// 
-    Future<Response<User>>getUserByName(
+    Future<Response<User>> getUserByName(
         String username, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -237,7 +237,7 @@ class UserApi {
     /// Logs user into the system
     ///
     /// 
-    Future<Response<String>>loginUser(
+    Future<Response<String>> loginUser(
         String username,
         String password, { 
         CancelToken cancelToken,
@@ -291,7 +291,7 @@ class UserApi {
     /// Logs out current logged in user session
     ///
     /// 
-    Future<Response>logoutUser({ 
+    Future<Response<void>> logoutUser({ 
         CancelToken cancelToken,
         Map<String, String> headers,
         ProgressCallback onSendProgress,
@@ -329,7 +329,7 @@ class UserApi {
     /// Updated user
     ///
     /// This can only be done by the logged in user.
-    Future<Response>updateUser(
+    Future<Response<void>> updateUser(
         String username,
         User body, { 
         CancelToken cancelToken,

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
@@ -23,7 +23,7 @@ class PetApi {
   ///
   /// * [Pet] body (required):
   ///   Pet object that needs to be added to the store
-  Future addPetWithHttpInfo(Pet body) async {
+  Future<Response> addPetWithHttpInfo(Pet body) async {
     // Verify required params are set.
     if (body == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: body');
@@ -71,7 +71,7 @@ class PetApi {
   ///
   /// * [Pet] body (required):
   ///   Pet object that needs to be added to the store
-  Future addPet(Pet body) async {
+  Future<void> addPet(Pet body) async {
     final response = await addPetWithHttpInfo(body);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -88,7 +88,7 @@ class PetApi {
   ///   Pet id to delete
   ///
   /// * [String] apiKey:
-  Future deletePetWithHttpInfo(int petId, { String apiKey }) async {
+  Future<Response> deletePetWithHttpInfo(int petId, { String apiKey }) async {
     // Verify required params are set.
     if (petId == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: petId');
@@ -143,7 +143,7 @@ class PetApi {
   ///   Pet id to delete
   ///
   /// * [String] apiKey:
-  Future deletePet(int petId, { String apiKey }) async {
+  Future<void> deletePet(int petId, { String apiKey }) async {
     final response = await deletePetWithHttpInfo(petId,  apiKey: apiKey );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -389,7 +389,7 @@ class PetApi {
   ///
   /// * [Pet] body (required):
   ///   Pet object that needs to be added to the store
-  Future updatePetWithHttpInfo(Pet body) async {
+  Future<Response> updatePetWithHttpInfo(Pet body) async {
     // Verify required params are set.
     if (body == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: body');
@@ -437,7 +437,7 @@ class PetApi {
   ///
   /// * [Pet] body (required):
   ///   Pet object that needs to be added to the store
-  Future updatePet(Pet body) async {
+  Future<void> updatePet(Pet body) async {
     final response = await updatePetWithHttpInfo(body);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -458,7 +458,7 @@ class PetApi {
   ///
   /// * [String] status:
   ///   Updated status of the pet
-  Future updatePetWithFormWithHttpInfo(int petId, { String name, String status }) async {
+  Future<Response> updatePetWithFormWithHttpInfo(int petId, { String name, String status }) async {
     // Verify required params are set.
     if (petId == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: petId');
@@ -527,7 +527,7 @@ class PetApi {
   ///
   /// * [String] status:
   ///   Updated status of the pet
-  Future updatePetWithForm(int petId, { String name, String status }) async {
+  Future<void> updatePetWithForm(int petId, { String name, String status }) async {
     final response = await updatePetWithFormWithHttpInfo(petId,  name: name, status: status );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
@@ -25,7 +25,7 @@ class StoreApi {
   ///
   /// * [String] orderId (required):
   ///   ID of the order that needs to be deleted
-  Future deleteOrderWithHttpInfo(String orderId) async {
+  Future<Response> deleteOrderWithHttpInfo(String orderId) async {
     // Verify required params are set.
     if (orderId == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: orderId');
@@ -76,7 +76,7 @@ class StoreApi {
   ///
   /// * [String] orderId (required):
   ///   ID of the order that needs to be deleted
-  Future deleteOrder(String orderId) async {
+  Future<void> deleteOrder(String orderId) async {
     final response = await deleteOrderWithHttpInfo(orderId);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
@@ -25,7 +25,7 @@ class UserApi {
   ///
   /// * [User] body (required):
   ///   Created user object
-  Future createUserWithHttpInfo(User body) async {
+  Future<Response> createUserWithHttpInfo(User body) async {
     // Verify required params are set.
     if (body == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: body');
@@ -75,7 +75,7 @@ class UserApi {
   ///
   /// * [User] body (required):
   ///   Created user object
-  Future createUser(User body) async {
+  Future<void> createUser(User body) async {
     final response = await createUserWithHttpInfo(body);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -90,7 +90,7 @@ class UserApi {
   ///
   /// * [List<User>] body (required):
   ///   List of user object
-  Future createUsersWithArrayInputWithHttpInfo(List<User> body) async {
+  Future<Response> createUsersWithArrayInputWithHttpInfo(List<User> body) async {
     // Verify required params are set.
     if (body == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: body');
@@ -138,7 +138,7 @@ class UserApi {
   ///
   /// * [List<User>] body (required):
   ///   List of user object
-  Future createUsersWithArrayInput(List<User> body) async {
+  Future<void> createUsersWithArrayInput(List<User> body) async {
     final response = await createUsersWithArrayInputWithHttpInfo(body);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -153,7 +153,7 @@ class UserApi {
   ///
   /// * [List<User>] body (required):
   ///   List of user object
-  Future createUsersWithListInputWithHttpInfo(List<User> body) async {
+  Future<Response> createUsersWithListInputWithHttpInfo(List<User> body) async {
     // Verify required params are set.
     if (body == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: body');
@@ -201,7 +201,7 @@ class UserApi {
   ///
   /// * [List<User>] body (required):
   ///   List of user object
-  Future createUsersWithListInput(List<User> body) async {
+  Future<void> createUsersWithListInput(List<User> body) async {
     final response = await createUsersWithListInputWithHttpInfo(body);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -218,7 +218,7 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be deleted
-  Future deleteUserWithHttpInfo(String username) async {
+  Future<Response> deleteUserWithHttpInfo(String username) async {
     // Verify required params are set.
     if (username == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: username');
@@ -269,7 +269,7 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be deleted
-  Future deleteUser(String username) async {
+  Future<void> deleteUser(String username) async {
     final response = await deleteUserWithHttpInfo(username);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -432,7 +432,7 @@ class UserApi {
   /// Logs out current logged in user session
   ///
   /// Note: This method returns the HTTP [Response].
-  Future logoutUserWithHttpInfo() async {
+  Future<Response> logoutUserWithHttpInfo() async {
     final path = '/user/logout'.replaceAll('{format}', 'json');
 
     Object postBody;
@@ -470,7 +470,7 @@ class UserApi {
   }
 
   /// Logs out current logged in user session
-  Future logoutUser() async {
+  Future<void> logoutUser() async {
     final response = await logoutUserWithHttpInfo();
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -490,7 +490,7 @@ class UserApi {
   ///
   /// * [User] body (required):
   ///   Updated user object
-  Future updateUserWithHttpInfo(String username, User body) async {
+  Future<Response> updateUserWithHttpInfo(String username, User body) async {
     // Verify required params are set.
     if (username == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: username');
@@ -547,7 +547,7 @@ class UserApi {
   ///
   /// * [User] body (required):
   ///   Updated user object
-  Future updateUser(String username, User body) async {
+  Future<void> updateUser(String username, User body) async {
     final response = await updateUserWithHttpInfo(username, body);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -18,7 +18,7 @@ class PetApi {
     /// Add a new pet to the store
     ///
     /// 
-    Future<Response<Pet>>addPet(
+    Future<Response<Pet>> addPet(
         Pet pet, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -82,7 +82,7 @@ class PetApi {
     /// Deletes a pet
     ///
     /// 
-    Future<Response>deletePet(
+    Future<Response<void>> deletePet(
         int petId, { 
         String apiKey,
         CancelToken cancelToken,
@@ -128,7 +128,7 @@ class PetApi {
     /// Finds Pets by status
     ///
     /// Multiple status values can be provided with comma separated strings
-    Future<Response<BuiltList<Pet>>>findPetsByStatus(
+    Future<Response<BuiltList<Pet>>> findPetsByStatus(
         BuiltList<String> status, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -187,7 +187,7 @@ class PetApi {
     /// Finds Pets by tags
     ///
     /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-    Future<Response<BuiltList<Pet>>>findPetsByTags(
+    Future<Response<BuiltList<Pet>>> findPetsByTags(
         BuiltList<String> tags, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -246,7 +246,7 @@ class PetApi {
     /// Find pet by ID
     ///
     /// Returns a single pet
-    Future<Response<Pet>>getPetById(
+    Future<Response<Pet>> getPetById(
         int petId, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -305,7 +305,7 @@ class PetApi {
     /// Update an existing pet
     ///
     /// 
-    Future<Response<Pet>>updatePet(
+    Future<Response<Pet>> updatePet(
         Pet pet, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -369,7 +369,7 @@ class PetApi {
     /// Updates a pet in the store with form data
     ///
     /// 
-    Future<Response>updatePetWithForm(
+    Future<Response<void>> updatePetWithForm(
         int petId, { 
         String name,
         String status,
@@ -422,7 +422,7 @@ class PetApi {
     /// uploads an image
     ///
     /// 
-    Future<Response<ApiResponse>>uploadFile(
+    Future<Response<ApiResponse>> uploadFile(
         int petId, { 
         String additionalMetadata,
         Uint8List file,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -15,7 +15,7 @@ class StoreApi {
     /// Delete purchase order by ID
     ///
     /// For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-    Future<Response>deleteOrder(
+    Future<Response<void>> deleteOrder(
         String orderId, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -54,7 +54,7 @@ class StoreApi {
     /// Returns pet inventories by status
     ///
     /// Returns a map of status codes to quantities
-    Future<Response<BuiltMap<String, int>>>getInventory({ 
+    Future<Response<BuiltMap<String, int>>> getInventory({ 
         CancelToken cancelToken,
         Map<String, String> headers,
         ProgressCallback onSendProgress,
@@ -113,7 +113,7 @@ class StoreApi {
     /// Find purchase order by ID
     ///
     /// For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-    Future<Response<Order>>getOrderById(
+    Future<Response<Order>> getOrderById(
         int orderId, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -165,7 +165,7 @@ class StoreApi {
     /// Place an order for a pet
     ///
     /// 
-    Future<Response<Order>>placeOrder(
+    Future<Response<Order>> placeOrder(
         Order order, { 
         CancelToken cancelToken,
         Map<String, String> headers,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -15,7 +15,7 @@ class UserApi {
     /// Create user
     ///
     /// This can only be done by the logged in user.
-    Future<Response>createUser(
+    Future<Response<void>> createUser(
         User user, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -67,7 +67,7 @@ class UserApi {
     /// Creates list of users with given input array
     ///
     /// 
-    Future<Response>createUsersWithArrayInput(
+    Future<Response<void>> createUsersWithArrayInput(
         BuiltList<User> user, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -120,7 +120,7 @@ class UserApi {
     /// Creates list of users with given input array
     ///
     /// 
-    Future<Response>createUsersWithListInput(
+    Future<Response<void>> createUsersWithListInput(
         BuiltList<User> user, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -173,7 +173,7 @@ class UserApi {
     /// Delete user
     ///
     /// This can only be done by the logged in user.
-    Future<Response>deleteUser(
+    Future<Response<void>> deleteUser(
         String username, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -219,7 +219,7 @@ class UserApi {
     /// Get user by user name
     ///
     /// 
-    Future<Response<User>>getUserByName(
+    Future<Response<User>> getUserByName(
         String username, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -271,7 +271,7 @@ class UserApi {
     /// Logs user into the system
     ///
     /// 
-    Future<Response<String>>loginUser(
+    Future<Response<String>> loginUser(
         String username,
         String password, { 
         CancelToken cancelToken,
@@ -325,7 +325,7 @@ class UserApi {
     /// Logs out current logged in user session
     ///
     /// 
-    Future<Response>logoutUser({ 
+    Future<Response<void>> logoutUser({ 
         CancelToken cancelToken,
         Map<String, String> headers,
         ProgressCallback onSendProgress,
@@ -370,7 +370,7 @@ class UserApi {
     /// Updated user
     ///
     /// This can only be done by the logged in user.
-    Future<Response>updateUser(
+    Future<Response<void>> updateUser(
         String username,
         User user, { 
         CancelToken cancelToken,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
@@ -14,7 +14,7 @@ class AnotherFakeApi {
     /// To test special tags
     ///
     /// To test special tags and operation ID starting with number
-    Future<Response<Client>>call123testSpecialTags(
+    Future<Response<Client>> call123testSpecialTags(
         Client client, { 
         CancelToken cancelToken,
         Map<String, String> headers,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/default_api.dart
@@ -14,7 +14,7 @@ class DefaultApi {
     /// 
     ///
     /// 
-    Future<Response<InlineResponseDefault>>fooGet({ 
+    Future<Response<InlineResponseDefault>> fooGet({ 
         CancelToken cancelToken,
         Map<String, String> headers,
         ProgressCallback onSendProgress,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -22,7 +22,7 @@ class FakeApi {
     /// Health check endpoint
     ///
     /// 
-    Future<Response<HealthCheckResult>>fakeHealthGet({ 
+    Future<Response<HealthCheckResult>> fakeHealthGet({ 
         CancelToken cancelToken,
         Map<String, String> headers,
         ProgressCallback onSendProgress,
@@ -73,7 +73,7 @@ class FakeApi {
     /// test http signature authentication
     ///
     /// 
-    Future<Response>fakeHttpSignatureTest(
+    Future<Response<void>> fakeHttpSignatureTest(
         Pet pet, { 
         String query1,
         String header1,
@@ -128,7 +128,7 @@ class FakeApi {
     /// 
     ///
     /// Test serialization of outer boolean types
-    Future<Response<bool>>fakeOuterBooleanSerialize({ 
+    Future<Response<bool>> fakeOuterBooleanSerialize({ 
         bool body,
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -185,7 +185,7 @@ class FakeApi {
     /// 
     ///
     /// Test serialization of object with outer number type
-    Future<Response<OuterComposite>>fakeOuterCompositeSerialize({ 
+    Future<Response<OuterComposite>> fakeOuterCompositeSerialize({ 
         OuterComposite outerComposite,
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -243,7 +243,7 @@ class FakeApi {
     /// 
     ///
     /// Test serialization of outer number types
-    Future<Response<num>>fakeOuterNumberSerialize({ 
+    Future<Response<num>> fakeOuterNumberSerialize({ 
         num body,
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -300,7 +300,7 @@ class FakeApi {
     /// 
     ///
     /// Test serialization of outer string types
-    Future<Response<String>>fakeOuterStringSerialize({ 
+    Future<Response<String>> fakeOuterStringSerialize({ 
         String body,
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -357,7 +357,7 @@ class FakeApi {
     /// 
     ///
     /// For this test, the body for this request much reference a schema named `File`.
-    Future<Response>testBodyWithFileSchema(
+    Future<Response<void>> testBodyWithFileSchema(
         FileSchemaTestClass fileSchemaTestClass, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -402,7 +402,7 @@ class FakeApi {
     /// 
     ///
     /// 
-    Future<Response>testBodyWithQueryParams(
+    Future<Response<void>> testBodyWithQueryParams(
         String query,
         User user, { 
         CancelToken cancelToken,
@@ -449,7 +449,7 @@ class FakeApi {
     /// To test \"client\" model
     ///
     /// To test \"client\" model
-    Future<Response<Client>>testClientModel(
+    Future<Response<Client>> testClientModel(
         Client client, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -507,7 +507,7 @@ class FakeApi {
     /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
     ///
     /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    Future<Response>testEndpointParameters(
+    Future<Response<void>> testEndpointParameters(
         num number,
         double double_,
         String patternWithoutDelimiter,
@@ -583,7 +583,7 @@ class FakeApi {
     /// To test enum parameters
     ///
     /// To test enum parameters
-    Future<Response>testEnumParameters({ 
+    Future<Response<void>> testEnumParameters({ 
         BuiltList<String> enumHeaderStringArray,
         String enumHeaderString,
         BuiltList<String> enumQueryStringArray,
@@ -642,7 +642,7 @@ class FakeApi {
     /// Fake endpoint to test group parameters (optional)
     ///
     /// Fake endpoint to test group parameters (optional)
-    Future<Response>testGroupParameters(
+    Future<Response<void>> testGroupParameters(
         int requiredStringGroup,
         bool requiredBooleanGroup,
         int requiredInt64Group, { 
@@ -697,7 +697,7 @@ class FakeApi {
     /// test inline additionalProperties
     ///
     /// 
-    Future<Response>testInlineAdditionalProperties(
+    Future<Response<void>> testInlineAdditionalProperties(
         BuiltMap<String, String> requestBody, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -742,7 +742,7 @@ class FakeApi {
     /// test json serialization of form data
     ///
     /// 
-    Future<Response>testJsonFormData(
+    Future<Response<void>> testJsonFormData(
         String param,
         String param2, { 
         CancelToken cancelToken,
@@ -789,7 +789,7 @@ class FakeApi {
     /// 
     ///
     /// To test the collection format in query parameters
-    Future<Response>testQueryParameterCollectionFormat(
+    Future<Response<void>> testQueryParameterCollectionFormat(
         BuiltList<String> pipe,
         BuiltList<String> ioutil,
         BuiltList<String> http,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
@@ -14,7 +14,7 @@ class FakeClassnameTags123Api {
     /// To test class name in snake case
     ///
     /// To test class name in snake case
-    Future<Response<Client>>testClassname(
+    Future<Response<Client>> testClassname(
         Client client, { 
         CancelToken cancelToken,
         Map<String, String> headers,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -18,7 +18,7 @@ class PetApi {
     /// Add a new pet to the store
     ///
     /// 
-    Future<Response>addPet(
+    Future<Response<void>> addPet(
         Pet pet, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -69,7 +69,7 @@ class PetApi {
     /// Deletes a pet
     ///
     /// 
-    Future<Response>deletePet(
+    Future<Response<void>> deletePet(
         int petId, { 
         String apiKey,
         CancelToken cancelToken,
@@ -115,7 +115,7 @@ class PetApi {
     /// Finds Pets by status
     ///
     /// Multiple status values can be provided with comma separated strings
-    Future<Response<BuiltList<Pet>>>findPetsByStatus(
+    Future<Response<BuiltList<Pet>>> findPetsByStatus(
         BuiltList<String> status, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -174,7 +174,7 @@ class PetApi {
     /// Finds Pets by tags
     ///
     /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-    Future<Response<BuiltList<Pet>>>findPetsByTags(
+    Future<Response<BuiltList<Pet>>> findPetsByTags(
         BuiltList<String> tags, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -233,7 +233,7 @@ class PetApi {
     /// Find pet by ID
     ///
     /// Returns a single pet
-    Future<Response<Pet>>getPetById(
+    Future<Response<Pet>> getPetById(
         int petId, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -292,7 +292,7 @@ class PetApi {
     /// Update an existing pet
     ///
     /// 
-    Future<Response>updatePet(
+    Future<Response<void>> updatePet(
         Pet pet, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -343,7 +343,7 @@ class PetApi {
     /// Updates a pet in the store with form data
     ///
     /// 
-    Future<Response>updatePetWithForm(
+    Future<Response<void>> updatePetWithForm(
         int petId, { 
         String name,
         String status,
@@ -396,7 +396,7 @@ class PetApi {
     /// uploads an image
     ///
     /// 
-    Future<Response<ApiResponse>>uploadFile(
+    Future<Response<ApiResponse>> uploadFile(
         int petId, { 
         String additionalMetadata,
         Uint8List file,
@@ -466,7 +466,7 @@ class PetApi {
     /// uploads an image (required)
     ///
     /// 
-    Future<Response<ApiResponse>>uploadFileWithRequiredFile(
+    Future<Response<ApiResponse>> uploadFileWithRequiredFile(
         int petId,
         Uint8List requiredFile, { 
         String additionalMetadata,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
@@ -15,7 +15,7 @@ class StoreApi {
     /// Delete purchase order by ID
     ///
     /// For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-    Future<Response>deleteOrder(
+    Future<Response<void>> deleteOrder(
         String orderId, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -54,7 +54,7 @@ class StoreApi {
     /// Returns pet inventories by status
     ///
     /// Returns a map of status codes to quantities
-    Future<Response<BuiltMap<String, int>>>getInventory({ 
+    Future<Response<BuiltMap<String, int>>> getInventory({ 
         CancelToken cancelToken,
         Map<String, String> headers,
         ProgressCallback onSendProgress,
@@ -113,7 +113,7 @@ class StoreApi {
     /// Find purchase order by ID
     ///
     /// For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-    Future<Response<Order>>getOrderById(
+    Future<Response<Order>> getOrderById(
         int orderId, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -165,7 +165,7 @@ class StoreApi {
     /// Place an order for a pet
     ///
     /// 
-    Future<Response<Order>>placeOrder(
+    Future<Response<Order>> placeOrder(
         Order order, { 
         CancelToken cancelToken,
         Map<String, String> headers,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
@@ -15,7 +15,7 @@ class UserApi {
     /// Create user
     ///
     /// This can only be done by the logged in user.
-    Future<Response>createUser(
+    Future<Response<void>> createUser(
         User user, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -60,7 +60,7 @@ class UserApi {
     /// Creates list of users with given input array
     ///
     /// 
-    Future<Response>createUsersWithArrayInput(
+    Future<Response<void>> createUsersWithArrayInput(
         BuiltList<User> user, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -106,7 +106,7 @@ class UserApi {
     /// Creates list of users with given input array
     ///
     /// 
-    Future<Response>createUsersWithListInput(
+    Future<Response<void>> createUsersWithListInput(
         BuiltList<User> user, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -152,7 +152,7 @@ class UserApi {
     /// Delete user
     ///
     /// This can only be done by the logged in user.
-    Future<Response>deleteUser(
+    Future<Response<void>> deleteUser(
         String username, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -191,7 +191,7 @@ class UserApi {
     /// Get user by user name
     ///
     /// 
-    Future<Response<User>>getUserByName(
+    Future<Response<User>> getUserByName(
         String username, { 
         CancelToken cancelToken,
         Map<String, String> headers,
@@ -243,7 +243,7 @@ class UserApi {
     /// Logs user into the system
     ///
     /// 
-    Future<Response<String>>loginUser(
+    Future<Response<String>> loginUser(
         String username,
         String password, { 
         CancelToken cancelToken,
@@ -297,7 +297,7 @@ class UserApi {
     /// Logs out current logged in user session
     ///
     /// 
-    Future<Response>logoutUser({ 
+    Future<Response<void>> logoutUser({ 
         CancelToken cancelToken,
         Map<String, String> headers,
         ProgressCallback onSendProgress,
@@ -335,7 +335,7 @@ class UserApi {
     /// Updated user
     ///
     /// This can only be done by the logged in user.
-    Future<Response>updateUser(
+    Future<Response<void>> updateUser(
         String username,
         User user, { 
         CancelToken cancelToken,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
@@ -95,7 +95,7 @@ class PetApi {
   ///   Pet id to delete
   ///
   /// * [String] apiKey:
-  Future deletePetWithHttpInfo(int petId, { String apiKey }) async {
+  Future<Response> deletePetWithHttpInfo(int petId, { String apiKey }) async {
     // Verify required params are set.
     if (petId == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: petId');
@@ -150,7 +150,7 @@ class PetApi {
   ///   Pet id to delete
   ///
   /// * [String] apiKey:
-  Future deletePet(int petId, { String apiKey }) async {
+  Future<void> deletePet(int petId, { String apiKey }) async {
     final response = await deletePetWithHttpInfo(petId,  apiKey: apiKey );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -472,7 +472,7 @@ class PetApi {
   ///
   /// * [String] status:
   ///   Updated status of the pet
-  Future updatePetWithFormWithHttpInfo(int petId, { String name, String status }) async {
+  Future<Response> updatePetWithFormWithHttpInfo(int petId, { String name, String status }) async {
     // Verify required params are set.
     if (petId == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: petId');
@@ -541,7 +541,7 @@ class PetApi {
   ///
   /// * [String] status:
   ///   Updated status of the pet
-  Future updatePetWithForm(int petId, { String name, String status }) async {
+  Future<void> updatePetWithForm(int petId, { String name, String status }) async {
     final response = await updatePetWithFormWithHttpInfo(petId,  name: name, status: status );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
@@ -25,7 +25,7 @@ class StoreApi {
   ///
   /// * [String] orderId (required):
   ///   ID of the order that needs to be deleted
-  Future deleteOrderWithHttpInfo(String orderId) async {
+  Future<Response> deleteOrderWithHttpInfo(String orderId) async {
     // Verify required params are set.
     if (orderId == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: orderId');
@@ -76,7 +76,7 @@ class StoreApi {
   ///
   /// * [String] orderId (required):
   ///   ID of the order that needs to be deleted
-  Future deleteOrder(String orderId) async {
+  Future<void> deleteOrder(String orderId) async {
     final response = await deleteOrderWithHttpInfo(orderId);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
@@ -25,7 +25,7 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Created user object
-  Future createUserWithHttpInfo(User user) async {
+  Future<Response> createUserWithHttpInfo(User user) async {
     // Verify required params are set.
     if (user == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: user');
@@ -75,7 +75,7 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Created user object
-  Future createUser(User user) async {
+  Future<void> createUser(User user) async {
     final response = await createUserWithHttpInfo(user);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -90,7 +90,7 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future createUsersWithArrayInputWithHttpInfo(List<User> user) async {
+  Future<Response> createUsersWithArrayInputWithHttpInfo(List<User> user) async {
     // Verify required params are set.
     if (user == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: user');
@@ -138,7 +138,7 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future createUsersWithArrayInput(List<User> user) async {
+  Future<void> createUsersWithArrayInput(List<User> user) async {
     final response = await createUsersWithArrayInputWithHttpInfo(user);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -153,7 +153,7 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future createUsersWithListInputWithHttpInfo(List<User> user) async {
+  Future<Response> createUsersWithListInputWithHttpInfo(List<User> user) async {
     // Verify required params are set.
     if (user == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: user');
@@ -201,7 +201,7 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future createUsersWithListInput(List<User> user) async {
+  Future<void> createUsersWithListInput(List<User> user) async {
     final response = await createUsersWithListInputWithHttpInfo(user);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -218,7 +218,7 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be deleted
-  Future deleteUserWithHttpInfo(String username) async {
+  Future<Response> deleteUserWithHttpInfo(String username) async {
     // Verify required params are set.
     if (username == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: username');
@@ -269,7 +269,7 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be deleted
-  Future deleteUser(String username) async {
+  Future<void> deleteUser(String username) async {
     final response = await deleteUserWithHttpInfo(username);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -432,7 +432,7 @@ class UserApi {
   /// Logs out current logged in user session
   ///
   /// Note: This method returns the HTTP [Response].
-  Future logoutUserWithHttpInfo() async {
+  Future<Response> logoutUserWithHttpInfo() async {
     final path = '/user/logout'.replaceAll('{format}', 'json');
 
     Object postBody;
@@ -470,7 +470,7 @@ class UserApi {
   }
 
   /// Logs out current logged in user session
-  Future logoutUser() async {
+  Future<void> logoutUser() async {
     final response = await logoutUserWithHttpInfo();
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -490,7 +490,7 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Updated user object
-  Future updateUserWithHttpInfo(String username, User user) async {
+  Future<Response> updateUserWithHttpInfo(String username, User user) async {
     // Verify required params are set.
     if (username == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: username');
@@ -547,7 +547,7 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Updated user object
-  Future updateUser(String username, User user) async {
+  Future<void> updateUser(String username, User user) async {
     final response = await updateUserWithHttpInfo(username, user);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -84,7 +84,7 @@ class FakeApi {
   ///
   /// * [String] header1:
   ///   header parameter
-  Future fakeHttpSignatureTestWithHttpInfo(Pet pet, { String query1, String header1 }) async {
+  Future<Response> fakeHttpSignatureTestWithHttpInfo(Pet pet, { String query1, String header1 }) async {
     // Verify required params are set.
     if (pet == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: pet');
@@ -146,7 +146,7 @@ class FakeApi {
   ///
   /// * [String] header1:
   ///   header parameter
-  Future fakeHttpSignatureTest(Pet pet, { String query1, String header1 }) async {
+  Future<void> fakeHttpSignatureTest(Pet pet, { String query1, String header1 }) async {
     final response = await fakeHttpSignatureTestWithHttpInfo(pet,  query1: query1, header1: header1 );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -428,7 +428,7 @@ class FakeApi {
   /// Parameters:
   ///
   /// * [FileSchemaTestClass] fileSchemaTestClass (required):
-  Future testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass fileSchemaTestClass) async {
+  Future<Response> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass fileSchemaTestClass) async {
     // Verify required params are set.
     if (fileSchemaTestClass == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: fileSchemaTestClass');
@@ -475,7 +475,7 @@ class FakeApi {
   /// Parameters:
   ///
   /// * [FileSchemaTestClass] fileSchemaTestClass (required):
-  Future testBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass) async {
+  Future<void> testBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass) async {
     final response = await testBodyWithFileSchemaWithHttpInfo(fileSchemaTestClass);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -488,7 +488,7 @@ class FakeApi {
   /// * [String] query (required):
   ///
   /// * [User] user (required):
-  Future testBodyWithQueryParamsWithHttpInfo(String query, User user) async {
+  Future<Response> testBodyWithQueryParamsWithHttpInfo(String query, User user) async {
     // Verify required params are set.
     if (query == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: query');
@@ -540,7 +540,7 @@ class FakeApi {
   /// * [String] query (required):
   ///
   /// * [User] user (required):
-  Future testBodyWithQueryParams(String query, User user) async {
+  Future<void> testBodyWithQueryParams(String query, User user) async {
     final response = await testBodyWithQueryParamsWithHttpInfo(query, user);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -670,7 +670,7 @@ class FakeApi {
   ///
   /// * [String] callback:
   ///   None
-  Future testEndpointParametersWithHttpInfo(num number, double double_, String patternWithoutDelimiter, String byte, { int integer, int int32, int int64, double float, String string, MultipartFile binary, DateTime date, DateTime dateTime, String password, String callback }) async {
+  Future<Response> testEndpointParametersWithHttpInfo(num number, double double_, String patternWithoutDelimiter, String byte, { int integer, int int32, int int64, double float, String string, MultipartFile binary, DateTime date, DateTime dateTime, String password, String callback }) async {
     // Verify required params are set.
     if (number == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: number');
@@ -864,7 +864,7 @@ class FakeApi {
   ///
   /// * [String] callback:
   ///   None
-  Future testEndpointParameters(num number, double double_, String patternWithoutDelimiter, String byte, { int integer, int int32, int int64, double float, String string, MultipartFile binary, DateTime date, DateTime dateTime, String password, String callback }) async {
+  Future<void> testEndpointParameters(num number, double double_, String patternWithoutDelimiter, String byte, { int integer, int int32, int int64, double float, String string, MultipartFile binary, DateTime date, DateTime dateTime, String password, String callback }) async {
     final response = await testEndpointParametersWithHttpInfo(number, double_, patternWithoutDelimiter, byte,  integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -902,7 +902,7 @@ class FakeApi {
   ///
   /// * [String] enumFormString:
   ///   Form parameter enum test (string)
-  Future testEnumParametersWithHttpInfo({ List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, int enumQueryInteger, double enumQueryDouble, List<String> enumFormStringArray, String enumFormString }) async {
+  Future<Response> testEnumParametersWithHttpInfo({ List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, int enumQueryInteger, double enumQueryDouble, List<String> enumFormStringArray, String enumFormString }) async {
     // Verify required params are set.
 
     final path = '/fake'.replaceAll('{format}', 'json');
@@ -1004,7 +1004,7 @@ class FakeApi {
   ///
   /// * [String] enumFormString:
   ///   Form parameter enum test (string)
-  Future testEnumParameters({ List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, int enumQueryInteger, double enumQueryDouble, List<String> enumFormStringArray, String enumFormString }) async {
+  Future<void> testEnumParameters({ List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, int enumQueryInteger, double enumQueryDouble, List<String> enumFormStringArray, String enumFormString }) async {
     final response = await testEnumParametersWithHttpInfo( enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -1036,7 +1036,7 @@ class FakeApi {
   ///
   /// * [int] int64Group:
   ///   Integer in group parameters
-  Future testGroupParametersWithHttpInfo(int requiredStringGroup, bool requiredBooleanGroup, int requiredInt64Group, { int stringGroup, bool booleanGroup, int int64Group }) async {
+  Future<Response> testGroupParametersWithHttpInfo(int requiredStringGroup, bool requiredBooleanGroup, int requiredInt64Group, { int stringGroup, bool booleanGroup, int int64Group }) async {
     // Verify required params are set.
     if (requiredStringGroup == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: requiredStringGroup');
@@ -1121,7 +1121,7 @@ class FakeApi {
   ///
   /// * [int] int64Group:
   ///   Integer in group parameters
-  Future testGroupParameters(int requiredStringGroup, bool requiredBooleanGroup, int requiredInt64Group, { int stringGroup, bool booleanGroup, int int64Group }) async {
+  Future<void> testGroupParameters(int requiredStringGroup, bool requiredBooleanGroup, int requiredInt64Group, { int stringGroup, bool booleanGroup, int int64Group }) async {
     final response = await testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group,  stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -1136,7 +1136,7 @@ class FakeApi {
   ///
   /// * [Map<String, String>] requestBody (required):
   ///   request body
-  Future testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> requestBody) async {
+  Future<Response> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> requestBody) async {
     // Verify required params are set.
     if (requestBody == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: requestBody');
@@ -1184,7 +1184,7 @@ class FakeApi {
   ///
   /// * [Map<String, String>] requestBody (required):
   ///   request body
-  Future testInlineAdditionalProperties(Map<String, String> requestBody) async {
+  Future<void> testInlineAdditionalProperties(Map<String, String> requestBody) async {
     final response = await testInlineAdditionalPropertiesWithHttpInfo(requestBody);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -1202,7 +1202,7 @@ class FakeApi {
   ///
   /// * [String] param2 (required):
   ///   field2
-  Future testJsonFormDataWithHttpInfo(String param, String param2) async {
+  Future<Response> testJsonFormDataWithHttpInfo(String param, String param2) async {
     // Verify required params are set.
     if (param == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: param');
@@ -1270,7 +1270,7 @@ class FakeApi {
   ///
   /// * [String] param2 (required):
   ///   field2
-  Future testJsonFormData(String param, String param2) async {
+  Future<void> testJsonFormData(String param, String param2) async {
     final response = await testJsonFormDataWithHttpInfo(param, param2);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -1292,7 +1292,7 @@ class FakeApi {
   /// * [List<String>] url (required):
   ///
   /// * [List<String>] context (required):
-  Future testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) async {
+  Future<Response> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) async {
     // Verify required params are set.
     if (pipe == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: pipe');
@@ -1365,7 +1365,7 @@ class FakeApi {
   /// * [List<String>] url (required):
   ///
   /// * [List<String>] context (required):
-  Future testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) async {
+  Future<void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) async {
     final response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -23,7 +23,7 @@ class PetApi {
   ///
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
-  Future addPetWithHttpInfo(Pet pet) async {
+  Future<Response> addPetWithHttpInfo(Pet pet) async {
     // Verify required params are set.
     if (pet == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: pet');
@@ -71,7 +71,7 @@ class PetApi {
   ///
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
-  Future addPet(Pet pet) async {
+  Future<void> addPet(Pet pet) async {
     final response = await addPetWithHttpInfo(pet);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -88,7 +88,7 @@ class PetApi {
   ///   Pet id to delete
   ///
   /// * [String] apiKey:
-  Future deletePetWithHttpInfo(int petId, { String apiKey }) async {
+  Future<Response> deletePetWithHttpInfo(int petId, { String apiKey }) async {
     // Verify required params are set.
     if (petId == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: petId');
@@ -143,7 +143,7 @@ class PetApi {
   ///   Pet id to delete
   ///
   /// * [String] apiKey:
-  Future deletePet(int petId, { String apiKey }) async {
+  Future<void> deletePet(int petId, { String apiKey }) async {
     final response = await deletePetWithHttpInfo(petId,  apiKey: apiKey );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -389,7 +389,7 @@ class PetApi {
   ///
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
-  Future updatePetWithHttpInfo(Pet pet) async {
+  Future<Response> updatePetWithHttpInfo(Pet pet) async {
     // Verify required params are set.
     if (pet == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: pet');
@@ -437,7 +437,7 @@ class PetApi {
   ///
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
-  Future updatePet(Pet pet) async {
+  Future<void> updatePet(Pet pet) async {
     final response = await updatePetWithHttpInfo(pet);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -458,7 +458,7 @@ class PetApi {
   ///
   /// * [String] status:
   ///   Updated status of the pet
-  Future updatePetWithFormWithHttpInfo(int petId, { String name, String status }) async {
+  Future<Response> updatePetWithFormWithHttpInfo(int petId, { String name, String status }) async {
     // Verify required params are set.
     if (petId == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: petId');
@@ -527,7 +527,7 @@ class PetApi {
   ///
   /// * [String] status:
   ///   Updated status of the pet
-  Future updatePetWithForm(int petId, { String name, String status }) async {
+  Future<void> updatePetWithForm(int petId, { String name, String status }) async {
     final response = await updatePetWithFormWithHttpInfo(petId,  name: name, status: status );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/store_api.dart
@@ -25,7 +25,7 @@ class StoreApi {
   ///
   /// * [String] orderId (required):
   ///   ID of the order that needs to be deleted
-  Future deleteOrderWithHttpInfo(String orderId) async {
+  Future<Response> deleteOrderWithHttpInfo(String orderId) async {
     // Verify required params are set.
     if (orderId == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: orderId');
@@ -76,7 +76,7 @@ class StoreApi {
   ///
   /// * [String] orderId (required):
   ///   ID of the order that needs to be deleted
-  Future deleteOrder(String orderId) async {
+  Future<void> deleteOrder(String orderId) async {
     final response = await deleteOrderWithHttpInfo(orderId);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/user_api.dart
@@ -25,7 +25,7 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Created user object
-  Future createUserWithHttpInfo(User user) async {
+  Future<Response> createUserWithHttpInfo(User user) async {
     // Verify required params are set.
     if (user == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: user');
@@ -75,7 +75,7 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Created user object
-  Future createUser(User user) async {
+  Future<void> createUser(User user) async {
     final response = await createUserWithHttpInfo(user);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -90,7 +90,7 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future createUsersWithArrayInputWithHttpInfo(List<User> user) async {
+  Future<Response> createUsersWithArrayInputWithHttpInfo(List<User> user) async {
     // Verify required params are set.
     if (user == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: user');
@@ -138,7 +138,7 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future createUsersWithArrayInput(List<User> user) async {
+  Future<void> createUsersWithArrayInput(List<User> user) async {
     final response = await createUsersWithArrayInputWithHttpInfo(user);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -153,7 +153,7 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future createUsersWithListInputWithHttpInfo(List<User> user) async {
+  Future<Response> createUsersWithListInputWithHttpInfo(List<User> user) async {
     // Verify required params are set.
     if (user == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: user');
@@ -201,7 +201,7 @@ class UserApi {
   ///
   /// * [List<User>] user (required):
   ///   List of user object
-  Future createUsersWithListInput(List<User> user) async {
+  Future<void> createUsersWithListInput(List<User> user) async {
     final response = await createUsersWithListInputWithHttpInfo(user);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -218,7 +218,7 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be deleted
-  Future deleteUserWithHttpInfo(String username) async {
+  Future<Response> deleteUserWithHttpInfo(String username) async {
     // Verify required params are set.
     if (username == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: username');
@@ -269,7 +269,7 @@ class UserApi {
   ///
   /// * [String] username (required):
   ///   The name that needs to be deleted
-  Future deleteUser(String username) async {
+  Future<void> deleteUser(String username) async {
     final response = await deleteUserWithHttpInfo(username);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -432,7 +432,7 @@ class UserApi {
   /// Logs out current logged in user session
   ///
   /// Note: This method returns the HTTP [Response].
-  Future logoutUserWithHttpInfo() async {
+  Future<Response> logoutUserWithHttpInfo() async {
     final path = '/user/logout'.replaceAll('{format}', 'json');
 
     Object postBody;
@@ -470,7 +470,7 @@ class UserApi {
   }
 
   /// Logs out current logged in user session
-  Future logoutUser() async {
+  Future<void> logoutUser() async {
     final response = await logoutUserWithHttpInfo();
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));
@@ -490,7 +490,7 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Updated user object
-  Future updateUserWithHttpInfo(String username, User user) async {
+  Future<Response> updateUserWithHttpInfo(String username, User user) async {
     // Verify required params are set.
     if (username == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: username');
@@ -547,7 +547,7 @@ class UserApi {
   ///
   /// * [User] user (required):
   ///   Updated user object
-  Future updateUser(String username, User user) async {
+  Future<void> updateUser(String username, User user) async {
     final response = await updateUserWithHttpInfo(username, user);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, _decodeBodyBytes(response));


### PR DESCRIPTION
* don't rely on implicit dynamics
* add space between return type and some method names

Note: `http.Response` is not generically typed for dart but `dio.Response<Type>` is.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)