### PR TITLE
[DART-DIO] Remove break statement in api auth key for loop to allow more than one api key

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/auth/api_key_auth.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/auth/api_key_auth.mustache
@@ -19,7 +19,6 @@ class ApiKeyAuthInterceptor extends AuthInterceptor {
                 } else {
                     options.headers[authKeyName] = apiKey;
                 }
-                break;
             }
         }
         return super.onRequest(options);


### PR DESCRIPTION
Fixes bug from #8254