### PR TITLE
Tweak regexp in underscore method

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
@@ -61,7 +61,7 @@ public class StringUtils {
                 .build();
     }
 
-    private static Pattern capitalLetterPattern = Pattern.compile("([A-Z]+)([A-Z][a-z])");
+    private static Pattern capitalLetterPattern = Pattern.compile("([A-Z]+)([A-Z][a-z][a-z]+)");
     private static Pattern lowercasePattern = Pattern.compile("([a-z\\d])([A-Z])");
     private static Pattern pkgSeparatorPattern = Pattern.compile("\\.");
     private static Pattern dollarPattern = Pattern.compile("\\$");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/StringUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/StringUtilsTest.java
@@ -11,6 +11,7 @@ public class StringUtilsTest {
     public void testUnderscore() {
         Assert.assertEquals(underscore("abcd"), "abcd");
         Assert.assertEquals(underscore("abCd"), "ab_cd");
+        Assert.assertEquals(underscore("ListABCs"), "list_abcs");
     }
 
     @Test


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The rule to split a capitalized word with plural didn't work properly, leading
to weird name generation in a few languages. This is an attempt at fixing it.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.