### PR TITLE
[dart][dart-dio] Add support for default values

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -125,20 +125,13 @@ public class DartDioClientCodegen extends DartClientCodegen {
 
     @Override
     public String toDefaultValue(Schema schema) {
-        if (ModelUtils.isMapSchema(schema)) {
-            return "const {}";
-        } else if (ModelUtils.isArraySchema(schema)) {
-            return "const []";
-        }
-
         if (schema.getDefault() != null) {
             if (ModelUtils.isStringSchema(schema)) {
                 return "'" + schema.getDefault().toString().replaceAll("'", "\\'") + "'";
             }
             return schema.getDefault().toString();
-        } else {
-            return "null";
         }
+        return null;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
@@ -22,6 +22,9 @@ abstract class {{classname}} implements Built<{{classname}}, {{classname}}Builde
     // Boilerplate code needed to wire-up generated code
     {{classname}}._();
 
+    static void _initializeBuilder({{{classname}}}Builder b) => b{{#vars}}{{#defaultValue}}
+        ..{{{name}}} = {{#isEnum}}{{^isContainer}}const {{{classname}}}{{{enumName}}}._({{/isContainer}}{{/isEnum}}{{{defaultValue}}}{{#isEnum}}{{^isContainer}}){{/isContainer}}{{/isEnum}}{{/defaultValue}}{{/vars}};
+
     factory {{classname}}([updates({{classname}}Builder b)]) = _${{classname}};
     static Serializer<{{classname}}> get serializer => _${{#lambda.camelcase}}{{{classname}}}{{/lambda.camelcase}}Serializer;
 }

--- a/modules/openapi-generator/src/main/resources/dart-dio/object_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/object_doc.mustache
@@ -8,7 +8,7 @@ import 'package:{{pubName}}/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{{description}}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{{description}}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{defaultValue}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dartdio/DartDioModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dartdio/DartDioModelTest.java
@@ -69,7 +69,7 @@ public class DartDioModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.dataType, "int");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertNull(property1.defaultValue);
         Assert.assertEquals(property1.baseType, "int");
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);
@@ -79,7 +79,7 @@ public class DartDioModelTest {
         Assert.assertEquals(property2.baseName, "name");
         Assert.assertEquals(property2.dataType, "String");
         Assert.assertEquals(property2.name, "name");
-        Assert.assertEquals(property2.defaultValue, "null");
+        Assert.assertNull(property2.defaultValue);
         Assert.assertEquals(property2.baseType, "String");
         Assert.assertTrue(property2.required);
         Assert.assertTrue(property2.isPrimitiveType);
@@ -90,7 +90,7 @@ public class DartDioModelTest {
         Assert.assertEquals(property3.complexType, "DateTime");
         Assert.assertEquals(property3.dataType, "DateTime");
         Assert.assertEquals(property3.name, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertNull(property3.defaultValue);
         Assert.assertEquals(property3.baseType, "DateTime");
         Assert.assertFalse(property3.required);
         Assert.assertFalse(property3.isContainer);
@@ -128,7 +128,7 @@ public class DartDioModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.dataType, "int");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertNull(property1.defaultValue);
         Assert.assertEquals(property1.baseType, "int");
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);
@@ -138,7 +138,7 @@ public class DartDioModelTest {
         Assert.assertEquals(property2.baseName, "name");
         Assert.assertEquals(property2.dataType, "String");
         Assert.assertEquals(property2.name, "name");
-        Assert.assertEquals(property2.defaultValue, "null");
+        Assert.assertNull(property2.defaultValue);
         Assert.assertEquals(property2.baseType, "String");
         Assert.assertTrue(property2.required);
         Assert.assertTrue(property2.isPrimitiveType);
@@ -149,7 +149,7 @@ public class DartDioModelTest {
         Assert.assertEquals(property3.complexType, "OffsetDateTime");
         Assert.assertEquals(property3.dataType, "OffsetDateTime");
         Assert.assertEquals(property3.name, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertNull(property3.defaultValue);
         Assert.assertEquals(property3.baseType, "OffsetDateTime");
         Assert.assertFalse(property3.required);
         Assert.assertFalse(property3.isContainer);
@@ -159,7 +159,7 @@ public class DartDioModelTest {
         Assert.assertEquals(property4.complexType, "OffsetDate");
         Assert.assertEquals(property4.dataType, "OffsetDate");
         Assert.assertEquals(property4.name, "birthDate");
-        Assert.assertEquals(property4.defaultValue, "null");
+        Assert.assertNull(property4.defaultValue);
         Assert.assertEquals(property4.baseType, "OffsetDate");
         Assert.assertFalse(property4.required);
         Assert.assertFalse(property4.isContainer);
@@ -187,7 +187,7 @@ public class DartDioModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.dataType, "int");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertNull(property1.defaultValue);
         Assert.assertEquals(property1.baseType, "int");
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);

--- a/samples/client/petstore/dart-dio/petstore_client_lib/doc/ApiResponse.md
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/doc/ApiResponse.md
@@ -8,9 +8,9 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**code** | **int** |  | [optional] [default to null]
-**type** | **String** |  | [optional] [default to null]
-**message** | **String** |  | [optional] [default to null]
+**code** | **int** |  | [optional] 
+**type** | **String** |  | [optional] 
+**message** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/dart-dio/petstore_client_lib/doc/Category.md
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/doc/Category.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**name** | **String** |  | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**name** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/dart-dio/petstore_client_lib/doc/Order.md
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/doc/Order.md
@@ -8,11 +8,11 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**petId** | **int** |  | [optional] [default to null]
-**quantity** | **int** |  | [optional] [default to null]
-**shipDate** | [**DateTime**](DateTime.md) |  | [optional] [default to null]
-**status** | **String** | Order Status | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**petId** | **int** |  | [optional] 
+**quantity** | **int** |  | [optional] 
+**shipDate** | [**DateTime**](DateTime.md) |  | [optional] 
+**status** | **String** | Order Status | [optional] 
 **complete** | **bool** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/dart-dio/petstore_client_lib/doc/Pet.md
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/doc/Pet.md
@@ -8,12 +8,12 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**category** | [**Category**](Category.md) |  | [optional] [default to null]
-**name** | **String** |  | [default to null]
-**photoUrls** | **BuiltList<String>** |  | [default to const []]
-**tags** | [**BuiltList<Tag>**](Tag.md) |  | [optional] [default to const []]
-**status** | **String** | pet status in the store | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**category** | [**Category**](Category.md) |  | [optional] 
+**name** | **String** |  | 
+**photoUrls** | **BuiltList<String>** |  | 
+**tags** | [**BuiltList<Tag>**](Tag.md) |  | [optional] 
+**status** | **String** | pet status in the store | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/dart-dio/petstore_client_lib/doc/PetApi.md
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/doc/PetApi.md
@@ -87,8 +87,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| Pet id to delete | [default to null]
- **apiKey** | **String**|  | [optional] [default to null]
+ **petId** | **int**| Pet id to delete | 
+ **apiKey** | **String**|  | [optional] 
 
 ### Return type
 
@@ -133,7 +133,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**BuiltList<String>**](String.md)| Status values that need to be considered for filter | [default to const []]
+ **status** | [**BuiltList<String>**](String.md)| Status values that need to be considered for filter | 
 
 ### Return type
 
@@ -178,7 +178,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **tags** | [**BuiltList<String>**](String.md)| Tags to filter by | [default to const []]
+ **tags** | [**BuiltList<String>**](String.md)| Tags to filter by | 
 
 ### Return type
 
@@ -225,7 +225,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| ID of pet to return | [default to null]
+ **petId** | **int**| ID of pet to return | 
 
 ### Return type
 
@@ -311,9 +311,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| ID of pet that needs to be updated | [default to null]
- **name** | **String**| Updated name of the pet | [optional] [default to null]
- **status** | **String**| Updated status of the pet | [optional] [default to null]
+ **petId** | **int**| ID of pet that needs to be updated | 
+ **name** | **String**| Updated name of the pet | [optional] 
+ **status** | **String**| Updated status of the pet | [optional] 
 
 ### Return type
 
@@ -358,9 +358,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| ID of pet to update | [default to null]
- **additionalMetadata** | **String**| Additional data to pass to server | [optional] [default to null]
- **file** | **Uint8List**| file to upload | [optional] [default to null]
+ **petId** | **int**| ID of pet to update | 
+ **additionalMetadata** | **String**| Additional data to pass to server | [optional] 
+ **file** | **Uint8List**| file to upload | [optional] 
 
 ### Return type
 

--- a/samples/client/petstore/dart-dio/petstore_client_lib/doc/StoreApi.md
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/doc/StoreApi.md
@@ -40,7 +40,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **String**| ID of the order that needs to be deleted | [default to null]
+ **orderId** | **String**| ID of the order that needs to be deleted | 
 
 ### Return type
 
@@ -126,7 +126,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **int**| ID of pet that needs to be fetched | [default to null]
+ **orderId** | **int**| ID of pet that needs to be fetched | 
 
 ### Return type
 

--- a/samples/client/petstore/dart-dio/petstore_client_lib/doc/Tag.md
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/doc/Tag.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**name** | **String** |  | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**name** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/dart-dio/petstore_client_lib/doc/User.md
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/doc/User.md
@@ -8,14 +8,14 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**username** | **String** |  | [optional] [default to null]
-**firstName** | **String** |  | [optional] [default to null]
-**lastName** | **String** |  | [optional] [default to null]
-**email** | **String** |  | [optional] [default to null]
-**password** | **String** |  | [optional] [default to null]
-**phone** | **String** |  | [optional] [default to null]
-**userStatus** | **int** | User Status | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**username** | **String** |  | [optional] 
+**firstName** | **String** |  | [optional] 
+**lastName** | **String** |  | [optional] 
+**email** | **String** |  | [optional] 
+**password** | **String** |  | [optional] 
+**phone** | **String** |  | [optional] 
+**userStatus** | **int** | User Status | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/dart-dio/petstore_client_lib/doc/UserApi.md
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/doc/UserApi.md
@@ -166,7 +166,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **String**| The name that needs to be deleted | [default to null]
+ **username** | **String**| The name that needs to be deleted | 
 
 ### Return type
 
@@ -207,7 +207,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **String**| The name that needs to be fetched. Use user1 for testing. | [default to null]
+ **username** | **String**| The name that needs to be fetched. Use user1 for testing. | 
 
 ### Return type
 
@@ -249,8 +249,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **String**| The user name for login | [default to null]
- **password** | **String**| The password for login in clear text | [default to null]
+ **username** | **String**| The user name for login | 
+ **password** | **String**| The password for login in clear text | 
 
 ### Return type
 
@@ -329,7 +329,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **String**| name that need to be deleted | [default to null]
+ **username** | **String**| name that need to be deleted | 
  **body** | [**User**](User.md)| Updated user object | 
 
 ### Return type

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/api_response.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/api_response.dart
@@ -20,6 +20,8 @@ abstract class ApiResponse implements Built<ApiResponse, ApiResponseBuilder> {
     // Boilerplate code needed to wire-up generated code
     ApiResponse._();
 
+    static void _initializeBuilder(ApiResponseBuilder b) => b;
+
     factory ApiResponse([updates(ApiResponseBuilder b)]) = _$ApiResponse;
     static Serializer<ApiResponse> get serializer => _$apiResponseSerializer;
 }

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/category.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/category.dart
@@ -16,6 +16,8 @@ abstract class Category implements Built<Category, CategoryBuilder> {
     // Boilerplate code needed to wire-up generated code
     Category._();
 
+    static void _initializeBuilder(CategoryBuilder b) => b;
+
     factory Category([updates(CategoryBuilder b)]) = _$Category;
     static Serializer<Category> get serializer => _$categorySerializer;
 }

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
@@ -35,6 +35,9 @@ abstract class Order implements Built<Order, OrderBuilder> {
     // Boilerplate code needed to wire-up generated code
     Order._();
 
+    static void _initializeBuilder(OrderBuilder b) => b
+        ..complete = false;
+
     factory Order([updates(OrderBuilder b)]) = _$Order;
     static Serializer<Order> get serializer => _$orderSerializer;
 }

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
@@ -37,6 +37,8 @@ abstract class Pet implements Built<Pet, PetBuilder> {
     // Boilerplate code needed to wire-up generated code
     Pet._();
 
+    static void _initializeBuilder(PetBuilder b) => b;
+
     factory Pet([updates(PetBuilder b)]) = _$Pet;
     static Serializer<Pet> get serializer => _$petSerializer;
 }

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/tag.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/tag.dart
@@ -16,6 +16,8 @@ abstract class Tag implements Built<Tag, TagBuilder> {
     // Boilerplate code needed to wire-up generated code
     Tag._();
 
+    static void _initializeBuilder(TagBuilder b) => b;
+
     factory Tag([updates(TagBuilder b)]) = _$Tag;
     static Serializer<Tag> get serializer => _$tagSerializer;
 }

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/user.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/model/user.dart
@@ -41,6 +41,8 @@ abstract class User implements Built<User, UserBuilder> {
     // Boilerplate code needed to wire-up generated code
     User._();
 
+    static void _initializeBuilder(UserBuilder b) => b;
+
     factory User([updates(UserBuilder b)]) = _$User;
     static Serializer<User> get serializer => _$userSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/ApiResponse.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/ApiResponse.md
@@ -8,9 +8,9 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**code** | **int** |  | [optional] [default to null]
-**type** | **String** |  | [optional] [default to null]
-**message** | **String** |  | [optional] [default to null]
+**code** | **int** |  | [optional] 
+**type** | **String** |  | [optional] 
+**message** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/Category.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/Category.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**name** | **String** |  | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**name** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/InlineObject.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/InlineObject.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**name** | **String** | Updated name of the pet | [optional] [default to null]
-**status** | **String** | Updated status of the pet | [optional] [default to null]
+**name** | **String** | Updated name of the pet | [optional] 
+**status** | **String** | Updated status of the pet | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/InlineObject1.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/InlineObject1.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**additionalMetadata** | **String** | Additional data to pass to server | [optional] [default to null]
-**file** | [**Uint8List**](Uint8List.md) | file to upload | [optional] [default to null]
+**additionalMetadata** | **String** | Additional data to pass to server | [optional] 
+**file** | [**Uint8List**](Uint8List.md) | file to upload | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/Order.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/Order.md
@@ -8,11 +8,11 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**petId** | **int** |  | [optional] [default to null]
-**quantity** | **int** |  | [optional] [default to null]
-**shipDate** | [**DateTime**](DateTime.md) |  | [optional] [default to null]
-**status** | **String** | Order Status | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**petId** | **int** |  | [optional] 
+**quantity** | **int** |  | [optional] 
+**shipDate** | [**DateTime**](DateTime.md) |  | [optional] 
+**status** | **String** | Order Status | [optional] 
 **complete** | **bool** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/Pet.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/Pet.md
@@ -8,12 +8,12 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**category** | [**Category**](Category.md) |  | [optional] [default to null]
-**name** | **String** |  | [default to null]
-**photoUrls** | **BuiltList<String>** |  | [default to const []]
-**tags** | [**BuiltList<Tag>**](Tag.md) |  | [optional] [default to const []]
-**status** | **String** | pet status in the store | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**category** | [**Category**](Category.md) |  | [optional] 
+**name** | **String** |  | 
+**photoUrls** | **BuiltList<String>** |  | 
+**tags** | [**BuiltList<Tag>**](Tag.md) |  | [optional] 
+**status** | **String** | pet status in the store | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/PetApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/PetApi.md
@@ -88,8 +88,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| Pet id to delete | [default to null]
- **apiKey** | **String**|  | [optional] [default to null]
+ **petId** | **int**| Pet id to delete | 
+ **apiKey** | **String**|  | [optional] 
 
 ### Return type
 
@@ -134,7 +134,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**BuiltList<String>**](String.md)| Status values that need to be considered for filter | [default to const []]
+ **status** | [**BuiltList<String>**](String.md)| Status values that need to be considered for filter | 
 
 ### Return type
 
@@ -179,7 +179,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **tags** | [**BuiltList<String>**](String.md)| Tags to filter by | [default to const []]
+ **tags** | [**BuiltList<String>**](String.md)| Tags to filter by | 
 
 ### Return type
 
@@ -226,7 +226,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| ID of pet to return | [default to null]
+ **petId** | **int**| ID of pet to return | 
 
 ### Return type
 
@@ -313,9 +313,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| ID of pet that needs to be updated | [default to null]
- **name** | **String**| Updated name of the pet | [optional] [default to null]
- **status** | **String**| Updated status of the pet | [optional] [default to null]
+ **petId** | **int**| ID of pet that needs to be updated | 
+ **name** | **String**| Updated name of the pet | [optional] 
+ **status** | **String**| Updated status of the pet | [optional] 
 
 ### Return type
 
@@ -360,9 +360,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| ID of pet to update | [default to null]
- **additionalMetadata** | **String**| Additional data to pass to server | [optional] [default to null]
- **file** | **Uint8List**| file to upload | [optional] [default to null]
+ **petId** | **int**| ID of pet to update | 
+ **additionalMetadata** | **String**| Additional data to pass to server | [optional] 
+ **file** | **Uint8List**| file to upload | [optional] 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/StoreApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/StoreApi.md
@@ -40,7 +40,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **String**| ID of the order that needs to be deleted | [default to null]
+ **orderId** | **String**| ID of the order that needs to be deleted | 
 
 ### Return type
 
@@ -126,7 +126,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **int**| ID of pet that needs to be fetched | [default to null]
+ **orderId** | **int**| ID of pet that needs to be fetched | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/Tag.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/Tag.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**name** | **String** |  | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**name** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/User.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/User.md
@@ -8,14 +8,14 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**username** | **String** |  | [optional] [default to null]
-**firstName** | **String** |  | [optional] [default to null]
-**lastName** | **String** |  | [optional] [default to null]
-**email** | **String** |  | [optional] [default to null]
-**password** | **String** |  | [optional] [default to null]
-**phone** | **String** |  | [optional] [default to null]
-**userStatus** | **int** | User Status | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**username** | **String** |  | [optional] 
+**firstName** | **String** |  | [optional] 
+**lastName** | **String** |  | [optional] 
+**email** | **String** |  | [optional] 
+**password** | **String** |  | [optional] 
+**phone** | **String** |  | [optional] 
+**userStatus** | **int** | User Status | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/UserApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/doc/UserApi.md
@@ -182,7 +182,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **String**| The name that needs to be deleted | [default to null]
+ **username** | **String**| The name that needs to be deleted | 
 
 ### Return type
 
@@ -223,7 +223,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **String**| The name that needs to be fetched. Use user1 for testing. | [default to null]
+ **username** | **String**| The name that needs to be fetched. Use user1 for testing. | 
 
 ### Return type
 
@@ -265,8 +265,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **String**| The user name for login | [default to null]
- **password** | **String**| The password for login in clear text | [default to null]
+ **username** | **String**| The user name for login | 
+ **password** | **String**| The password for login in clear text | 
 
 ### Return type
 
@@ -353,7 +353,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **String**| name that need to be deleted | [default to null]
+ **username** | **String**| name that need to be deleted | 
  **user** | [**User**](User.md)| Updated user object | 
 
 ### Return type

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/api_response.dart
@@ -20,6 +20,8 @@ abstract class ApiResponse implements Built<ApiResponse, ApiResponseBuilder> {
     // Boilerplate code needed to wire-up generated code
     ApiResponse._();
 
+    static void _initializeBuilder(ApiResponseBuilder b) => b;
+
     factory ApiResponse([updates(ApiResponseBuilder b)]) = _$ApiResponse;
     static Serializer<ApiResponse> get serializer => _$apiResponseSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/category.dart
@@ -16,6 +16,8 @@ abstract class Category implements Built<Category, CategoryBuilder> {
     // Boilerplate code needed to wire-up generated code
     Category._();
 
+    static void _initializeBuilder(CategoryBuilder b) => b;
+
     factory Category([updates(CategoryBuilder b)]) = _$Category;
     static Serializer<Category> get serializer => _$categorySerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/inline_object.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/inline_object.dart
@@ -18,6 +18,8 @@ abstract class InlineObject implements Built<InlineObject, InlineObjectBuilder> 
     // Boilerplate code needed to wire-up generated code
     InlineObject._();
 
+    static void _initializeBuilder(InlineObjectBuilder b) => b;
+
     factory InlineObject([updates(InlineObjectBuilder b)]) = _$InlineObject;
     static Serializer<InlineObject> get serializer => _$inlineObjectSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/inline_object1.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/inline_object1.dart
@@ -19,6 +19,8 @@ abstract class InlineObject1 implements Built<InlineObject1, InlineObject1Builde
     // Boilerplate code needed to wire-up generated code
     InlineObject1._();
 
+    static void _initializeBuilder(InlineObject1Builder b) => b;
+
     factory InlineObject1([updates(InlineObject1Builder b)]) = _$InlineObject1;
     static Serializer<InlineObject1> get serializer => _$inlineObject1Serializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/order.dart
@@ -35,6 +35,9 @@ abstract class Order implements Built<Order, OrderBuilder> {
     // Boilerplate code needed to wire-up generated code
     Order._();
 
+    static void _initializeBuilder(OrderBuilder b) => b
+        ..complete = false;
+
     factory Order([updates(OrderBuilder b)]) = _$Order;
     static Serializer<Order> get serializer => _$orderSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/pet.dart
@@ -37,6 +37,8 @@ abstract class Pet implements Built<Pet, PetBuilder> {
     // Boilerplate code needed to wire-up generated code
     Pet._();
 
+    static void _initializeBuilder(PetBuilder b) => b;
+
     factory Pet([updates(PetBuilder b)]) = _$Pet;
     static Serializer<Pet> get serializer => _$petSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/tag.dart
@@ -16,6 +16,8 @@ abstract class Tag implements Built<Tag, TagBuilder> {
     // Boilerplate code needed to wire-up generated code
     Tag._();
 
+    static void _initializeBuilder(TagBuilder b) => b;
+
     factory Tag([updates(TagBuilder b)]) = _$Tag;
     static Serializer<Tag> get serializer => _$tagSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/model/user.dart
@@ -41,6 +41,8 @@ abstract class User implements Built<User, UserBuilder> {
     // Boilerplate code needed to wire-up generated code
     User._();
 
+    static void _initializeBuilder(UserBuilder b) => b;
+
     factory User([updates(UserBuilder b)]) = _$User;
     static Serializer<User> get serializer => _$userSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/AdditionalPropertiesClass.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/AdditionalPropertiesClass.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**mapProperty** | **BuiltMap<String, String>** |  | [optional] [default to const {}]
-**mapOfMapProperty** | [**BuiltMap<String, BuiltMap<String, String>>**](BuiltMap.md) |  | [optional] [default to const {}]
+**mapProperty** | **BuiltMap<String, String>** |  | [optional] 
+**mapOfMapProperty** | [**BuiltMap<String, BuiltMap<String, String>>**](BuiltMap.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Animal.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Animal.md
@@ -9,7 +9,7 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **String** |  | 
-**color** | **String** |  | [optional] [default to &#39;red&#39;]
+**color** | **String** |  | [optional] [default to 'red']
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Animal.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Animal.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**className** | **String** |  | [default to null]
+**className** | **String** |  | 
 **color** | **String** |  | [optional] [default to &#39;red&#39;]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ApiResponse.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ApiResponse.md
@@ -8,9 +8,9 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**code** | **int** |  | [optional] [default to null]
-**type** | **String** |  | [optional] [default to null]
-**message** | **String** |  | [optional] [default to null]
+**code** | **int** |  | [optional] 
+**type** | **String** |  | [optional] 
+**message** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ArrayOfArrayOfNumberOnly.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ArrayOfArrayOfNumberOnly.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**arrayArrayNumber** | [**BuiltList<BuiltList<num>>**](BuiltList.md) |  | [optional] [default to const []]
+**arrayArrayNumber** | [**BuiltList<BuiltList<num>>**](BuiltList.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ArrayOfNumberOnly.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ArrayOfNumberOnly.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**arrayNumber** | **BuiltList<num>** |  | [optional] [default to const []]
+**arrayNumber** | **BuiltList<num>** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ArrayTest.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ArrayTest.md
@@ -8,9 +8,9 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**arrayOfString** | **BuiltList<String>** |  | [optional] [default to const []]
-**arrayArrayOfInteger** | [**BuiltList<BuiltList<int>>**](BuiltList.md) |  | [optional] [default to const []]
-**arrayArrayOfModel** | [**BuiltList<BuiltList<ReadOnlyFirst>>**](BuiltList.md) |  | [optional] [default to const []]
+**arrayOfString** | **BuiltList<String>** |  | [optional] 
+**arrayArrayOfInteger** | [**BuiltList<BuiltList<int>>**](BuiltList.md) |  | [optional] 
+**arrayArrayOfModel** | [**BuiltList<BuiltList<ReadOnlyFirst>>**](BuiltList.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Capitalization.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Capitalization.md
@@ -8,12 +8,12 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**smallCamel** | **String** |  | [optional] [default to null]
-**capitalCamel** | **String** |  | [optional] [default to null]
-**smallSnake** | **String** |  | [optional] [default to null]
-**capitalSnake** | **String** |  | [optional] [default to null]
-**sCAETHFlowPoints** | **String** |  | [optional] [default to null]
-**ATT_NAME** | **String** | Name of the pet  | [optional] [default to null]
+**smallCamel** | **String** |  | [optional] 
+**capitalCamel** | **String** |  | [optional] 
+**smallSnake** | **String** |  | [optional] 
+**capitalSnake** | **String** |  | [optional] 
+**sCAETHFlowPoints** | **String** |  | [optional] 
+**ATT_NAME** | **String** | Name of the pet  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Cat.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Cat.md
@@ -8,9 +8,9 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**className** | **String** |  | [default to null]
+**className** | **String** |  | 
 **color** | **String** |  | [optional] [default to &#39;red&#39;]
-**declawed** | **bool** |  | [optional] [default to null]
+**declawed** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Cat.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Cat.md
@@ -9,7 +9,7 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **String** |  | 
-**color** | **String** |  | [optional] [default to &#39;red&#39;]
+**color** | **String** |  | [optional] [default to 'red']
 **declawed** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/CatAllOf.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/CatAllOf.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**declawed** | **bool** |  | [optional] [default to null]
+**declawed** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Category.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Category.md
@@ -9,7 +9,7 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **int** |  | [optional] 
-**name** | **String** |  | [default to &#39;default-name&#39;]
+**name** | **String** |  | [default to 'default-name']
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Category.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Category.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
+**id** | **int** |  | [optional] 
 **name** | **String** |  | [default to &#39;default-name&#39;]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ClassModel.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ClassModel.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**class_** | **String** |  | [optional] [default to null]
+**class_** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Dog.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Dog.md
@@ -8,9 +8,9 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**className** | **String** |  | [default to null]
+**className** | **String** |  | 
 **color** | **String** |  | [optional] [default to &#39;red&#39;]
-**breed** | **String** |  | [optional] [default to null]
+**breed** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Dog.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Dog.md
@@ -9,7 +9,7 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **className** | **String** |  | 
-**color** | **String** |  | [optional] [default to &#39;red&#39;]
+**color** | **String** |  | [optional] [default to 'red']
 **breed** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/DogAllOf.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/DogAllOf.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**breed** | **String** |  | [optional] [default to null]
+**breed** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/EnumArrays.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/EnumArrays.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**justSymbol** | **String** |  | [optional] [default to null]
-**arrayEnum** | **BuiltList<String>** |  | [optional] [default to const []]
+**justSymbol** | **String** |  | [optional] 
+**arrayEnum** | **BuiltList<String>** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/EnumTest.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/EnumTest.md
@@ -8,14 +8,14 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**enumString** | **String** |  | [optional] [default to null]
-**enumStringRequired** | **String** |  | [default to null]
-**enumInteger** | **int** |  | [optional] [default to null]
-**enumNumber** | **double** |  | [optional] [default to null]
-**outerEnum** | [**OuterEnum**](OuterEnum.md) |  | [optional] [default to null]
-**outerEnumInteger** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] [default to null]
-**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] [default to null]
-**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] [default to null]
+**enumString** | **String** |  | [optional] 
+**enumStringRequired** | **String** |  | 
+**enumInteger** | **int** |  | [optional] 
+**enumNumber** | **double** |  | [optional] 
+**outerEnum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
+**outerEnumInteger** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
+**outerEnumDefaultValue** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
+**outerEnumIntegerDefaultValue** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FakeApi.md
@@ -92,8 +92,8 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
- **query1** | **String**| query parameter | [optional] [default to null]
- **header1** | **String**| header parameter | [optional] [default to null]
+ **query1** | **String**| query parameter | [optional] 
+ **header1** | **String**| header parameter | [optional] 
 
 ### Return type
 
@@ -348,7 +348,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **query** | **String**|  | [default to null]
+ **query** | **String**|  | 
  **user** | [**User**](User.md)|  | 
 
 ### Return type
@@ -450,20 +450,20 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **number** | **num**| None | [default to null]
- **double_** | **double**| None | [default to null]
- **patternWithoutDelimiter** | **String**| None | [default to null]
- **byte** | **String**| None | [default to null]
- **integer** | **int**| None | [optional] [default to null]
- **int32** | **int**| None | [optional] [default to null]
- **int64** | **int**| None | [optional] [default to null]
- **float** | **double**| None | [optional] [default to null]
- **string** | **String**| None | [optional] [default to null]
- **binary** | **Uint8List**| None | [optional] [default to null]
- **date** | **DateTime**| None | [optional] [default to null]
- **dateTime** | **DateTime**| None | [optional] [default to null]
- **password** | **String**| None | [optional] [default to null]
- **callback** | **String**| None | [optional] [default to null]
+ **number** | **num**| None | 
+ **double_** | **double**| None | 
+ **patternWithoutDelimiter** | **String**| None | 
+ **byte** | **String**| None | 
+ **integer** | **int**| None | [optional] 
+ **int32** | **int**| None | [optional] 
+ **int64** | **int**| None | [optional] 
+ **float** | **double**| None | [optional] 
+ **string** | **String**| None | [optional] 
+ **binary** | **Uint8List**| None | [optional] 
+ **date** | **DateTime**| None | [optional] 
+ **dateTime** | **DateTime**| None | [optional] 
+ **password** | **String**| None | [optional] 
+ **callback** | **String**| None | [optional] 
 
 ### Return type
 
@@ -512,12 +512,12 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **enumHeaderStringArray** | [**BuiltList<String>**](String.md)| Header parameter enum test (string array) | [optional] [default to const []]
+ **enumHeaderStringArray** | [**BuiltList<String>**](String.md)| Header parameter enum test (string array) | [optional] 
  **enumHeaderString** | **String**| Header parameter enum test (string) | [optional] [default to '-efg']
- **enumQueryStringArray** | [**BuiltList<String>**](String.md)| Query parameter enum test (string array) | [optional] [default to const []]
+ **enumQueryStringArray** | [**BuiltList<String>**](String.md)| Query parameter enum test (string array) | [optional] 
  **enumQueryString** | **String**| Query parameter enum test (string) | [optional] [default to '-efg']
- **enumQueryInteger** | **int**| Query parameter enum test (double) | [optional] [default to null]
- **enumQueryDouble** | **double**| Query parameter enum test (double) | [optional] [default to null]
+ **enumQueryInteger** | **int**| Query parameter enum test (double) | [optional] 
+ **enumQueryDouble** | **double**| Query parameter enum test (double) | [optional] 
  **enumFormStringArray** | [**BuiltList<String>**](String.md)| Form parameter enum test (string array) | [optional] [default to '$']
  **enumFormString** | **String**| Form parameter enum test (string) | [optional] [default to '-efg']
 
@@ -569,12 +569,12 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **requiredStringGroup** | **int**| Required String in group parameters | [default to null]
- **requiredBooleanGroup** | **bool**| Required Boolean in group parameters | [default to null]
- **requiredInt64Group** | **int**| Required Integer in group parameters | [default to null]
- **stringGroup** | **int**| String in group parameters | [optional] [default to null]
- **booleanGroup** | **bool**| Boolean in group parameters | [optional] [default to null]
- **int64Group** | **int**| Integer in group parameters | [optional] [default to null]
+ **requiredStringGroup** | **int**| Required String in group parameters | 
+ **requiredBooleanGroup** | **bool**| Required Boolean in group parameters | 
+ **requiredInt64Group** | **int**| Required Integer in group parameters | 
+ **stringGroup** | **int**| String in group parameters | [optional] 
+ **booleanGroup** | **bool**| Boolean in group parameters | [optional] 
+ **int64Group** | **int**| Integer in group parameters | [optional] 
 
 ### Return type
 
@@ -655,8 +655,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **param** | **String**| field1 | [default to null]
- **param2** | **String**| field2 | [default to null]
+ **param** | **String**| field1 | 
+ **param2** | **String**| field2 | 
 
 ### Return type
 
@@ -702,11 +702,11 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **pipe** | [**BuiltList<String>**](String.md)|  | [default to const []]
- **ioutil** | [**BuiltList<String>**](String.md)|  | [default to const []]
- **http** | [**BuiltList<String>**](String.md)|  | [default to const []]
- **url** | [**BuiltList<String>**](String.md)|  | [default to const []]
- **context** | [**BuiltList<String>**](String.md)|  | [default to const []]
+ **pipe** | [**BuiltList<String>**](String.md)|  | 
+ **ioutil** | [**BuiltList<String>**](String.md)|  | 
+ **http** | [**BuiltList<String>**](String.md)|  | 
+ **url** | [**BuiltList<String>**](String.md)|  | 
+ **context** | [**BuiltList<String>**](String.md)|  | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FileSchemaTestClass.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FileSchemaTestClass.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**file** | [**ModelFile**](ModelFile.md) |  | [optional] [default to null]
-**files** | [**BuiltList<ModelFile>**](ModelFile.md) |  | [optional] [default to const []]
+**file** | [**ModelFile**](ModelFile.md) |  | [optional] 
+**files** | [**BuiltList<ModelFile>**](ModelFile.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Foo.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Foo.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] [default to &#39;bar&#39;]
+**bar** | **String** |  | [optional] [default to 'bar']
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FormatTest.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FormatTest.md
@@ -8,22 +8,22 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**integer** | **int** |  | [optional] [default to null]
-**int32** | **int** |  | [optional] [default to null]
-**int64** | **int** |  | [optional] [default to null]
-**number** | **num** |  | [default to null]
-**float** | **double** |  | [optional] [default to null]
-**double_** | **double** |  | [optional] [default to null]
-**decimal** | **double** |  | [optional] [default to null]
-**string** | **String** |  | [optional] [default to null]
-**byte** | **String** |  | [default to null]
-**binary** | [**Uint8List**](Uint8List.md) |  | [optional] [default to null]
-**date** | [**DateTime**](DateTime.md) |  | [default to null]
-**dateTime** | [**DateTime**](DateTime.md) |  | [optional] [default to null]
-**uuid** | **String** |  | [optional] [default to null]
-**password** | **String** |  | [default to null]
-**patternWithDigits** | **String** | A string that is a 10 digit number. Can have leading zeros. | [optional] [default to null]
-**patternWithDigitsAndDelimiter** | **String** | A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01. | [optional] [default to null]
+**integer** | **int** |  | [optional] 
+**int32** | **int** |  | [optional] 
+**int64** | **int** |  | [optional] 
+**number** | **num** |  | 
+**float** | **double** |  | [optional] 
+**double_** | **double** |  | [optional] 
+**decimal** | **double** |  | [optional] 
+**string** | **String** |  | [optional] 
+**byte** | **String** |  | 
+**binary** | [**Uint8List**](Uint8List.md) |  | [optional] 
+**date** | [**DateTime**](DateTime.md) |  | 
+**dateTime** | [**DateTime**](DateTime.md) |  | [optional] 
+**uuid** | **String** |  | [optional] 
+**password** | **String** |  | 
+**patternWithDigits** | **String** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
+**patternWithDigitsAndDelimiter** | **String** | A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/HasOnlyReadOnly.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/HasOnlyReadOnly.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] [default to null]
-**foo** | **String** |  | [optional] [default to null]
+**bar** | **String** |  | [optional] 
+**foo** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/HealthCheckResult.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/HealthCheckResult.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**nullableMessage** | **String** |  | [optional] [default to null]
+**nullableMessage** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**name** | **String** | Updated name of the pet | [optional] [default to null]
-**status** | **String** | Updated status of the pet | [optional] [default to null]
+**name** | **String** | Updated name of the pet | [optional] 
+**status** | **String** | Updated status of the pet | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject1.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject1.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**additionalMetadata** | **String** | Additional data to pass to server | [optional] [default to null]
-**file** | [**Uint8List**](Uint8List.md) | file to upload | [optional] [default to null]
+**additionalMetadata** | **String** | Additional data to pass to server | [optional] 
+**file** | [**Uint8List**](Uint8List.md) | file to upload | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject2.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject2.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**enumFormStringArray** | **BuiltList<String>** | Form parameter enum test (string array) | [optional] [default to const []]
+**enumFormStringArray** | **BuiltList<String>** | Form parameter enum test (string array) | [optional] 
 **enumFormString** | **String** | Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject2.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject2.md
@@ -9,7 +9,7 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **enumFormStringArray** | **BuiltList<String>** | Form parameter enum test (string array) | [optional] 
-**enumFormString** | **String** | Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
+**enumFormString** | **String** | Form parameter enum test (string) | [optional] [default to '-efg']
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject3.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject3.md
@@ -8,20 +8,20 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**integer** | **int** | None | [optional] [default to null]
-**int32** | **int** | None | [optional] [default to null]
-**int64** | **int** | None | [optional] [default to null]
-**number** | **num** | None | [default to null]
-**float** | **double** | None | [optional] [default to null]
-**double_** | **double** | None | [default to null]
-**string** | **String** | None | [optional] [default to null]
-**patternWithoutDelimiter** | **String** | None | [default to null]
-**byte** | **String** | None | [default to null]
-**binary** | [**Uint8List**](Uint8List.md) | None | [optional] [default to null]
-**date** | [**DateTime**](DateTime.md) | None | [optional] [default to null]
-**dateTime** | [**DateTime**](DateTime.md) | None | [optional] [default to null]
-**password** | **String** | None | [optional] [default to null]
-**callback** | **String** | None | [optional] [default to null]
+**integer** | **int** | None | [optional] 
+**int32** | **int** | None | [optional] 
+**int64** | **int** | None | [optional] 
+**number** | **num** | None | 
+**float** | **double** | None | [optional] 
+**double_** | **double** | None | 
+**string** | **String** | None | [optional] 
+**patternWithoutDelimiter** | **String** | None | 
+**byte** | **String** | None | 
+**binary** | [**Uint8List**](Uint8List.md) | None | [optional] 
+**date** | [**DateTime**](DateTime.md) | None | [optional] 
+**dateTime** | [**DateTime**](DateTime.md) | None | [optional] 
+**password** | **String** | None | [optional] 
+**callback** | **String** | None | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject4.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject4.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**param** | **String** | field1 | [default to null]
-**param2** | **String** | field2 | [default to null]
+**param** | **String** | field1 | 
+**param2** | **String** | field2 | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject5.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineObject5.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**additionalMetadata** | **String** | Additional data to pass to server | [optional] [default to null]
-**requiredFile** | [**Uint8List**](Uint8List.md) | file to upload | [default to null]
+**additionalMetadata** | **String** | Additional data to pass to server | [optional] 
+**requiredFile** | [**Uint8List**](Uint8List.md) | file to upload | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineResponseDefault.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/InlineResponseDefault.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**string** | [**Foo**](Foo.md) |  | [optional] [default to null]
+**string** | [**Foo**](Foo.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/MapTest.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/MapTest.md
@@ -8,10 +8,10 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**mapMapOfString** | [**BuiltMap<String, BuiltMap<String, String>>**](BuiltMap.md) |  | [optional] [default to const {}]
-**mapOfEnumString** | **BuiltMap<String, String>** |  | [optional] [default to const {}]
-**directMap** | **BuiltMap<String, bool>** |  | [optional] [default to const {}]
-**indirectMap** | **BuiltMap<String, bool>** |  | [optional] [default to const {}]
+**mapMapOfString** | [**BuiltMap<String, BuiltMap<String, String>>**](BuiltMap.md) |  | [optional] 
+**mapOfEnumString** | **BuiltMap<String, String>** |  | [optional] 
+**directMap** | **BuiltMap<String, bool>** |  | [optional] 
+**indirectMap** | **BuiltMap<String, bool>** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -8,9 +8,9 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**uuid** | **String** |  | [optional] [default to null]
-**dateTime** | [**DateTime**](DateTime.md) |  | [optional] [default to null]
-**map** | [**BuiltMap<String, Animal>**](Animal.md) |  | [optional] [default to const {}]
+**uuid** | **String** |  | [optional] 
+**dateTime** | [**DateTime**](DateTime.md) |  | [optional] 
+**map** | [**BuiltMap<String, Animal>**](Animal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Model200Response.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Model200Response.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**name** | **int** |  | [optional] [default to null]
-**class_** | **String** |  | [optional] [default to null]
+**name** | **int** |  | [optional] 
+**class_** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ModelClient.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ModelClient.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**client** | **String** |  | [optional] [default to null]
+**client** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ModelFile.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ModelFile.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**sourceURI** | **String** | Test capitalization | [optional] [default to null]
+**sourceURI** | **String** | Test capitalization | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ModelList.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ModelList.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**n123list** | **String** |  | [optional] [default to null]
+**n123list** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ModelReturn.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ModelReturn.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**return_** | **int** |  | [optional] [default to null]
+**return_** | **int** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Name.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Name.md
@@ -8,10 +8,10 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**name** | **int** |  | [default to null]
-**snakeCase** | **int** |  | [optional] [default to null]
-**property** | **String** |  | [optional] [default to null]
-**n123number** | **int** |  | [optional] [default to null]
+**name** | **int** |  | 
+**snakeCase** | **int** |  | [optional] 
+**property** | **String** |  | [optional] 
+**n123number** | **int** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/NullableClass.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/NullableClass.md
@@ -8,18 +8,18 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**integerProp** | **int** |  | [optional] [default to null]
-**numberProp** | **num** |  | [optional] [default to null]
-**booleanProp** | **bool** |  | [optional] [default to null]
-**stringProp** | **String** |  | [optional] [default to null]
-**dateProp** | [**DateTime**](DateTime.md) |  | [optional] [default to null]
-**datetimeProp** | [**DateTime**](DateTime.md) |  | [optional] [default to null]
-**arrayNullableProp** | [**BuiltList<JsonObject>**](JsonObject.md) |  | [optional] [default to const []]
-**arrayAndItemsNullableProp** | [**BuiltList<JsonObject>**](JsonObject.md) |  | [optional] [default to const []]
-**arrayItemsNullable** | [**BuiltList<JsonObject>**](JsonObject.md) |  | [optional] [default to const []]
-**objectNullableProp** | [**BuiltMap<String, JsonObject>**](JsonObject.md) |  | [optional] [default to const {}]
-**objectAndItemsNullableProp** | [**BuiltMap<String, JsonObject>**](JsonObject.md) |  | [optional] [default to const {}]
-**objectItemsNullable** | [**BuiltMap<String, JsonObject>**](JsonObject.md) |  | [optional] [default to const {}]
+**integerProp** | **int** |  | [optional] 
+**numberProp** | **num** |  | [optional] 
+**booleanProp** | **bool** |  | [optional] 
+**stringProp** | **String** |  | [optional] 
+**dateProp** | [**DateTime**](DateTime.md) |  | [optional] 
+**datetimeProp** | [**DateTime**](DateTime.md) |  | [optional] 
+**arrayNullableProp** | [**BuiltList<JsonObject>**](JsonObject.md) |  | [optional] 
+**arrayAndItemsNullableProp** | [**BuiltList<JsonObject>**](JsonObject.md) |  | [optional] 
+**arrayItemsNullable** | [**BuiltList<JsonObject>**](JsonObject.md) |  | [optional] 
+**objectNullableProp** | [**BuiltMap<String, JsonObject>**](JsonObject.md) |  | [optional] 
+**objectAndItemsNullableProp** | [**BuiltMap<String, JsonObject>**](JsonObject.md) |  | [optional] 
+**objectItemsNullable** | [**BuiltMap<String, JsonObject>**](JsonObject.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/NumberOnly.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/NumberOnly.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**justNumber** | **num** |  | [optional] [default to null]
+**justNumber** | **num** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Order.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Order.md
@@ -8,11 +8,11 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**petId** | **int** |  | [optional] [default to null]
-**quantity** | **int** |  | [optional] [default to null]
-**shipDate** | [**DateTime**](DateTime.md) |  | [optional] [default to null]
-**status** | **String** | Order Status | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**petId** | **int** |  | [optional] 
+**quantity** | **int** |  | [optional] 
+**shipDate** | [**DateTime**](DateTime.md) |  | [optional] 
+**status** | **String** | Order Status | [optional] 
 **complete** | **bool** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/OuterComposite.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/OuterComposite.md
@@ -8,9 +8,9 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**myNumber** | **num** |  | [optional] [default to null]
-**myString** | **String** |  | [optional] [default to null]
-**myBoolean** | **bool** |  | [optional] [default to null]
+**myNumber** | **num** |  | [optional] 
+**myString** | **String** |  | [optional] 
+**myBoolean** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Pet.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Pet.md
@@ -8,12 +8,12 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**category** | [**Category**](Category.md) |  | [optional] [default to null]
-**name** | **String** |  | [default to null]
-**photoUrls** | **BuiltList<String>** |  | [default to const []]
-**tags** | [**BuiltList<Tag>**](Tag.md) |  | [optional] [default to const []]
-**status** | **String** | pet status in the store | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**category** | [**Category**](Category.md) |  | [optional] 
+**name** | **String** |  | 
+**photoUrls** | **BuiltList<String>** |  | 
+**tags** | [**BuiltList<Tag>**](Tag.md) |  | [optional] 
+**status** | **String** | pet status in the store | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/PetApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/PetApi.md
@@ -88,8 +88,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| Pet id to delete | [default to null]
- **apiKey** | **String**|  | [optional] [default to null]
+ **petId** | **int**| Pet id to delete | 
+ **apiKey** | **String**|  | [optional] 
 
 ### Return type
 
@@ -134,7 +134,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**BuiltList<String>**](String.md)| Status values that need to be considered for filter | [default to const []]
+ **status** | [**BuiltList<String>**](String.md)| Status values that need to be considered for filter | 
 
 ### Return type
 
@@ -179,7 +179,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **tags** | [**BuiltList<String>**](String.md)| Tags to filter by | [default to const []]
+ **tags** | [**BuiltList<String>**](String.md)| Tags to filter by | 
 
 ### Return type
 
@@ -226,7 +226,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| ID of pet to return | [default to null]
+ **petId** | **int**| ID of pet to return | 
 
 ### Return type
 
@@ -312,9 +312,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| ID of pet that needs to be updated | [default to null]
- **name** | **String**| Updated name of the pet | [optional] [default to null]
- **status** | **String**| Updated status of the pet | [optional] [default to null]
+ **petId** | **int**| ID of pet that needs to be updated | 
+ **name** | **String**| Updated name of the pet | [optional] 
+ **status** | **String**| Updated status of the pet | [optional] 
 
 ### Return type
 
@@ -359,9 +359,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| ID of pet to update | [default to null]
- **additionalMetadata** | **String**| Additional data to pass to server | [optional] [default to null]
- **file** | **Uint8List**| file to upload | [optional] [default to null]
+ **petId** | **int**| ID of pet to update | 
+ **additionalMetadata** | **String**| Additional data to pass to server | [optional] 
+ **file** | **Uint8List**| file to upload | [optional] 
 
 ### Return type
 
@@ -406,9 +406,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **int**| ID of pet to update | [default to null]
- **requiredFile** | **Uint8List**| file to upload | [default to null]
- **additionalMetadata** | **String**| Additional data to pass to server | [optional] [default to null]
+ **petId** | **int**| ID of pet to update | 
+ **requiredFile** | **Uint8List**| file to upload | 
+ **additionalMetadata** | **String**| Additional data to pass to server | [optional] 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ReadOnlyFirst.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/ReadOnlyFirst.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] [default to null]
-**baz** | **String** |  | [optional] [default to null]
+**bar** | **String** |  | [optional] 
+**baz** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/SpecialModelName.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/SpecialModelName.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket** | **int** |  | [optional] [default to null]
+**dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket** | **int** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/StoreApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/StoreApi.md
@@ -40,7 +40,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **String**| ID of the order that needs to be deleted | [default to null]
+ **orderId** | **String**| ID of the order that needs to be deleted | 
 
 ### Return type
 
@@ -126,7 +126,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **int**| ID of pet that needs to be fetched | [default to null]
+ **orderId** | **int**| ID of pet that needs to be fetched | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Tag.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/Tag.md
@@ -8,8 +8,8 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**name** | **String** |  | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**name** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/User.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/User.md
@@ -8,14 +8,14 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **int** |  | [optional] [default to null]
-**username** | **String** |  | [optional] [default to null]
-**firstName** | **String** |  | [optional] [default to null]
-**lastName** | **String** |  | [optional] [default to null]
-**email** | **String** |  | [optional] [default to null]
-**password** | **String** |  | [optional] [default to null]
-**phone** | **String** |  | [optional] [default to null]
-**userStatus** | **int** | User Status | [optional] [default to null]
+**id** | **int** |  | [optional] 
+**username** | **String** |  | [optional] 
+**firstName** | **String** |  | [optional] 
+**lastName** | **String** |  | [optional] 
+**email** | **String** |  | [optional] 
+**password** | **String** |  | [optional] 
+**phone** | **String** |  | [optional] 
+**userStatus** | **int** | User Status | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/UserApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/UserApi.md
@@ -166,7 +166,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **String**| The name that needs to be deleted | [default to null]
+ **username** | **String**| The name that needs to be deleted | 
 
 ### Return type
 
@@ -207,7 +207,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **String**| The name that needs to be fetched. Use user1 for testing. | [default to null]
+ **username** | **String**| The name that needs to be fetched. Use user1 for testing. | 
 
 ### Return type
 
@@ -249,8 +249,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **String**| The user name for login | [default to null]
- **password** | **String**| The password for login in clear text | [default to null]
+ **username** | **String**| The user name for login | 
+ **password** | **String**| The password for login in clear text | 
 
 ### Return type
 
@@ -329,7 +329,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **String**| name that need to be deleted | [default to null]
+ **username** | **String**| name that need to be deleted | 
  **user** | [**User**](User.md)| Updated user object | 
 
 ### Return type

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/additional_properties_class.dart
@@ -17,6 +17,8 @@ abstract class AdditionalPropertiesClass implements Built<AdditionalPropertiesCl
     // Boilerplate code needed to wire-up generated code
     AdditionalPropertiesClass._();
 
+    static void _initializeBuilder(AdditionalPropertiesClassBuilder b) => b;
+
     factory AdditionalPropertiesClass([updates(AdditionalPropertiesClassBuilder b)]) = _$AdditionalPropertiesClass;
     static Serializer<AdditionalPropertiesClass> get serializer => _$additionalPropertiesClassSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/animal.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/animal.dart
@@ -16,6 +16,9 @@ abstract class Animal implements Built<Animal, AnimalBuilder> {
     // Boilerplate code needed to wire-up generated code
     Animal._();
 
+    static void _initializeBuilder(AnimalBuilder b) => b
+        ..color = 'red';
+
     factory Animal([updates(AnimalBuilder b)]) = _$Animal;
     static Serializer<Animal> get serializer => _$animalSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/api_response.dart
@@ -20,6 +20,8 @@ abstract class ApiResponse implements Built<ApiResponse, ApiResponseBuilder> {
     // Boilerplate code needed to wire-up generated code
     ApiResponse._();
 
+    static void _initializeBuilder(ApiResponseBuilder b) => b;
+
     factory ApiResponse([updates(ApiResponseBuilder b)]) = _$ApiResponse;
     static Serializer<ApiResponse> get serializer => _$apiResponseSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
@@ -13,6 +13,8 @@ abstract class ArrayOfArrayOfNumberOnly implements Built<ArrayOfArrayOfNumberOnl
     // Boilerplate code needed to wire-up generated code
     ArrayOfArrayOfNumberOnly._();
 
+    static void _initializeBuilder(ArrayOfArrayOfNumberOnlyBuilder b) => b;
+
     factory ArrayOfArrayOfNumberOnly([updates(ArrayOfArrayOfNumberOnlyBuilder b)]) = _$ArrayOfArrayOfNumberOnly;
     static Serializer<ArrayOfArrayOfNumberOnly> get serializer => _$arrayOfArrayOfNumberOnlySerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/array_of_number_only.dart
@@ -13,6 +13,8 @@ abstract class ArrayOfNumberOnly implements Built<ArrayOfNumberOnly, ArrayOfNumb
     // Boilerplate code needed to wire-up generated code
     ArrayOfNumberOnly._();
 
+    static void _initializeBuilder(ArrayOfNumberOnlyBuilder b) => b;
+
     factory ArrayOfNumberOnly([updates(ArrayOfNumberOnlyBuilder b)]) = _$ArrayOfNumberOnly;
     static Serializer<ArrayOfNumberOnly> get serializer => _$arrayOfNumberOnlySerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/array_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/array_test.dart
@@ -22,6 +22,8 @@ abstract class ArrayTest implements Built<ArrayTest, ArrayTestBuilder> {
     // Boilerplate code needed to wire-up generated code
     ArrayTest._();
 
+    static void _initializeBuilder(ArrayTestBuilder b) => b;
+
     factory ArrayTest([updates(ArrayTestBuilder b)]) = _$ArrayTest;
     static Serializer<ArrayTest> get serializer => _$arrayTestSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/capitalization.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/capitalization.dart
@@ -33,6 +33,8 @@ abstract class Capitalization implements Built<Capitalization, CapitalizationBui
     // Boilerplate code needed to wire-up generated code
     Capitalization._();
 
+    static void _initializeBuilder(CapitalizationBuilder b) => b;
+
     factory Capitalization([updates(CapitalizationBuilder b)]) = _$Capitalization;
     static Serializer<Capitalization> get serializer => _$capitalizationSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/cat.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/cat.dart
@@ -22,6 +22,9 @@ abstract class Cat implements Built<Cat, CatBuilder> {
     // Boilerplate code needed to wire-up generated code
     Cat._();
 
+    static void _initializeBuilder(CatBuilder b) => b
+        ..color = 'red';
+
     factory Cat([updates(CatBuilder b)]) = _$Cat;
     static Serializer<Cat> get serializer => _$catSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/cat_all_of.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/cat_all_of.dart
@@ -12,6 +12,8 @@ abstract class CatAllOf implements Built<CatAllOf, CatAllOfBuilder> {
     // Boilerplate code needed to wire-up generated code
     CatAllOf._();
 
+    static void _initializeBuilder(CatAllOfBuilder b) => b;
+
     factory CatAllOf([updates(CatAllOfBuilder b)]) = _$CatAllOf;
     static Serializer<CatAllOf> get serializer => _$catAllOfSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/category.dart
@@ -16,6 +16,9 @@ abstract class Category implements Built<Category, CategoryBuilder> {
     // Boilerplate code needed to wire-up generated code
     Category._();
 
+    static void _initializeBuilder(CategoryBuilder b) => b
+        ..name = 'default-name';
+
     factory Category([updates(CategoryBuilder b)]) = _$Category;
     static Serializer<Category> get serializer => _$categorySerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/class_model.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/class_model.dart
@@ -12,6 +12,8 @@ abstract class ClassModel implements Built<ClassModel, ClassModelBuilder> {
     // Boilerplate code needed to wire-up generated code
     ClassModel._();
 
+    static void _initializeBuilder(ClassModelBuilder b) => b;
+
     factory ClassModel([updates(ClassModelBuilder b)]) = _$ClassModel;
     static Serializer<ClassModel> get serializer => _$classModelSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/dog.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/dog.dart
@@ -22,6 +22,9 @@ abstract class Dog implements Built<Dog, DogBuilder> {
     // Boilerplate code needed to wire-up generated code
     Dog._();
 
+    static void _initializeBuilder(DogBuilder b) => b
+        ..color = 'red';
+
     factory Dog([updates(DogBuilder b)]) = _$Dog;
     static Serializer<Dog> get serializer => _$dogSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/dog_all_of.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/dog_all_of.dart
@@ -12,6 +12,8 @@ abstract class DogAllOf implements Built<DogAllOf, DogAllOfBuilder> {
     // Boilerplate code needed to wire-up generated code
     DogAllOf._();
 
+    static void _initializeBuilder(DogAllOfBuilder b) => b;
+
     factory DogAllOf([updates(DogAllOfBuilder b)]) = _$DogAllOf;
     static Serializer<DogAllOf> get serializer => _$dogAllOfSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -19,6 +19,8 @@ abstract class EnumArrays implements Built<EnumArrays, EnumArraysBuilder> {
     // Boilerplate code needed to wire-up generated code
     EnumArrays._();
 
+    static void _initializeBuilder(EnumArraysBuilder b) => b;
+
     factory EnumArrays([updates(EnumArraysBuilder b)]) = _$EnumArrays;
     static Serializer<EnumArrays> get serializer => _$enumArraysSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -53,6 +53,8 @@ abstract class EnumTest implements Built<EnumTest, EnumTestBuilder> {
     // Boilerplate code needed to wire-up generated code
     EnumTest._();
 
+    static void _initializeBuilder(EnumTestBuilder b) => b;
+
     factory EnumTest([updates(EnumTestBuilder b)]) = _$EnumTest;
     static Serializer<EnumTest> get serializer => _$enumTestSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
@@ -18,6 +18,8 @@ abstract class FileSchemaTestClass implements Built<FileSchemaTestClass, FileSch
     // Boilerplate code needed to wire-up generated code
     FileSchemaTestClass._();
 
+    static void _initializeBuilder(FileSchemaTestClassBuilder b) => b;
+
     factory FileSchemaTestClass([updates(FileSchemaTestClassBuilder b)]) = _$FileSchemaTestClass;
     static Serializer<FileSchemaTestClass> get serializer => _$fileSchemaTestClassSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/foo.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/foo.dart
@@ -12,6 +12,9 @@ abstract class Foo implements Built<Foo, FooBuilder> {
     // Boilerplate code needed to wire-up generated code
     Foo._();
 
+    static void _initializeBuilder(FooBuilder b) => b
+        ..bar = 'bar';
+
     factory Foo([updates(FooBuilder b)]) = _$Foo;
     static Serializer<Foo> get serializer => _$fooSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/format_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/format_test.dart
@@ -75,6 +75,8 @@ abstract class FormatTest implements Built<FormatTest, FormatTestBuilder> {
     // Boilerplate code needed to wire-up generated code
     FormatTest._();
 
+    static void _initializeBuilder(FormatTestBuilder b) => b;
+
     factory FormatTest([updates(FormatTestBuilder b)]) = _$FormatTest;
     static Serializer<FormatTest> get serializer => _$formatTestSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/has_only_read_only.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/has_only_read_only.dart
@@ -16,6 +16,8 @@ abstract class HasOnlyReadOnly implements Built<HasOnlyReadOnly, HasOnlyReadOnly
     // Boilerplate code needed to wire-up generated code
     HasOnlyReadOnly._();
 
+    static void _initializeBuilder(HasOnlyReadOnlyBuilder b) => b;
+
     factory HasOnlyReadOnly([updates(HasOnlyReadOnlyBuilder b)]) = _$HasOnlyReadOnly;
     static Serializer<HasOnlyReadOnly> get serializer => _$hasOnlyReadOnlySerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/health_check_result.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/health_check_result.dart
@@ -12,6 +12,8 @@ abstract class HealthCheckResult implements Built<HealthCheckResult, HealthCheck
     // Boilerplate code needed to wire-up generated code
     HealthCheckResult._();
 
+    static void _initializeBuilder(HealthCheckResultBuilder b) => b;
+
     factory HealthCheckResult([updates(HealthCheckResultBuilder b)]) = _$HealthCheckResult;
     static Serializer<HealthCheckResult> get serializer => _$healthCheckResultSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object.dart
@@ -18,6 +18,8 @@ abstract class InlineObject implements Built<InlineObject, InlineObjectBuilder> 
     // Boilerplate code needed to wire-up generated code
     InlineObject._();
 
+    static void _initializeBuilder(InlineObjectBuilder b) => b;
+
     factory InlineObject([updates(InlineObjectBuilder b)]) = _$InlineObject;
     static Serializer<InlineObject> get serializer => _$inlineObjectSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object1.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object1.dart
@@ -19,6 +19,8 @@ abstract class InlineObject1 implements Built<InlineObject1, InlineObject1Builde
     // Boilerplate code needed to wire-up generated code
     InlineObject1._();
 
+    static void _initializeBuilder(InlineObject1Builder b) => b;
+
     factory InlineObject1([updates(InlineObject1Builder b)]) = _$InlineObject1;
     static Serializer<InlineObject1> get serializer => _$inlineObject1Serializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object2.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object2.dart
@@ -21,6 +21,9 @@ abstract class InlineObject2 implements Built<InlineObject2, InlineObject2Builde
     // Boilerplate code needed to wire-up generated code
     InlineObject2._();
 
+    static void _initializeBuilder(InlineObject2Builder b) => b
+        ..enumFormString = const InlineObject2EnumFormStringEnum._('-efg');
+
     factory InlineObject2([updates(InlineObject2Builder b)]) = _$InlineObject2;
     static Serializer<InlineObject2> get serializer => _$inlineObject2Serializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object3.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object3.dart
@@ -79,6 +79,8 @@ abstract class InlineObject3 implements Built<InlineObject3, InlineObject3Builde
     // Boilerplate code needed to wire-up generated code
     InlineObject3._();
 
+    static void _initializeBuilder(InlineObject3Builder b) => b;
+
     factory InlineObject3([updates(InlineObject3Builder b)]) = _$InlineObject3;
     static Serializer<InlineObject3> get serializer => _$inlineObject3Serializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object4.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object4.dart
@@ -18,6 +18,8 @@ abstract class InlineObject4 implements Built<InlineObject4, InlineObject4Builde
     // Boilerplate code needed to wire-up generated code
     InlineObject4._();
 
+    static void _initializeBuilder(InlineObject4Builder b) => b;
+
     factory InlineObject4([updates(InlineObject4Builder b)]) = _$InlineObject4;
     static Serializer<InlineObject4> get serializer => _$inlineObject4Serializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object5.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_object5.dart
@@ -19,6 +19,8 @@ abstract class InlineObject5 implements Built<InlineObject5, InlineObject5Builde
     // Boilerplate code needed to wire-up generated code
     InlineObject5._();
 
+    static void _initializeBuilder(InlineObject5Builder b) => b;
+
     factory InlineObject5([updates(InlineObject5Builder b)]) = _$InlineObject5;
     static Serializer<InlineObject5> get serializer => _$inlineObject5Serializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_response_default.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/inline_response_default.dart
@@ -13,6 +13,8 @@ abstract class InlineResponseDefault implements Built<InlineResponseDefault, Inl
     // Boilerplate code needed to wire-up generated code
     InlineResponseDefault._();
 
+    static void _initializeBuilder(InlineResponseDefaultBuilder b) => b;
+
     factory InlineResponseDefault([updates(InlineResponseDefaultBuilder b)]) = _$InlineResponseDefault;
     static Serializer<InlineResponseDefault> get serializer => _$inlineResponseDefaultSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/map_test.dart
@@ -26,6 +26,8 @@ abstract class MapTest implements Built<MapTest, MapTestBuilder> {
     // Boilerplate code needed to wire-up generated code
     MapTest._();
 
+    static void _initializeBuilder(MapTestBuilder b) => b;
+
     factory MapTest([updates(MapTestBuilder b)]) = _$MapTest;
     static Serializer<MapTest> get serializer => _$mapTestSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
@@ -22,6 +22,8 @@ abstract class MixedPropertiesAndAdditionalPropertiesClass implements Built<Mixe
     // Boilerplate code needed to wire-up generated code
     MixedPropertiesAndAdditionalPropertiesClass._();
 
+    static void _initializeBuilder(MixedPropertiesAndAdditionalPropertiesClassBuilder b) => b;
+
     factory MixedPropertiesAndAdditionalPropertiesClass([updates(MixedPropertiesAndAdditionalPropertiesClassBuilder b)]) = _$MixedPropertiesAndAdditionalPropertiesClass;
     static Serializer<MixedPropertiesAndAdditionalPropertiesClass> get serializer => _$mixedPropertiesAndAdditionalPropertiesClassSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model200_response.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model200_response.dart
@@ -16,6 +16,8 @@ abstract class Model200Response implements Built<Model200Response, Model200Respo
     // Boilerplate code needed to wire-up generated code
     Model200Response._();
 
+    static void _initializeBuilder(Model200ResponseBuilder b) => b;
+
     factory Model200Response([updates(Model200ResponseBuilder b)]) = _$Model200Response;
     static Serializer<Model200Response> get serializer => _$model200ResponseSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_client.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_client.dart
@@ -12,6 +12,8 @@ abstract class ModelClient implements Built<ModelClient, ModelClientBuilder> {
     // Boilerplate code needed to wire-up generated code
     ModelClient._();
 
+    static void _initializeBuilder(ModelClientBuilder b) => b;
+
     factory ModelClient([updates(ModelClientBuilder b)]) = _$ModelClient;
     static Serializer<ModelClient> get serializer => _$modelClientSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_file.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_file.dart
@@ -13,6 +13,8 @@ abstract class ModelFile implements Built<ModelFile, ModelFileBuilder> {
     // Boilerplate code needed to wire-up generated code
     ModelFile._();
 
+    static void _initializeBuilder(ModelFileBuilder b) => b;
+
     factory ModelFile([updates(ModelFileBuilder b)]) = _$ModelFile;
     static Serializer<ModelFile> get serializer => _$modelFileSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_list.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_list.dart
@@ -12,6 +12,8 @@ abstract class ModelList implements Built<ModelList, ModelListBuilder> {
     // Boilerplate code needed to wire-up generated code
     ModelList._();
 
+    static void _initializeBuilder(ModelListBuilder b) => b;
+
     factory ModelList([updates(ModelListBuilder b)]) = _$ModelList;
     static Serializer<ModelList> get serializer => _$modelListSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_return.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/model_return.dart
@@ -12,6 +12,8 @@ abstract class ModelReturn implements Built<ModelReturn, ModelReturnBuilder> {
     // Boilerplate code needed to wire-up generated code
     ModelReturn._();
 
+    static void _initializeBuilder(ModelReturnBuilder b) => b;
+
     factory ModelReturn([updates(ModelReturnBuilder b)]) = _$ModelReturn;
     static Serializer<ModelReturn> get serializer => _$modelReturnSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/name.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/name.dart
@@ -24,6 +24,8 @@ abstract class Name implements Built<Name, NameBuilder> {
     // Boilerplate code needed to wire-up generated code
     Name._();
 
+    static void _initializeBuilder(NameBuilder b) => b;
+
     factory Name([updates(NameBuilder b)]) = _$Name;
     static Serializer<Name> get serializer => _$nameSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -58,6 +58,8 @@ abstract class NullableClass implements Built<NullableClass, NullableClassBuilde
     // Boilerplate code needed to wire-up generated code
     NullableClass._();
 
+    static void _initializeBuilder(NullableClassBuilder b) => b;
+
     factory NullableClass([updates(NullableClassBuilder b)]) = _$NullableClass;
     static Serializer<NullableClass> get serializer => _$nullableClassSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/number_only.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/number_only.dart
@@ -12,6 +12,8 @@ abstract class NumberOnly implements Built<NumberOnly, NumberOnlyBuilder> {
     // Boilerplate code needed to wire-up generated code
     NumberOnly._();
 
+    static void _initializeBuilder(NumberOnlyBuilder b) => b;
+
     factory NumberOnly([updates(NumberOnlyBuilder b)]) = _$NumberOnly;
     static Serializer<NumberOnly> get serializer => _$numberOnlySerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/order.dart
@@ -35,6 +35,9 @@ abstract class Order implements Built<Order, OrderBuilder> {
     // Boilerplate code needed to wire-up generated code
     Order._();
 
+    static void _initializeBuilder(OrderBuilder b) => b
+        ..complete = false;
+
     factory Order([updates(OrderBuilder b)]) = _$Order;
     static Serializer<Order> get serializer => _$orderSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/outer_composite.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/outer_composite.dart
@@ -20,6 +20,8 @@ abstract class OuterComposite implements Built<OuterComposite, OuterCompositeBui
     // Boilerplate code needed to wire-up generated code
     OuterComposite._();
 
+    static void _initializeBuilder(OuterCompositeBuilder b) => b;
+
     factory OuterComposite([updates(OuterCompositeBuilder b)]) = _$OuterComposite;
     static Serializer<OuterComposite> get serializer => _$outerCompositeSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/pet.dart
@@ -37,6 +37,8 @@ abstract class Pet implements Built<Pet, PetBuilder> {
     // Boilerplate code needed to wire-up generated code
     Pet._();
 
+    static void _initializeBuilder(PetBuilder b) => b;
+
     factory Pet([updates(PetBuilder b)]) = _$Pet;
     static Serializer<Pet> get serializer => _$petSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/read_only_first.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/read_only_first.dart
@@ -16,6 +16,8 @@ abstract class ReadOnlyFirst implements Built<ReadOnlyFirst, ReadOnlyFirstBuilde
     // Boilerplate code needed to wire-up generated code
     ReadOnlyFirst._();
 
+    static void _initializeBuilder(ReadOnlyFirstBuilder b) => b;
+
     factory ReadOnlyFirst([updates(ReadOnlyFirstBuilder b)]) = _$ReadOnlyFirst;
     static Serializer<ReadOnlyFirst> get serializer => _$readOnlyFirstSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/special_model_name.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/special_model_name.dart
@@ -12,6 +12,8 @@ abstract class SpecialModelName implements Built<SpecialModelName, SpecialModelN
     // Boilerplate code needed to wire-up generated code
     SpecialModelName._();
 
+    static void _initializeBuilder(SpecialModelNameBuilder b) => b;
+
     factory SpecialModelName([updates(SpecialModelNameBuilder b)]) = _$SpecialModelName;
     static Serializer<SpecialModelName> get serializer => _$specialModelNameSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/tag.dart
@@ -16,6 +16,8 @@ abstract class Tag implements Built<Tag, TagBuilder> {
     // Boilerplate code needed to wire-up generated code
     Tag._();
 
+    static void _initializeBuilder(TagBuilder b) => b;
+
     factory Tag([updates(TagBuilder b)]) = _$Tag;
     static Serializer<Tag> get serializer => _$tagSerializer;
 }

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/user.dart
@@ -41,6 +41,8 @@ abstract class User implements Built<User, UserBuilder> {
     // Boilerplate code needed to wire-up generated code
     User._();
 
+    static void _initializeBuilder(UserBuilder b) => b;
+
     factory User([updates(UserBuilder b)]) = _$User;
     static Serializer<User> get serializer => _$userSerializer;
 }


### PR DESCRIPTION
This PR adds support for default values to the dart-dio generator.

* return `null` when there is no default value instead of `"null"` (this also removes the "defaults to null" from model docs)
* don't need any collection literal default values for built_value
* use built_value's `_initializeBuilder` to set default values
*  fix formatting of default values in model doc

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)