### PR TITLE
[cwiki] Added Enum documentation and fix newline problem for description

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ConfluenceWikiCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ConfluenceWikiCodegen.java
@@ -124,6 +124,11 @@ public class ConfluenceWikiCodegen extends DefaultCodegen implements CodegenConf
     }
 
     @Override
+    public Map<String, Object> postProcessModels(Map<String, Object> objs) {
+        return postProcessModelsEnum(objs);
+    }
+    
+    @Override
     public String escapeQuotationMark(String input) {
         // just return the original string
         return input;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ConfluenceWikiCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ConfluenceWikiCodegen.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
 import org.openapitools.codegen.utils.ModelUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 
@@ -138,5 +139,15 @@ public class ConfluenceWikiCodegen extends DefaultCodegen implements CodegenConf
     public String escapeUnsafeCharacters(String input) {
         // just return the original string
         return input;
+    }
+    
+    @Override
+    public String escapeText(String input) {
+        if (input == null) {
+            return input;
+        }
+        
+        // chomp tailing newline because it breaks the tables and keep all other sign to show documentation properly
+        return StringUtils.chomp(input);
     }
 }

--- a/modules/openapi-generator/src/main/resources/confluenceWikiDocs/index.mustache
+++ b/modules/openapi-generator/src/main/resources/confluenceWikiDocs/index.mustache
@@ -75,10 +75,13 @@ h2. Models
         {anchor:{{classname}}ModelAnchor}
         h3. {{classname}}
 
