### PR TITLE
Changed generated python client to accept None as request body

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -123,6 +123,12 @@ class {{classname}}(object):
             kwargs['{{paramName}}'] = \
                 {{paramName}}
 {{/requiredParams}}
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.{{operationId}} = Endpoint(

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -170,7 +170,7 @@ class RESTClientObject(object):
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is
                 # provided in serialized form
-                elif isinstance(body, str) or isinstance(body, bytes):
+                elif isinstance(body, str) or isinstance(body, bytes) or body is None:
                     request_body = body
                     r = self.pool_manager.request(
                         method, url,

--- a/samples/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -100,6 +100,12 @@ class AnotherFakeApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['body'] = \
                 body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.call_123_test_special_tags = Endpoint(

--- a/samples/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/api/fake_api.py
@@ -103,6 +103,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.array_model = Endpoint(
@@ -213,6 +219,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.boolean = Endpoint(
@@ -327,6 +339,12 @@ class FakeApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['xml_item'] = \
                 xml_item
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.create_xml_item = Endpoint(
@@ -444,6 +462,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.number_with_validations = Endpoint(
@@ -554,6 +578,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.object_model_with_ref_props = Endpoint(
@@ -664,6 +694,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.string = Endpoint(
@@ -774,6 +810,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.string_enum = Endpoint(
@@ -888,6 +930,12 @@ class FakeApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['body'] = \
                 body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_body_with_file_schema = Endpoint(
@@ -1007,6 +1055,12 @@ class FakeApi(object):
                 query
             kwargs['body'] = \
                 body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_body_with_query_params = Endpoint(
@@ -1129,6 +1183,12 @@ class FakeApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['body'] = \
                 body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_client_model = Endpoint(
@@ -1263,6 +1323,12 @@ class FakeApi(object):
                 path_integer
             kwargs['header_number'] = \
                 header_number
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_endpoint_enums_length_one = Endpoint(
@@ -1449,6 +1515,12 @@ class FakeApi(object):
                 pattern_without_delimiter
             kwargs['byte'] = \
                 byte
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_endpoint_parameters = Endpoint(
@@ -1688,6 +1760,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_enum_parameters = Endpoint(
@@ -1903,6 +1981,12 @@ class FakeApi(object):
                 required_boolean_group
             kwargs['required_int64_group'] = \
                 required_int64_group
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_group_parameters = Endpoint(
@@ -2044,6 +2128,12 @@ class FakeApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['param'] = \
                 param
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_inline_additional_properties = Endpoint(
@@ -2163,6 +2253,12 @@ class FakeApi(object):
                 param
             kwargs['param2'] = \
                 param2
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_json_form_data = Endpoint(

--- a/samples/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
@@ -100,6 +100,12 @@ class FakeClassnameTags123Api(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['body'] = \
                 body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_classname = Endpoint(

--- a/samples/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/api/pet_api.py
@@ -100,6 +100,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['body'] = \
                 body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.add_pet = Endpoint(
@@ -219,6 +225,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['pet_id'] = \
                 pet_id
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.delete_pet = Endpoint(
@@ -341,6 +353,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['status'] = \
                 status
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.find_pets_by_status = Endpoint(
@@ -469,6 +487,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['tags'] = \
                 tags
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.find_pets_by_tags = Endpoint(
@@ -590,6 +614,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['pet_id'] = \
                 pet_id
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.get_pet_by_id = Endpoint(
@@ -709,6 +739,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['body'] = \
                 body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.update_pet = Endpoint(
@@ -829,6 +865,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['pet_id'] = \
                 pet_id
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.update_pet_with_form = Endpoint(
@@ -960,6 +1002,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['pet_id'] = \
                 pet_id
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.upload_file = Endpoint(
@@ -1101,6 +1149,12 @@ class PetApi(object):
                 pet_id
             kwargs['required_file'] = \
                 required_file
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.upload_file_with_required_file = Endpoint(

--- a/samples/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/client/petstore/python/petstore_api/api/store_api.py
@@ -100,6 +100,12 @@ class StoreApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['order_id'] = \
                 order_id
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.delete_order = Endpoint(
@@ -210,6 +216,12 @@ class StoreApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.get_inventory = Endpoint(
@@ -322,6 +334,12 @@ class StoreApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['order_id'] = \
                 order_id
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.get_order_by_id = Endpoint(
@@ -445,6 +463,12 @@ class StoreApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['body'] = \
                 body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.place_order = Endpoint(

--- a/samples/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/client/petstore/python/petstore_api/api/user_api.py
@@ -100,6 +100,12 @@ class UserApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['body'] = \
                 body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.create_user = Endpoint(
@@ -213,6 +219,12 @@ class UserApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['body'] = \
                 body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.create_users_with_array_input = Endpoint(
@@ -326,6 +338,12 @@ class UserApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['body'] = \
                 body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.create_users_with_list_input = Endpoint(
@@ -440,6 +458,12 @@ class UserApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['username'] = \
                 username
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.delete_user = Endpoint(
@@ -554,6 +578,12 @@ class UserApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['username'] = \
                 username
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.get_user_by_name = Endpoint(
@@ -675,6 +705,12 @@ class UserApi(object):
                 username
             kwargs['password'] = \
                 password
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.login_user = Endpoint(
@@ -793,6 +829,12 @@ class UserApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.logout_user = Endpoint(
@@ -905,6 +947,12 @@ class UserApi(object):
                 username
             kwargs['body'] = \
                 body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.update_user = Endpoint(

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -178,7 +178,7 @@ class RESTClientObject(object):
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is
                 # provided in serialized form
-                elif isinstance(body, str) or isinstance(body, bytes):
+                elif isinstance(body, str) or isinstance(body, bytes) or body is None:
                     request_body = body
                     r = self.pool_manager.request(
                         method, url,

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/api/usage_api.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/api/usage_api.py
@@ -94,6 +94,12 @@ class UsageApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.any_key = Endpoint(
@@ -202,6 +208,12 @@ class UsageApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.both_keys = Endpoint(
@@ -310,6 +322,12 @@ class UsageApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.key_in_header = Endpoint(
@@ -417,6 +435,12 @@ class UsageApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.key_in_query = Endpoint(

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/rest.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/rest.py
@@ -178,7 +178,7 @@ class RESTClientObject(object):
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is
                 # provided in serialized form
-                elif isinstance(body, str) or isinstance(body, bytes):
+                elif isinstance(body, str) or isinstance(body, bytes) or body is None:
                     request_body = body
                     r = self.pool_manager.request(
                         method, url,

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api/usage_api.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api/usage_api.py
@@ -94,6 +94,12 @@ class UsageApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.custom_server = Endpoint(
@@ -248,6 +254,12 @@ class UsageApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.default_server = Endpoint(

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/rest.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/rest.py
@@ -178,7 +178,7 @@ class RESTClientObject(object):
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is
                 # provided in serialized form
-                elif isinstance(body, str) or isinstance(body, bytes):
+                elif isinstance(body, str) or isinstance(body, bytes) or body is None:
                     request_body = body
                     r = self.pool_manager.request(
                         method, url,

--- a/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -100,6 +100,12 @@ class AnotherFakeApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['client'] = \
                 client
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.call_123_test_special_tags = Endpoint(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
@@ -94,6 +94,12 @@ class DefaultApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.foo_get = Endpoint(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -106,6 +106,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.additional_properties_with_array_of_enums = Endpoint(
@@ -218,6 +224,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.array_model = Endpoint(
@@ -329,6 +341,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.array_of_enums = Endpoint(
@@ -441,6 +459,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.boolean = Endpoint(
@@ -553,6 +577,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.composed_one_of_number_with_validations = Endpoint(
@@ -663,6 +693,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.fake_health_get = Endpoint(
@@ -773,6 +809,12 @@ class FakeApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['mammal'] = \
                 mammal
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.mammal = Endpoint(
@@ -887,6 +929,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.number_with_validations = Endpoint(
@@ -999,6 +1047,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.object_model_with_ref_props = Endpoint(
@@ -1111,6 +1165,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.string = Endpoint(
@@ -1223,6 +1283,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.string_enum = Endpoint(
@@ -1340,6 +1406,12 @@ class FakeApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['file_schema_test_class'] = \
                 file_schema_test_class
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_body_with_file_schema = Endpoint(
@@ -1459,6 +1531,12 @@ class FakeApi(object):
                 query
             kwargs['user'] = \
                 user
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_body_with_query_params = Endpoint(
@@ -1581,6 +1659,12 @@ class FakeApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['client'] = \
                 client
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_client_model = Endpoint(
@@ -1721,6 +1805,12 @@ class FakeApi(object):
                 pattern_without_delimiter
             kwargs['byte'] = \
                 byte
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_endpoint_parameters = Endpoint(
@@ -1960,6 +2050,12 @@ class FakeApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_enum_parameters = Endpoint(
@@ -2175,6 +2271,12 @@ class FakeApi(object):
                 required_boolean_group
             kwargs['required_int64_group'] = \
                 required_int64_group
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_group_parameters = Endpoint(
@@ -2318,6 +2420,12 @@ class FakeApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['request_body'] = \
                 request_body
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_inline_additional_properties = Endpoint(
@@ -2437,6 +2545,12 @@ class FakeApi(object):
                 param
             kwargs['param2'] = \
                 param2
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_json_form_data = Endpoint(
@@ -2576,6 +2690,12 @@ class FakeApi(object):
                 url
             kwargs['context'] = \
                 context
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_query_parameter_collection_format = Endpoint(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
@@ -100,6 +100,12 @@ class FakeClassnameTags123Api(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['client'] = \
                 client
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.test_classname = Endpoint(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -100,6 +100,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['pet'] = \
                 pet
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.add_pet = Endpoint(
@@ -229,6 +235,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['pet_id'] = \
                 pet_id
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.delete_pet = Endpoint(
@@ -351,6 +363,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['status'] = \
                 status
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.find_pets_by_status = Endpoint(
@@ -480,6 +498,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['tags'] = \
                 tags
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.find_pets_by_tags = Endpoint(
@@ -602,6 +626,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['pet_id'] = \
                 pet_id
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.get_pet_by_id = Endpoint(
@@ -721,6 +751,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['pet'] = \
                 pet
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.update_pet = Endpoint(
@@ -851,6 +887,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['pet_id'] = \
                 pet_id
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.update_pet_with_form = Endpoint(
@@ -981,6 +1023,12 @@ class PetApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['pet_id'] = \
                 pet_id
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.upload_file = Endpoint(
@@ -1116,6 +1164,12 @@ class PetApi(object):
                 pet_id
             kwargs['required_file'] = \
                 required_file
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.upload_file_with_required_file = Endpoint(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
@@ -100,6 +100,12 @@ class StoreApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['order_id'] = \
                 order_id
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.delete_order = Endpoint(
@@ -210,6 +216,12 @@ class StoreApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.get_inventory = Endpoint(
@@ -322,6 +334,12 @@ class StoreApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['order_id'] = \
                 order_id
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.get_order_by_id = Endpoint(
@@ -445,6 +463,12 @@ class StoreApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['order'] = \
                 order
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.place_order = Endpoint(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
@@ -100,6 +100,12 @@ class UserApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['user'] = \
                 user
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.create_user = Endpoint(
@@ -215,6 +221,12 @@ class UserApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['user'] = \
                 user
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.create_users_with_array_input = Endpoint(
@@ -330,6 +342,12 @@ class UserApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['user'] = \
                 user
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.create_users_with_list_input = Endpoint(
@@ -446,6 +464,12 @@ class UserApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['username'] = \
                 username
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.delete_user = Endpoint(
@@ -560,6 +584,12 @@ class UserApi(object):
             kwargs['_host_index'] = kwargs.get('_host_index')
             kwargs['username'] = \
                 username
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.get_user_by_name = Endpoint(
@@ -681,6 +711,12 @@ class UserApi(object):
                 username
             kwargs['password'] = \
                 password
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.login_user = Endpoint(
@@ -799,6 +835,12 @@ class UserApi(object):
                 '_check_return_type', True
             )
             kwargs['_host_index'] = kwargs.get('_host_index')
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.logout_user = Endpoint(
@@ -911,6 +953,12 @@ class UserApi(object):
                 username
             kwargs['user'] = \
                 user
+
+            if 'body' not in kwargs:
+                body = 'body' in self.params_map['all']
+                body_nullable = 'body' in self.params_map['nullable']
+                if body and not body_nullable:
+                    kwargs['body'] = ''
             return self.call_with_http_info(**kwargs)
 
         self.update_user = Endpoint(

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -178,7 +178,7 @@ class RESTClientObject(object):
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is
                 # provided in serialized form
-                elif isinstance(body, str) or isinstance(body, bytes):
+                elif isinstance(body, str) or isinstance(body, bytes) or body is None:
                     request_body = body
                     r = self.pool_manager.request(
                         method, url,


### PR DESCRIPTION
This allows optional request bodies to work properly, previously they would always fail when body was None.

Resolves: #8300

Signed-off-by: Ellis Wright <ellis.wright@cyberark.com>

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @arun-nalla (2019/11) @spacether (2019/11)