### PR TITLE
[GO][Client] Return error in Execute() methods

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -36,7 +36,7 @@ type {{classname}} interface {
 	 * {{nickname}}Execute executes the request{{#returnType}}
 	 * @return {{{.}}}{{/returnType}}
 	 */
-	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, GenericOpenAPIError)
+	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error)
 	{{/operation}}
 }
 {{/generateInterfaces}}
@@ -61,7 +61,7 @@ func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Reques
 	return r
 }{{/isPathParam}}{{/allParams}}
 
-func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, GenericOpenAPIError) {
+func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
 	return r.ApiService.{{nickname}}Execute(r)
 }
 
@@ -86,14 +86,13 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#pathParam
  * Execute executes the request{{#returnType}}
  * @return {{{.}}}{{/returnType}}
  */
-func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, GenericOpenAPIError) {
+func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.Method{{httpMethod}}
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		{{#returnType}}
 		localVarReturnValue  {{{.}}}
 		{{/returnType}}
@@ -101,8 +100,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "{{{classname}}}Service.{{{nickname}}}")
 	if err != nil {
-		executionError.error = err.Error()
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "{{{path}}}"{{#pathParams}}
@@ -115,32 +113,27 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{#required}}
 	{{^isPathParam}}
 	if r.{{paramName}} == nil {
-		executionError.error = "{{paramName}} is required and must be specified"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} is required and must be specified")
 	}
 	{{/isPathParam}}
 	{{#minItems}}
 	if len({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) < {{minItems}} {
-		executionError.error = "{{paramName}} must have at least {{minItems}} elements"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minItems}} elements")
 	}
 	{{/minItems}}
 	{{#maxItems}}
 	if len({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) > {{maxItems}} {
-		executionError.error = "{{paramName}} must have less than {{maxItems}} elements"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxItems}} elements")
 	}
 	{{/maxItems}}
 	{{#minLength}}
 	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) < {{minLength}} {
-		executionError.error = "{{paramName}} must have at least {{minLength}} elements"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minLength}} elements")
 	}
 	{{/minLength}}
 	{{#maxLength}}
 	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) > {{maxLength}} {
-		executionError.error = "{{paramName}} must have less than {{maxLength}} elements"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxLength}} elements")
 	}
 	{{/maxLength}}
 	{{#minimum}}
@@ -151,8 +144,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{^isString}}
 	if {{^isPathParam}}*{{/isPathParam}}r.{{paramName}} < {{minimum}} {
 	{{/isString}}
-		executionError.error = "{{paramName}} must be greater than {{minimum}}"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be greater than {{minimum}}")
 	}
 	{{/minimum}}
 	{{#maximum}}
@@ -163,8 +155,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{^isString}}
 	if {{^isPathParam}}*{{/isPathParam}}r.{{paramName}} > {{maximum}} {
 	{{/isString}}
-		executionError.error = "{{paramName}} must be less than {{maximum}}"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be less than {{maximum}}")
 	}
 	{{/maximum}}
 	{{/required}}
@@ -267,8 +258,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	if r.{{paramName}} != nil {
 		paramJson, err := parameterToJson(*r.{{paramName}})
 		if err != nil {
-			executionError.error = err.Error()
-			return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+			return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
 		}
 		localVarFormParams.Add("{{baseName}}", paramJson)
 	}
@@ -323,22 +313,19 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 {{/authMethods}}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -384,7 +371,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 
 	{{/returnType}}
-	return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, executionError
+	return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, nil
 }
 {{/operation}}
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/go/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api_doc.mustache
@@ -43,7 +43,7 @@ func main() {
     configuration := {{goImportAlias}}.NewConfiguration()
     api_client := {{goImportAlias}}.NewAPIClient(configuration)
     resp, r, err := api_client.{{classname}}.{{operationId}}(context.Background(){{#pathParams}}, {{paramName}}{{/pathParams}}){{#allParams}}{{^isPathParam}}.{{vendorExtensions.x-export-param-name}}({{paramName}}){{/isPathParam}}{{/allParams}}.Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `{{classname}}.{{operationId}}``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/modules/openapi-generator/src/main/resources/go/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api_doc.mustache
@@ -53,7 +53,7 @@ func main() {
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
         if openapiErr, ok := err.(openapiError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     {{#returnType}}

--- a/modules/openapi-generator/src/main/resources/go/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api_doc.mustache
@@ -35,6 +35,11 @@ import (
     {{goImportAlias}} "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte
+}
+
 func main() {
     {{#allParams}}
     {{paramName}} := {{{vendorExtensions.x-go-example}}} // {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
@@ -46,6 +51,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `{{classname}}.{{operationId}}``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     {{#returnType}}
     // response from `{{operationId}}`: {{{.}}}
@@ -73,7 +82,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-{{#returnType}}{{#returnTypeIsPrimitive}}**{{{returnType}}}**{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}[**{{{returnType}}}**]({{returnBaseType}}.md){{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}} (empty response body){{/returnType}}
+{{#returnType}}{{#returnTypeIsPrimitive}}**{{{returnType}}}**{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}[**{{{returnType}}}**]({{returnBaseType}}.md){{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}} (empty response body){{/returnType}}, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/modules/openapi-generator/src/main/resources/go/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api_doc.mustache
@@ -35,11 +35,6 @@ import (
     {{goImportAlias}} "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte
-}
-
 func main() {
     {{#allParams}}
     {{paramName}} := {{{vendorExtensions.x-go-example}}} // {{{dataType}}} | {{{description}}}{{^required}} (optional){{/required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
@@ -51,7 +46,7 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `{{classname}}.{{operationId}}``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.({{goImportAlias}}.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
             fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
@@ -84,7 +79,7 @@ Name | Type | Description  | Notes
 
 {{#returnType}}{{#returnTypeIsPrimitive}}**{{{returnType}}}**{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}[**{{{returnType}}}**]({{returnBaseType}}.md){{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}} (empty response body){{/returnType}}, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `{{goImportAlias}}.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/auth_test.go
+++ b/samples/client/petstore/go/auth_test.go
@@ -43,7 +43,7 @@ func TestOAuth2(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -52,7 +52,7 @@ func TestOAuth2(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -78,7 +78,7 @@ func TestBasicAuth(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(auth).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -87,7 +87,7 @@ func TestBasicAuth(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -108,7 +108,7 @@ func TestAccessToken(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(nil).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -117,7 +117,7 @@ func TestAccessToken(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -138,7 +138,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -146,7 +146,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 	}
 
 	_, r, err = client.PetApi.GetPetById(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 
@@ -156,7 +156,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 	}
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -173,7 +173,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(nil).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -181,7 +181,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 	}
 
 	_, r, err = client.PetApi.GetPetById(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 
@@ -191,7 +191,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 	}
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -206,7 +206,7 @@ func TestDefaultHeader(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -215,7 +215,7 @@ func TestDefaultHeader(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(context.Background(), 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -230,7 +230,7 @@ func TestDefaultHeader(t *testing.T) {
 func TestHostOverride(t *testing.T) {
 	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while finding pets by status: %v", err)
 	}
 
@@ -242,7 +242,7 @@ func TestHostOverride(t *testing.T) {
 func TestSchemeOverride(t *testing.T) {
 	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while finding pets by status: %v", err)
 	}
 

--- a/samples/client/petstore/go/fake_api_test.go
+++ b/samples/client/petstore/go/fake_api_test.go
@@ -19,7 +19,7 @@ func TestPutBodyWithFileSchema(t *testing.T) {
 
 	r, err := client.FakeApi.TestBodyWithFileSchema(context.Background()).Body(schema).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {

--- a/samples/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_another_fake.go
@@ -37,7 +37,7 @@ type AnotherFakeApi interface {
 	 * Call123TestSpecialTagsExecute executes the request
 	 * @return Client
 	 */
-	Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, GenericOpenAPIError)
+	Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, error)
 }
 
 // AnotherFakeApiService AnotherFakeApi service
@@ -54,7 +54,7 @@ func (r ApiCall123TestSpecialTagsRequest) Body(body Client) ApiCall123TestSpecia
 	return r
 }
 
-func (r ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, error) {
 	return r.ApiService.Call123TestSpecialTagsExecute(r)
 }
 
@@ -75,21 +75,19 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context) Api
  * Execute executes the request
  * @return Client
  */
-func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Client
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AnotherFakeApiService.Call123TestSpecialTags")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/another-fake/dummy"
@@ -98,8 +96,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -123,22 +120,19 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -158,5 +152,5 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -39,7 +39,7 @@ type FakeApi interface {
 	/*
 	 * CreateXmlItemExecute executes the request
 	 */
-	CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_nethttp.Response, error)
 
 	/*
 	 * FakeOuterBooleanSerialize Method for FakeOuterBooleanSerialize
@@ -53,7 +53,7 @@ type FakeApi interface {
 	 * FakeOuterBooleanSerializeExecute executes the request
 	 * @return bool
 	 */
-	FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterCompositeSerialize Method for FakeOuterCompositeSerialize
@@ -67,7 +67,7 @@ type FakeApi interface {
 	 * FakeOuterCompositeSerializeExecute executes the request
 	 * @return OuterComposite
 	 */
-	FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterNumberSerialize Method for FakeOuterNumberSerialize
@@ -81,7 +81,7 @@ type FakeApi interface {
 	 * FakeOuterNumberSerializeExecute executes the request
 	 * @return float32
 	 */
-	FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterStringSerialize Method for FakeOuterStringSerialize
@@ -95,7 +95,7 @@ type FakeApi interface {
 	 * FakeOuterStringSerializeExecute executes the request
 	 * @return string
 	 */
-	FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, error)
 
 	/*
 	 * TestBodyWithFileSchema Method for TestBodyWithFileSchema
@@ -108,7 +108,7 @@ type FakeApi interface {
 	/*
 	 * TestBodyWithFileSchemaExecute executes the request
 	 */
-	TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestBodyWithQueryParams Method for TestBodyWithQueryParams
@@ -120,7 +120,7 @@ type FakeApi interface {
 	/*
 	 * TestBodyWithQueryParamsExecute executes the request
 	 */
-	TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestClientModel To test \"client\" model
@@ -134,7 +134,7 @@ type FakeApi interface {
 	 * TestClientModelExecute executes the request
 	 * @return Client
 	 */
-	TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, GenericOpenAPIError)
+	TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, error)
 
 	/*
 	 * TestEndpointParameters Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -150,7 +150,7 @@ type FakeApi interface {
 	/*
 	 * TestEndpointParametersExecute executes the request
 	 */
-	TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestEnumParameters To test enum parameters
@@ -163,7 +163,7 @@ type FakeApi interface {
 	/*
 	 * TestEnumParametersExecute executes the request
 	 */
-	TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestGroupParameters Fake endpoint to test group parameters (optional)
@@ -176,7 +176,7 @@ type FakeApi interface {
 	/*
 	 * TestGroupParametersExecute executes the request
 	 */
-	TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestInlineAdditionalProperties test inline additionalProperties
@@ -188,7 +188,7 @@ type FakeApi interface {
 	/*
 	 * TestInlineAdditionalPropertiesExecute executes the request
 	 */
-	TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestJsonFormData test json serialization of form data
@@ -200,7 +200,7 @@ type FakeApi interface {
 	/*
 	 * TestJsonFormDataExecute executes the request
 	 */
-	TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestQueryParameterCollectionFormat Method for TestQueryParameterCollectionFormat
@@ -213,7 +213,7 @@ type FakeApi interface {
 	/*
 	 * TestQueryParameterCollectionFormatExecute executes the request
 	 */
-	TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, error)
 }
 
 // FakeApiService FakeApi service
@@ -230,7 +230,7 @@ func (r ApiCreateXmlItemRequest) XmlItem(xmlItem XmlItem) ApiCreateXmlItemReques
 	return r
 }
 
-func (r ApiCreateXmlItemRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateXmlItemRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateXmlItemExecute(r)
 }
 
@@ -250,20 +250,18 @@ func (a *FakeApiService) CreateXmlItem(ctx _context.Context) ApiCreateXmlItemReq
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.CreateXmlItem")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/create_xml_item"
@@ -272,8 +270,7 @@ func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_neth
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.xmlItem == nil {
-		executionError.error = "xmlItem is required and must be specified"
-		return nil, executionError
+		return nil, reportError("xmlItem is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -297,22 +294,19 @@ func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_neth
 	localVarPostBody = r.xmlItem
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -323,7 +317,7 @@ func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_neth
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterBooleanSerializeRequest struct {
@@ -337,7 +331,7 @@ func (r ApiFakeOuterBooleanSerializeRequest) Body(body bool) ApiFakeOuterBoolean
 	return r
 }
 
-func (r ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterBooleanSerializeExecute(r)
 }
 
@@ -358,21 +352,19 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context) ApiFake
  * Execute executes the request
  * @return bool
  */
-func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  bool
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterBooleanSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/boolean"
@@ -402,22 +394,19 @@ func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanS
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -437,7 +426,7 @@ func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanS
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterCompositeSerializeRequest struct {
@@ -451,7 +440,7 @@ func (r ApiFakeOuterCompositeSerializeRequest) Body(body OuterComposite) ApiFake
 	return r
 }
 
-func (r ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterCompositeSerializeExecute(r)
 }
 
@@ -472,21 +461,19 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context) ApiFa
  * Execute executes the request
  * @return OuterComposite
  */
-func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  OuterComposite
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterCompositeSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/composite"
@@ -516,22 +503,19 @@ func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompos
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -551,7 +535,7 @@ func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompos
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterNumberSerializeRequest struct {
@@ -565,7 +549,7 @@ func (r ApiFakeOuterNumberSerializeRequest) Body(body float32) ApiFakeOuterNumbe
 	return r
 }
 
-func (r ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterNumberSerializeExecute(r)
 }
 
@@ -586,21 +570,19 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context) ApiFakeO
  * Execute executes the request
  * @return float32
  */
-func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  float32
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterNumberSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/number"
@@ -630,22 +612,19 @@ func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSer
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -665,7 +644,7 @@ func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSer
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterStringSerializeRequest struct {
@@ -679,7 +658,7 @@ func (r ApiFakeOuterStringSerializeRequest) Body(body string) ApiFakeOuterString
 	return r
 }
 
-func (r ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterStringSerializeExecute(r)
 }
 
@@ -700,21 +679,19 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context) ApiFakeO
  * Execute executes the request
  * @return string
  */
-func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  string
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterStringSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/string"
@@ -744,22 +721,19 @@ func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSer
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -779,7 +753,7 @@ func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSer
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiTestBodyWithFileSchemaRequest struct {
@@ -793,7 +767,7 @@ func (r ApiTestBodyWithFileSchemaRequest) Body(body FileSchemaTestClass) ApiTest
 	return r
 }
 
-func (r ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestBodyWithFileSchemaExecute(r)
 }
 
@@ -813,20 +787,18 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context) ApiTestBod
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestBodyWithFileSchema")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/body-with-file-schema"
@@ -835,8 +807,7 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -860,22 +831,19 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -886,7 +854,7 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestBodyWithQueryParamsRequest struct {
@@ -905,7 +873,7 @@ func (r ApiTestBodyWithQueryParamsRequest) Body(body User) ApiTestBodyWithQueryP
 	return r
 }
 
-func (r ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestBodyWithQueryParamsExecute(r)
 }
 
@@ -924,20 +892,18 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context) ApiTestBo
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestBodyWithQueryParams")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/body-with-query-params"
@@ -946,12 +912,10 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.query == nil {
-		executionError.error = "query is required and must be specified"
-		return nil, executionError
+		return nil, reportError("query is required and must be specified")
 	}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	localVarQueryParams.Add("query", parameterToString(*r.query, ""))
@@ -976,22 +940,19 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1002,7 +963,7 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestClientModelRequest struct {
@@ -1016,7 +977,7 @@ func (r ApiTestClientModelRequest) Body(body Client) ApiTestClientModelRequest {
 	return r
 }
 
-func (r ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error) {
 	return r.ApiService.TestClientModelExecute(r)
 }
 
@@ -1037,21 +998,19 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context) ApiTestClientMode
  * Execute executes the request
  * @return Client
  */
-func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Client
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestClientModel")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1060,8 +1019,7 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1085,22 +1043,19 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1120,7 +1075,7 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiTestEndpointParametersRequest struct {
@@ -1199,7 +1154,7 @@ func (r ApiTestEndpointParametersRequest) Callback(callback string) ApiTestEndpo
 	return r
 }
 
-func (r ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestEndpointParametersExecute(r)
 }
 
@@ -1222,20 +1177,18 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context) ApiTestEnd
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestEndpointParameters")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1244,36 +1197,28 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.number == nil {
-		executionError.error = "number is required and must be specified"
-		return nil, executionError
+		return nil, reportError("number is required and must be specified")
 	}
 	if *r.number < 32.1 {
-		executionError.error = "number must be greater than 32.1"
-		return nil, executionError
+		return nil, reportError("number must be greater than 32.1")
 	}
 	if *r.number > 543.2 {
-		executionError.error = "number must be less than 543.2"
-		return nil, executionError
+		return nil, reportError("number must be less than 543.2")
 	}
 	if r.double == nil {
-		executionError.error = "double is required and must be specified"
-		return nil, executionError
+		return nil, reportError("double is required and must be specified")
 	}
 	if *r.double < 67.8 {
-		executionError.error = "double must be greater than 67.8"
-		return nil, executionError
+		return nil, reportError("double must be greater than 67.8")
 	}
 	if *r.double > 123.4 {
-		executionError.error = "double must be less than 123.4"
-		return nil, executionError
+		return nil, reportError("double must be less than 123.4")
 	}
 	if r.patternWithoutDelimiter == nil {
-		executionError.error = "patternWithoutDelimiter is required and must be specified"
-		return nil, executionError
+		return nil, reportError("patternWithoutDelimiter is required and must be specified")
 	}
 	if r.byte_ == nil {
-		executionError.error = "byte_ is required and must be specified"
-		return nil, executionError
+		return nil, reportError("byte_ is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1337,22 +1282,19 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1363,7 +1305,7 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestEnumParametersRequest struct {
@@ -1412,7 +1354,7 @@ func (r ApiTestEnumParametersRequest) EnumFormString(enumFormString string) ApiT
 	return r
 }
 
-func (r ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestEnumParametersExecute(r)
 }
 
@@ -1432,20 +1374,18 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context) ApiTestEnumPar
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestEnumParameters")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1497,22 +1437,19 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1523,7 +1460,7 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestGroupParametersRequest struct {
@@ -1562,7 +1499,7 @@ func (r ApiTestGroupParametersRequest) Int64Group(int64Group int64) ApiTestGroup
 	return r
 }
 
-func (r ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestGroupParametersExecute(r)
 }
 
@@ -1582,20 +1519,18 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context) ApiTestGroupP
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestGroupParameters")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1604,16 +1539,13 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.requiredStringGroup == nil {
-		executionError.error = "requiredStringGroup is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requiredStringGroup is required and must be specified")
 	}
 	if r.requiredBooleanGroup == nil {
-		executionError.error = "requiredBooleanGroup is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requiredBooleanGroup is required and must be specified")
 	}
 	if r.requiredInt64Group == nil {
-		executionError.error = "requiredInt64Group is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requiredInt64Group is required and must be specified")
 	}
 
 	localVarQueryParams.Add("required_string_group", parameterToString(*r.requiredStringGroup, ""))
@@ -1647,22 +1579,19 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1673,7 +1602,7 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestInlineAdditionalPropertiesRequest struct {
@@ -1687,7 +1616,7 @@ func (r ApiTestInlineAdditionalPropertiesRequest) Param(param map[string]string)
 	return r
 }
 
-func (r ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestInlineAdditionalPropertiesExecute(r)
 }
 
@@ -1706,20 +1635,18 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context) Ap
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestInlineAdditionalProperties")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/inline-additionalProperties"
@@ -1728,8 +1655,7 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.param == nil {
-		executionError.error = "param is required and must be specified"
-		return nil, executionError
+		return nil, reportError("param is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1753,22 +1679,19 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 	localVarPostBody = r.param
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1779,7 +1702,7 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestJsonFormDataRequest struct {
@@ -1798,7 +1721,7 @@ func (r ApiTestJsonFormDataRequest) Param2(param2 string) ApiTestJsonFormDataReq
 	return r
 }
 
-func (r ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestJsonFormDataExecute(r)
 }
 
@@ -1817,20 +1740,18 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context) ApiTestJsonFormD
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestJsonFormData")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/jsonFormData"
@@ -1839,12 +1760,10 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.param == nil {
-		executionError.error = "param is required and must be specified"
-		return nil, executionError
+		return nil, reportError("param is required and must be specified")
 	}
 	if r.param2 == nil {
-		executionError.error = "param2 is required and must be specified"
-		return nil, executionError
+		return nil, reportError("param2 is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1868,22 +1787,19 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 	localVarFormParams.Add("param2", parameterToString(*r.param2, ""))
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1894,7 +1810,7 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestQueryParameterCollectionFormatRequest struct {
@@ -1928,7 +1844,7 @@ func (r ApiTestQueryParameterCollectionFormatRequest) Context(context []string) 
 	return r
 }
 
-func (r ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestQueryParameterCollectionFormatExecute(r)
 }
 
@@ -1948,20 +1864,18 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestQueryParameterCollectionFormat")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/test-query-paramters"
@@ -1970,24 +1884,19 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.pipe == nil {
-		executionError.error = "pipe is required and must be specified"
-		return nil, executionError
+		return nil, reportError("pipe is required and must be specified")
 	}
 	if r.ioutil == nil {
-		executionError.error = "ioutil is required and must be specified"
-		return nil, executionError
+		return nil, reportError("ioutil is required and must be specified")
 	}
 	if r.http == nil {
-		executionError.error = "http is required and must be specified"
-		return nil, executionError
+		return nil, reportError("http is required and must be specified")
 	}
 	if r.url == nil {
-		executionError.error = "url is required and must be specified"
-		return nil, executionError
+		return nil, reportError("url is required and must be specified")
 	}
 	if r.context == nil {
-		executionError.error = "context is required and must be specified"
-		return nil, executionError
+		return nil, reportError("context is required and must be specified")
 	}
 
 	localVarQueryParams.Add("pipe", parameterToString(*r.pipe, "csv"))
@@ -2024,22 +1933,19 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -2050,5 +1956,5 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }

--- a/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -37,7 +37,7 @@ type FakeClassnameTags123Api interface {
 	 * TestClassnameExecute executes the request
 	 * @return Client
 	 */
-	TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, GenericOpenAPIError)
+	TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, error)
 }
 
 // FakeClassnameTags123ApiService FakeClassnameTags123Api service
@@ -54,7 +54,7 @@ func (r ApiTestClassnameRequest) Body(body Client) ApiTestClassnameRequest {
 	return r
 }
 
-func (r ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
 	return r.ApiService.TestClassnameExecute(r)
 }
 
@@ -75,21 +75,19 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context) Api
  * Execute executes the request
  * @return Client
  */
-func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Client
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeClassnameTags123ApiService.TestClassname")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake_classname_test"
@@ -98,8 +96,7 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -137,22 +134,19 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -172,5 +166,5 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/client/petstore/go/go-petstore/api_pet.go
@@ -37,7 +37,7 @@ type PetApi interface {
 	/*
 	 * AddPetExecute executes the request
 	 */
-	AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, GenericOpenAPIError)
+	AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, error)
 
 	/*
 	 * DeletePet Deletes a pet
@@ -50,7 +50,7 @@ type PetApi interface {
 	/*
 	 * DeletePetExecute executes the request
 	 */
-	DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, GenericOpenAPIError)
+	DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, error)
 
 	/*
 	 * FindPetsByStatus Finds Pets by status
@@ -64,7 +64,7 @@ type PetApi interface {
 	 * FindPetsByStatusExecute executes the request
 	 * @return []Pet
 	 */
-	FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError)
+	FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, error)
 
 	/*
 	 * FindPetsByTags Finds Pets by tags
@@ -78,7 +78,7 @@ type PetApi interface {
 	 * FindPetsByTagsExecute executes the request
 	 * @return []Pet
 	 */
-	FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError)
+	FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, error)
 
 	/*
 	 * GetPetById Find pet by ID
@@ -93,7 +93,7 @@ type PetApi interface {
 	 * GetPetByIdExecute executes the request
 	 * @return Pet
 	 */
-	GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, GenericOpenAPIError)
+	GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, error)
 
 	/*
 	 * UpdatePet Update an existing pet
@@ -105,7 +105,7 @@ type PetApi interface {
 	/*
 	 * UpdatePetExecute executes the request
 	 */
-	UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, GenericOpenAPIError)
+	UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, error)
 
 	/*
 	 * UpdatePetWithForm Updates a pet in the store with form data
@@ -118,7 +118,7 @@ type PetApi interface {
 	/*
 	 * UpdatePetWithFormExecute executes the request
 	 */
-	UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, GenericOpenAPIError)
+	UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, error)
 
 	/*
 	 * UploadFile uploads an image
@@ -132,7 +132,7 @@ type PetApi interface {
 	 * UploadFileExecute executes the request
 	 * @return ApiResponse
 	 */
-	UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError)
+	UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, error)
 
 	/*
 	 * UploadFileWithRequiredFile uploads an image (required)
@@ -146,7 +146,7 @@ type PetApi interface {
 	 * UploadFileWithRequiredFileExecute executes the request
 	 * @return ApiResponse
 	 */
-	UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError)
+	UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, error)
 }
 
 // PetApiService PetApi service
