### PR TITLE
[dart][dart-dio] Add missing imports for container parameters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
@@ -558,6 +558,18 @@ public class DartClientCodegen extends DefaultCodegen {
                 }
             }
         }
+        for (CodegenParameter p : op.allParams) {
+            if (p.isContainer) {
+                final String type = p.isArray ? "array" : "map";
+                if (typeMapping().containsKey(type)) {
+                    final String value = typeMapping().get(type);
+                    // Also add container imports for parameters.
+                    if (needToImport(value)) {
+                        op.imports.add(value);
+                    }
+                }
+            }
+        }
         return op;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -327,7 +327,7 @@ public class DartDioClientCodegen extends DartClientCodegen {
             Set<String> imports = new HashSet<>();
             for (String item : op.imports) {
                 if (needToImport(item)) {
-                    if (importMapping().containsKey(item) && needToImport(item)) {
+                    if (importMapping().containsKey(item)) {
                         fullImports.add(importMapping().get(item));
                     } else {
                         imports.add(underscore(item));


### PR DESCRIPTION
This adds missing imports for operations that have container type parameters.
Also remove redundant needToImport check.

Fixes https://github.com/OpenAPITools/openapi-generator/issues/8273
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)