### PR TITLE
Allow generators to override example creation when no examples are provided in the spec

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3617,14 +3617,7 @@ public class DefaultCodegen implements CodegenConfig {
                 }
             }
 
-            // generate examples
-            String exampleStatusCode = "200";
-            for (String key : operation.getResponses().keySet()) {
-                if (operation.getResponses().get(key) == methodResponse && !key.equals("default")) {
-                    exampleStatusCode = key;
-                }
-            }
-            op.examples = new ExampleGenerator(schemas, this.openAPI).generateFromResponseSchema(exampleStatusCode, responseSchema, getProducesInfo(this.openAPI, operation));
+            op.examples = generateExamplesFromResponse(schemas, operation, methodResponse);
             op.defaultResponse = toDefaultValue(responseSchema);
             op.returnType = cm.dataType;
             op.returnFormat = cm.dataFormat;
@@ -3659,6 +3652,27 @@ public class DefaultCodegen implements CodegenConfig {
             }
         }
         addHeaders(methodResponse, op.responseHeaders);
+    }
+
+    /**
+     * Generate examples from the provided operation
+     *
+     * @param schemas        a map of the schemas in the openapi spec
+     * @param operation      endpoint Operation
+     * @param methodResponse the default ApiResponse for the endpoint
+     * @return A List of example responses
+     */
+    protected List<Map<String, String>> generateExamplesFromResponse(Map<String, Schema> schemas, Operation operation, ApiResponse methodResponse) {
+        Schema responseSchema = unaliasSchema(ModelUtils.getSchemaFromResponse(methodResponse), importMapping);
+
+        String exampleStatusCode = "200";
+        for (String key : operation.getResponses().keySet()) {
+            if (operation.getResponses().get(key) == methodResponse && !key.equals("default")) {
+                exampleStatusCode = key;
+            }
+        }
+
+        return new ExampleGenerator(schemas, this.openAPI).generateFromResponseSchema(exampleStatusCode, responseSchema, getProducesInfo(this.openAPI, operation));
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
@@ -184,9 +184,7 @@ public class ExampleGenerator {
         }
 
         if (output.size() == 0) {
-            Map<String, String> kv = new HashMap<>();
-            kv.put(OUTPUT, NONE);
-            output.add(kv);
+            createDefaultExamples(output);
         }
         return output;
     }
@@ -212,11 +210,15 @@ public class ExampleGenerator {
         }
 
         if (output.size() == 0) {
-            Map<String, String> kv = new HashMap<>();
-            kv.put(OUTPUT, NONE);
-            output.add(kv);
+            createDefaultExamples(output);
         }
         return output;
+    }
+
+    protected void createDefaultExamples(List<Map<String, String>> examples) {
+        Map<String, String> example = new HashMap<>();
+        example.put(OUTPUT, NONE);
+        examples.add(example);
     }
 
     private Object resolvePropertyToExample(String propertyName, String mediaType, Schema property, Set<String> processedModels) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
@@ -152,4 +152,39 @@ public class ExampleGeneratorTest {
         assertEquals(String.format(Locale.ROOT, "{%n  \"example_schema_property\" : \"example schema property value\"%n}"), examples.get(0).get("example"));
         assertEquals("200", examples.get(0).get("statusCode"));
     }
+
+    @Test
+    public void generateNothingFromResponseSchemaWithModel() {
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
+
+        new InlineModelResolver().flatten(openAPI);
+
+        ExampleGenerator exampleGenerator = new ExampleGenerator(openAPI.getComponents().getSchemas(), openAPI) {
+            @Override
+            protected Map<String, Object> createExampleFromModelValues(Schema schema, String mediaType, Set<String> processedModels) {
+                return null;
+            }
+
+            @Override
+            protected void createDefaultExamples(List<Map<String, String>> examples) {
+            }
+        };
+        Set<String> mediaTypeKeys = new TreeSet<>();
+        mediaTypeKeys.add("application/json");
+        List<Map<String, String>> examples = exampleGenerator.generateFromResponseSchema(
+                "200",
+                openAPI
+                        .getPaths()
+                        .get("/generate_from_response_schema_with_model")
+                        .getGet()
+                        .getResponses()
+                        .get("200")
+                        .getContent()
+                        .get("application/json")
+                        .getSchema(),
+                mediaTypeKeys
+        );
+
+        assertEquals(0, examples.size());
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
@@ -1,6 +1,7 @@
 package org.openapitools.codegen;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
 import org.openapitools.codegen.examples.ExampleGenerator;
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
This is a potential implementation to address #8229.

I tried to be fairly conservative with the changes as it is in the default generator and I believe this change is backwards compatible. Though, I'm sure there is further related related refactoring that could be done if there are suggestions.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