@@ -163,7 +163,7 @@ func (r ApiAddPetRequest) Body(body Pet) ApiAddPetRequest {
 	return r
 }
 
-func (r ApiAddPetRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiAddPetRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.AddPetExecute(r)
 }
 
@@ -182,20 +182,18 @@ func (a *PetApiService) AddPet(ctx _context.Context) ApiAddPetRequest {
 /*
  * Execute executes the request
  */
-func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.AddPet")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet"
@@ -204,8 +202,7 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, G
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -229,22 +226,19 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, G
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -255,7 +249,7 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, G
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiDeletePetRequest struct {
@@ -270,7 +264,7 @@ func (r ApiDeletePetRequest) ApiKey(apiKey string) ApiDeletePetRequest {
 	return r
 }
 
-func (r ApiDeletePetRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiDeletePetRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeletePetExecute(r)
 }
 
@@ -291,20 +285,18 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64) ApiDeletePe
 /*
  * Execute executes the request
  */
-func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.DeletePet")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
@@ -336,22 +328,19 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -362,7 +351,7 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiFindPetsByStatusRequest struct {
@@ -376,7 +365,7 @@ func (r ApiFindPetsByStatusRequest) Status(status []string) ApiFindPetsByStatusR
 	return r
 }
 
-func (r ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	return r.ApiService.FindPetsByStatusExecute(r)
 }
 
@@ -397,21 +386,19 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context) ApiFindPetsByStat
  * Execute executes the request
  * @return []Pet
  */
-func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  []Pet
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.FindPetsByStatus")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/findByStatus"
@@ -420,8 +407,7 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.status == nil {
-		executionError.error = "status is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("status is required and must be specified")
 	}
 
 	localVarQueryParams.Add("status", parameterToString(*r.status, "csv"))
@@ -444,22 +430,19 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -479,7 +462,7 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFindPetsByTagsRequest struct {
@@ -493,7 +476,7 @@ func (r ApiFindPetsByTagsRequest) Tags(tags []string) ApiFindPetsByTagsRequest {
 	return r
 }
 
-func (r ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	return r.ApiService.FindPetsByTagsExecute(r)
 }
 
@@ -514,21 +497,19 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context) ApiFindPetsByTagsRe
  * Execute executes the request
  * @return []Pet
  */
-func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  []Pet
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.FindPetsByTags")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/findByTags"
@@ -537,8 +518,7 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.tags == nil {
-		executionError.error = "tags is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("tags is required and must be specified")
 	}
 
 	localVarQueryParams.Add("tags", parameterToString(*r.tags, "csv"))
@@ -561,22 +541,19 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -596,7 +573,7 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetPetByIdRequest struct {
@@ -606,7 +583,7 @@ type ApiGetPetByIdRequest struct {
 }
 
 
-func (r ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
 	return r.ApiService.GetPetByIdExecute(r)
 }
 
@@ -629,21 +606,19 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) ApiGetPetB
  * Execute executes the request
  * @return Pet
  */
-func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Pet
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.GetPetById")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
@@ -686,22 +661,19 @@ func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethtt
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -721,7 +693,7 @@ func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethtt
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiUpdatePetRequest struct {
@@ -735,7 +707,7 @@ func (r ApiUpdatePetRequest) Body(body Pet) ApiUpdatePetRequest {
 	return r
 }
 
-func (r ApiUpdatePetRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.UpdatePetExecute(r)
 }
 
@@ -754,20 +726,18 @@ func (a *PetApiService) UpdatePet(ctx _context.Context) ApiUpdatePetRequest {
 /*
  * Execute executes the request
  */
-func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UpdatePet")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet"
@@ -776,8 +746,7 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -801,22 +770,19 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -827,7 +793,7 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiUpdatePetWithFormRequest struct {
@@ -847,7 +813,7 @@ func (r ApiUpdatePetWithFormRequest) Status(status string) ApiUpdatePetWithFormR
 	return r
 }
 
-func (r ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.UpdatePetWithFormExecute(r)
 }
 
@@ -868,20 +834,18 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64) Api
 /*
  * Execute executes the request
  */
-func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UpdatePetWithForm")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
@@ -916,22 +880,19 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -942,7 +903,7 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiUploadFileRequest struct {
@@ -962,7 +923,7 @@ func (r ApiUploadFileRequest) File(file *os.File) ApiUploadFileRequest {
 	return r
 }
 
-func (r ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
 	return r.ApiService.UploadFileExecute(r)
 }
 
@@ -984,21 +945,19 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64) ApiUploadF
  * Execute executes the request
  * @return ApiResponse
  */
-func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  ApiResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UploadFile")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}/uploadImage"
@@ -1041,22 +1000,19 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1076,7 +1032,7 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiUploadFileWithRequiredFileRequest struct {
@@ -1096,7 +1052,7 @@ func (r ApiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetad
 	return r
 }
 
-func (r ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
 	return r.ApiService.UploadFileWithRequiredFileExecute(r)
 }
 
@@ -1118,21 +1074,19 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
  * Execute executes the request
  * @return ApiResponse
  */
-func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  ApiResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UploadFileWithRequiredFile")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/{petId}/uploadImageWithRequiredFile"
@@ -1142,8 +1096,7 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.requiredFile == nil {
-		executionError.error = "requiredFile is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("requiredFile is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1176,22 +1129,19 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1211,5 +1161,5 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/client/petstore/go/go-petstore/api_store.go
+++ b/samples/client/petstore/go/go-petstore/api_store.go
@@ -38,7 +38,7 @@ type StoreApi interface {
 	/*
 	 * DeleteOrderExecute executes the request
 	 */
-	DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, GenericOpenAPIError)
+	DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, error)
 
 	/*
 	 * GetInventory Returns pet inventories by status
@@ -52,7 +52,7 @@ type StoreApi interface {
 	 * GetInventoryExecute executes the request
 	 * @return map[string]int32
 	 */
-	GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, GenericOpenAPIError)
+	GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, error)
 
 	/*
 	 * GetOrderById Find purchase order by ID
@@ -67,7 +67,7 @@ type StoreApi interface {
 	 * GetOrderByIdExecute executes the request
 	 * @return Order
 	 */
-	GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, GenericOpenAPIError)
+	GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, error)
 
 	/*
 	 * PlaceOrder Place an order for a pet
@@ -80,7 +80,7 @@ type StoreApi interface {
 	 * PlaceOrderExecute executes the request
 	 * @return Order
 	 */
-	PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, GenericOpenAPIError)
+	PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, error)
 }
 
 // StoreApiService StoreApi service
@@ -93,7 +93,7 @@ type ApiDeleteOrderRequest struct {
 }
 
 
-func (r ApiDeleteOrderRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteOrderExecute(r)
 }
 
@@ -115,20 +115,18 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) ApiD
 /*
  * Execute executes the request
  */
-func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.DeleteOrder")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
@@ -157,22 +155,19 @@ func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -183,7 +178,7 @@ func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetInventoryRequest struct {
@@ -192,7 +187,7 @@ type ApiGetInventoryRequest struct {
 }
 
 
-func (r ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, error) {
 	return r.ApiService.GetInventoryExecute(r)
 }
 
@@ -213,21 +208,19 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) ApiGetInventoryRequ
  * Execute executes the request
  * @return map[string]int32
  */
-func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  map[string]int32
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.GetInventory")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/inventory"
@@ -269,22 +262,19 @@ func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[str
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -304,7 +294,7 @@ func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[str
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetOrderByIdRequest struct {
@@ -314,7 +304,7 @@ type ApiGetOrderByIdRequest struct {
 }
 
 
-func (r ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
 	return r.ApiService.GetOrderByIdExecute(r)
 }
 
@@ -337,21 +327,19 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) ApiG
  * Execute executes the request
  * @return Order
  */
-func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Order
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.GetOrderById")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
@@ -361,12 +349,10 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.orderId < 1 {
-		executionError.error = "orderId must be greater than 1"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("orderId must be greater than 1")
 	}
 	if r.orderId > 5 {
-		executionError.error = "orderId must be less than 5"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("orderId must be less than 5")
 	}
 
 	// to determine the Content-Type header
@@ -388,22 +374,19 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -423,7 +406,7 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPlaceOrderRequest struct {
@@ -437,7 +420,7 @@ func (r ApiPlaceOrderRequest) Body(body Order) ApiPlaceOrderRequest {
 	return r
 }
 
-func (r ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
 	return r.ApiService.PlaceOrderExecute(r)
 }
 
@@ -457,21 +440,19 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context) ApiPlaceOrderRequest 
  * Execute executes the request
  * @return Order
  */
-func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Order
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.PlaceOrder")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order"
@@ -480,8 +461,7 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -505,22 +485,19 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -540,5 +517,5 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/client/petstore/go/go-petstore/api_user.go
+++ b/samples/client/petstore/go/go-petstore/api_user.go
@@ -37,7 +37,7 @@ type UserApi interface {
 	/*
 	 * CreateUserExecute executes the request
 	 */
-	CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, error)
 
 	/*
 	 * CreateUsersWithArrayInput Creates list of users with given input array
@@ -49,7 +49,7 @@ type UserApi interface {
 	/*
 	 * CreateUsersWithArrayInputExecute executes the request
 	 */
-	CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, error)
 
 	/*
 	 * CreateUsersWithListInput Creates list of users with given input array
@@ -61,7 +61,7 @@ type UserApi interface {
 	/*
 	 * CreateUsersWithListInputExecute executes the request
 	 */
-	CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, error)
 
 	/*
 	 * DeleteUser Delete user
@@ -75,7 +75,7 @@ type UserApi interface {
 	/*
 	 * DeleteUserExecute executes the request
 	 */
-	DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, error)
 
 	/*
 	 * GetUserByName Get user by user name
@@ -89,7 +89,7 @@ type UserApi interface {
 	 * GetUserByNameExecute executes the request
 	 * @return User
 	 */
-	GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, GenericOpenAPIError)
+	GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, error)
 
 	/*
 	 * LoginUser Logs user into the system
@@ -102,7 +102,7 @@ type UserApi interface {
 	 * LoginUserExecute executes the request
 	 * @return string
 	 */
-	LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, GenericOpenAPIError)
+	LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, error)
 
 	/*
 	 * LogoutUser Logs out current logged in user session
@@ -114,7 +114,7 @@ type UserApi interface {
 	/*
 	 * LogoutUserExecute executes the request
 	 */
-	LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, error)
 
 	/*
 	 * UpdateUser Updated user
@@ -128,7 +128,7 @@ type UserApi interface {
 	/*
 	 * UpdateUserExecute executes the request
 	 */
-	UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, error)
 }
 
 // UserApiService UserApi service
@@ -145,7 +145,7 @@ func (r ApiCreateUserRequest) Body(body User) ApiCreateUserRequest {
 	return r
 }
 
-func (r ApiCreateUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateUserExecute(r)
 }
 
@@ -165,20 +165,18 @@ func (a *UserApiService) CreateUser(ctx _context.Context) ApiCreateUserRequest {
 /*
  * Execute executes the request
  */
-func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user"
@@ -187,8 +185,7 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -212,22 +209,19 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -238,7 +232,7 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiCreateUsersWithArrayInputRequest struct {
@@ -252,7 +246,7 @@ func (r ApiCreateUsersWithArrayInputRequest) Body(body []User) ApiCreateUsersWit
 	return r
 }
 
-func (r ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateUsersWithArrayInputExecute(r)
 }
 
@@ -271,20 +265,18 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context) ApiCrea
 /*
  * Execute executes the request
  */
-func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUsersWithArrayInput")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/createWithArray"
@@ -293,8 +285,7 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -318,22 +309,19 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -344,7 +332,7 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiCreateUsersWithListInputRequest struct {
@@ -358,7 +346,7 @@ func (r ApiCreateUsersWithListInputRequest) Body(body []User) ApiCreateUsersWith
 	return r
 }
 
-func (r ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateUsersWithListInputExecute(r)
 }
 
@@ -377,20 +365,18 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context) ApiCreat
 /*
  * Execute executes the request
  */
-func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUsersWithListInput")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/createWithList"
@@ -399,8 +385,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -424,22 +409,19 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -450,7 +432,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiDeleteUserRequest struct {
@@ -460,7 +442,7 @@ type ApiDeleteUserRequest struct {
 }
 
 
-func (r ApiDeleteUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteUserExecute(r)
 }
 
@@ -482,20 +464,18 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) ApiDe
 /*
  * Execute executes the request
  */
-func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.DeleteUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
@@ -524,22 +504,19 @@ func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Re
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -550,7 +527,7 @@ func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetUserByNameRequest struct {
@@ -560,7 +537,7 @@ type ApiGetUserByNameRequest struct {
 }
 
 
-func (r ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
 	return r.ApiService.GetUserByNameExecute(r)
 }
 
@@ -582,21 +559,19 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) Ap
  * Execute executes the request
  * @return User
  */
