### PR TITLE
[dart-dio] Fix failing integration tests

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -86,7 +86,7 @@ class {{classname}} {
         var serializedBody = {{paramName}};
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
-        final bodySerializer = _serializers.serializerForType({{baseType}});
+        final bodySerializer = _serializers.serializerForType({{{baseType}}}) as Serializer<{{{baseType}}}>;
         final serializedBody = _serializers.serializeWith(bodySerializer, {{paramName}});
         {{/isPrimitiveType}}
         {{/isArray}}

--- a/pom.xml
+++ b/pom.xml
@@ -1352,10 +1352,9 @@
                 <module>samples/client/petstore/dart2/petstore</module>
                 <module>samples/openapi3/client/petstore/dart2/petstore_client_lib</module>
                 <module>samples/openapi3/client/petstore/dart2/petstore</module>
-                <!-- comment out due to CircleCI failure
                 <module>samples/client/petstore/dart-dio/petstore_client_lib</module>
                 <module>samples/openapi3/client/petstore/dart-dio/petstore_client_lib</module>
-                <module>samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake</module> -->
+                <module>samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake</module>
                 <module>samples/client/petstore/dart-jaguar/openapi</module>
                 <module>samples/client/petstore/dart-jaguar/flutter_petstore/openapi</module>
             </modules>

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -50,7 +50,7 @@ class PetApi {
             'application/xml',
         ];
 
-        final bodySerializer = _serializers.serializerForType(Pet);
+        final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
         final serializedBody = _serializers.serializeWith(bodySerializer, body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
@@ -368,7 +368,7 @@ class PetApi {
             'application/xml',
         ];
 
-        final bodySerializer = _serializers.serializerForType(Pet);
+        final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
         final serializedBody = _serializers.serializeWith(bodySerializer, body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -220,7 +220,7 @@ class StoreApi {
 
         final contentTypes = <String>[];
 
-        final bodySerializer = _serializers.serializerForType(Order);
+        final bodySerializer = _serializers.serializerForType(Order) as Serializer<Order>;
         final serializedBody = _serializers.serializeWith(bodySerializer, body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -44,7 +44,7 @@ class UserApi {
 
         final contentTypes = <String>[];
 
-        final bodySerializer = _serializers.serializerForType(User);
+        final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
         final serializedBody = _serializers.serializeWith(bodySerializer, body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;
@@ -405,7 +405,7 @@ class UserApi {
 
         final contentTypes = <String>[];
 
-        final bodySerializer = _serializers.serializerForType(User);
+        final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
         final serializedBody = _serializers.serializeWith(bodySerializer, body);
         final jsonbody = json.encode(serializedBody);
         bodyData = jsonbody;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -50,7 +50,7 @@ class PetApi {
             'application/xml',
         ];
 
-        final bodySerializer = _serializers.serializerForType(Pet);
+        final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
         final serializedBody = _serializers.serializeWith(bodySerializer, pet);
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
@@ -384,7 +384,7 @@ class PetApi {
             'application/xml',
         ];
 
-        final bodySerializer = _serializers.serializerForType(Pet);
+        final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
         final serializedBody = _serializers.serializeWith(bodySerializer, pet);
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -222,7 +222,7 @@ class StoreApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(Order);
+        final bodySerializer = _serializers.serializerForType(Order) as Serializer<Order>;
         final serializedBody = _serializers.serializeWith(bodySerializer, order);
         final jsonorder = json.encode(serializedBody);
         bodyData = jsonorder;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -46,7 +46,7 @@ class UserApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(User);
+        final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
         final serializedBody = _serializers.serializeWith(bodySerializer, user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
@@ -448,7 +448,7 @@ class UserApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(User);
+        final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
         final serializedBody = _serializers.serializeWith(bodySerializer, user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
@@ -45,7 +45,7 @@ class AnotherFakeApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(ModelClient);
+        final bodySerializer = _serializers.serializerForType(ModelClient) as Serializer<ModelClient>;
         final serializedBody = _serializers.serializeWith(bodySerializer, modelClient);
         final jsonmodelClient = json.encode(serializedBody);
         bodyData = jsonmodelClient;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -118,7 +118,7 @@ class FakeApi {
             'application/xml',
         ];
 
-        final bodySerializer = _serializers.serializerForType(Pet);
+        final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
         final serializedBody = _serializers.serializeWith(bodySerializer, pet);
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
@@ -238,7 +238,7 @@ class FakeApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(OuterComposite);
+        final bodySerializer = _serializers.serializerForType(OuterComposite) as Serializer<OuterComposite>;
         final serializedBody = _serializers.serializeWith(bodySerializer, outerComposite);
         final jsonouterComposite = json.encode(serializedBody);
         bodyData = jsonouterComposite;
@@ -432,7 +432,7 @@ class FakeApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(FileSchemaTestClass);
+        final bodySerializer = _serializers.serializerForType(FileSchemaTestClass) as Serializer<FileSchemaTestClass>;
         final serializedBody = _serializers.serializeWith(bodySerializer, fileSchemaTestClass);
         final jsonfileSchemaTestClass = json.encode(serializedBody);
         bodyData = jsonfileSchemaTestClass;
@@ -486,7 +486,7 @@ class FakeApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(User);
+        final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
         final serializedBody = _serializers.serializeWith(bodySerializer, user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
@@ -538,7 +538,7 @@ class FakeApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(ModelClient);
+        final bodySerializer = _serializers.serializerForType(ModelClient) as Serializer<ModelClient>;
         final serializedBody = _serializers.serializeWith(bodySerializer, modelClient);
         final jsonmodelClient = json.encode(serializedBody);
         bodyData = jsonmodelClient;
@@ -814,7 +814,7 @@ class FakeApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(String);
+        final bodySerializer = _serializers.serializerForType(String) as Serializer<String>;
         final serializedBody = _serializers.serializeWith(bodySerializer, requestBody);
         final jsonrequestBody = json.encode(serializedBody);
         bodyData = jsonrequestBody;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
@@ -45,7 +45,7 @@ class FakeClassnameTags123Api {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(ModelClient);
+        final bodySerializer = _serializers.serializerForType(ModelClient) as Serializer<ModelClient>;
         final serializedBody = _serializers.serializeWith(bodySerializer, modelClient);
         final jsonmodelClient = json.encode(serializedBody);
         bodyData = jsonmodelClient;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -50,7 +50,7 @@ class PetApi {
             'application/xml',
         ];
 
-        final bodySerializer = _serializers.serializerForType(Pet);
+        final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
         final serializedBody = _serializers.serializeWith(bodySerializer, pet);
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;
@@ -368,7 +368,7 @@ class PetApi {
             'application/xml',
         ];
 
-        final bodySerializer = _serializers.serializerForType(Pet);
+        final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
         final serializedBody = _serializers.serializeWith(bodySerializer, pet);
         final jsonpet = json.encode(serializedBody);
         bodyData = jsonpet;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
@@ -222,7 +222,7 @@ class StoreApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(Order);
+        final bodySerializer = _serializers.serializerForType(Order) as Serializer<Order>;
         final serializedBody = _serializers.serializeWith(bodySerializer, order);
         final jsonorder = json.encode(serializedBody);
         bodyData = jsonorder;

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
@@ -46,7 +46,7 @@ class UserApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(User);
+        final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
         final serializedBody = _serializers.serializeWith(bodySerializer, user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;
@@ -413,7 +413,7 @@ class UserApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(User);
+        final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
         final serializedBody = _serializers.serializeWith(bodySerializer, user);
         final jsonuser = json.encode(serializedBody);
         bodyData = jsonuser;


### PR DESCRIPTION
This happened due to the merge of #6384 where implicit-dynamics were still allowed.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)