### PR TITLE
[bug][dart][dart-dio] Fix serialization of map body params

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -77,11 +77,17 @@ class {{classname}} {
         {{/hasFormParams}}
         {{#bodyParam}}
 
+        {{#isContainer}}
         {{#isArray}}
         const type = FullType(BuiltList, [FullType({{baseType}})]);
         final serializedBody = _serializers.serialize({{paramName}}, specifiedType: type);
         {{/isArray}}
-        {{^isArray}}
+        {{#isMap}}
+        const type = FullType(BuiltMap, [FullType(String), FullType({{baseType}})]);
+        final serializedBody = _serializers.serialize({{paramName}}, specifiedType: type);
+        {{/isMap}}
+        {{/isContainer}}
+        {{^isContainer}}
         {{#isPrimitiveType}}
         var serializedBody = {{paramName}};
         {{/isPrimitiveType}}
@@ -89,7 +95,7 @@ class {{classname}} {
         final bodySerializer = _serializers.serializerForType({{{baseType}}}) as Serializer<{{{baseType}}}>;
         final serializedBody = _serializers.serializeWith(bodySerializer, {{paramName}});
         {{/isPrimitiveType}}
-        {{/isArray}}
+        {{/isContainer}}
         final json{{paramName}} = json.encode(serializedBody);
         bodyData = json{{paramName}};
         {{/bodyParam}}

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -814,8 +814,8 @@ class FakeApi {
             'application/json',
         ];
 
-        final bodySerializer = _serializers.serializerForType(String) as Serializer<String>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, requestBody);
+        const type = FullType(BuiltMap, [FullType(String), FullType(String)]);
+        final serializedBody = _serializers.serialize(requestBody, specifiedType: type);
         final jsonrequestBody = json.encode(serializedBody);
         bodyData = jsonrequestBody;
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes cases where the request body is a map.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)