### PR TITLE
[dart][dart-dio] Generate the correct serializers

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -289,6 +289,7 @@ public class DartDioClientCodegen extends DartClientCodegen {
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         List<CodegenOperation> operationList = (List<CodegenOperation>) operations.get("operation");
 
+        Set<Map<String, Object>> serializers = new HashSet<>();
         Set<String> modelImports = new HashSet<>();
         Set<String> fullImports = new HashSet<>();
 
@@ -314,6 +315,13 @@ public class DartDioClientCodegen extends DartClientCodegen {
                     param.baseType = "MultipartFile";
                     param.dataType = "MultipartFile";
                 }
+                if (param.isContainer) {
+                    final Map<String, Object> serializer = new HashMap<>();
+                    serializer.put("isArray", param.isArray);
+                    serializer.put("isMap", param.isMap);
+                    serializer.put("baseType", param.baseType);
+                    serializers.add(serializer);
+                }
             }
 
             op.vendorExtensions.put("x-is-json", isJson);
@@ -336,10 +344,19 @@ public class DartDioClientCodegen extends DartClientCodegen {
             }
             modelImports.addAll(imports);
             op.imports = imports;
+
+            if (op.returnContainer != null) {
+                final Map<String, Object> serializer = new HashMap<>();
+                serializer.put("isArray", Objects.equals("array", op.returnContainer));
+                serializer.put("isMap", Objects.equals("map", op.returnContainer));
+                serializer.put("baseType", op.returnBaseType);
+                serializers.add(serializer);
+            }
         }
 
         objs.put("modelImports", modelImports);
         objs.put("fullImports", fullImports);
+        objs.put("serializers", serializers);
 
         return objs;
     }

--- a/modules/openapi-generator/src/main/resources/dart-dio/serializers.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/serializers.mustache
@@ -10,25 +10,26 @@ import 'package:built_value/standard_json_plugin.dart';
 import 'package:{{pubName}}/local_date_serializer.dart';{{/timeMachine}}
 {{#models}}{{#model}}import 'package:{{pubName}}/model/{{classFilename}}.dart';
 {{/model}}{{/models}}
-
 part 'serializers.g.dart';
 
-@SerializersFor(const [
-{{#models}}{{#model}}{{classname}},
-{{/model}}{{/models}}
+@SerializersFor(const [{{#models}}{{#model}}
+  {{classname}},{{/model}}{{/models}}
 ])
-
-//allow all models to be serialized within a list
-Serializers serializers = (_$serializers.toBuilder()
-{{#models}}{{#model}}..addBuilderFactory(
-const FullType(BuiltList, const [const FullType({{classname}})]),
-() => new ListBuilder<{{classname}}>())
-{{/model}}{{/models}}
-..add(Iso8601DateTimeSerializer())
-).build();
+Serializers serializers = (_$serializers.toBuilder(){{#apiInfo}}{{#apis}}{{#serializers}}
+      ..addBuilderFactory(
+{{#isArray}}
+        const FullType(BuiltList, [FullType({{baseType}})]),
+        () => ListBuilder<{{baseType}}>(),
+{{/isArray}}
+{{#isMap}}
+        const FullType(BuiltMap, [FullType(String), FullType({{baseType}})]),
+        () => MapBuilder<String, {{baseType}}>(),
+{{/isMap}}
+      ){{/serializers}}{{/apis}}{{/apiInfo}}{{#timeMachine}}
+      ..add(OffsetDateSerializer())
+      ..add(OffsetDateTimeSerializer()){{/timeMachine}}
+      ..add(Iso8601DateTimeSerializer()))
+    .build();
 
 Serializers standardSerializers =
-(serializers.toBuilder()
-{{#timeMachine}}..add(OffsetDateSerializer())
-..add(OffsetDateTimeSerializer())
-{{/timeMachine}}..addPlugin(StandardJsonPlugin())).build();
+    (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/serializers.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/serializers.dart
@@ -20,43 +20,31 @@ import 'package:openapi/model/pet.dart';
 import 'package:openapi/model/tag.dart';
 import 'package:openapi/model/user.dart';
 
-
 part 'serializers.g.dart';
 
 @SerializersFor(const [
-ApiResponse,
-Category,
-Order,
-Pet,
-Tag,
-User,
-
+  ApiResponse,
+  Category,
+  Order,
+  Pet,
+  Tag,
+  User,
 ])
-
-//allow all models to be serialized within a list
 Serializers serializers = (_$serializers.toBuilder()
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ApiResponse)]),
-() => new ListBuilder<ApiResponse>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Category)]),
-() => new ListBuilder<Category>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Order)]),
-() => new ListBuilder<Order>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Pet)]),
-() => new ListBuilder<Pet>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Tag)]),
-() => new ListBuilder<Tag>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(User)]),
-() => new ListBuilder<User>())
-
-..add(Iso8601DateTimeSerializer())
-).build();
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(Pet)]),
+        () => ListBuilder<Pet>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(int)]),
+        () => MapBuilder<String, int>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(User)]),
+        () => ListBuilder<User>(),
+      )
+      ..add(Iso8601DateTimeSerializer()))
+    .build();
 
 Serializers standardSerializers =
