### PR TITLE
[Swift 5] fix XcodeGen deploy target to match cocoapods

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/XcodeGen.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/XcodeGen.mustache
@@ -3,7 +3,7 @@ targets:
   {{projectName}}:
     type: framework
     platform: iOS
-    deploymentTarget: "10.0"
+    deploymentTarget: "9.0"
     sources: [{{projectName}}]
     info:
       path: ./Info.plist

--- a/samples/client/petstore/swift5/alamofireLibrary/project.yml
+++ b/samples/client/petstore/swift5/alamofireLibrary/project.yml
@@ -3,7 +3,7 @@ targets:
   PetstoreClient:
     type: framework
     platform: iOS
-    deploymentTarget: "10.0"
+    deploymentTarget: "9.0"
     sources: [PetstoreClient]
     info:
       path: ./Info.plist

--- a/samples/client/petstore/swift5/combineLibrary/project.yml
+++ b/samples/client/petstore/swift5/combineLibrary/project.yml
@@ -3,7 +3,7 @@ targets:
   PetstoreClient:
     type: framework
     platform: iOS
-    deploymentTarget: "10.0"
+    deploymentTarget: "9.0"
     sources: [PetstoreClient]
     info:
       path: ./Info.plist

--- a/samples/client/petstore/swift5/default/project.yml
+++ b/samples/client/petstore/swift5/default/project.yml
@@ -3,7 +3,7 @@ targets:
   PetstoreClient:
     type: framework
     platform: iOS
-    deploymentTarget: "10.0"
+    deploymentTarget: "9.0"
     sources: [PetstoreClient]
     info:
       path: ./Info.plist

--- a/samples/client/petstore/swift5/deprecated/project.yml
+++ b/samples/client/petstore/swift5/deprecated/project.yml
@@ -3,7 +3,7 @@ targets:
   PetstoreClient:
     type: framework
     platform: iOS
-    deploymentTarget: "10.0"
+    deploymentTarget: "9.0"
     sources: [PetstoreClient]
     info:
       path: ./Info.plist

--- a/samples/client/petstore/swift5/nonPublicApi/project.yml
+++ b/samples/client/petstore/swift5/nonPublicApi/project.yml
@@ -3,7 +3,7 @@ targets:
   PetstoreClient:
     type: framework
     platform: iOS
-    deploymentTarget: "10.0"
+    deploymentTarget: "9.0"
     sources: [PetstoreClient]
     info:
       path: ./Info.plist

--- a/samples/client/petstore/swift5/objcCompatible/project.yml
+++ b/samples/client/petstore/swift5/objcCompatible/project.yml
@@ -3,7 +3,7 @@ targets:
   PetstoreClient:
     type: framework
     platform: iOS
-    deploymentTarget: "10.0"
+    deploymentTarget: "9.0"
     sources: [PetstoreClient]
     info:
       path: ./Info.plist

--- a/samples/client/petstore/swift5/promisekitLibrary/project.yml
+++ b/samples/client/petstore/swift5/promisekitLibrary/project.yml
@@ -3,7 +3,7 @@ targets:
   PetstoreClient:
     type: framework
     platform: iOS
-    deploymentTarget: "10.0"
+    deploymentTarget: "9.0"
     sources: [PetstoreClient]
     info:
       path: ./Info.plist

--- a/samples/client/petstore/swift5/readonlyProperties/project.yml
+++ b/samples/client/petstore/swift5/readonlyProperties/project.yml
@@ -3,7 +3,7 @@ targets:
   PetstoreClient:
     type: framework
     platform: iOS
-    deploymentTarget: "10.0"
+    deploymentTarget: "9.0"
     sources: [PetstoreClient]
     info:
       path: ./Info.plist

--- a/samples/client/petstore/swift5/resultLibrary/project.yml
+++ b/samples/client/petstore/swift5/resultLibrary/project.yml
@@ -3,7 +3,7 @@ targets:
   PetstoreClient:
     type: framework
     platform: iOS
-    deploymentTarget: "10.0"
+    deploymentTarget: "9.0"
     sources: [PetstoreClient]
     info:
       path: ./Info.plist

--- a/samples/client/petstore/swift5/rxswiftLibrary/project.yml
+++ b/samples/client/petstore/swift5/rxswiftLibrary/project.yml
@@ -3,7 +3,7 @@ targets:
   PetstoreClient:
     type: framework
     platform: iOS
-    deploymentTarget: "10.0"
+    deploymentTarget: "9.0"
     sources: [PetstoreClient]
     info:
       path: ./Info.plist

--- a/samples/client/petstore/swift5/urlsessionLibrary/project.yml
+++ b/samples/client/petstore/swift5/urlsessionLibrary/project.yml
@@ -3,7 +3,7 @@ targets:
   PetstoreClient:
     type: framework
     platform: iOS
-    deploymentTarget: "10.0"
+    deploymentTarget: "9.0"
     sources: [PetstoreClient]
     info:
       path: ./Info.plist


### PR DESCRIPTION
Currently the Swift 5 generator supports iOS 9 as minimum supported version, but in XcodeGen the minimum iOS version supported is 10.
This PR fixes that.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [X] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11)