-        {{description}}
-
-        ||Field Name||Required||Type||Description||Enum||
+        {{{description}}}
+        {{#isEnum}} ||Name||Value||Description||
+        {{#allowableValues}} {{#enumVars}} |{{{name}}} |{{{value}}} |{{{enumDescription}}} |
+        {{/enumVars}} 
+        {{/allowableValues}} {{/isEnum}}
+        {{^isEnum}}||Field Name||Required||Type||Description||Enum||
         {{#vars}} |{{baseName}} |{{#required}}(/){{/required}}{{^required}}(x){{/required}} |{noformat:nopanel=true}{{{dataType}}}{noformat} |{{description}} | {{#isEnum}} {{_enum}} {{/isEnum}} |
-        {{/vars}}
+        {{/vars}} {{/isEnum}}
     {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/confluenceWikiDocs/index.mustache
+++ b/modules/openapi-generator/src/main/resources/confluenceWikiDocs/index.mustache
@@ -76,6 +76,7 @@ h2. Models
         h3. {{classname}}
 
         {{{description}}}
+        
         {{#isEnum}} ||Name||Value||Description||
         {{#allowableValues}} {{#enumVars}} |{{{name}}} |{{{value}}} |{{{enumDescription}}} |
         {{/enumVars}} 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/confluencewiki/ConfluenceWikiTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/confluencewiki/ConfluenceWikiTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ * Copyright 2018 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.confluencewiki;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.*;
+import org.apache.commons.lang3.StringUtils;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.DefaultCodegen;
+import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.languages.ConfluenceWikiCodegen;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConfluenceWikiTest {
+    
+    @Test(description = "convert a model with an enum")
+    public void converterTest() {
+        final StringSchema enumSchema = new StringSchema();
+        enumSchema.setEnum(Arrays.asList("VALUE1", "VALUE2", "VALUE3"));
+        final Schema model = new Schema().type("object").addProperties("name", enumSchema);
+
+        final ConfluenceWikiCodegen codegen = new ConfluenceWikiCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.vars.size(), 1);
+
+        final CodegenProperty enumVar = cm.vars.get(0);
+        Assert.assertEquals(enumVar.baseName, "name");
+        Assert.assertEquals(enumVar.dataType, "String");
+        Assert.assertEquals(enumVar.datatypeWithEnum, "NameEnum");
+        Assert.assertEquals(enumVar.name, "name");
+        Assert.assertEquals(enumVar.defaultValue, "null");
+        Assert.assertEquals(enumVar.baseType, "string");
+        Assert.assertTrue(enumVar.isEnum);
+    }
+
+    @Test(description = "convert a model with an enum inside a list")
+    public void converterInArrayTest() {
+        final ArraySchema enumSchema = new ArraySchema().items(
+                new StringSchema().addEnumItem("Aaaa").addEnumItem("Bbbb"));
+        final Schema model = new Schema().type("object").addProperties("name", enumSchema);
+
+        final DefaultCodegen codegen = new ConfluenceWikiCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.vars.size(), 1);
+
+        final CodegenProperty enumVar = cm.vars.get(0);
+        Assert.assertEquals(enumVar.baseName, "name");
+        Assert.assertEquals(enumVar.dataType, "array[String]");
+        Assert.assertEquals(enumVar.datatypeWithEnum, "array[String]");
+        Assert.assertEquals(enumVar.name, "name");
+        Assert.assertEquals(enumVar.defaultValue, "null");
+        Assert.assertEquals(enumVar.baseType, "array");
+        Assert.assertTrue(enumVar.isEnum);
+
+        Assert.assertEquals(enumVar.mostInnerItems.baseName, "name");
+        Assert.assertEquals(enumVar.mostInnerItems.dataType, "String");
+        Assert.assertEquals(enumVar.mostInnerItems.datatypeWithEnum, "NameEnum");
+        Assert.assertEquals(enumVar.mostInnerItems.name, "name");
+        Assert.assertEquals(enumVar.mostInnerItems.defaultValue, "null");
+        Assert.assertEquals(enumVar.mostInnerItems.baseType, "string");
+
+        Assert.assertEquals(enumVar.mostInnerItems.baseType, enumVar.items.baseType);
+    }
+
+    @Test(description = "convert a model with an enum inside a list")
+    public void converterInArrayInArrayTest() {
+        final ArraySchema enumSchema = new ArraySchema().items(
+                new ArraySchema().items(
+                        new StringSchema().addEnumItem("Aaaa").addEnumItem("Bbbb")));
+        final Schema model = new Schema().type("object").addProperties("name", enumSchema);
+
+        final DefaultCodegen codegen = new ConfluenceWikiCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.vars.size(), 1);
+
+        final CodegenProperty enumVar = cm.vars.get(0);
+        Assert.assertEquals(enumVar.baseName, "name");
+        Assert.assertEquals(enumVar.dataType, "array[array[String]]");
+        Assert.assertEquals(enumVar.datatypeWithEnum, "array[array[String]]");
+        Assert.assertEquals(enumVar.name, "name");
+        Assert.assertEquals(enumVar.defaultValue, "null");
+        Assert.assertEquals(enumVar.baseType, "array");
+        Assert.assertTrue(enumVar.isEnum);
+
+        Assert.assertEquals(enumVar.mostInnerItems.baseName, "name");
+        Assert.assertEquals(enumVar.mostInnerItems.dataType, "String");
+        Assert.assertEquals(enumVar.mostInnerItems.datatypeWithEnum, "NameEnum");
+        Assert.assertEquals(enumVar.mostInnerItems.name, "name");
+        Assert.assertEquals(enumVar.mostInnerItems.defaultValue, "null");
+        Assert.assertEquals(enumVar.mostInnerItems.baseType, "string");
+
+        Assert.assertEquals(enumVar.mostInnerItems.baseType, enumVar.items.items.baseType);
+    }
+
+    @Test(description = "not override identical parent enums")
+    public void overrideEnumTest() {
+        final StringSchema identicalEnumProperty = new StringSchema();
+        identicalEnumProperty.setEnum(Arrays.asList("VALUE1", "VALUE2", "VALUE3"));
+
+        final StringSchema subEnumProperty = new StringSchema();
+        subEnumProperty.setEnum(Arrays.asList("SUB1", "SUB2", "SUB3"));
+
+        // Add one enum property to the parent
+        final Map<String, Schema> parentProperties = new HashMap<>();
+        parentProperties.put("sharedThing", identicalEnumProperty);
+
+        // Add TWO enums to the subType model; one of which is identical to the one in parent class
+        final Map<String, Schema> subProperties = new HashMap<>();
+        subProperties.put("unsharedThing", subEnumProperty);
+
+        final Schema parentModel = new Schema();
+        parentModel.setProperties(parentProperties);
+        parentModel.name("parentModel");
+
+        Discriminator discriminator = new Discriminator().mapping("name", StringUtils.EMPTY);
+        discriminator.setPropertyName("model_type");
+        parentModel.setDiscriminator(discriminator);
+
+        final ComposedSchema composedSchema = new ComposedSchema()
+                .addAllOfItem(new Schema().$ref(parentModel.getName()));
+        composedSchema.setName("sample");
+
+        final ConfluenceWikiCodegen codegen = new ConfluenceWikiCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        openAPI.setComponents(new Components()
+                .addSchemas(parentModel.getName(), parentModel)
+                .addSchemas(composedSchema.getName(), composedSchema)
+        );
+
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", composedSchema);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.parent, "ParentModel");
+        Assert.assertTrue(cm.imports.contains("ParentModel"));
+    }
+
+    @Test
+    public void testEnumTestSchema() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml");
+        ConfluenceWikiCodegen codegen = new ConfluenceWikiCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        Schema enumTest = openAPI.getComponents().getSchemas().get("Enum_Test");
+        Assert.assertNotNull(enumTest);
+        CodegenModel cm = codegen.fromModel("Enum_Test", enumTest);
+
+        Assert.assertEquals(cm.getVars().size(), 8);
+        CodegenProperty cp0 = cm.getVars().get(0);
+        Assert.assertEquals(cp0.dataType, "String");
+        CodegenProperty cp1 = cm.getVars().get(1);
+        Assert.assertEquals(cp1.dataType, "String");
+        CodegenProperty cp2 = cm.getVars().get(2);
+        Assert.assertEquals(cp2.dataType, "Integer");
+        CodegenProperty cp3 = cm.getVars().get(3);
+        Assert.assertEquals(cp3.dataType, "Double");
+        CodegenProperty cp4 = cm.getVars().get(4);
+        Assert.assertEquals(cp4.dataType, "OuterEnum");
+        CodegenProperty cp5 = cm.getVars().get(5);
+        Assert.assertEquals(cp5.dataType, "OuterEnumInteger");
+        CodegenProperty cp6 = cm.getVars().get(6);
+        Assert.assertEquals(cp6.dataType, "OuterEnumDefaultValue");
+        CodegenProperty cp7 = cm.getVars().get(7);
+        Assert.assertEquals(cp7.dataType, "OuterEnumIntegerDefaultValue");
+    }
+}


### PR DESCRIPTION
I recognized that enums are not documented well in confluence wiki markup. Therefore I created this PR which renders the enum values as a table in the model section. Additionaly I removed the escaping of values to make sure the text is displayed correctly in wiki (i. e. " instead of \" or with multiline comments).

Input:
```yaml
FooType:
  description: >
    A simple enum with:
    * Multiline description
    * Enum value
    * Enum description
  type: string
  enum:
  - "F-Code"
  x-enum-varnames:
  - FOO
  x-enum-descriptions:
  - The amazing foo enum
```

Output:
```md
h3. FooType

A simple enum with:
* Multiline description
* Enum value
* Enum description

||Name||Value||Description||
|FOO |"F-Code" |The amazing foo enum |
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
