### PR TITLE
[powershell] Fix fields null check in powershell model template

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/model_simple.mustache
@@ -73,7 +73,7 @@ function Initialize-{{{apiNamePrefix}}}{{{classname}}} {
         {{#vars}}
         {{^isNullable}}
         {{#required}}
-        if (!${{{name}}}) {
+        if (${{{name}}} -eq $null) {
             throw "invalid value for '{{{name}}}', '{{{name}}}' cannot be null."
         }
 

--- a/samples/client/petstore/powershell/src/PSPetstore/Model/Pet.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Model/Pet.ps1
@@ -59,11 +59,11 @@ function Initialize-PSPet {
         'Creating PSCustomObject: PSPetstore => PSPet' | Write-Debug
         $PSBoundParameters | Out-DebugParameter | Write-Debug
 
-        if (!$Name) {
+        if ($Name -eq $null) {
             throw "invalid value for 'Name', 'Name' cannot be null."
         }
 
-        if (!$PhotoUrls) {
+        if ($PhotoUrls -eq $null) {
             throw "invalid value for 'PhotoUrls', 'PhotoUrls' cannot be null."
         }
 


### PR DESCRIPTION
If field is boolean, the value might be $False.
The current null checking does not allow $False to be set.
 
@wing328 

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
