### PR TITLE
[go] Add constructor and IsValid method to enum types

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_enum.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_enum.mustache
@@ -12,6 +12,14 @@ const (
 	{{/allowableValues}}
 )
 
+var allowed{{{classname}}}EnumValues = []{{{classname}}}{
+	{{#allowableValues}}
+	{{#enumVars}}
+	{{{value}}},
+	{{/enumVars}}
+	{{/allowableValues}}
+}
+
 func (v *{{{classname}}}) UnmarshalJSON(src []byte) error {
 	var value {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
 	err := json.Unmarshal(src, &value)
@@ -19,7 +27,7 @@ func (v *{{{classname}}}) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := {{{classname}}}(value)
-	for _, existing := range []{{classname}}{ {{#allowableValues}}{{#enumVars}}{{{value}}}, {{/enumVars}} {{/allowableValues}} } {
+	for _, existing := range allowed{{{classname}}}EnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -27,6 +35,27 @@ func (v *{{{classname}}}) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid {{classname}}", value)
+}
+
+// New{{{classname}}}FromValue returns a pointer to a valid {{{classname}}}
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func New{{{classname}}}FromValue(v {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}) (*{{{classname}}}, error) {
+	ev := {{{classname}}}(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for {{{classname}}}: valid values are %v", v, allowed{{{classname}}}EnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v {{{classname}}}) IsValid() bool {
+	for _, existing := range allowed{{{classname}}}EnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to {{{name}}} value

--- a/samples/client/petstore/go/go-petstore/model_enum_class.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_class.go
@@ -25,6 +25,12 @@ const (
 	XYZ EnumClass = "(xyz)"
 )
 
+var allowedEnumClassEnumValues = []EnumClass{
+	"_abc",
+	"-efg",
+	"(xyz)",
+}
+
 func (v *EnumClass) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -32,7 +38,7 @@ func (v *EnumClass) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := EnumClass(value)
-	for _, existing := range []EnumClass{ "_abc", "-efg", "(xyz)",   } {
+	for _, existing := range allowedEnumClassEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +46,27 @@ func (v *EnumClass) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid EnumClass", value)
+}
+
+// NewEnumClassFromValue returns a pointer to a valid EnumClass
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewEnumClassFromValue(v string) (*EnumClass, error) {
+	ev := EnumClass(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for EnumClass: valid values are %v", v, allowedEnumClassEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v EnumClass) IsValid() bool {
+	for _, existing := range allowedEnumClassEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to EnumClass value

--- a/samples/client/petstore/go/go-petstore/model_outer_enum.go
+++ b/samples/client/petstore/go/go-petstore/model_outer_enum.go
@@ -25,6 +25,12 @@ const (
 	DELIVERED OuterEnum = "delivered"
 )
 
+var allowedOuterEnumEnumValues = []OuterEnum{
+	"placed",
+	"approved",
+	"delivered",
+}
+
 func (v *OuterEnum) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -32,7 +38,7 @@ func (v *OuterEnum) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := OuterEnum(value)
-	for _, existing := range []OuterEnum{ "placed", "approved", "delivered",   } {
+	for _, existing := range allowedOuterEnumEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +46,27 @@ func (v *OuterEnum) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid OuterEnum", value)
+}
+
+// NewOuterEnumFromValue returns a pointer to a valid OuterEnum
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewOuterEnumFromValue(v string) (*OuterEnum, error) {
+	ev := OuterEnum(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for OuterEnum: valid values are %v", v, allowedOuterEnumEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v OuterEnum) IsValid() bool {
+	for _, existing := range allowedOuterEnumEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to OuterEnum value

--- a/samples/openapi3/client/petstore/go/go-petstore/model_enum_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_enum_class.go
@@ -25,6 +25,12 @@ const (
 	ENUMCLASS_XYZ EnumClass = "(xyz)"
 )
 
+var allowedEnumClassEnumValues = []EnumClass{
+	"_abc",
+	"-efg",
+	"(xyz)",
+}
+
 func (v *EnumClass) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -32,7 +38,7 @@ func (v *EnumClass) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := EnumClass(value)
-	for _, existing := range []EnumClass{ "_abc", "-efg", "(xyz)",   } {
+	for _, existing := range allowedEnumClassEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +46,27 @@ func (v *EnumClass) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid EnumClass", value)
+}
+
+// NewEnumClassFromValue returns a pointer to a valid EnumClass
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewEnumClassFromValue(v string) (*EnumClass, error) {
+	ev := EnumClass(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for EnumClass: valid values are %v", v, allowedEnumClassEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v EnumClass) IsValid() bool {
+	for _, existing := range allowedEnumClassEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to EnumClass value

--- a/samples/openapi3/client/petstore/go/go-petstore/model_outer_enum.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_outer_enum.go
@@ -25,6 +25,12 @@ const (
 	OUTERENUM_DELIVERED OuterEnum = "delivered"
 )
 
+var allowedOuterEnumEnumValues = []OuterEnum{
+	"placed",
+	"approved",
+	"delivered",
+}
+
 func (v *OuterEnum) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -32,7 +38,7 @@ func (v *OuterEnum) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := OuterEnum(value)
-	for _, existing := range []OuterEnum{ "placed", "approved", "delivered",   } {
+	for _, existing := range allowedOuterEnumEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +46,27 @@ func (v *OuterEnum) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid OuterEnum", value)
+}
+
+// NewOuterEnumFromValue returns a pointer to a valid OuterEnum
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewOuterEnumFromValue(v string) (*OuterEnum, error) {
+	ev := OuterEnum(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for OuterEnum: valid values are %v", v, allowedOuterEnumEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v OuterEnum) IsValid() bool {
+	for _, existing := range allowedOuterEnumEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to OuterEnum value

--- a/samples/openapi3/client/petstore/go/go-petstore/model_outer_enum_default_value.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_outer_enum_default_value.go
@@ -25,6 +25,12 @@ const (
 	OUTERENUMDEFAULTVALUE_DELIVERED OuterEnumDefaultValue = "delivered"
 )
 
+var allowedOuterEnumDefaultValueEnumValues = []OuterEnumDefaultValue{
+	"placed",
+	"approved",
+	"delivered",
+}
+
 func (v *OuterEnumDefaultValue) UnmarshalJSON(src []byte) error {
 	var value string
 	err := json.Unmarshal(src, &value)
@@ -32,7 +38,7 @@ func (v *OuterEnumDefaultValue) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := OuterEnumDefaultValue(value)
-	for _, existing := range []OuterEnumDefaultValue{ "placed", "approved", "delivered",   } {
+	for _, existing := range allowedOuterEnumDefaultValueEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +46,27 @@ func (v *OuterEnumDefaultValue) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid OuterEnumDefaultValue", value)
+}
+
+// NewOuterEnumDefaultValueFromValue returns a pointer to a valid OuterEnumDefaultValue
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewOuterEnumDefaultValueFromValue(v string) (*OuterEnumDefaultValue, error) {
+	ev := OuterEnumDefaultValue(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for OuterEnumDefaultValue: valid values are %v", v, allowedOuterEnumDefaultValueEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v OuterEnumDefaultValue) IsValid() bool {
+	for _, existing := range allowedOuterEnumDefaultValueEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to OuterEnumDefaultValue value

--- a/samples/openapi3/client/petstore/go/go-petstore/model_outer_enum_integer.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_outer_enum_integer.go
@@ -25,6 +25,12 @@ const (
 	OUTERENUMINTEGER__2 OuterEnumInteger = 2
 )
 
+var allowedOuterEnumIntegerEnumValues = []OuterEnumInteger{
+	0,
+	1,
+	2,
+}
+
 func (v *OuterEnumInteger) UnmarshalJSON(src []byte) error {
 	var value int32
 	err := json.Unmarshal(src, &value)
@@ -32,7 +38,7 @@ func (v *OuterEnumInteger) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := OuterEnumInteger(value)
-	for _, existing := range []OuterEnumInteger{ 0, 1, 2,   } {
+	for _, existing := range allowedOuterEnumIntegerEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +46,27 @@ func (v *OuterEnumInteger) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid OuterEnumInteger", value)
+}
+
+// NewOuterEnumIntegerFromValue returns a pointer to a valid OuterEnumInteger
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewOuterEnumIntegerFromValue(v int32) (*OuterEnumInteger, error) {
+	ev := OuterEnumInteger(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for OuterEnumInteger: valid values are %v", v, allowedOuterEnumIntegerEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v OuterEnumInteger) IsValid() bool {
+	for _, existing := range allowedOuterEnumIntegerEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to OuterEnumInteger value

--- a/samples/openapi3/client/petstore/go/go-petstore/model_outer_enum_integer_default_value.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_outer_enum_integer_default_value.go
@@ -25,6 +25,12 @@ const (
 	OUTERENUMINTEGERDEFAULTVALUE__2 OuterEnumIntegerDefaultValue = 2
 )
 
+var allowedOuterEnumIntegerDefaultValueEnumValues = []OuterEnumIntegerDefaultValue{
+	0,
+	1,
+	2,
+}
+
 func (v *OuterEnumIntegerDefaultValue) UnmarshalJSON(src []byte) error {
 	var value int32
 	err := json.Unmarshal(src, &value)
@@ -32,7 +38,7 @@ func (v *OuterEnumIntegerDefaultValue) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := OuterEnumIntegerDefaultValue(value)
-	for _, existing := range []OuterEnumIntegerDefaultValue{ 0, 1, 2,   } {
+	for _, existing := range allowedOuterEnumIntegerDefaultValueEnumValues {
 		if existing == enumTypeValue {
 			*v = enumTypeValue
 			return nil
@@ -40,6 +46,27 @@ func (v *OuterEnumIntegerDefaultValue) UnmarshalJSON(src []byte) error {
 	}
 
 	return fmt.Errorf("%+v is not a valid OuterEnumIntegerDefaultValue", value)
+}
+
+// NewOuterEnumIntegerDefaultValueFromValue returns a pointer to a valid OuterEnumIntegerDefaultValue
+// for the value passed as argument, or an error if the value passed is not allowed by the enum
+func NewOuterEnumIntegerDefaultValueFromValue(v int32) (*OuterEnumIntegerDefaultValue, error) {
+	ev := OuterEnumIntegerDefaultValue(v)
+	if ev.IsValid() {
+		return &ev, nil
+	} else {
+		return nil, fmt.Errorf("invalid value '%v' for OuterEnumIntegerDefaultValue: valid values are %v", v, allowedOuterEnumIntegerDefaultValueEnumValues)
+	}
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise
+func (v OuterEnumIntegerDefaultValue) IsValid() bool {
+	for _, existing := range allowedOuterEnumIntegerDefaultValueEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
 }
 
 // Ptr returns reference to OuterEnumIntegerDefaultValue value


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Add constructor and IsValid method to enum types.
This allows users of library to make they have valid value when not using the constants directly

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
