### PR TITLE
[powershell] Fix error message templates for some field names

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/model_simple.mustache
@@ -246,12 +246,12 @@ function ConvertFrom-{{{apiNamePrefix}}}JsonTo{{{classname}}} {
         {{#requiredVars}}
         {{#-first}}
         If ([string]::IsNullOrEmpty($Json) -or $Json -eq "{}") { # empty json
-            throw "Error! Empty JSON cannot be serialized due to the required property `{{{baseName}}}` missing."
+            throw "Error! Empty JSON cannot be serialized due to the required property '{{{baseName}}}' missing."
         }
 
         {{/-first}}
         if (!([bool]($JsonParameters.PSobject.Properties.name -match "{{{baseName}}}"))) {
-            throw "Error! JSON cannot be serialized due to the required property `{{{baseName}}}` missing."
+            throw "Error! JSON cannot be serialized due to the required property '{{{baseName}}}' missing."
         } else {
             ${{name}} = $JsonParameters.PSobject.Properties["{{{baseName}}}"].value
         }

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Pet.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Pet.ps1
@@ -120,17 +120,17 @@ function ConvertFrom-PSJsonToPet {
         }
 
         If ([string]::IsNullOrEmpty($Json) -or $Json -eq "{}") { # empty json
-            throw "Error! Empty JSON cannot be serialized due to the required property `name` missing."
+            throw "Error! Empty JSON cannot be serialized due to the required property 'name' missing."
         }
 
         if (!([bool]($JsonParameters.PSobject.Properties.name -match "name"))) {
-            throw "Error! JSON cannot be serialized due to the required property `name` missing."
+            throw "Error! JSON cannot be serialized due to the required property 'name' missing."
         } else {
             $Name = $JsonParameters.PSobject.Properties["name"].value
         }
 
         if (!([bool]($JsonParameters.PSobject.Properties.name -match "photoUrls"))) {
-            throw "Error! JSON cannot be serialized due to the required property `photoUrls` missing."
+            throw "Error! JSON cannot be serialized due to the required property 'photoUrls' missing."
         } else {
             $PhotoUrls = $JsonParameters.PSobject.Properties["photoUrls"].value
         }


### PR DESCRIPTION
some fields may start with a "u" character which causes
Powershell to think it is a unicode escape sequence.

Fields such as `updatedAt` for example causes errors on build:
``` 
The Unicode escape sequence is not valid. A valid sequence is `u{ followed by one to six hex digits and a closing '}'.
```

@wing328 

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
