### PR TITLE
typescript-fetch: Fix two spaces after get headers()

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -172,7 +172,7 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders | undefined {
+    get headers(): HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -183,7 +183,7 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders | undefined {
+    get headers(): HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -183,7 +183,7 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders | undefined {
+    get headers(): HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -183,7 +183,7 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders | undefined {
+    get headers(): HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -183,7 +183,7 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders | undefined {
+    get headers(): HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -183,7 +183,7 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders | undefined {
+    get headers(): HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -183,7 +183,7 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders | undefined {
+    get headers(): HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
@@ -183,7 +183,7 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders | undefined {
+    get headers(): HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -183,7 +183,7 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders | undefined {
+    get headers(): HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -183,7 +183,7 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders | undefined {
+    get headers(): HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -183,7 +183,7 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders | undefined {
+    get headers(): HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 


### PR DESCRIPTION
This is a very small change and not at all important: there are two spaces after `get header():` instead of just the normal one. 😄 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@leonyu