### PR TITLE
[goserver] Fix single inheritance code generation for goserver

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/model.mustache
@@ -17,6 +17,16 @@ const (
 ){{/isEnum}}{{^isEnum}}{{#description}}
 // {{classname}} - {{{description}}}{{/description}}
 type {{classname}} struct {
+{{#parent}}
+{{^isMap}}
+{{^isArray}}
+	{{{parent}}}
+{{/isArray}}
+{{/isMap}}
+{{#isArray}}
+	Items {{{parent}}}
+{{/isArray}}
+{{/parent}}
 {{#vars}}{{#description}}
 	// {{{description}}}{{/description}}
 	{{name}} {{#isNullable}}*{{/isNullable}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`


### PR DESCRIPTION
This pull request is intended to fix an issue introduced with https://github.com/OpenAPITools/openapi-generator/pull/4934.

The line `supportsInheritance = true` has been included in the cosntructor of `AbstractGoCodegen`, which is also the parent class of the go server code generator. The pull request implements changes in the go client's and go deprecated's  `model.mustache`, but not in the go server, even if the change in `AbstractGoCodegen` affects also this generator.

This PR addresses this.

@antihax @grokify @kemokemo @bkabrda

@wing328 possibly this should be included also in `5.1.x`.