### PR TITLE
Go onoef discriminator err

### DIFF
--- a/bin/configs/go-petstore.yaml
+++ b/bin/configs/go-petstore.yaml
@@ -7,3 +7,4 @@ additionalProperties:
   packageName: petstore
   disallowAdditionalPropertiesIfNotPresent: false
   generateInterfaces: true
+  useOneOfDiscriminatorLookup: true

--- a/modules/openapi-generator/src/main/resources/go/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_oneof.mustache
@@ -48,8 +48,39 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	}
 
 	{{/mappedModels}}
-	{{/discriminator}}
 	return nil
+	{{/discriminator}}
+	{{^discriminator}}
+	match := 0
+	var err error
+	{{#oneOf}}
+	// try to unmarshal data into {{{.}}}
+	err = json.Unmarshal(data, &dst.{{{.}}})
+	if err == nil {
+		json{{{.}}}, _ := json.Marshal(dst.{{{.}}})
+		if string(json{{{.}}}) == "{}" { // empty struct
+			dst.{{{.}}} = nil
+		} else {
+			match++
+		}
+	} else {
+		dst.{{{.}}} = nil
+	}
+
+	{{/oneOf}}
+	if match > 1 { // more than 1 match
+		// reset to nil
+	{{#oneOf}}
+		dst.{{{.}}} = nil
+	{{/oneOf}}
+
+		return fmt.Errorf("Data matches more than one schema in oneOf({{classname}})")
+	} else if match == 1 {
+		return nil // exactly one match
+	} else { // no match
+		return fmt.Errorf("Data failed to match schemas in oneOf({{classname}})")
+	}
+	{{/discriminator}}
 	{{/useOneOfDiscriminatorLookup}}
 	{{^useOneOfDiscriminatorLookup}}
 	match := 0

--- a/samples/client/petstore/go/go-petstore/api/openapi.yaml
+++ b/samples/client/petstore/go/go-petstore/api/openapi.yaml
@@ -2126,3 +2126,4 @@ components:
     http_basic_test:
       scheme: basic
       type: http
+x-original-swagger-version: "2.0"

--- a/samples/client/petstore/go/go-petstore/api/openapi.yaml
+++ b/samples/client/petstore/go/go-petstore/api/openapi.yaml
@@ -2126,4 +2126,3 @@ components:
     http_basic_test:
       scheme: basic
       type: http
-x-original-swagger-version: "2.0"

--- a/samples/openapi3/client/petstore/go/go-petstore/model_mammal.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_mammal.go
@@ -34,45 +34,39 @@ func ZebraAsMammal(v *Zebra) Mammal {
 
 // Unmarshal JSON data into one of the pointers in the struct
 func (dst *Mammal) UnmarshalJSON(data []byte) error {
-	match := 0
 	var err error
-	// try to unmarshal data into Whale
-	err = json.Unmarshal(data, &dst.Whale)
-	if err == nil {
-		jsonWhale, _ := json.Marshal(dst.Whale)
-		if string(jsonWhale) == "{}" { // empty struct
+	// use discriminator value to speed up the lookup
+	var jsonDict map[string]interface{}
+	err = json.Unmarshal(data, &jsonDict)
+	if err != nil {
+		return fmt.Errorf("Failed to unmarshal JSON into map for the discrimintor lookup.")
+	}
+
+	// check if the discriminator value is 'whale'
+	if jsonDict["className"] == "whale" {
+		// try to unmarshal JSON data into Whale
+		err = json.Unmarshal(data, &dst.Whale)
+		if err == nil {
+			return nil // data stored in dst.Whale, return on the first match
+		} else {
 			dst.Whale = nil
-		} else {
-			match++
+			return fmt.Errorf("Failed to unmarshal Mammal as Whale: %s", err.Error())
 		}
-	} else {
-		dst.Whale = nil
 	}
 
-	// try to unmarshal data into Zebra
-	err = json.Unmarshal(data, &dst.Zebra)
-	if err == nil {
-		jsonZebra, _ := json.Marshal(dst.Zebra)
-		if string(jsonZebra) == "{}" { // empty struct
+	// check if the discriminator value is 'zebra'
+	if jsonDict["className"] == "zebra" {
+		// try to unmarshal JSON data into Zebra
+		err = json.Unmarshal(data, &dst.Zebra)
+		if err == nil {
+			return nil // data stored in dst.Zebra, return on the first match
+		} else {
 			dst.Zebra = nil
-		} else {
-			match++
+			return fmt.Errorf("Failed to unmarshal Mammal as Zebra: %s", err.Error())
 		}
-	} else {
-		dst.Zebra = nil
 	}
 
-	if match > 1 { // more than 1 match
-		// reset to nil
-		dst.Whale = nil
-		dst.Zebra = nil
-
-		return fmt.Errorf("Data matches more than one schema in oneOf(Mammal)")
-	} else if match == 1 {
-		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("Data failed to match schemas in oneOf(Mammal)")
-	}
+	return nil
 }
 
 // Marshal data from the first non-nil pointers in the struct to JSON


### PR DESCRIPTION

Here is the logic I have tried to implement
```txt
if useOneOfDiscriminatorLookup and discriminator:
  use discriminator to marshal
else:
  use object marshalling and check if it fits into any struct
```
Since mustache does not have `and` operator, there is a block of code that is used twice. 
```txt
if useOneOfDiscriminatorLookup:
  if discriminator:
    use discriminator to marshal
  else:
    use object marshaling and check if fits into any struct
else:
  use object marshaling and check if fits into any struct
  ```

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)