-func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  User
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.GetUserByName")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
@@ -625,22 +600,19 @@ func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -660,7 +632,7 @@ func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiLoginUserRequest struct {
@@ -679,7 +651,7 @@ func (r ApiLoginUserRequest) Password(password string) ApiLoginUserRequest {
 	return r
 }
 
-func (r ApiLoginUserRequest) Execute() (string, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
 	return r.ApiService.LoginUserExecute(r)
 }
 
@@ -699,21 +671,19 @@ func (a *UserApiService) LoginUser(ctx _context.Context) ApiLoginUserRequest {
  * Execute executes the request
  * @return string
  */
-func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  string
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.LoginUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/login"
@@ -722,12 +692,10 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.username == nil {
-		executionError.error = "username is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("username is required and must be specified")
 	}
 	if r.password == nil {
-		executionError.error = "password is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("password is required and must be specified")
 	}
 
 	localVarQueryParams.Add("username", parameterToString(*r.username, ""))
@@ -751,22 +719,19 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -786,7 +751,7 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiLogoutUserRequest struct {
@@ -795,7 +760,7 @@ type ApiLogoutUserRequest struct {
 }
 
 
-func (r ApiLogoutUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.LogoutUserExecute(r)
 }
 
@@ -814,20 +779,18 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) ApiLogoutUserRequest {
 /*
  * Execute executes the request
  */
-func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.LogoutUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/logout"
@@ -855,22 +818,19 @@ func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Re
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -881,7 +841,7 @@ func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiUpdateUserRequest struct {
@@ -896,7 +856,7 @@ func (r ApiUpdateUserRequest) Body(body User) ApiUpdateUserRequest {
 	return r
 }
 
-func (r ApiUpdateUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.UpdateUserExecute(r)
 }
 
@@ -918,20 +878,18 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string) ApiUp
 /*
  * Execute executes the request
  */
-func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.UpdateUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
@@ -941,8 +899,7 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -966,22 +923,19 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -992,5 +946,5 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }

--- a/samples/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
@@ -34,7 +34,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.AnotherFakeApi.Call123TestSpecialTags(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `AnotherFakeApi.Call123TestSpecialTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
@@ -28,6 +28,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := *openapiclient.NewClient() // Client | client model
 
@@ -37,6 +42,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `AnotherFakeApi.Call123TestSpecialTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `Call123TestSpecialTags`: Client
     fmt.Fprintf(os.Stdout, "Response from `AnotherFakeApi.Call123TestSpecialTags`: %v\n", resp)
@@ -58,7 +67,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Client**](Client.md)
+[**Client**](Client.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
@@ -28,11 +28,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := *openapiclient.NewClient() // Client | client model
 
@@ -42,9 +37,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `AnotherFakeApi.Call123TestSpecialTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `Call123TestSpecialTags`: Client
@@ -69,7 +64,7 @@ Name | Type | Description  | Notes
 
 [**Client**](Client.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -47,7 +47,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.CreateXmlItem(context.Background()).XmlItem(xmlItem).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.CreateXmlItem``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -111,7 +111,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterBooleanSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterBooleanSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -177,7 +177,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterCompositeSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterCompositeSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -243,7 +243,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterNumberSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterNumberSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -309,7 +309,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterStringSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterStringSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -375,7 +375,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestBodyWithFileSchema(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithFileSchema``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -438,7 +438,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestBodyWithQueryParams(context.Background()).Query(query).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithQueryParams``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -503,7 +503,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestClientModel(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestClientModel``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -583,7 +583,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestEndpointParameters(context.Background()).Number(number).Double(double).PatternWithoutDelimiter(patternWithoutDelimiter).Byte_(byte_).Integer(integer).Int32_(int32_).Int64_(int64_).Float(float).String_(string_).Binary(binary).Date(date).DateTime(dateTime).Password(password).Callback(callback).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEndpointParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -667,7 +667,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestEnumParameters(context.Background()).EnumHeaderStringArray(enumHeaderStringArray).EnumHeaderString(enumHeaderString).EnumQueryStringArray(enumQueryStringArray).EnumQueryString(enumQueryString).EnumQueryInteger(enumQueryInteger).EnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEnumParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -743,7 +743,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestGroupParameters(context.Background()).RequiredStringGroup(requiredStringGroup).RequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).BooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestGroupParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -810,7 +810,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestInlineAdditionalProperties(context.Background()).Param(param).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestInlineAdditionalProperties``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -873,7 +873,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestJsonFormData(context.Background()).Param(param).Param2(param2).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestJsonFormData``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -942,7 +942,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestQueryParameterCollectionFormat(context.Background()).Pipe(pipe).Ioutil(ioutil).Http(http).Url(url).Context(context).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestQueryParameterCollectionFormat``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -41,6 +41,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     xmlItem := *openapiclient.NewXmlItem() // XmlItem | XmlItem Body
 
@@ -50,6 +55,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.CreateXmlItem``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -69,7 +78,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -105,6 +116,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := true // bool | Input boolean as post body (optional)
 
@@ -114,6 +130,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterBooleanSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FakeOuterBooleanSerialize`: bool
     fmt.Fprintf(os.Stdout, "Response from `FakeApi.FakeOuterBooleanSerialize`: %v\n", resp)
@@ -135,7 +155,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**bool**
+**bool**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -171,6 +193,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := *openapiclient.NewOuterComposite() // OuterComposite | Input composite as post body (optional)
 
@@ -180,6 +207,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterCompositeSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FakeOuterCompositeSerialize`: OuterComposite
     fmt.Fprintf(os.Stdout, "Response from `FakeApi.FakeOuterCompositeSerialize`: %v\n", resp)
@@ -201,7 +232,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**OuterComposite**](OuterComposite.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -237,6 +270,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := float32(8.14) // float32 | Input number as post body (optional)
 
@@ -246,6 +284,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterNumberSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FakeOuterNumberSerialize`: float32
     fmt.Fprintf(os.Stdout, "Response from `FakeApi.FakeOuterNumberSerialize`: %v\n", resp)
@@ -267,7 +309,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**float32**
+**float32**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -303,6 +347,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := "body_example" // string | Input string as post body (optional)
 
@@ -312,6 +361,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterStringSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FakeOuterStringSerialize`: string
     fmt.Fprintf(os.Stdout, "Response from `FakeApi.FakeOuterStringSerialize`: %v\n", resp)
@@ -333,7 +386,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**string**
+**string**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -369,6 +424,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := *openapiclient.NewFileSchemaTestClass() // FileSchemaTestClass | 
 
@@ -378,6 +438,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithFileSchema``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -397,7 +461,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -431,6 +497,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     query := "query_example" // string | 
     body := *openapiclient.NewUser() // User | 
@@ -441,6 +512,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithQueryParams``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -461,7 +536,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -497,6 +574,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := *openapiclient.NewClient() // Client | client model
 
@@ -506,6 +588,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestClientModel``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `TestClientModel`: Client
     fmt.Fprintf(os.Stdout, "Response from `FakeApi.TestClientModel`: %v\n", resp)
@@ -527,7 +613,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Client**](Client.md)
+[**Client**](Client.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -564,6 +652,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     number := float32(8.14) // float32 | None
     double := float64(1.2) // float64 | None
@@ -586,6 +679,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEndpointParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -618,7 +715,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -654,6 +753,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     enumHeaderStringArray := []string{"EnumHeaderStringArray_example"} // []string | Header parameter enum test (string array) (optional)
     enumHeaderString := "enumHeaderString_example" // string | Header parameter enum test (string) (optional) (default to "-efg")
@@ -670,6 +774,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEnumParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -696,7 +804,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -732,6 +842,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     requiredStringGroup := int32(56) // int32 | Required String in group parameters
     requiredBooleanGroup := true // bool | Required Boolean in group parameters
@@ -746,6 +861,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestGroupParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -770,7 +889,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -804,6 +925,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     param := map[string]string{"key": "Inner_example"} // map[string]string | request body
 
@@ -813,6 +939,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestInlineAdditionalProperties``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -832,7 +962,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -866,6 +998,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     param := "param_example" // string | field1
     param2 := "param2_example" // string | field2
@@ -876,6 +1013,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestJsonFormData``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -896,7 +1037,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -932,6 +1075,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     pipe := []string{"Inner_example"} // []string | 
     ioutil := []string{"Inner_example"} // []string | 
@@ -945,6 +1093,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestQueryParameterCollectionFormat``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -968,7 +1120,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -41,11 +41,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     xmlItem := *openapiclient.NewXmlItem() // XmlItem | XmlItem Body
 
@@ -55,9 +50,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.CreateXmlItem``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -80,7 +75,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -116,11 +111,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := true // bool | Input boolean as post body (optional)
 
@@ -130,9 +120,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterBooleanSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FakeOuterBooleanSerialize`: bool
@@ -157,7 +147,7 @@ Name | Type | Description  | Notes
 
 **bool**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -193,11 +183,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := *openapiclient.NewOuterComposite() // OuterComposite | Input composite as post body (optional)
 
@@ -207,9 +192,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterCompositeSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FakeOuterCompositeSerialize`: OuterComposite
@@ -234,7 +219,7 @@ Name | Type | Description  | Notes
 
 [**OuterComposite**](OuterComposite.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -270,11 +255,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := float32(8.14) // float32 | Input number as post body (optional)
 
@@ -284,9 +264,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterNumberSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FakeOuterNumberSerialize`: float32
@@ -311,7 +291,7 @@ Name | Type | Description  | Notes
 
 **float32**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -347,11 +327,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := "body_example" // string | Input string as post body (optional)
 
@@ -361,9 +336,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterStringSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FakeOuterStringSerialize`: string
@@ -388,7 +363,7 @@ Name | Type | Description  | Notes
 
 **string**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -424,11 +399,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := *openapiclient.NewFileSchemaTestClass() // FileSchemaTestClass | 
 
@@ -438,9 +408,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithFileSchema``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -463,7 +433,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -497,11 +467,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     query := "query_example" // string | 
     body := *openapiclient.NewUser() // User | 
@@ -512,9 +477,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithQueryParams``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -538,7 +503,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -574,11 +539,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := *openapiclient.NewClient() // Client | client model
 
@@ -588,9 +548,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestClientModel``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `TestClientModel`: Client
@@ -615,7 +575,7 @@ Name | Type | Description  | Notes
 
 [**Client**](Client.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -652,11 +612,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     number := float32(8.14) // float32 | None
     double := float64(1.2) // float64 | None
@@ -679,9 +634,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEndpointParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -717,7 +672,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -753,11 +708,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     enumHeaderStringArray := []string{"EnumHeaderStringArray_example"} // []string | Header parameter enum test (string array) (optional)
     enumHeaderString := "enumHeaderString_example" // string | Header parameter enum test (string) (optional) (default to "-efg")
@@ -774,9 +724,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEnumParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -806,7 +756,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -842,11 +792,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     requiredStringGroup := int32(56) // int32 | Required String in group parameters
     requiredBooleanGroup := true // bool | Required Boolean in group parameters
@@ -861,9 +806,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestGroupParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -891,7 +836,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -925,11 +870,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     param := map[string]string{"key": "Inner_example"} // map[string]string | request body
 
@@ -939,9 +879,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestInlineAdditionalProperties``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -964,7 +904,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -998,11 +938,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     param := "param_example" // string | field1
     param2 := "param2_example" // string | field2
@@ -1013,9 +948,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestJsonFormData``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -1039,7 +974,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -1075,11 +1010,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     pipe := []string{"Inner_example"} // []string | 
     ioutil := []string{"Inner_example"} // []string | 
@@ -1093,9 +1023,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestQueryParameterCollectionFormat``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -1122,7 +1052,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
@@ -34,7 +34,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeClassnameTags123Api.TestClassname(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeClassnameTags123Api.TestClassname``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
@@ -28,6 +28,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := *openapiclient.NewClient() // Client | client model
 
@@ -37,6 +42,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeClassnameTags123Api.TestClassname``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `TestClassname`: Client
     fmt.Fprintf(os.Stdout, "Response from `FakeClassnameTags123Api.TestClassname`: %v\n", resp)
@@ -58,7 +67,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Client**](Client.md)
+[**Client**](Client.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
@@ -28,11 +28,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := *openapiclient.NewClient() // Client | client model
 
@@ -42,9 +37,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeClassnameTags123Api.TestClassname``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `TestClassname`: Client
@@ -69,7 +64,7 @@ Name | Type | Description  | Notes
 
 [**Client**](Client.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/PetApi.md
@@ -40,7 +40,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.AddPet(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.AddPet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -103,7 +103,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.DeletePet(context.Background(), petId).ApiKey(apiKey).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.DeletePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -172,7 +172,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.FindPetsByStatus(context.Background()).Status(status).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByStatus``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -238,7 +238,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.FindPetsByTags(context.Background()).Tags(tags).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -304,7 +304,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.GetPetById(context.Background(), petId).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.GetPetById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -372,7 +372,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UpdatePet(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -436,7 +436,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UpdatePetWithForm(context.Background(), petId).Name(name).Status(status).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePetWithForm``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -506,7 +506,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UploadFile(context.Background(), petId).AdditionalMetadata(additionalMetadata).File(file).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -578,7 +578,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UploadFileWithRequiredFile(context.Background(), petId).RequiredFile(requiredFile).AdditionalMetadata(additionalMetadata).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFileWithRequiredFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/PetApi.md
@@ -34,11 +34,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := *openapiclient.NewPet("doggie", []string{"PhotoUrls_example"}) // Pet | Pet object that needs to be added to the store
 
@@ -48,9 +43,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.AddPet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -73,7 +68,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -107,11 +102,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     petId := int64(789) // int64 | Pet id to delete
     apiKey := "apiKey_example" // string |  (optional)
@@ -122,9 +112,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.DeletePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -152,7 +142,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -188,11 +178,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     status := []string{"Status_example"} // []string | Status values that need to be considered for filter
 
@@ -202,9 +187,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByStatus``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FindPetsByStatus`: []Pet
@@ -229,7 +214,7 @@ Name | Type | Description  | Notes
 
 [**[]Pet**](Pet.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -265,11 +250,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     tags := []string{"Inner_example"} // []string | Tags to filter by
 
@@ -279,9 +259,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FindPetsByTags`: []Pet
@@ -306,7 +286,7 @@ Name | Type | Description  | Notes
 
 [**[]Pet**](Pet.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -342,11 +322,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     petId := int64(789) // int64 | ID of pet to return
 
@@ -356,9 +331,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.GetPetById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `GetPetById`: Pet
@@ -387,7 +362,7 @@ Name | Type | Description  | Notes
 
 [**Pet**](Pet.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -421,11 +396,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := *openapiclient.NewPet("doggie", []string{"PhotoUrls_example"}) // Pet | Pet object that needs to be added to the store
 
@@ -435,9 +405,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -460,7 +430,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -494,11 +464,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     petId := int64(789) // int64 | ID of pet that needs to be updated
     name := "name_example" // string | Updated name of the pet (optional)
@@ -510,9 +475,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePetWithForm``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -541,7 +506,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -575,11 +540,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     petId := int64(789) // int64 | ID of pet to update
     additionalMetadata := "additionalMetadata_example" // string | Additional data to pass to server (optional)
@@ -591,9 +551,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `UploadFile`: ApiResponse
@@ -624,7 +584,7 @@ Name | Type | Description  | Notes
 
 [**ApiResponse**](ApiResponse.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -658,11 +618,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     petId := int64(789) // int64 | ID of pet to update
     requiredFile := os.NewFile(1234, "some_file") // *os.File | file to upload
@@ -674,9 +629,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFileWithRequiredFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `UploadFileWithRequiredFile`: ApiResponse
@@ -707,7 +662,7 @@ Name | Type | Description  | Notes
 
 [**ApiResponse**](ApiResponse.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/PetApi.md
@@ -34,6 +34,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := *openapiclient.NewPet("doggie", []string{"PhotoUrls_example"}) // Pet | Pet object that needs to be added to the store
 
@@ -43,6 +48,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.AddPet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -62,7 +71,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -96,6 +107,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     petId := int64(789) // int64 | Pet id to delete
     apiKey := "apiKey_example" // string |  (optional)
@@ -106,6 +122,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.DeletePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -130,7 +150,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -166,6 +188,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     status := []string{"Status_example"} // []string | Status values that need to be considered for filter
 
@@ -175,6 +202,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByStatus``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FindPetsByStatus`: []Pet
     fmt.Fprintf(os.Stdout, "Response from `PetApi.FindPetsByStatus`: %v\n", resp)
@@ -196,7 +227,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**[]Pet**](Pet.md)
+[**[]Pet**](Pet.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -232,6 +265,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     tags := []string{"Inner_example"} // []string | Tags to filter by
 
@@ -241,6 +279,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FindPetsByTags`: []Pet
     fmt.Fprintf(os.Stdout, "Response from `PetApi.FindPetsByTags`: %v\n", resp)
@@ -262,7 +304,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**[]Pet**](Pet.md)
+[**[]Pet**](Pet.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -298,6 +342,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     petId := int64(789) // int64 | ID of pet to return
 
@@ -307,6 +356,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.GetPetById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `GetPetById`: Pet
     fmt.Fprintf(os.Stdout, "Response from `PetApi.GetPetById`: %v\n", resp)
@@ -332,7 +385,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Pet**](Pet.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -366,6 +421,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := *openapiclient.NewPet("doggie", []string{"PhotoUrls_example"}) // Pet | Pet object that needs to be added to the store
 
@@ -375,6 +435,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -394,7 +458,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -428,6 +494,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     petId := int64(789) // int64 | ID of pet that needs to be updated
     name := "name_example" // string | Updated name of the pet (optional)
@@ -439,6 +510,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePetWithForm``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -464,7 +539,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -498,6 +575,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     petId := int64(789) // int64 | ID of pet to update
     additionalMetadata := "additionalMetadata_example" // string | Additional data to pass to server (optional)
@@ -509,6 +591,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `UploadFile`: ApiResponse
     fmt.Fprintf(os.Stdout, "Response from `PetApi.UploadFile`: %v\n", resp)
@@ -536,7 +622,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**ApiResponse**](ApiResponse.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -570,6 +658,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     petId := int64(789) // int64 | ID of pet to update
     requiredFile := os.NewFile(1234, "some_file") // *os.File | file to upload
@@ -581,6 +674,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFileWithRequiredFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `UploadFileWithRequiredFile`: ApiResponse
     fmt.Fprintf(os.Stdout, "Response from `PetApi.UploadFileWithRequiredFile`: %v\n", resp)
@@ -608,7 +705,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**ApiResponse**](ApiResponse.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -37,7 +37,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.DeleteOrder(context.Background(), orderId).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.DeleteOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -104,7 +104,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.GetInventory(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetInventory``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -166,7 +166,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.GetOrderById(context.Background(), orderId).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetOrderById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -234,7 +234,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.PlaceOrder(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.PlaceOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -31,6 +31,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     orderId := "orderId_example" // string | ID of the order that needs to be deleted
 
@@ -40,6 +45,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.DeleteOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -63,7 +72,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -99,6 +110,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -107,6 +123,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetInventory``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `GetInventory`: map[string]int32
     fmt.Fprintf(os.Stdout, "Response from `StoreApi.GetInventory`: %v\n", resp)
@@ -124,7 +144,9 @@ Other parameters are passed through a pointer to a apiGetInventoryRequest struct
 
 ### Return type
 
-**map[string]int32**
+**map[string]int32**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -160,6 +182,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     orderId := int64(789) // int64 | ID of pet that needs to be fetched
 
@@ -169,6 +196,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetOrderById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `GetOrderById`: Order
     fmt.Fprintf(os.Stdout, "Response from `StoreApi.GetOrderById`: %v\n", resp)
@@ -194,7 +225,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Order**](Order.md)
+[**Order**](Order.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -228,6 +261,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := *openapiclient.NewOrder() // Order | order placed for purchasing the pet
 
@@ -237,6 +275,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.PlaceOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `PlaceOrder`: Order
     fmt.Fprintf(os.Stdout, "Response from `StoreApi.PlaceOrder`: %v\n", resp)
@@ -258,7 +300,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Order**](Order.md)
+[**Order**](Order.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -31,11 +31,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     orderId := "orderId_example" // string | ID of the order that needs to be deleted
 
@@ -45,9 +40,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.DeleteOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -74,7 +69,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -110,11 +105,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -123,9 +113,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetInventory``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `GetInventory`: map[string]int32
@@ -146,7 +136,7 @@ Other parameters are passed through a pointer to a apiGetInventoryRequest struct
 
 **map[string]int32**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -182,11 +172,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     orderId := int64(789) // int64 | ID of pet that needs to be fetched
 
@@ -196,9 +181,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetOrderById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `GetOrderById`: Order
@@ -227,7 +212,7 @@ Name | Type | Description  | Notes
 
 [**Order**](Order.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -261,11 +246,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := *openapiclient.NewOrder() // Order | order placed for purchasing the pet
 
@@ -275,9 +255,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.PlaceOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `PlaceOrder`: Order
@@ -302,7 +282,7 @@ Name | Type | Description  | Notes
 
 [**Order**](Order.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/UserApi.md
@@ -41,7 +41,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.CreateUser(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -103,7 +103,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.CreateUsersWithArrayInput(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithArrayInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -165,7 +165,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.CreateUsersWithListInput(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithListInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -229,7 +229,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.DeleteUser(context.Background(), username).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.DeleteUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -295,7 +295,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.GetUserByName(context.Background(), username).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.GetUserByName``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -364,7 +364,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.LoginUser(context.Background()).Username(username).Password(password).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LoginUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -428,7 +428,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.LogoutUser(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LogoutUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -489,7 +489,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.UpdateUser(context.Background(), username).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.UpdateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/UserApi.md
@@ -35,11 +35,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := *openapiclient.NewUser() // User | Created user object
 
@@ -49,9 +44,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -74,7 +69,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -108,11 +103,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := []openapiclient.User{*openapiclient.NewUser()} // []User | List of user object
 
@@ -122,9 +112,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithArrayInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -147,7 +137,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -181,11 +171,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := []openapiclient.User{*openapiclient.NewUser()} // []User | List of user object
 
@@ -195,9 +180,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithListInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -220,7 +205,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -256,11 +241,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     username := "username_example" // string | The name that needs to be deleted
 
@@ -270,9 +250,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.DeleteUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -299,7 +279,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -333,11 +313,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     username := "username_example" // string | The name that needs to be fetched. Use user1 for testing.
 
@@ -347,9 +322,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.GetUserByName``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `GetUserByName`: User
@@ -378,7 +353,7 @@ Name | Type | Description  | Notes
 
 [**User**](User.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -412,11 +387,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     username := "username_example" // string | The user name for login
     password := "password_example" // string | The password for login in clear text
@@ -427,9 +397,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LoginUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `LoginUser`: string
@@ -455,7 +425,7 @@ Name | Type | Description  | Notes
 
 **string**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -489,11 +459,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -502,9 +467,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LogoutUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -523,7 +488,7 @@ Other parameters are passed through a pointer to a apiLogoutUserRequest struct v
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -559,11 +524,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     username := "username_example" // string | name that need to be deleted
     body := *openapiclient.NewUser() // User | Updated user object
@@ -574,9 +534,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.UpdateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -604,7 +564,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/UserApi.md
@@ -35,6 +35,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := *openapiclient.NewUser() // User | Created user object
 
@@ -44,6 +49,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -63,7 +72,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -97,6 +108,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := []openapiclient.User{*openapiclient.NewUser()} // []User | List of user object
 
@@ -106,6 +122,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithArrayInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -125,7 +145,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -159,6 +181,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := []openapiclient.User{*openapiclient.NewUser()} // []User | List of user object
 
@@ -168,6 +195,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithListInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -187,7 +218,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -223,6 +256,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     username := "username_example" // string | The name that needs to be deleted
 
@@ -232,6 +270,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.DeleteUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -255,7 +297,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -289,6 +333,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     username := "username_example" // string | The name that needs to be fetched. Use user1 for testing.
 
@@ -298,6 +347,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.GetUserByName``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `GetUserByName`: User
     fmt.Fprintf(os.Stdout, "Response from `UserApi.GetUserByName`: %v\n", resp)
@@ -323,7 +376,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**User**](User.md)
+[**User**](User.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -357,6 +412,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     username := "username_example" // string | The user name for login
     password := "password_example" // string | The password for login in clear text
@@ -367,6 +427,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LoginUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `LoginUser`: string
     fmt.Fprintf(os.Stdout, "Response from `UserApi.LoginUser`: %v\n", resp)
@@ -389,7 +453,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**string**
+**string**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -423,6 +489,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -431,6 +502,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LogoutUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -446,7 +521,9 @@ Other parameters are passed through a pointer to a apiLogoutUserRequest struct v
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -482,6 +559,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     username := "username_example" // string | name that need to be deleted
     body := *openapiclient.NewUser() // User | Updated user object
@@ -492,6 +574,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.UpdateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -516,7 +602,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/client/petstore/go/mock/mock_api_pet.go
+++ b/samples/client/petstore/go/mock/mock_api_pet.go
@@ -20,70 +20,70 @@ func (m *MockPetApi) AddPet(ctx context.Context) sw.ApiAddPetRequest {
 	return sw.ApiAddPetRequest{ApiService: m}
 }
 
-func (m *MockPetApi) AddPetExecute(r sw.ApiAddPetRequest) (*http.Response, sw.GenericOpenAPIError) {
-	return &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) AddPetExecute(r sw.ApiAddPetRequest) (*http.Response, error) {
+	return &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) DeletePet(ctx context.Context, petId int64) sw.ApiDeletePetRequest {
 	return sw.ApiDeletePetRequest{ApiService: m}
 }
 
-func (m *MockPetApi) DeletePetExecute(r sw.ApiDeletePetRequest) (*http.Response, sw.GenericOpenAPIError) {
-	return &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) DeletePetExecute(r sw.ApiDeletePetRequest) (*http.Response, error) {
+	return &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) FindPetsByStatus(ctx context.Context) sw.ApiFindPetsByStatusRequest {
 	return sw.ApiFindPetsByStatusRequest{ApiService: m}
 }
 
-func (m *MockPetApi) FindPetsByStatusExecute(r sw.ApiFindPetsByStatusRequest) ([]sw.Pet, *http.Response, sw.GenericOpenAPIError) {
-	return []sw.Pet{}, &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) FindPetsByStatusExecute(r sw.ApiFindPetsByStatusRequest) ([]sw.Pet, *http.Response, error) {
+	return []sw.Pet{}, &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) FindPetsByTags(ctx context.Context) sw.ApiFindPetsByTagsRequest {
 	return sw.ApiFindPetsByTagsRequest{ApiService: m}
 }
 
-func (m *MockPetApi) FindPetsByTagsExecute(r sw.ApiFindPetsByTagsRequest) ([]sw.Pet, *http.Response, sw.GenericOpenAPIError) {
-	return []sw.Pet{}, &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) FindPetsByTagsExecute(r sw.ApiFindPetsByTagsRequest) ([]sw.Pet, *http.Response, error) {
+	return []sw.Pet{}, &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) GetPetById(ctx context.Context, petId int64) sw.ApiGetPetByIdRequest {
 	return sw.ApiGetPetByIdRequest{ApiService: m}
 }
 
-func (m *MockPetApi) GetPetByIdExecute(r sw.ApiGetPetByIdRequest) (sw.Pet, *http.Response, sw.GenericOpenAPIError) {
-	return sw.Pet{}, &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) GetPetByIdExecute(r sw.ApiGetPetByIdRequest) (sw.Pet, *http.Response, error) {
+	return sw.Pet{}, &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) UpdatePet(ctx context.Context) sw.ApiUpdatePetRequest {
 	return sw.ApiUpdatePetRequest{ApiService: m}
 }
 
-func (m *MockPetApi) UpdatePetExecute(r sw.ApiUpdatePetRequest) (*http.Response, sw.GenericOpenAPIError) {
-	return &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) UpdatePetExecute(r sw.ApiUpdatePetRequest) (*http.Response, error) {
+	return &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) UpdatePetWithForm(ctx context.Context, petId int64) sw.ApiUpdatePetWithFormRequest {
 	return sw.ApiUpdatePetWithFormRequest{ApiService: m}
 }
 
-func (m *MockPetApi) UpdatePetWithFormExecute(r sw.ApiUpdatePetWithFormRequest) (*http.Response, sw.GenericOpenAPIError) {
-	return &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) UpdatePetWithFormExecute(r sw.ApiUpdatePetWithFormRequest) (*http.Response, error) {
+	return &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) UploadFile(ctx context.Context, petId int64) sw.ApiUploadFileRequest {
 	return sw.ApiUploadFileRequest{ApiService: m}
 }
 
-func (m *MockPetApi) UploadFileExecute(r sw.ApiUploadFileRequest) (sw.ApiResponse, *http.Response, sw.GenericOpenAPIError) {
-	return sw.ApiResponse{}, &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) UploadFileExecute(r sw.ApiUploadFileRequest) (sw.ApiResponse, *http.Response, error) {
+	return sw.ApiResponse{}, &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) UploadFileWithRequiredFile(ctx context.Context, petId int64) sw.ApiUploadFileWithRequiredFileRequest {
 	return sw.ApiUploadFileWithRequiredFileRequest{ApiService: m}
 }
 
-func (m *MockPetApi) UploadFileWithRequiredFileExecute(r sw.ApiUploadFileWithRequiredFileRequest) (sw.ApiResponse, *http.Response, sw.GenericOpenAPIError) {
-	return sw.ApiResponse{}, &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) UploadFileWithRequiredFileExecute(r sw.ApiUploadFileWithRequiredFileRequest) (sw.ApiResponse, *http.Response, error) {
+	return sw.ApiResponse{}, &http.Response{StatusCode:200}, nil
 }

--- a/samples/client/petstore/go/pet_api_test.go
+++ b/samples/client/petstore/go/pet_api_test.go
@@ -34,7 +34,7 @@ func TestAddPet(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -54,7 +54,7 @@ func TestAddPetMock(t *testing.T) {
 func TestFindPetsByStatusWithMissingParam(t *testing.T) {
 	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while testing TestFindPetsByStatusWithMissingParam: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -69,12 +69,13 @@ func TestGetPetById(t *testing.T) {
 func TestGetPetByIdWithInvalidID(t *testing.T) {
 	resp, r, err := client.PetApi.GetPetById(context.Background(), 999999999).Execute()
 	if r != nil && r.StatusCode == 404 {
-		assertedError := err
+		assertedError, ok := err.(sw.GenericOpenAPIError)
 		a := assert.New(t)
+		a.True(ok)
 		a.Contains(string(assertedError.Body()), "type")
 
 		a.Contains(assertedError.Error(), "Not Found")
-	} else if err.Error() != "" {
+	} else if err != nil {
 		t.Fatalf("Error while getting pet by invalid id: %v", err)
 		t.Log(r)
 	} else {
@@ -84,7 +85,7 @@ func TestGetPetByIdWithInvalidID(t *testing.T) {
 
 func TestUpdatePetWithForm(t *testing.T) {
 	r, err := client.PetApi.UpdatePetWithForm(context.Background(), 12830).Name("golang").Status("available").Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while updating pet by id: %v", err)
 		t.Log(r)
 	}
@@ -99,7 +100,7 @@ func TestUpdatePetWithForm(t *testing.T) {
 func TestFindPetsByTag(t *testing.T) {
 	var found = false
 	resp, r, err := client.PetApi.FindPetsByTags(context.Background()).Tags([]string{"tag2"}).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting pet by tag: %v", err)
 		t.Log(r)
 	} else {
@@ -128,7 +129,7 @@ func TestFindPetsByTag(t *testing.T) {
 
 func TestFindPetsByStatus(t *testing.T) {
 	resp, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status([]string{"available"}).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting pet by id: %v", err)
 		t.Log(r)
 	} else {
@@ -155,7 +156,7 @@ func TestUploadFile(t *testing.T) {
 
 	_, r, err := client.PetApi.UploadFile(context.Background(), 12830).AdditionalMetadata("golang").File(file).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)
 	}
 
@@ -173,7 +174,7 @@ func TestUploadFileRequired(t *testing.T) {
 
 	_, r, err := client.PetApi.UploadFileWithRequiredFile(context.Background(), 12830).RequiredFile(file).AdditionalMetadata("golang").Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)
 	}
 
@@ -185,7 +186,7 @@ func TestUploadFileRequired(t *testing.T) {
 func TestDeletePet(t *testing.T) {
 	r, err := client.PetApi.DeletePet(context.Background(), 12830).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -275,7 +276,7 @@ func waitOnFunctions(t *testing.T, errc chan error, n int) {
 func deletePet(t *testing.T, id int64) {
 	r, err := client.PetApi.DeletePet(context.Background(), id).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -286,7 +287,7 @@ func deletePet(t *testing.T, id int64) {
 func isPetCorrect(t *testing.T, id int64, name string, status string) {
 	assert := assert.New(t)
 	resp, r, err := client.PetApi.GetPetById(context.Background(), id).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting pet by id: %v", err)
 	} else {
 		assert.Equal(*resp.Id, int64(id), "Pet id should be equal")

--- a/samples/client/petstore/go/store_api_test.go
+++ b/samples/client/petstore/go/store_api_test.go
@@ -20,7 +20,7 @@ func TestPlaceOrder(t *testing.T) {
 
 	_, r, err := client.StoreApi.PlaceOrder(context.Background()).Body(newOrder).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		// Skip parsing time error due to error in Petstore Test Server
 		// https://github.com/OpenAPITools/openapi-generator/issues/1292
 		if regexp.

--- a/samples/client/petstore/go/user_api_test.go
+++ b/samples/client/petstore/go/user_api_test.go
@@ -22,7 +22,7 @@ func TestCreateUser(t *testing.T) {
 
 	apiResponse, err := client.UserApi.CreateUser(context.Background()).Body(newUser).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding user: %v", err)
 	}
 	if apiResponse.StatusCode != 200 {
@@ -56,7 +56,7 @@ func TestCreateUsersWithArrayInput(t *testing.T) {
 	}
 
 	apiResponse, err := client.UserApi.CreateUsersWithArrayInput(context.Background()).Body(newUsers).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding users: %v", err)
 	}
 	if apiResponse.StatusCode != 200 {
@@ -82,7 +82,7 @@ func TestGetUserByName(t *testing.T) {
 	assert := assert.New(t)
 
 	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher").Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting user by id: %v", err)
 	} else {
 		assert.Equal(*resp.Id, int64(1000), "User id should be equal")
@@ -99,7 +99,7 @@ func TestGetUserByNameWithInvalidID(t *testing.T) {
 	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "999999999").Execute()
 	if apiResponse != nil && apiResponse.StatusCode == 404 {
 		return // This is a pass condition. API will return with a 404 error.
-	} else if err.Error() != "" {
+	} else if err != nil {
 		t.Fatalf("Error while getting user by invalid id: %v", err)
 		t.Log(apiResponse)
 	} else {
@@ -124,7 +124,7 @@ func TestUpdateUser(t *testing.T) {
 		UserStatus: sw.PtrInt32(1)}
 
 	apiResponse, err := client.UserApi.UpdateUser(context.Background(), "gopher").Body(newUser).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting user by id: %v", err)
 	}
 	if apiResponse.StatusCode != 200 {
@@ -133,7 +133,7 @@ func TestUpdateUser(t *testing.T) {
 
 	//verify changings are correct
 	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher").Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting user by id: %v", err)
 	} else {
 		assert.Equal(*resp.Id, int64(1000), "User id should be equal")

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/api_usage.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/api_usage.go
@@ -32,7 +32,7 @@ type ApiAnyKeyRequest struct {
 }
 
 
-func (r ApiAnyKeyRequest) Execute() (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiAnyKeyRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
 	return r.ApiService.AnyKeyExecute(r)
 }
 
@@ -53,21 +53,19 @@ func (a *UsageApiService) AnyKey(ctx _context.Context) ApiAnyKeyRequest {
  * Execute executes the request
  * @return map[string]interface{}
  */
-func (a *UsageApiService) AnyKeyExecute(r ApiAnyKeyRequest) (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UsageApiService) AnyKeyExecute(r ApiAnyKeyRequest) (map[string]interface{}, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  map[string]interface{}
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.AnyKey")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/any"
@@ -123,22 +121,19 @@ func (a *UsageApiService) AnyKeyExecute(r ApiAnyKeyRequest) (map[string]interfac
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -158,7 +153,7 @@ func (a *UsageApiService) AnyKeyExecute(r ApiAnyKeyRequest) (map[string]interfac
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiBothKeysRequest struct {
@@ -167,7 +162,7 @@ type ApiBothKeysRequest struct {
 }
 
 
-func (r ApiBothKeysRequest) Execute() (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiBothKeysRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
 	return r.ApiService.BothKeysExecute(r)
 }
 
@@ -188,21 +183,19 @@ func (a *UsageApiService) BothKeys(ctx _context.Context) ApiBothKeysRequest {
  * Execute executes the request
  * @return map[string]interface{}
  */
-func (a *UsageApiService) BothKeysExecute(r ApiBothKeysRequest) (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UsageApiService) BothKeysExecute(r ApiBothKeysRequest) (map[string]interface{}, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  map[string]interface{}
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.BothKeys")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/both"
@@ -258,22 +251,19 @@ func (a *UsageApiService) BothKeysExecute(r ApiBothKeysRequest) (map[string]inte
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -293,7 +283,7 @@ func (a *UsageApiService) BothKeysExecute(r ApiBothKeysRequest) (map[string]inte
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiKeyInHeaderRequest struct {
@@ -302,7 +292,7 @@ type ApiKeyInHeaderRequest struct {
 }
 
 
-func (r ApiKeyInHeaderRequest) Execute() (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiKeyInHeaderRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
 	return r.ApiService.KeyInHeaderExecute(r)
 }
 
@@ -323,21 +313,19 @@ func (a *UsageApiService) KeyInHeader(ctx _context.Context) ApiKeyInHeaderReques
  * Execute executes the request
  * @return map[string]interface{}
  */
-func (a *UsageApiService) KeyInHeaderExecute(r ApiKeyInHeaderRequest) (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UsageApiService) KeyInHeaderExecute(r ApiKeyInHeaderRequest) (map[string]interface{}, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  map[string]interface{}
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.KeyInHeader")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/header"
@@ -379,22 +367,19 @@ func (a *UsageApiService) KeyInHeaderExecute(r ApiKeyInHeaderRequest) (map[strin
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -414,7 +399,7 @@ func (a *UsageApiService) KeyInHeaderExecute(r ApiKeyInHeaderRequest) (map[strin
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiKeyInQueryRequest struct {
@@ -423,7 +408,7 @@ type ApiKeyInQueryRequest struct {
 }
 
 
-func (r ApiKeyInQueryRequest) Execute() (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiKeyInQueryRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
 	return r.ApiService.KeyInQueryExecute(r)
 }
 
@@ -444,21 +429,19 @@ func (a *UsageApiService) KeyInQuery(ctx _context.Context) ApiKeyInQueryRequest 
  * Execute executes the request
  * @return map[string]interface{}
  */
-func (a *UsageApiService) KeyInQueryExecute(r ApiKeyInQueryRequest) (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UsageApiService) KeyInQueryExecute(r ApiKeyInQueryRequest) (map[string]interface{}, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  map[string]interface{}
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.KeyInQuery")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/query"
@@ -500,22 +483,19 @@ func (a *UsageApiService) KeyInQueryExecute(r ApiKeyInQueryRequest) (map[string]
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -535,5 +515,5 @@ func (a *UsageApiService) KeyInQueryExecute(r ApiKeyInQueryRequest) (map[string]
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/docs/UsageApi.md
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/docs/UsageApi.md
@@ -36,7 +36,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UsageApi.AnyKey(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.AnyKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -97,7 +97,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UsageApi.BothKeys(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.BothKeys``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -158,7 +158,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UsageApi.KeyInHeader(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.KeyInHeader``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -219,7 +219,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UsageApi.KeyInQuery(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.KeyInQuery``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/docs/UsageApi.md
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/docs/UsageApi.md
@@ -31,11 +31,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -44,9 +39,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.AnyKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `AnyKey`: map[string]interface{}
@@ -67,7 +62,7 @@ Other parameters are passed through a pointer to a apiAnyKeyRequest struct via t
 
 **map[string]interface{}**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -103,11 +98,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -116,9 +106,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.BothKeys``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `BothKeys`: map[string]interface{}
@@ -139,7 +129,7 @@ Other parameters are passed through a pointer to a apiBothKeysRequest struct via
 
 **map[string]interface{}**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -175,11 +165,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -188,9 +173,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.KeyInHeader``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `KeyInHeader`: map[string]interface{}
@@ -211,7 +196,7 @@ Other parameters are passed through a pointer to a apiKeyInHeaderRequest struct 
 
 **map[string]interface{}**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -247,11 +232,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -260,9 +240,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.KeyInQuery``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `KeyInQuery`: map[string]interface{}
@@ -283,7 +263,7 @@ Other parameters are passed through a pointer to a apiKeyInQueryRequest struct v
 
 **map[string]interface{}**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/docs/UsageApi.md
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/docs/UsageApi.md
@@ -31,6 +31,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -39,6 +44,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.AnyKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `AnyKey`: map[string]interface{}
     fmt.Fprintf(os.Stdout, "Response from `UsageApi.AnyKey`: %v\n", resp)
@@ -56,7 +65,9 @@ Other parameters are passed through a pointer to a apiAnyKeyRequest struct via t
 
 ### Return type
 
-**map[string]interface{}**
+**map[string]interface{}**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -92,6 +103,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -100,6 +116,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.BothKeys``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `BothKeys`: map[string]interface{}
     fmt.Fprintf(os.Stdout, "Response from `UsageApi.BothKeys`: %v\n", resp)
@@ -117,7 +137,9 @@ Other parameters are passed through a pointer to a apiBothKeysRequest struct via
 
 ### Return type
 
-**map[string]interface{}**
+**map[string]interface{}**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -153,6 +175,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -161,6 +188,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.KeyInHeader``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `KeyInHeader`: map[string]interface{}
     fmt.Fprintf(os.Stdout, "Response from `UsageApi.KeyInHeader`: %v\n", resp)
@@ -178,7 +209,9 @@ Other parameters are passed through a pointer to a apiKeyInHeaderRequest struct 
 
 ### Return type
 
-**map[string]interface{}**
+**map[string]interface{}**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -214,6 +247,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -222,6 +260,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.KeyInQuery``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `KeyInQuery`: map[string]interface{}
     fmt.Fprintf(os.Stdout, "Response from `UsageApi.KeyInQuery`: %v\n", resp)
@@ -239,7 +281,9 @@ Other parameters are passed through a pointer to a apiKeyInQueryRequest struct v
 
 ### Return type
 
-**map[string]interface{}**
+**map[string]interface{}**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/auth_test.go
+++ b/samples/openapi3/client/petstore/go/auth_test.go
@@ -43,7 +43,7 @@ func TestOAuth2(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -52,7 +52,7 @@ func TestOAuth2(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -78,7 +78,7 @@ func TestBasicAuth(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(auth).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -87,7 +87,7 @@ func TestBasicAuth(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -108,7 +108,7 @@ func TestAccessToken(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(nil).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -117,7 +117,7 @@ func TestAccessToken(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -138,7 +138,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -146,7 +146,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 	}
 
 	_, r, err = client.PetApi.GetPetById(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 
@@ -156,7 +156,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 	}
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -173,7 +173,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(nil).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -181,7 +181,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 	}
 
 	_, r, err = client.PetApi.GetPetById(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 
@@ -191,7 +191,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 	}
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -206,7 +206,7 @@ func TestDefaultHeader(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -215,7 +215,7 @@ func TestDefaultHeader(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(context.Background(), 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -230,7 +230,7 @@ func TestDefaultHeader(t *testing.T) {
 func TestHostOverride(t *testing.T) {
 	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while finding pets by status: %v", err)
 	}
 
@@ -242,7 +242,7 @@ func TestHostOverride(t *testing.T) {
 func TestSchemeOverride(t *testing.T) {
 	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while finding pets by status: %v", err)
 	}
 

--- a/samples/openapi3/client/petstore/go/fake_api_test.go
+++ b/samples/openapi3/client/petstore/go/fake_api_test.go
@@ -19,7 +19,7 @@ func TestPutBodyWithFileSchema(t *testing.T) {
 
 	r, err := client.FakeApi.TestBodyWithFileSchema(context.Background()).FileSchemaTestClass(schema).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {

--- a/samples/openapi3/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_another_fake.go
@@ -37,7 +37,7 @@ type AnotherFakeApi interface {
 	 * Call123TestSpecialTagsExecute executes the request
 	 * @return Client
 	 */
-	Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, GenericOpenAPIError)
+	Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, error)
 }
 
 // AnotherFakeApiService AnotherFakeApi service
@@ -54,7 +54,7 @@ func (r ApiCall123TestSpecialTagsRequest) Client(client Client) ApiCall123TestSp
 	return r
 }
 
-func (r ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, error) {
 	return r.ApiService.Call123TestSpecialTagsExecute(r)
 }
 
@@ -75,21 +75,19 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context) Api
  * Execute executes the request
  * @return Client
  */
-func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Client
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AnotherFakeApiService.Call123TestSpecialTags")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/another-fake/dummy"
@@ -98,8 +96,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.client == nil {
-		executionError.error = "client is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("client is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -123,22 +120,19 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 	localVarPostBody = r.client
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -158,5 +152,5 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_default.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_default.go
@@ -36,7 +36,7 @@ type DefaultApi interface {
 	 * FooGetExecute executes the request
 	 * @return InlineResponseDefault
 	 */
-	FooGetExecute(r ApiFooGetRequest) (InlineResponseDefault, *_nethttp.Response, GenericOpenAPIError)
+	FooGetExecute(r ApiFooGetRequest) (InlineResponseDefault, *_nethttp.Response, error)
 }
 
 // DefaultApiService DefaultApi service
@@ -48,7 +48,7 @@ type ApiFooGetRequest struct {
 }
 
 
-func (r ApiFooGetRequest) Execute() (InlineResponseDefault, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFooGetRequest) Execute() (InlineResponseDefault, *_nethttp.Response, error) {
 	return r.ApiService.FooGetExecute(r)
 }
 
@@ -68,21 +68,19 @@ func (a *DefaultApiService) FooGet(ctx _context.Context) ApiFooGetRequest {
  * Execute executes the request
  * @return InlineResponseDefault
  */
-func (a *DefaultApiService) FooGetExecute(r ApiFooGetRequest) (InlineResponseDefault, *_nethttp.Response, GenericOpenAPIError) {
+func (a *DefaultApiService) FooGetExecute(r ApiFooGetRequest) (InlineResponseDefault, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  InlineResponseDefault
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultApiService.FooGet")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/foo"
@@ -110,22 +108,19 @@ func (a *DefaultApiService) FooGetExecute(r ApiFooGetRequest) (InlineResponseDef
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -152,5 +147,5 @@ func (a *DefaultApiService) FooGetExecute(r ApiFooGetRequest) (InlineResponseDef
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
@@ -39,7 +39,7 @@ type FakeApi interface {
 	 * FakeHealthGetExecute executes the request
 	 * @return HealthCheckResult
 	 */
-	FakeHealthGetExecute(r ApiFakeHealthGetRequest) (HealthCheckResult, *_nethttp.Response, GenericOpenAPIError)
+	FakeHealthGetExecute(r ApiFakeHealthGetRequest) (HealthCheckResult, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterBooleanSerialize Method for FakeOuterBooleanSerialize
@@ -53,7 +53,7 @@ type FakeApi interface {
 	 * FakeOuterBooleanSerializeExecute executes the request
 	 * @return bool
 	 */
-	FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterCompositeSerialize Method for FakeOuterCompositeSerialize
@@ -67,7 +67,7 @@ type FakeApi interface {
 	 * FakeOuterCompositeSerializeExecute executes the request
 	 * @return OuterComposite
 	 */
-	FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterNumberSerialize Method for FakeOuterNumberSerialize
@@ -81,7 +81,7 @@ type FakeApi interface {
 	 * FakeOuterNumberSerializeExecute executes the request
 	 * @return float32
 	 */
-	FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterStringSerialize Method for FakeOuterStringSerialize
@@ -95,7 +95,7 @@ type FakeApi interface {
 	 * FakeOuterStringSerializeExecute executes the request
 	 * @return string
 	 */
-	FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, error)
 
 	/*
 	 * TestBodyWithFileSchema Method for TestBodyWithFileSchema
@@ -108,7 +108,7 @@ type FakeApi interface {
 	/*
 	 * TestBodyWithFileSchemaExecute executes the request
 	 */
-	TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestBodyWithQueryParams Method for TestBodyWithQueryParams
@@ -120,7 +120,7 @@ type FakeApi interface {
 	/*
 	 * TestBodyWithQueryParamsExecute executes the request
 	 */
-	TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestClientModel To test \"client\" model
@@ -134,7 +134,7 @@ type FakeApi interface {
 	 * TestClientModelExecute executes the request
 	 * @return Client
 	 */
-	TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, GenericOpenAPIError)
+	TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, error)
 
 	/*
 	 * TestEndpointParameters Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -151,7 +151,7 @@ type FakeApi interface {
 	/*
 	 * TestEndpointParametersExecute executes the request
 	 */
-	TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestEnumParameters To test enum parameters
@@ -164,7 +164,7 @@ type FakeApi interface {
 	/*
 	 * TestEnumParametersExecute executes the request
 	 */
-	TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestGroupParameters Fake endpoint to test group parameters (optional)
@@ -177,7 +177,7 @@ type FakeApi interface {
 	/*
 	 * TestGroupParametersExecute executes the request
 	 */
-	TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestInlineAdditionalProperties test inline additionalProperties
@@ -189,7 +189,7 @@ type FakeApi interface {
 	/*
 	 * TestInlineAdditionalPropertiesExecute executes the request
 	 */
-	TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestJsonFormData test json serialization of form data
@@ -201,7 +201,7 @@ type FakeApi interface {
 	/*
 	 * TestJsonFormDataExecute executes the request
 	 */
-	TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestQueryParameterCollectionFormat Method for TestQueryParameterCollectionFormat
@@ -214,7 +214,7 @@ type FakeApi interface {
 	/*
 	 * TestQueryParameterCollectionFormatExecute executes the request
 	 */
-	TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, error)
 }
 
 // FakeApiService FakeApi service
@@ -226,7 +226,7 @@ type ApiFakeHealthGetRequest struct {
 }
 
 
-func (r ApiFakeHealthGetRequest) Execute() (HealthCheckResult, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeHealthGetRequest) Execute() (HealthCheckResult, *_nethttp.Response, error) {
 	return r.ApiService.FakeHealthGetExecute(r)
 }
 
@@ -246,21 +246,19 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) ApiFakeHealthGetReq
  * Execute executes the request
  * @return HealthCheckResult
  */
-func (a *FakeApiService) FakeHealthGetExecute(r ApiFakeHealthGetRequest) (HealthCheckResult, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeHealthGetExecute(r ApiFakeHealthGetRequest) (HealthCheckResult, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  HealthCheckResult
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeHealthGet")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/health"
@@ -288,22 +286,19 @@ func (a *FakeApiService) FakeHealthGetExecute(r ApiFakeHealthGetRequest) (Health
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -323,7 +318,7 @@ func (a *FakeApiService) FakeHealthGetExecute(r ApiFakeHealthGetRequest) (Health
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterBooleanSerializeRequest struct {
@@ -337,7 +332,7 @@ func (r ApiFakeOuterBooleanSerializeRequest) Body(body bool) ApiFakeOuterBoolean
 	return r
 }
 
-func (r ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterBooleanSerializeExecute(r)
 }
 
@@ -358,21 +353,19 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context) ApiFake
  * Execute executes the request
  * @return bool
  */
-func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  bool
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterBooleanSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/boolean"
@@ -402,22 +395,19 @@ func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanS
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -437,7 +427,7 @@ func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanS
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterCompositeSerializeRequest struct {
@@ -451,7 +441,7 @@ func (r ApiFakeOuterCompositeSerializeRequest) OuterComposite(outerComposite Out
 	return r
 }
 
-func (r ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterCompositeSerializeExecute(r)
 }
 
@@ -472,21 +462,19 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context) ApiFa
  * Execute executes the request
  * @return OuterComposite
  */
-func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  OuterComposite
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterCompositeSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/composite"
@@ -516,22 +504,19 @@ func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompos
 	localVarPostBody = r.outerComposite
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -551,7 +536,7 @@ func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompos
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterNumberSerializeRequest struct {
@@ -565,7 +550,7 @@ func (r ApiFakeOuterNumberSerializeRequest) Body(body float32) ApiFakeOuterNumbe
 	return r
 }
 
-func (r ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterNumberSerializeExecute(r)
 }
 
@@ -586,21 +571,19 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context) ApiFakeO
  * Execute executes the request
  * @return float32
  */
-func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  float32
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterNumberSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/number"
@@ -630,22 +613,19 @@ func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSer
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -665,7 +645,7 @@ func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSer
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterStringSerializeRequest struct {
@@ -679,7 +659,7 @@ func (r ApiFakeOuterStringSerializeRequest) Body(body string) ApiFakeOuterString
 	return r
 }
 
-func (r ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterStringSerializeExecute(r)
 }
 
@@ -700,21 +680,19 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context) ApiFakeO
  * Execute executes the request
  * @return string
  */
-func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  string
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterStringSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/string"
@@ -744,22 +722,19 @@ func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSer
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -779,7 +754,7 @@ func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSer
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiTestBodyWithFileSchemaRequest struct {
@@ -793,7 +768,7 @@ func (r ApiTestBodyWithFileSchemaRequest) FileSchemaTestClass(fileSchemaTestClas
 	return r
 }
 
-func (r ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestBodyWithFileSchemaExecute(r)
 }
 
@@ -813,20 +788,18 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context) ApiTestBod
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestBodyWithFileSchema")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/body-with-file-schema"
@@ -835,8 +808,7 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.fileSchemaTestClass == nil {
-		executionError.error = "fileSchemaTestClass is required and must be specified"
-		return nil, executionError
+		return nil, reportError("fileSchemaTestClass is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -860,22 +832,19 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 	localVarPostBody = r.fileSchemaTestClass
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -886,7 +855,7 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestBodyWithQueryParamsRequest struct {
@@ -905,7 +874,7 @@ func (r ApiTestBodyWithQueryParamsRequest) User(user User) ApiTestBodyWithQueryP
 	return r
 }
 
-func (r ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestBodyWithQueryParamsExecute(r)
 }
 
@@ -924,20 +893,18 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context) ApiTestBo
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestBodyWithQueryParams")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/body-with-query-params"
@@ -946,12 +913,10 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.query == nil {
-		executionError.error = "query is required and must be specified"
-		return nil, executionError
+		return nil, reportError("query is required and must be specified")
 	}
 	if r.user == nil {
-		executionError.error = "user is required and must be specified"
-		return nil, executionError
+		return nil, reportError("user is required and must be specified")
 	}
 
 	localVarQueryParams.Add("query", parameterToString(*r.query, ""))
@@ -976,22 +941,19 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 	localVarPostBody = r.user
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1002,7 +964,7 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestClientModelRequest struct {
@@ -1016,7 +978,7 @@ func (r ApiTestClientModelRequest) Client(client Client) ApiTestClientModelReque
 	return r
 }
 
-func (r ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error) {
 	return r.ApiService.TestClientModelExecute(r)
 }
 
@@ -1037,21 +999,19 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context) ApiTestClientMode
  * Execute executes the request
  * @return Client
  */
-func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Client
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestClientModel")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1060,8 +1020,7 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.client == nil {
-		executionError.error = "client is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("client is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1085,22 +1044,19 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 	localVarPostBody = r.client
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1120,7 +1076,7 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiTestEndpointParametersRequest struct {
@@ -1199,7 +1155,7 @@ func (r ApiTestEndpointParametersRequest) Callback(callback string) ApiTestEndpo
 	return r
 }
 
-func (r ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestEndpointParametersExecute(r)
 }
 
@@ -1223,20 +1179,18 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context) ApiTestEnd
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestEndpointParameters")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1245,36 +1199,28 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.number == nil {
-		executionError.error = "number is required and must be specified"
-		return nil, executionError
+		return nil, reportError("number is required and must be specified")
 	}
 	if *r.number < 32.1 {
-		executionError.error = "number must be greater than 32.1"
-		return nil, executionError
+		return nil, reportError("number must be greater than 32.1")
 	}
 	if *r.number > 543.2 {
-		executionError.error = "number must be less than 543.2"
-		return nil, executionError
+		return nil, reportError("number must be less than 543.2")
 	}
 	if r.double == nil {
-		executionError.error = "double is required and must be specified"
-		return nil, executionError
+		return nil, reportError("double is required and must be specified")
 	}
 	if *r.double < 67.8 {
-		executionError.error = "double must be greater than 67.8"
-		return nil, executionError
+		return nil, reportError("double must be greater than 67.8")
 	}
 	if *r.double > 123.4 {
-		executionError.error = "double must be less than 123.4"
-		return nil, executionError
+		return nil, reportError("double must be less than 123.4")
 	}
 	if r.patternWithoutDelimiter == nil {
-		executionError.error = "patternWithoutDelimiter is required and must be specified"
-		return nil, executionError
+		return nil, reportError("patternWithoutDelimiter is required and must be specified")
 	}
 	if r.byte_ == nil {
-		executionError.error = "byte_ is required and must be specified"
-		return nil, executionError
+		return nil, reportError("byte_ is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1338,22 +1284,19 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1364,7 +1307,7 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestEnumParametersRequest struct {
@@ -1413,7 +1356,7 @@ func (r ApiTestEnumParametersRequest) EnumFormString(enumFormString string) ApiT
 	return r
 }
 
-func (r ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestEnumParametersExecute(r)
 }
 
@@ -1433,20 +1376,18 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context) ApiTestEnumPar
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestEnumParameters")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1506,22 +1447,19 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1532,7 +1470,7 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestGroupParametersRequest struct {
@@ -1571,7 +1509,7 @@ func (r ApiTestGroupParametersRequest) Int64Group(int64Group int64) ApiTestGroup
 	return r
 }
 
-func (r ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestGroupParametersExecute(r)
 }
 
@@ -1591,20 +1529,18 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context) ApiTestGroupP
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestGroupParameters")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1613,16 +1549,13 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.requiredStringGroup == nil {
-		executionError.error = "requiredStringGroup is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requiredStringGroup is required and must be specified")
 	}
 	if r.requiredBooleanGroup == nil {
-		executionError.error = "requiredBooleanGroup is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requiredBooleanGroup is required and must be specified")
 	}
 	if r.requiredInt64Group == nil {
-		executionError.error = "requiredInt64Group is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requiredInt64Group is required and must be specified")
 	}
 
 	localVarQueryParams.Add("required_string_group", parameterToString(*r.requiredStringGroup, ""))
@@ -1656,22 +1589,19 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1682,7 +1612,7 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestInlineAdditionalPropertiesRequest struct {
@@ -1696,7 +1626,7 @@ func (r ApiTestInlineAdditionalPropertiesRequest) RequestBody(requestBody map[st
 	return r
 }
 
-func (r ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestInlineAdditionalPropertiesExecute(r)
 }
 
@@ -1715,20 +1645,18 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context) Ap
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestInlineAdditionalProperties")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/inline-additionalProperties"
@@ -1737,8 +1665,7 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.requestBody == nil {
-		executionError.error = "requestBody is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requestBody is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1762,22 +1689,19 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 	localVarPostBody = r.requestBody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1788,7 +1712,7 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestJsonFormDataRequest struct {
@@ -1807,7 +1731,7 @@ func (r ApiTestJsonFormDataRequest) Param2(param2 string) ApiTestJsonFormDataReq
 	return r
 }
 
-func (r ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestJsonFormDataExecute(r)
 }
 
@@ -1826,20 +1750,18 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context) ApiTestJsonFormD
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestJsonFormData")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/jsonFormData"
@@ -1848,12 +1770,10 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.param == nil {
-		executionError.error = "param is required and must be specified"
-		return nil, executionError
+		return nil, reportError("param is required and must be specified")
 	}
 	if r.param2 == nil {
-		executionError.error = "param2 is required and must be specified"
-		return nil, executionError
+		return nil, reportError("param2 is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1877,22 +1797,19 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 	localVarFormParams.Add("param2", parameterToString(*r.param2, ""))
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1903,7 +1820,7 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestQueryParameterCollectionFormatRequest struct {
@@ -1937,7 +1854,7 @@ func (r ApiTestQueryParameterCollectionFormatRequest) Context(context []string) 
 	return r
 }
 
-func (r ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestQueryParameterCollectionFormatExecute(r)
 }
 
@@ -1957,20 +1874,18 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestQueryParameterCollectionFormat")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/test-query-paramters"
@@ -1979,24 +1894,19 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.pipe == nil {
-		executionError.error = "pipe is required and must be specified"
-		return nil, executionError
+		return nil, reportError("pipe is required and must be specified")
 	}
 	if r.ioutil == nil {
-		executionError.error = "ioutil is required and must be specified"
-		return nil, executionError
+		return nil, reportError("ioutil is required and must be specified")
 	}
 	if r.http == nil {
-		executionError.error = "http is required and must be specified"
-		return nil, executionError
+		return nil, reportError("http is required and must be specified")
 	}
 	if r.url == nil {
-		executionError.error = "url is required and must be specified"
-		return nil, executionError
+		return nil, reportError("url is required and must be specified")
 	}
 	if r.context == nil {
-		executionError.error = "context is required and must be specified"
-		return nil, executionError
+		return nil, reportError("context is required and must be specified")
 	}
 
 	{
@@ -2043,22 +1953,19 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -2069,5 +1976,5 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -37,7 +37,7 @@ type FakeClassnameTags123Api interface {
 	 * TestClassnameExecute executes the request
 	 * @return Client
 	 */
-	TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, GenericOpenAPIError)
+	TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, error)
 }
 
 // FakeClassnameTags123ApiService FakeClassnameTags123Api service
@@ -54,7 +54,7 @@ func (r ApiTestClassnameRequest) Client(client Client) ApiTestClassnameRequest {
 	return r
 }
 
-func (r ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
 	return r.ApiService.TestClassnameExecute(r)
 }
 
@@ -75,21 +75,19 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context) Api
  * Execute executes the request
  * @return Client
  */
-func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Client
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeClassnameTags123ApiService.TestClassname")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake_classname_test"
@@ -98,8 +96,7 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.client == nil {
-		executionError.error = "client is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("client is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -137,22 +134,19 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -172,5 +166,5 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
@@ -37,7 +37,7 @@ type PetApi interface {
 	/*
 	 * AddPetExecute executes the request
 	 */
-	AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, GenericOpenAPIError)
+	AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, error)
 
 	/*
 	 * DeletePet Deletes a pet
@@ -50,7 +50,7 @@ type PetApi interface {
 	/*
 	 * DeletePetExecute executes the request
 	 */
-	DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, GenericOpenAPIError)
+	DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, error)
 
 	/*
 	 * FindPetsByStatus Finds Pets by status
@@ -64,7 +64,7 @@ type PetApi interface {
 	 * FindPetsByStatusExecute executes the request
 	 * @return []Pet
 	 */
-	FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError)
+	FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, error)
 
 	/*
 	 * FindPetsByTags Finds Pets by tags
@@ -78,7 +78,7 @@ type PetApi interface {
 	 * FindPetsByTagsExecute executes the request
 	 * @return []Pet
 	 */
-	FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError)
+	FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, error)
 
 	/*
 	 * GetPetById Find pet by ID
@@ -93,7 +93,7 @@ type PetApi interface {
 	 * GetPetByIdExecute executes the request
 	 * @return Pet
 	 */
-	GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, GenericOpenAPIError)
+	GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, error)
 
 	/*
 	 * UpdatePet Update an existing pet
@@ -105,7 +105,7 @@ type PetApi interface {
 	/*
 	 * UpdatePetExecute executes the request
 	 */
-	UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, GenericOpenAPIError)
+	UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, error)
 
 	/*
 	 * UpdatePetWithForm Updates a pet in the store with form data
@@ -118,7 +118,7 @@ type PetApi interface {
 	/*
 	 * UpdatePetWithFormExecute executes the request
 	 */
-	UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, GenericOpenAPIError)
+	UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, error)
 
 	/*
 	 * UploadFile uploads an image
@@ -132,7 +132,7 @@ type PetApi interface {
 	 * UploadFileExecute executes the request
 	 * @return ApiResponse
 	 */
-	UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError)
+	UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, error)
 
 	/*
 	 * UploadFileWithRequiredFile uploads an image (required)
@@ -146,7 +146,7 @@ type PetApi interface {
 	 * UploadFileWithRequiredFileExecute executes the request
 	 * @return ApiResponse
 	 */
-	UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError)
+	UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, error)
 }
 
 // PetApiService PetApi service
@@ -163,7 +163,7 @@ func (r ApiAddPetRequest) Pet(pet Pet) ApiAddPetRequest {
 	return r
 }
 
-func (r ApiAddPetRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiAddPetRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.AddPetExecute(r)
 }
 
@@ -182,20 +182,18 @@ func (a *PetApiService) AddPet(ctx _context.Context) ApiAddPetRequest {
 /*
  * Execute executes the request
  */
-func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.AddPet")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet"
@@ -204,8 +202,7 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, G
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.pet == nil {
-		executionError.error = "pet is required and must be specified"
-		return nil, executionError
+		return nil, reportError("pet is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -229,22 +226,19 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, G
 	localVarPostBody = r.pet
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -255,7 +249,7 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, G
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiDeletePetRequest struct {
@@ -270,7 +264,7 @@ func (r ApiDeletePetRequest) ApiKey(apiKey string) ApiDeletePetRequest {
 	return r
 }
 
-func (r ApiDeletePetRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiDeletePetRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeletePetExecute(r)
 }
 
@@ -291,20 +285,18 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64) ApiDeletePe
 /*
  * Execute executes the request
  */
-func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.DeletePet")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
@@ -336,22 +328,19 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -362,7 +351,7 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiFindPetsByStatusRequest struct {
@@ -376,7 +365,7 @@ func (r ApiFindPetsByStatusRequest) Status(status []string) ApiFindPetsByStatusR
 	return r
 }
 
-func (r ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	return r.ApiService.FindPetsByStatusExecute(r)
 }
 
@@ -397,21 +386,19 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context) ApiFindPetsByStat
  * Execute executes the request
  * @return []Pet
  */
-func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  []Pet
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.FindPetsByStatus")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/findByStatus"
@@ -420,8 +407,7 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.status == nil {
-		executionError.error = "status is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("status is required and must be specified")
 	}
 
 	localVarQueryParams.Add("status", parameterToString(*r.status, "csv"))
@@ -444,22 +430,19 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -479,7 +462,7 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFindPetsByTagsRequest struct {
@@ -493,7 +476,7 @@ func (r ApiFindPetsByTagsRequest) Tags(tags []string) ApiFindPetsByTagsRequest {
 	return r
 }
 
-func (r ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	return r.ApiService.FindPetsByTagsExecute(r)
 }
 
@@ -514,21 +497,19 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context) ApiFindPetsByTagsRe
  * Execute executes the request
  * @return []Pet
  */
-func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  []Pet
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.FindPetsByTags")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/findByTags"
@@ -537,8 +518,7 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.tags == nil {
-		executionError.error = "tags is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("tags is required and must be specified")
 	}
 
 	localVarQueryParams.Add("tags", parameterToString(*r.tags, "csv"))
@@ -561,22 +541,19 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -596,7 +573,7 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetPetByIdRequest struct {
@@ -606,7 +583,7 @@ type ApiGetPetByIdRequest struct {
 }
 
 
-func (r ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
 	return r.ApiService.GetPetByIdExecute(r)
 }
 
@@ -629,21 +606,19 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) ApiGetPetB
  * Execute executes the request
  * @return Pet
  */
-func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Pet
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.GetPetById")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
@@ -686,22 +661,19 @@ func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethtt
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -721,7 +693,7 @@ func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethtt
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiUpdatePetRequest struct {
@@ -735,7 +707,7 @@ func (r ApiUpdatePetRequest) Pet(pet Pet) ApiUpdatePetRequest {
 	return r
 }
 
-func (r ApiUpdatePetRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.UpdatePetExecute(r)
 }
 
@@ -754,20 +726,18 @@ func (a *PetApiService) UpdatePet(ctx _context.Context) ApiUpdatePetRequest {
 /*
  * Execute executes the request
  */
-func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UpdatePet")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet"
@@ -776,8 +746,7 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.pet == nil {
-		executionError.error = "pet is required and must be specified"
-		return nil, executionError
+		return nil, reportError("pet is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -801,22 +770,19 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 	localVarPostBody = r.pet
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -827,7 +793,7 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiUpdatePetWithFormRequest struct {
@@ -847,7 +813,7 @@ func (r ApiUpdatePetWithFormRequest) Status(status string) ApiUpdatePetWithFormR
 	return r
 }
 
-func (r ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.UpdatePetWithFormExecute(r)
 }
 
@@ -868,20 +834,18 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64) Api
 /*
  * Execute executes the request
  */
-func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UpdatePetWithForm")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
@@ -916,22 +880,19 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -942,7 +903,7 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiUploadFileRequest struct {
@@ -962,7 +923,7 @@ func (r ApiUploadFileRequest) File(file *os.File) ApiUploadFileRequest {
 	return r
 }
 
-func (r ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
 	return r.ApiService.UploadFileExecute(r)
 }
 
@@ -984,21 +945,19 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64) ApiUploadF
  * Execute executes the request
  * @return ApiResponse
  */
-func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  ApiResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UploadFile")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}/uploadImage"
@@ -1041,22 +1000,19 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1076,7 +1032,7 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiUploadFileWithRequiredFileRequest struct {
@@ -1096,7 +1052,7 @@ func (r ApiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetad
 	return r
 }
 
-func (r ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
 	return r.ApiService.UploadFileWithRequiredFileExecute(r)
 }
 
@@ -1118,21 +1074,19 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
  * Execute executes the request
  * @return ApiResponse
  */
-func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  ApiResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UploadFileWithRequiredFile")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/{petId}/uploadImageWithRequiredFile"
@@ -1142,8 +1096,7 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.requiredFile == nil {
-		executionError.error = "requiredFile is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("requiredFile is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1176,22 +1129,19 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1211,5 +1161,5 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_store.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_store.go
@@ -38,7 +38,7 @@ type StoreApi interface {
 	/*
 	 * DeleteOrderExecute executes the request
 	 */
-	DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, GenericOpenAPIError)
+	DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, error)
 
 	/*
 	 * GetInventory Returns pet inventories by status
@@ -52,7 +52,7 @@ type StoreApi interface {
 	 * GetInventoryExecute executes the request
 	 * @return map[string]int32
 	 */
-	GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, GenericOpenAPIError)
+	GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, error)
 
 	/*
 	 * GetOrderById Find purchase order by ID
@@ -67,7 +67,7 @@ type StoreApi interface {
 	 * GetOrderByIdExecute executes the request
 	 * @return Order
 	 */
-	GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, GenericOpenAPIError)
+	GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, error)
 
 	/*
 	 * PlaceOrder Place an order for a pet
@@ -80,7 +80,7 @@ type StoreApi interface {
 	 * PlaceOrderExecute executes the request
 	 * @return Order
 	 */
-	PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, GenericOpenAPIError)
+	PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, error)
 }
 
 // StoreApiService StoreApi service
@@ -93,7 +93,7 @@ type ApiDeleteOrderRequest struct {
 }
 
 
-func (r ApiDeleteOrderRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteOrderExecute(r)
 }
 
@@ -115,20 +115,18 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) ApiD
 /*
  * Execute executes the request
  */
-func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.DeleteOrder")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
@@ -157,22 +155,19 @@ func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -183,7 +178,7 @@ func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetInventoryRequest struct {
@@ -192,7 +187,7 @@ type ApiGetInventoryRequest struct {
 }
 
 
-func (r ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, error) {
 	return r.ApiService.GetInventoryExecute(r)
 }
 
@@ -213,21 +208,19 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) ApiGetInventoryRequ
  * Execute executes the request
  * @return map[string]int32
  */
-func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  map[string]int32
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.GetInventory")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/inventory"
@@ -269,22 +262,19 @@ func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[str
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -304,7 +294,7 @@ func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[str
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetOrderByIdRequest struct {
@@ -314,7 +304,7 @@ type ApiGetOrderByIdRequest struct {
 }
 
 
-func (r ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
 	return r.ApiService.GetOrderByIdExecute(r)
 }
 
@@ -337,21 +327,19 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) ApiG
  * Execute executes the request
  * @return Order
  */
-func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Order
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.GetOrderById")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
@@ -361,12 +349,10 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.orderId < 1 {
-		executionError.error = "orderId must be greater than 1"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("orderId must be greater than 1")
 	}
 	if r.orderId > 5 {
-		executionError.error = "orderId must be less than 5"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("orderId must be less than 5")
 	}
 
 	// to determine the Content-Type header
@@ -388,22 +374,19 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -423,7 +406,7 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPlaceOrderRequest struct {
@@ -437,7 +420,7 @@ func (r ApiPlaceOrderRequest) Order(order Order) ApiPlaceOrderRequest {
 	return r
 }
 
-func (r ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
 	return r.ApiService.PlaceOrderExecute(r)
 }
 
@@ -457,21 +440,19 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context) ApiPlaceOrderRequest 
  * Execute executes the request
  * @return Order
  */
-func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Order
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.PlaceOrder")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order"
@@ -480,8 +461,7 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.order == nil {
-		executionError.error = "order is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("order is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -505,22 +485,19 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 	localVarPostBody = r.order
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -540,5 +517,5 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_user.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_user.go
@@ -37,7 +37,7 @@ type UserApi interface {
 	/*
 	 * CreateUserExecute executes the request
 	 */
-	CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, error)
 
 	/*
 	 * CreateUsersWithArrayInput Creates list of users with given input array
@@ -49,7 +49,7 @@ type UserApi interface {
 	/*
 	 * CreateUsersWithArrayInputExecute executes the request
 	 */
-	CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, error)
 
 	/*
 	 * CreateUsersWithListInput Creates list of users with given input array
@@ -61,7 +61,7 @@ type UserApi interface {
 	/*
 	 * CreateUsersWithListInputExecute executes the request
 	 */
-	CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, error)
 
 	/*
 	 * DeleteUser Delete user
@@ -75,7 +75,7 @@ type UserApi interface {
 	/*
 	 * DeleteUserExecute executes the request
 	 */
-	DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, error)
 
 	/*
 	 * GetUserByName Get user by user name
@@ -89,7 +89,7 @@ type UserApi interface {
 	 * GetUserByNameExecute executes the request
 	 * @return User
 	 */
-	GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, GenericOpenAPIError)
+	GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, error)
 
 	/*
 	 * LoginUser Logs user into the system
@@ -102,7 +102,7 @@ type UserApi interface {
 	 * LoginUserExecute executes the request
 	 * @return string
 	 */
-	LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, GenericOpenAPIError)
+	LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, error)
 
 	/*
 	 * LogoutUser Logs out current logged in user session
@@ -114,7 +114,7 @@ type UserApi interface {
 	/*
 	 * LogoutUserExecute executes the request
 	 */
-	LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, error)
 
 	/*
 	 * UpdateUser Updated user
@@ -128,7 +128,7 @@ type UserApi interface {
 	/*
 	 * UpdateUserExecute executes the request
 	 */
-	UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, error)
 }
 
 // UserApiService UserApi service
@@ -145,7 +145,7 @@ func (r ApiCreateUserRequest) User(user User) ApiCreateUserRequest {
 	return r
 }
 
-func (r ApiCreateUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateUserExecute(r)
 }
 
@@ -165,20 +165,18 @@ func (a *UserApiService) CreateUser(ctx _context.Context) ApiCreateUserRequest {
 /*
  * Execute executes the request
  */
-func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user"
@@ -187,8 +185,7 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.user == nil {
-		executionError.error = "user is required and must be specified"
-		return nil, executionError
+		return nil, reportError("user is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -212,22 +209,19 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 	localVarPostBody = r.user
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -238,7 +232,7 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiCreateUsersWithArrayInputRequest struct {
@@ -252,7 +246,7 @@ func (r ApiCreateUsersWithArrayInputRequest) User(user []User) ApiCreateUsersWit
 	return r
 }
 
-func (r ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateUsersWithArrayInputExecute(r)
 }
 
@@ -271,20 +265,18 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context) ApiCrea
 /*
  * Execute executes the request
  */
-func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUsersWithArrayInput")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/createWithArray"
@@ -293,8 +285,7 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.user == nil {
-		executionError.error = "user is required and must be specified"
-		return nil, executionError
+		return nil, reportError("user is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -318,22 +309,19 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 	localVarPostBody = r.user
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -344,7 +332,7 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiCreateUsersWithListInputRequest struct {
@@ -358,7 +346,7 @@ func (r ApiCreateUsersWithListInputRequest) User(user []User) ApiCreateUsersWith
 	return r
 }
 
-func (r ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateUsersWithListInputExecute(r)
 }
 
@@ -377,20 +365,18 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context) ApiCreat
 /*
  * Execute executes the request
  */
-func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUsersWithListInput")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/createWithList"
@@ -399,8 +385,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.user == nil {
-		executionError.error = "user is required and must be specified"
-		return nil, executionError
+		return nil, reportError("user is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -424,22 +409,19 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 	localVarPostBody = r.user
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -450,7 +432,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiDeleteUserRequest struct {
@@ -460,7 +442,7 @@ type ApiDeleteUserRequest struct {
 }
 
 
-func (r ApiDeleteUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteUserExecute(r)
 }
 
@@ -482,20 +464,18 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) ApiDe
 /*
  * Execute executes the request
  */
-func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.DeleteUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
@@ -524,22 +504,19 @@ func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Re
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -550,7 +527,7 @@ func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetUserByNameRequest struct {
@@ -560,7 +537,7 @@ type ApiGetUserByNameRequest struct {
 }
 
 
-func (r ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
 	return r.ApiService.GetUserByNameExecute(r)
 }
 
@@ -582,21 +559,19 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) Ap
  * Execute executes the request
  * @return User
  */
-func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  User
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.GetUserByName")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
@@ -625,22 +600,19 @@ func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -660,7 +632,7 @@ func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiLoginUserRequest struct {
@@ -679,7 +651,7 @@ func (r ApiLoginUserRequest) Password(password string) ApiLoginUserRequest {
 	return r
 }
 
-func (r ApiLoginUserRequest) Execute() (string, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
 	return r.ApiService.LoginUserExecute(r)
 }
 
@@ -699,21 +671,19 @@ func (a *UserApiService) LoginUser(ctx _context.Context) ApiLoginUserRequest {
  * Execute executes the request
  * @return string
  */
-func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  string
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.LoginUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/login"
@@ -722,12 +692,10 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.username == nil {
-		executionError.error = "username is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("username is required and must be specified")
 	}
 	if r.password == nil {
-		executionError.error = "password is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("password is required and must be specified")
 	}
 
 	localVarQueryParams.Add("username", parameterToString(*r.username, ""))
@@ -751,22 +719,19 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -786,7 +751,7 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiLogoutUserRequest struct {
@@ -795,7 +760,7 @@ type ApiLogoutUserRequest struct {
 }
 
 
-func (r ApiLogoutUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.LogoutUserExecute(r)
 }
 
@@ -814,20 +779,18 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) ApiLogoutUserRequest {
 /*
  * Execute executes the request
  */
-func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.LogoutUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/logout"
@@ -855,22 +818,19 @@ func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Re
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -881,7 +841,7 @@ func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiUpdateUserRequest struct {
@@ -896,7 +856,7 @@ func (r ApiUpdateUserRequest) User(user User) ApiUpdateUserRequest {
 	return r
 }
 
-func (r ApiUpdateUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.UpdateUserExecute(r)
 }
 
@@ -918,20 +878,18 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string) ApiUp
 /*
  * Execute executes the request
  */
-func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.UpdateUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
@@ -941,8 +899,7 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.user == nil {
-		executionError.error = "user is required and must be specified"
-		return nil, executionError
+		return nil, reportError("user is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -966,22 +923,19 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 	localVarPostBody = r.user
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -992,5 +946,5 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
@@ -34,7 +34,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.AnotherFakeApi.Call123TestSpecialTags(context.Background()).Client(client).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `AnotherFakeApi.Call123TestSpecialTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
@@ -28,11 +28,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     client := *openapiclient.NewClient() // Client | client model
 
@@ -42,9 +37,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `AnotherFakeApi.Call123TestSpecialTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `Call123TestSpecialTags`: Client
@@ -69,7 +64,7 @@ Name | Type | Description  | Notes
 
 [**Client**](Client.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
@@ -28,6 +28,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     client := *openapiclient.NewClient() // Client | client model
 
@@ -37,6 +42,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `AnotherFakeApi.Call123TestSpecialTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `Call123TestSpecialTags`: Client
     fmt.Fprintf(os.Stdout, "Response from `AnotherFakeApi.Call123TestSpecialTags`: %v\n", resp)
@@ -58,7 +67,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Client**](Client.md)
+[**Client**](Client.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/DefaultApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/DefaultApi.md
@@ -31,7 +31,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.DefaultApi.FooGet(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.FooGet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/DefaultApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/DefaultApi.md
@@ -26,6 +26,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -34,6 +39,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.FooGet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FooGet`: InlineResponseDefault
     fmt.Fprintf(os.Stdout, "Response from `DefaultApi.FooGet`: %v\n", resp)
@@ -51,7 +60,9 @@ Other parameters are passed through a pointer to a apiFooGetRequest struct via t
 
 ### Return type
 
-[**InlineResponseDefault**](inline_response_default.md)
+[**InlineResponseDefault**](inline_response_default.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/DefaultApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/DefaultApi.md
@@ -26,11 +26,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -39,9 +34,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.FooGet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FooGet`: InlineResponseDefault
@@ -62,7 +57,7 @@ Other parameters are passed through a pointer to a apiFooGetRequest struct via t
 
 [**InlineResponseDefault**](inline_response_default.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -44,7 +44,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeHealthGet(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeHealthGet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -106,7 +106,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterBooleanSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterBooleanSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -172,7 +172,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterCompositeSerialize(context.Background()).OuterComposite(outerComposite).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterCompositeSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -238,7 +238,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterNumberSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterNumberSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -304,7 +304,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterStringSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterStringSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -370,7 +370,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestBodyWithFileSchema(context.Background()).FileSchemaTestClass(fileSchemaTestClass).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithFileSchema``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -433,7 +433,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestBodyWithQueryParams(context.Background()).Query(query).User(user).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithQueryParams``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -498,7 +498,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestClientModel(context.Background()).Client(client).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestClientModel``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -578,7 +578,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestEndpointParameters(context.Background()).Number(number).Double(double).PatternWithoutDelimiter(patternWithoutDelimiter).Byte_(byte_).Integer(integer).Int32_(int32_).Int64_(int64_).Float(float).String_(string_).Binary(binary).Date(date).DateTime(dateTime).Password(password).Callback(callback).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEndpointParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -662,7 +662,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestEnumParameters(context.Background()).EnumHeaderStringArray(enumHeaderStringArray).EnumHeaderString(enumHeaderString).EnumQueryStringArray(enumQueryStringArray).EnumQueryString(enumQueryString).EnumQueryInteger(enumQueryInteger).EnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEnumParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -738,7 +738,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestGroupParameters(context.Background()).RequiredStringGroup(requiredStringGroup).RequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).BooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestGroupParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -805,7 +805,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestInlineAdditionalProperties(context.Background()).RequestBody(requestBody).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestInlineAdditionalProperties``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -868,7 +868,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestJsonFormData(context.Background()).Param(param).Param2(param2).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestJsonFormData``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -937,7 +937,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestQueryParameterCollectionFormat(context.Background()).Pipe(pipe).Ioutil(ioutil).Http(http).Url(url).Context(context).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestQueryParameterCollectionFormat``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -39,11 +39,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -52,9 +47,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeHealthGet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FakeHealthGet`: HealthCheckResult
@@ -75,7 +70,7 @@ Other parameters are passed through a pointer to a apiFakeHealthGetRequest struc
 
 [**HealthCheckResult**](HealthCheckResult.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -111,11 +106,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := true // bool | Input boolean as post body (optional)
 
@@ -125,9 +115,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterBooleanSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FakeOuterBooleanSerialize`: bool
@@ -152,7 +142,7 @@ Name | Type | Description  | Notes
 
 **bool**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -188,11 +178,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     outerComposite := *openapiclient.NewOuterComposite() // OuterComposite | Input composite as post body (optional)
 
@@ -202,9 +187,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterCompositeSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FakeOuterCompositeSerialize`: OuterComposite
@@ -229,7 +214,7 @@ Name | Type | Description  | Notes
 
 [**OuterComposite**](OuterComposite.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -265,11 +250,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := float32(8.14) // float32 | Input number as post body (optional)
 
@@ -279,9 +259,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterNumberSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FakeOuterNumberSerialize`: float32
@@ -306,7 +286,7 @@ Name | Type | Description  | Notes
 
 **float32**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -342,11 +322,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     body := "body_example" // string | Input string as post body (optional)
 
@@ -356,9 +331,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterStringSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FakeOuterStringSerialize`: string
@@ -383,7 +358,7 @@ Name | Type | Description  | Notes
 
 **string**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -419,11 +394,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     fileSchemaTestClass := *openapiclient.NewFileSchemaTestClass() // FileSchemaTestClass | 
 
@@ -433,9 +403,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithFileSchema``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -458,7 +428,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -492,11 +462,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     query := "query_example" // string | 
     user := *openapiclient.NewUser() // User | 
@@ -507,9 +472,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithQueryParams``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -533,7 +498,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -569,11 +534,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     client := *openapiclient.NewClient() // Client | client model
 
@@ -583,9 +543,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestClientModel``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `TestClientModel`: Client
@@ -610,7 +570,7 @@ Name | Type | Description  | Notes
 
 [**Client**](Client.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -647,11 +607,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     number := float32(8.14) // float32 | None
     double := float64(1.2) // float64 | None
@@ -674,9 +629,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEndpointParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -712,7 +667,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -748,11 +703,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     enumHeaderStringArray := []string{"EnumHeaderStringArray_example"} // []string | Header parameter enum test (string array) (optional)
     enumHeaderString := "enumHeaderString_example" // string | Header parameter enum test (string) (optional) (default to "-efg")
@@ -769,9 +719,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEnumParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -801,7 +751,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -837,11 +787,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     requiredStringGroup := int32(56) // int32 | Required String in group parameters
     requiredBooleanGroup := true // bool | Required Boolean in group parameters
@@ -856,9 +801,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestGroupParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -886,7 +831,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -920,11 +865,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     requestBody := map[string]string{"key": "Inner_example"} // map[string]string | request body
 
@@ -934,9 +874,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestInlineAdditionalProperties``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -959,7 +899,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -993,11 +933,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     param := "param_example" // string | field1
     param2 := "param2_example" // string | field2
@@ -1008,9 +943,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestJsonFormData``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -1034,7 +969,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -1070,11 +1005,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     pipe := []string{"Inner_example"} // []string | 
     ioutil := []string{"Inner_example"} // []string | 
@@ -1088,9 +1018,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestQueryParameterCollectionFormat``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -1117,7 +1047,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -39,6 +39,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -47,6 +52,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeHealthGet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FakeHealthGet`: HealthCheckResult
     fmt.Fprintf(os.Stdout, "Response from `FakeApi.FakeHealthGet`: %v\n", resp)
@@ -64,7 +73,9 @@ Other parameters are passed through a pointer to a apiFakeHealthGetRequest struc
 
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**HealthCheckResult**](HealthCheckResult.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -100,6 +111,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := true // bool | Input boolean as post body (optional)
 
@@ -109,6 +125,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterBooleanSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FakeOuterBooleanSerialize`: bool
     fmt.Fprintf(os.Stdout, "Response from `FakeApi.FakeOuterBooleanSerialize`: %v\n", resp)
@@ -130,7 +150,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**bool**
+**bool**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -166,6 +188,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     outerComposite := *openapiclient.NewOuterComposite() // OuterComposite | Input composite as post body (optional)
 
@@ -175,6 +202,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterCompositeSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FakeOuterCompositeSerialize`: OuterComposite
     fmt.Fprintf(os.Stdout, "Response from `FakeApi.FakeOuterCompositeSerialize`: %v\n", resp)
@@ -196,7 +227,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**OuterComposite**](OuterComposite.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -232,6 +265,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := float32(8.14) // float32 | Input number as post body (optional)
 
@@ -241,6 +279,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterNumberSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FakeOuterNumberSerialize`: float32
     fmt.Fprintf(os.Stdout, "Response from `FakeApi.FakeOuterNumberSerialize`: %v\n", resp)
@@ -262,7 +304,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**float32**
+**float32**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -298,6 +342,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     body := "body_example" // string | Input string as post body (optional)
 
@@ -307,6 +356,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterStringSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FakeOuterStringSerialize`: string
     fmt.Fprintf(os.Stdout, "Response from `FakeApi.FakeOuterStringSerialize`: %v\n", resp)
@@ -328,7 +381,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**string**
+**string**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -364,6 +419,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     fileSchemaTestClass := *openapiclient.NewFileSchemaTestClass() // FileSchemaTestClass | 
 
@@ -373,6 +433,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithFileSchema``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -392,7 +456,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -426,6 +492,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     query := "query_example" // string | 
     user := *openapiclient.NewUser() // User | 
@@ -436,6 +507,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithQueryParams``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -456,7 +531,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -492,6 +569,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     client := *openapiclient.NewClient() // Client | client model
 
@@ -501,6 +583,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestClientModel``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `TestClientModel`: Client
     fmt.Fprintf(os.Stdout, "Response from `FakeApi.TestClientModel`: %v\n", resp)
@@ -522,7 +608,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Client**](Client.md)
+[**Client**](Client.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -559,6 +647,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     number := float32(8.14) // float32 | None
     double := float64(1.2) // float64 | None
@@ -581,6 +674,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEndpointParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -613,7 +710,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -649,6 +748,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     enumHeaderStringArray := []string{"EnumHeaderStringArray_example"} // []string | Header parameter enum test (string array) (optional)
     enumHeaderString := "enumHeaderString_example" // string | Header parameter enum test (string) (optional) (default to "-efg")
@@ -665,6 +769,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEnumParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -691,7 +799,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -727,6 +837,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     requiredStringGroup := int32(56) // int32 | Required String in group parameters
     requiredBooleanGroup := true // bool | Required Boolean in group parameters
@@ -741,6 +856,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestGroupParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -765,7 +884,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -799,6 +920,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     requestBody := map[string]string{"key": "Inner_example"} // map[string]string | request body
 
@@ -808,6 +934,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestInlineAdditionalProperties``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -827,7 +957,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -861,6 +993,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     param := "param_example" // string | field1
     param2 := "param2_example" // string | field2
@@ -871,6 +1008,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestJsonFormData``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -891,7 +1032,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -927,6 +1070,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     pipe := []string{"Inner_example"} // []string | 
     ioutil := []string{"Inner_example"} // []string | 
@@ -940,6 +1088,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestQueryParameterCollectionFormat``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -963,7 +1115,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
@@ -34,7 +34,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeClassnameTags123Api.TestClassname(context.Background()).Client(client).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeClassnameTags123Api.TestClassname``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
@@ -28,6 +28,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     client := *openapiclient.NewClient() // Client | client model
 
@@ -37,6 +42,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeClassnameTags123Api.TestClassname``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `TestClassname`: Client
     fmt.Fprintf(os.Stdout, "Response from `FakeClassnameTags123Api.TestClassname`: %v\n", resp)
@@ -58,7 +67,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Client**](Client.md)
+[**Client**](Client.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
@@ -28,11 +28,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     client := *openapiclient.NewClient() // Client | client model
 
@@ -42,9 +37,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeClassnameTags123Api.TestClassname``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `TestClassname`: Client
@@ -69,7 +64,7 @@ Name | Type | Description  | Notes
 
 [**Client**](Client.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
@@ -40,7 +40,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.AddPet(context.Background()).Pet(pet).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.AddPet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -103,7 +103,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.DeletePet(context.Background(), petId).ApiKey(apiKey).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.DeletePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -172,7 +172,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.FindPetsByStatus(context.Background()).Status(status).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByStatus``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -238,7 +238,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.FindPetsByTags(context.Background()).Tags(tags).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -304,7 +304,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.GetPetById(context.Background(), petId).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.GetPetById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -372,7 +372,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UpdatePet(context.Background()).Pet(pet).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -436,7 +436,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UpdatePetWithForm(context.Background(), petId).Name(name).Status(status).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePetWithForm``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -506,7 +506,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UploadFile(context.Background(), petId).AdditionalMetadata(additionalMetadata).File(file).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -578,7 +578,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UploadFileWithRequiredFile(context.Background(), petId).RequiredFile(requiredFile).AdditionalMetadata(additionalMetadata).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFileWithRequiredFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
@@ -34,11 +34,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     pet := *openapiclient.NewPet("doggie", []string{"PhotoUrls_example"}) // Pet | Pet object that needs to be added to the store
 
@@ -48,9 +43,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.AddPet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -73,7 +68,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -107,11 +102,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     petId := int64(789) // int64 | Pet id to delete
     apiKey := "apiKey_example" // string |  (optional)
@@ -122,9 +112,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.DeletePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -152,7 +142,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -188,11 +178,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     status := []string{"Status_example"} // []string | Status values that need to be considered for filter
 
@@ -202,9 +187,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByStatus``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FindPetsByStatus`: []Pet
@@ -229,7 +214,7 @@ Name | Type | Description  | Notes
 
 [**[]Pet**](Pet.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -265,11 +250,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     tags := []string{"Inner_example"} // []string | Tags to filter by
 
@@ -279,9 +259,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `FindPetsByTags`: []Pet
@@ -306,7 +286,7 @@ Name | Type | Description  | Notes
 
 [**[]Pet**](Pet.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -342,11 +322,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     petId := int64(789) // int64 | ID of pet to return
 
@@ -356,9 +331,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.GetPetById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `GetPetById`: Pet
@@ -387,7 +362,7 @@ Name | Type | Description  | Notes
 
 [**Pet**](Pet.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -421,11 +396,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     pet := *openapiclient.NewPet("doggie", []string{"PhotoUrls_example"}) // Pet | Pet object that needs to be added to the store
 
@@ -435,9 +405,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -460,7 +430,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -494,11 +464,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     petId := int64(789) // int64 | ID of pet that needs to be updated
     name := "name_example" // string | Updated name of the pet (optional)
@@ -510,9 +475,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePetWithForm``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -541,7 +506,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -575,11 +540,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     petId := int64(789) // int64 | ID of pet to update
     additionalMetadata := "additionalMetadata_example" // string | Additional data to pass to server (optional)
@@ -591,9 +551,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `UploadFile`: ApiResponse
@@ -624,7 +584,7 @@ Name | Type | Description  | Notes
 
 [**ApiResponse**](ApiResponse.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -658,11 +618,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     petId := int64(789) // int64 | ID of pet to update
     requiredFile := os.NewFile(1234, "some_file") // *os.File | file to upload
@@ -674,9 +629,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFileWithRequiredFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `UploadFileWithRequiredFile`: ApiResponse
@@ -707,7 +662,7 @@ Name | Type | Description  | Notes
 
 [**ApiResponse**](ApiResponse.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
@@ -34,6 +34,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     pet := *openapiclient.NewPet("doggie", []string{"PhotoUrls_example"}) // Pet | Pet object that needs to be added to the store
 
@@ -43,6 +48,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.AddPet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -62,7 +71,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -96,6 +107,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     petId := int64(789) // int64 | Pet id to delete
     apiKey := "apiKey_example" // string |  (optional)
@@ -106,6 +122,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.DeletePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -130,7 +150,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -166,6 +188,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     status := []string{"Status_example"} // []string | Status values that need to be considered for filter
 
@@ -175,6 +202,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByStatus``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FindPetsByStatus`: []Pet
     fmt.Fprintf(os.Stdout, "Response from `PetApi.FindPetsByStatus`: %v\n", resp)
@@ -196,7 +227,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**[]Pet**](Pet.md)
+[**[]Pet**](Pet.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -232,6 +265,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     tags := []string{"Inner_example"} // []string | Tags to filter by
 
@@ -241,6 +279,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `FindPetsByTags`: []Pet
     fmt.Fprintf(os.Stdout, "Response from `PetApi.FindPetsByTags`: %v\n", resp)
@@ -262,7 +304,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**[]Pet**](Pet.md)
+[**[]Pet**](Pet.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -298,6 +342,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     petId := int64(789) // int64 | ID of pet to return
 
@@ -307,6 +356,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.GetPetById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `GetPetById`: Pet
     fmt.Fprintf(os.Stdout, "Response from `PetApi.GetPetById`: %v\n", resp)
@@ -332,7 +385,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Pet**](Pet.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -366,6 +421,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     pet := *openapiclient.NewPet("doggie", []string{"PhotoUrls_example"}) // Pet | Pet object that needs to be added to the store
 
@@ -375,6 +435,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -394,7 +458,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -428,6 +494,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     petId := int64(789) // int64 | ID of pet that needs to be updated
     name := "name_example" // string | Updated name of the pet (optional)
@@ -439,6 +510,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePetWithForm``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -464,7 +539,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -498,6 +575,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     petId := int64(789) // int64 | ID of pet to update
     additionalMetadata := "additionalMetadata_example" // string | Additional data to pass to server (optional)
@@ -509,6 +591,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `UploadFile`: ApiResponse
     fmt.Fprintf(os.Stdout, "Response from `PetApi.UploadFile`: %v\n", resp)
@@ -536,7 +622,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**ApiResponse**](ApiResponse.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -570,6 +658,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     petId := int64(789) // int64 | ID of pet to update
     requiredFile := os.NewFile(1234, "some_file") // *os.File | file to upload
@@ -581,6 +674,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFileWithRequiredFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `UploadFileWithRequiredFile`: ApiResponse
     fmt.Fprintf(os.Stdout, "Response from `PetApi.UploadFileWithRequiredFile`: %v\n", resp)
@@ -608,7 +705,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**ApiResponse**](ApiResponse.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -37,7 +37,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.DeleteOrder(context.Background(), orderId).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.DeleteOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -104,7 +104,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.GetInventory(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetInventory``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -166,7 +166,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.GetOrderById(context.Background(), orderId).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetOrderById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -234,7 +234,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.PlaceOrder(context.Background()).Order(order).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.PlaceOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -31,11 +31,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     orderId := "orderId_example" // string | ID of the order that needs to be deleted
 
@@ -45,9 +40,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.DeleteOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -74,7 +69,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -110,11 +105,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -123,9 +113,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetInventory``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `GetInventory`: map[string]int32
@@ -146,7 +136,7 @@ Other parameters are passed through a pointer to a apiGetInventoryRequest struct
 
 **map[string]int32**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -182,11 +172,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     orderId := int64(789) // int64 | ID of pet that needs to be fetched
 
@@ -196,9 +181,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetOrderById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `GetOrderById`: Order
@@ -227,7 +212,7 @@ Name | Type | Description  | Notes
 
 [**Order**](Order.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -261,11 +246,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     order := *openapiclient.NewOrder() // Order | order placed for purchasing the pet
 
@@ -275,9 +255,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.PlaceOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `PlaceOrder`: Order
@@ -302,7 +282,7 @@ Name | Type | Description  | Notes
 
 [**Order**](Order.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -31,6 +31,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     orderId := "orderId_example" // string | ID of the order that needs to be deleted
 
@@ -40,6 +45,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.DeleteOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -63,7 +72,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -99,6 +110,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -107,6 +123,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetInventory``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `GetInventory`: map[string]int32
     fmt.Fprintf(os.Stdout, "Response from `StoreApi.GetInventory`: %v\n", resp)
@@ -124,7 +144,9 @@ Other parameters are passed through a pointer to a apiGetInventoryRequest struct
 
 ### Return type
 
-**map[string]int32**
+**map[string]int32**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -160,6 +182,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     orderId := int64(789) // int64 | ID of pet that needs to be fetched
 
@@ -169,6 +196,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetOrderById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `GetOrderById`: Order
     fmt.Fprintf(os.Stdout, "Response from `StoreApi.GetOrderById`: %v\n", resp)
@@ -194,7 +225,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Order**](Order.md)
+[**Order**](Order.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -228,6 +261,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     order := *openapiclient.NewOrder() // Order | order placed for purchasing the pet
 
@@ -237,6 +275,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.PlaceOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `PlaceOrder`: Order
     fmt.Fprintf(os.Stdout, "Response from `StoreApi.PlaceOrder`: %v\n", resp)
@@ -258,7 +300,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**Order**](Order.md)
+[**Order**](Order.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/UserApi.md
@@ -41,7 +41,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.CreateUser(context.Background()).User(user).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -103,7 +103,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.CreateUsersWithArrayInput(context.Background()).User(user).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithArrayInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -165,7 +165,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.CreateUsersWithListInput(context.Background()).User(user).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithListInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -229,7 +229,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.DeleteUser(context.Background(), username).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.DeleteUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -295,7 +295,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.GetUserByName(context.Background(), username).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.GetUserByName``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -364,7 +364,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.LoginUser(context.Background()).Username(username).Password(password).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LoginUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -428,7 +428,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.LogoutUser(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LogoutUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -489,7 +489,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.UpdateUser(context.Background(), username).User(user).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.UpdateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/UserApi.md
@@ -35,6 +35,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     user := *openapiclient.NewUser() // User | Created user object
 
@@ -44,6 +49,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -63,7 +72,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -97,6 +108,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     user := []openapiclient.User{*openapiclient.NewUser()} // []User | List of user object
 
@@ -106,6 +122,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithArrayInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -125,7 +145,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -159,6 +181,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     user := []openapiclient.User{*openapiclient.NewUser()} // []User | List of user object
 
@@ -168,6 +195,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithListInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -187,7 +218,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -223,6 +256,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     username := "username_example" // string | The name that needs to be deleted
 
@@ -232,6 +270,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.DeleteUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -255,7 +297,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -289,6 +333,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     username := "username_example" // string | The name that needs to be fetched. Use user1 for testing.
 
@@ -298,6 +347,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.GetUserByName``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `GetUserByName`: User
     fmt.Fprintf(os.Stdout, "Response from `UserApi.GetUserByName`: %v\n", resp)
@@ -323,7 +376,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**User**](User.md)
+[**User**](User.md), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -357,6 +412,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     username := "username_example" // string | The user name for login
     password := "password_example" // string | The password for login in clear text
@@ -367,6 +427,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LoginUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
     // response from `LoginUser`: string
     fmt.Fprintf(os.Stdout, "Response from `UserApi.LoginUser`: %v\n", resp)
@@ -389,7 +453,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**string**
+**string**, http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -423,6 +489,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -431,6 +502,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LogoutUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -446,7 +521,9 @@ Other parameters are passed through a pointer to a apiLogoutUserRequest struct v
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 
@@ -482,6 +559,11 @@ import (
     openapiclient "./openapi"
 )
 
+type openapiError interface {
+    Model() interface{}
+    Body() []byte 
+}
+
 func main() {
     username := "username_example" // string | name that need to be deleted
     user := *openapiclient.NewUser() // User | Updated user object
@@ -492,6 +574,10 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.UpdateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+        if openapiErr, ok := err.(openapiError); ok {
+            fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
+            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+        }
     }
 }
 ```
@@ -516,7 +602,9 @@ Name | Type | Description  | Notes
 
 ### Return type
 
- (empty response body)
+ (empty response body), http.Response and error
+
+The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/UserApi.md
@@ -35,11 +35,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     user := *openapiclient.NewUser() // User | Created user object
 
@@ -49,9 +44,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -74,7 +69,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -108,11 +103,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     user := []openapiclient.User{*openapiclient.NewUser()} // []User | List of user object
 
@@ -122,9 +112,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithArrayInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -147,7 +137,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -181,11 +171,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     user := []openapiclient.User{*openapiclient.NewUser()} // []User | List of user object
 
@@ -195,9 +180,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithListInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -220,7 +205,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -256,11 +241,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     username := "username_example" // string | The name that needs to be deleted
 
@@ -270,9 +250,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.DeleteUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -299,7 +279,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -333,11 +313,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     username := "username_example" // string | The name that needs to be fetched. Use user1 for testing.
 
@@ -347,9 +322,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.GetUserByName``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `GetUserByName`: User
@@ -378,7 +353,7 @@ Name | Type | Description  | Notes
 
 [**User**](User.md), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -412,11 +387,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     username := "username_example" // string | The user name for login
     password := "password_example" // string | The password for login in clear text
@@ -427,9 +397,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LoginUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
     // response from `LoginUser`: string
@@ -455,7 +425,7 @@ Name | Type | Description  | Notes
 
 **string**, http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -489,11 +459,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
 
     configuration := openapiclient.NewConfiguration()
@@ -502,9 +467,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LogoutUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -523,7 +488,7 @@ Other parameters are passed through a pointer to a apiLogoutUserRequest struct v
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 
@@ -559,11 +524,6 @@ import (
     openapiclient "./openapi"
 )
 
-type openapiError interface {
-    Model() interface{}
-    Body() []byte 
-}
-
 func main() {
     username := "username_example" // string | name that need to be deleted
     user := *openapiclient.NewUser() // User | Updated user object
@@ -574,9 +534,9 @@ func main() {
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.UpdateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-        if openapiErr, ok := err.(openapiError); ok {
+        if openapiErr, ok := err.(openapiclient.GenericOpenAPIError); ok {
             fmt.Fprintf(os.Stderr, "Model returned from error response: %v\n", openapiErr.Model())
-            fmt.Fprintf(os.Stderr, "Raw response body: %v\n", openapiErr.Body())
+            fmt.Fprintf(os.Stderr, "Raw response body: %s\n", openapiErr.Body())
         }
     }
 }
@@ -604,7 +564,7 @@ Name | Type | Description  | Notes
 
  (empty response body), http.Response and error
 
-The returned error provides `Body()` and `Model()` methods that can be accessed using a custom interface.
+The returned error provides `Body()` and `Model()` methods that can be accessed through type-asserting to the `openapiclient.GenericOpenAPIError` type or by using a custom interface.
 
 ### Authorization
 

--- a/samples/openapi3/client/petstore/go/http_signature_test.go
+++ b/samples/openapi3/client/petstore/go/http_signature_test.go
@@ -282,11 +282,11 @@ func executeHttpSignatureAuth(t *testing.T, authConfig *sw.HttpSignatureAuth, ex
 		authConfig.SigningScheme, authConfig.SigningAlgorithm, authConfig.SignatureMaxValidity, authConfig.SignedHeaders)
 
 	r, err2 := apiClient.PetApi.AddPet(authCtx).Pet(newPet).Execute()
-	if expectSuccess && err2.Error() != "" {
+	if expectSuccess && err2 != nil {
 		t.Fatalf("Error while adding pet: %v", err2)
 	}
 	if !expectSuccess {
-		if err2.Error() == "" {
+		if err2 == nil {
 			t.Fatalf("Error was expected, but no error was generated")
 		} else {
 			// Do not continue. Error is expected.
@@ -298,7 +298,7 @@ func executeHttpSignatureAuth(t *testing.T, authConfig *sw.HttpSignatureAuth, ex
 	}
 
 	_, r, err = apiClient.PetApi.GetPetById(authCtx, 12992).Execute()
-	if expectSuccess && err.Error() != "" {
+	if expectSuccess && err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 

--- a/samples/openapi3/client/petstore/go/pet_api_test.go
+++ b/samples/openapi3/client/petstore/go/pet_api_test.go
@@ -33,7 +33,7 @@ func TestAddPet(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -44,7 +44,7 @@ func TestAddPet(t *testing.T) {
 func TestFindPetsByStatusWithMissingParam(t *testing.T) {
 	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while testing TestFindPetsByStatusWithMissingParam: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -59,12 +59,13 @@ func TestGetPetById(t *testing.T) {
 func TestGetPetByIdWithInvalidID(t *testing.T) {
 	resp, r, err := client.PetApi.GetPetById(context.Background(), 999999999).Execute()
 	if r != nil && r.StatusCode == 404 {
-		assertedError:= err
+		assertedError, ok := err.(sw.GenericOpenAPIError)
 		a := assert.New(t)
+		a.True(ok)
 		a.Contains(string(assertedError.Body()), "type")
 
 		a.Contains(assertedError.Error(), "Not Found")
-	} else if err.Error() != "" {
+	} else if err != nil {
 		t.Fatalf("Error while getting pet by invalid id: %v", err)
 		t.Log(r)
 	} else {
@@ -74,7 +75,7 @@ func TestGetPetByIdWithInvalidID(t *testing.T) {
 
 func TestUpdatePetWithForm(t *testing.T) {
 	r, err := client.PetApi.UpdatePetWithForm(context.Background(), 12830).Name("golang").Status("available").Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while updating pet by id: %v", err)
 		t.Log(r)
 	}
@@ -89,7 +90,7 @@ func TestUpdatePetWithForm(t *testing.T) {
 func TestFindPetsByTag(t *testing.T) {
 	var found = false
 	resp, r, err := client.PetApi.FindPetsByTags(context.Background()).Tags([]string{"tag2"}).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting pet by tag: %v", err)
 		t.Log(r)
 	} else {
@@ -118,7 +119,7 @@ func TestFindPetsByTag(t *testing.T) {
 
 func TestFindPetsByStatus(t *testing.T) {
 	resp, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status([]string{"available"}).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting pet by id: %v", err)
 		t.Log(r)
 	} else {
@@ -145,7 +146,7 @@ func TestUploadFile(t *testing.T) {
 
 	_, r, err := client.PetApi.UploadFile(context.Background(), 12830).AdditionalMetadata("golang").File(file).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)
 	}
 
@@ -163,7 +164,7 @@ func TestUploadFileRequired(t *testing.T) {
 
 	_, r, err := client.PetApi.UploadFileWithRequiredFile(context.Background(), 12830).RequiredFile(file).AdditionalMetadata("golang").Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)
 	}
 
@@ -175,7 +176,7 @@ func TestUploadFileRequired(t *testing.T) {
 func TestDeletePet(t *testing.T) {
 	r, err := client.PetApi.DeletePet(context.Background(), 12830).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -265,7 +266,7 @@ func waitOnFunctions(t *testing.T, errc chan error, n int) {
 func deletePet(t *testing.T, id int64) {
 	r, err := client.PetApi.DeletePet(context.Background(), id).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -276,7 +277,7 @@ func deletePet(t *testing.T, id int64) {
 func isPetCorrect(t *testing.T, id int64, name string, status string) {
 	assert := assert.New(t)
 	resp, r, err := client.PetApi.GetPetById(context.Background(), id).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting pet by id: %v", err)
 	} else {
 		assert.Equal(*resp.Id, int64(id), "Pet id should be equal")

--- a/samples/openapi3/client/petstore/go/store_api_test.go
+++ b/samples/openapi3/client/petstore/go/store_api_test.go
@@ -20,7 +20,7 @@ func TestPlaceOrder(t *testing.T) {
 
 	_, r, err := client.StoreApi.PlaceOrder(context.Background()).Order(newOrder).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		// Skip parsing time error due to error in Petstore Test Server
 		// https://github.com/OpenAPITools/openapi-generator/issues/1292
 		if regexp.

--- a/samples/openapi3/client/petstore/go/user_api_test.go
+++ b/samples/openapi3/client/petstore/go/user_api_test.go
@@ -22,7 +22,7 @@ func TestCreateUser(t *testing.T) {
 
 	apiResponse, err := client.UserApi.CreateUser(context.Background()).User(newUser).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding user: %v", err)
 	}
 	if apiResponse.StatusCode != 200 {
@@ -56,7 +56,7 @@ func TestCreateUsersWithArrayInput(t *testing.T) {
 	}
 
 	apiResponse, err := client.UserApi.CreateUsersWithArrayInput(context.Background()).User(newUsers).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding users: %v", err)
 	}
 	if apiResponse.StatusCode != 200 {
@@ -83,7 +83,7 @@ func TestGetUserByName(t *testing.T) {
 	assert := assert.New(t)
 
 	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher").Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting user by id: %v", err)
 	} else {
 		assert.Equal(*resp.Id, int64(1000), "User id should be equal")
@@ -100,7 +100,7 @@ func TestGetUserByNameWithInvalidID(t *testing.T) {
 	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "999999999").Execute()
 	if apiResponse != nil && apiResponse.StatusCode == 404 {
 		return // This is a pass condition. API will return with a 404 error.
-	} else if err.Error() != "" {
+	} else if err != nil {
 		t.Fatalf("Error while getting user by invalid id: %v", err)
 		t.Log(apiResponse)
 	} else {
@@ -125,7 +125,7 @@ func TestUpdateUser(t *testing.T) {
 		UserStatus: sw.PtrInt32(1)}
 
 	apiResponse, err := client.UserApi.UpdateUser(context.Background(), "gopher").User(newUser).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting user by id: %v", err)
 	}
 	if apiResponse.StatusCode != 200 {
@@ -134,7 +134,7 @@ func TestUpdateUser(t *testing.T) {
 
 	//verify changings are correct
 	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher").Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting user by id: %v", err)
 	} else {
 		assert.Equal(*resp.Id, int64(1000), "User id should be equal")


### PR DESCRIPTION
Since #8137 the generated Go client no longer returns `error` results. It instead prefers the openapi-generator specific `GenericOpenAPIError` concrete type. This breaks expectations from Go developers: the main one being that returned errors are nullable and that a null error result means successful conclusion.

This PR reverts that change but tries to keep up with the spirit of the original PR by still allowing the response body to be accessed by client code. It also changes the generated documentation to make the possibility of getting detailed errors clearer.

Fixes #8263 (please refer to issue for aditional discussion).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)