-(serializers.toBuilder()
-..addPlugin(StandardJsonPlugin())).build();
+    (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/serializers.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/serializers.dart
@@ -20,43 +20,31 @@ import 'package:openapi/model/pet.dart';
 import 'package:openapi/model/tag.dart';
 import 'package:openapi/model/user.dart';
 
-
 part 'serializers.g.dart';
 
 @SerializersFor(const [
-ApiResponse,
-Category,
-Order,
-Pet,
-Tag,
-User,
-
+  ApiResponse,
+  Category,
+  Order,
+  Pet,
+  Tag,
+  User,
 ])
-
-//allow all models to be serialized within a list
 Serializers serializers = (_$serializers.toBuilder()
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ApiResponse)]),
-() => new ListBuilder<ApiResponse>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Category)]),
-() => new ListBuilder<Category>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Order)]),
-() => new ListBuilder<Order>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Pet)]),
-() => new ListBuilder<Pet>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Tag)]),
-() => new ListBuilder<Tag>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(User)]),
-() => new ListBuilder<User>())
-
-..add(Iso8601DateTimeSerializer())
-).build();
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(Pet)]),
+        () => ListBuilder<Pet>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(int)]),
+        () => MapBuilder<String, int>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(User)]),
+        () => ListBuilder<User>(),
+      )
+      ..add(Iso8601DateTimeSerializer()))
+    .build();
 
 Serializers standardSerializers =
-(serializers.toBuilder()
-..addPlugin(StandardJsonPlugin())).build();
+    (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/serializers.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/serializers.dart
@@ -57,191 +57,72 @@ import 'package:openapi/model/special_model_name.dart';
 import 'package:openapi/model/tag.dart';
 import 'package:openapi/model/user.dart';
 
-
 part 'serializers.g.dart';
 
 @SerializersFor(const [
-AdditionalPropertiesClass,
-Animal,
-ApiResponse,
-ArrayOfArrayOfNumberOnly,
-ArrayOfNumberOnly,
-ArrayTest,
-Capitalization,
-Cat,
-CatAllOf,
-Category,
-ClassModel,
-Dog,
-DogAllOf,
-EnumArrays,
-EnumTest,
-FileSchemaTestClass,
-Foo,
-FormatTest,
-HasOnlyReadOnly,
-HealthCheckResult,
-InlineResponseDefault,
-MapTest,
-MixedPropertiesAndAdditionalPropertiesClass,
-Model200Response,
-ModelClient,
-ModelEnumClass,
-ModelFile,
-ModelList,
-ModelReturn,
-Name,
-NullableClass,
-NumberOnly,
-Order,
-OuterComposite,
-OuterEnum,
-OuterEnumDefaultValue,
-OuterEnumInteger,
-OuterEnumIntegerDefaultValue,
-Pet,
-ReadOnlyFirst,
-SpecialModelName,
-Tag,
-User,
-
+  AdditionalPropertiesClass,
+  Animal,
+  ApiResponse,
+  ArrayOfArrayOfNumberOnly,
+  ArrayOfNumberOnly,
+  ArrayTest,
+  Capitalization,
+  Cat,
+  CatAllOf,
+  Category,
+  ClassModel,
+  Dog,
+  DogAllOf,
+  EnumArrays,
+  EnumTest,
+  FileSchemaTestClass,
+  Foo,
+  FormatTest,
+  HasOnlyReadOnly,
+  HealthCheckResult,
+  InlineResponseDefault,
+  MapTest,
+  MixedPropertiesAndAdditionalPropertiesClass,
+  Model200Response,
+  ModelClient,
+  ModelEnumClass,
+  ModelFile,
+  ModelList,
+  ModelReturn,
+  Name,
+  NullableClass,
+  NumberOnly,
+  Order,
+  OuterComposite,
+  OuterEnum,
+  OuterEnumDefaultValue,
+  OuterEnumInteger,
+  OuterEnumIntegerDefaultValue,
+  Pet,
+  ReadOnlyFirst,
+  SpecialModelName,
+  Tag,
+  User,
 ])
-
-//allow all models to be serialized within a list
 Serializers serializers = (_$serializers.toBuilder()
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(AdditionalPropertiesClass)]),
-() => new ListBuilder<AdditionalPropertiesClass>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Animal)]),
-() => new ListBuilder<Animal>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ApiResponse)]),
-() => new ListBuilder<ApiResponse>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ArrayOfArrayOfNumberOnly)]),
-() => new ListBuilder<ArrayOfArrayOfNumberOnly>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ArrayOfNumberOnly)]),
-() => new ListBuilder<ArrayOfNumberOnly>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ArrayTest)]),
-() => new ListBuilder<ArrayTest>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Capitalization)]),
-() => new ListBuilder<Capitalization>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Cat)]),
-() => new ListBuilder<Cat>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(CatAllOf)]),
-() => new ListBuilder<CatAllOf>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Category)]),
-() => new ListBuilder<Category>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ClassModel)]),
-() => new ListBuilder<ClassModel>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Dog)]),
-() => new ListBuilder<Dog>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(DogAllOf)]),
-() => new ListBuilder<DogAllOf>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(EnumArrays)]),
-() => new ListBuilder<EnumArrays>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(EnumTest)]),
-() => new ListBuilder<EnumTest>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(FileSchemaTestClass)]),
-() => new ListBuilder<FileSchemaTestClass>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Foo)]),
-() => new ListBuilder<Foo>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(FormatTest)]),
-() => new ListBuilder<FormatTest>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(HasOnlyReadOnly)]),
-() => new ListBuilder<HasOnlyReadOnly>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(HealthCheckResult)]),
-() => new ListBuilder<HealthCheckResult>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(InlineResponseDefault)]),
-() => new ListBuilder<InlineResponseDefault>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(MapTest)]),
-() => new ListBuilder<MapTest>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(MixedPropertiesAndAdditionalPropertiesClass)]),
-() => new ListBuilder<MixedPropertiesAndAdditionalPropertiesClass>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Model200Response)]),
-() => new ListBuilder<Model200Response>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ModelClient)]),
-() => new ListBuilder<ModelClient>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ModelEnumClass)]),
-() => new ListBuilder<ModelEnumClass>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ModelFile)]),
-() => new ListBuilder<ModelFile>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ModelList)]),
-() => new ListBuilder<ModelList>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ModelReturn)]),
-() => new ListBuilder<ModelReturn>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Name)]),
-() => new ListBuilder<Name>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(NullableClass)]),
-() => new ListBuilder<NullableClass>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(NumberOnly)]),
-() => new ListBuilder<NumberOnly>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Order)]),
-() => new ListBuilder<Order>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(OuterComposite)]),
-() => new ListBuilder<OuterComposite>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(OuterEnum)]),
-() => new ListBuilder<OuterEnum>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(OuterEnumDefaultValue)]),
-() => new ListBuilder<OuterEnumDefaultValue>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(OuterEnumInteger)]),
-() => new ListBuilder<OuterEnumInteger>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(OuterEnumIntegerDefaultValue)]),
-() => new ListBuilder<OuterEnumIntegerDefaultValue>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Pet)]),
-() => new ListBuilder<Pet>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(ReadOnlyFirst)]),
-() => new ListBuilder<ReadOnlyFirst>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(SpecialModelName)]),
-() => new ListBuilder<SpecialModelName>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(Tag)]),
-() => new ListBuilder<Tag>())
-..addBuilderFactory(
-const FullType(BuiltList, const [const FullType(User)]),
-() => new ListBuilder<User>())
-
-..add(Iso8601DateTimeSerializer())
-).build();
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(String)]),
+        () => MapBuilder<String, String>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(Pet)]),
+        () => ListBuilder<Pet>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltMap, [FullType(String), FullType(int)]),
+        () => MapBuilder<String, int>(),
+      )
+      ..addBuilderFactory(
+        const FullType(BuiltList, [FullType(User)]),
+        () => ListBuilder<User>(),
+      )
+      ..add(Iso8601DateTimeSerializer()))
+    .build();
 
 Serializers standardSerializers =
-(serializers.toBuilder()
-..addPlugin(StandardJsonPlugin())).build();
+    (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();


### PR DESCRIPTION
* only generate actually used serializers (anything used in body or response)
* generate previously missing serializers for collection types
* improve formatting

Fixes https://github.com/OpenAPITools/openapi-generator/issues/8270
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)