### PR TITLE
[GO]Change go bytearray typemapping

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -118,7 +118,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         typeMapping.put("File", "*os.File");
         typeMapping.put("file", "*os.File");
         typeMapping.put("binary", "*os.File");
-        typeMapping.put("ByteArray", "string");
+        typeMapping.put("ByteArray", "[]byte");
         typeMapping.put("null", "nil");
         // A 'type: object' OAS schema without any declared property is
         // (per JSON schema specification) "an unordered set of properties

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -1129,7 +1129,7 @@ type ApiTestEndpointParametersRequest struct {
 	number *float32
 	double *float64
 	patternWithoutDelimiter *string
-	byte_ *string
+	byte_ *[]byte
 	integer *int32
 	int32_ *int32
 	int64_ *int64
@@ -1154,7 +1154,7 @@ func (r ApiTestEndpointParametersRequest) PatternWithoutDelimiter(patternWithout
 	r.patternWithoutDelimiter = &patternWithoutDelimiter
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Byte_(byte_ string) ApiTestEndpointParametersRequest {
+func (r ApiTestEndpointParametersRequest) Byte_(byte_ []byte) ApiTestEndpointParametersRequest {
 	r.byte_ = &byte_
 	return r
 }

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -568,7 +568,7 @@ func main() {
     number := float32(8.14) // float32 | None
     double := float64(1.2) // float64 | None
     patternWithoutDelimiter := "patternWithoutDelimiter_example" // string | None
-    byte_ := string(BYTE_ARRAY_DATA_HERE) // string | None
+    byte_ := []byte(BYTE_ARRAY_DATA_HERE) // []byte | None
     integer := int32(56) // int32 | None (optional)
     int32_ := int32(56) // int32 | None (optional)
     int64_ := int64(789) // int64 | None (optional)
@@ -604,7 +604,7 @@ Name | Type | Description  | Notes
  **number** | **float32** | None | 
  **double** | **float64** | None | 
  **patternWithoutDelimiter** | **string** | None | 
- **byte_** | **string** | None | 
+ **byte_** | **[]byte** | None | 
  **integer** | **int32** | None | 
  **int32_** | **int32** | None | 
  **int64_** | **int64** | None | 

--- a/samples/client/petstore/go/go-petstore/docs/FormatTest.md
+++ b/samples/client/petstore/go/go-petstore/docs/FormatTest.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **Float** | Pointer to **float32** |  | [optional] 
 **Double** | Pointer to **float64** |  | [optional] 
 **String** | Pointer to **string** |  | [optional] 
-**Byte** | **string** |  | 
+**Byte** | [**[]byte**]([]byte.md) |  | 
 **Binary** | Pointer to ***os.File** |  | [optional] 
 **Date** | **string** |  | 
 **DateTime** | Pointer to **time.Time** |  | [optional] 
@@ -23,7 +23,7 @@ Name | Type | Description | Notes
 
 ### NewFormatTest
 
-`func NewFormatTest(number float32, byte_ string, date string, password string, ) *FormatTest`
+`func NewFormatTest(number float32, byte_ []byte, date string, password string, ) *FormatTest`
 
 NewFormatTest instantiates a new FormatTest object
 This constructor will assign default values to properties that have it defined,
@@ -210,20 +210,20 @@ HasString returns a boolean if a field has been set.
 
 ### GetByte
 
-`func (o *FormatTest) GetByte() string`
+`func (o *FormatTest) GetByte() []byte`
 
 GetByte returns the Byte field if non-nil, zero value otherwise.
 
 ### GetByteOk
 
-`func (o *FormatTest) GetByteOk() (*string, bool)`
+`func (o *FormatTest) GetByteOk() (*[]byte, bool)`
 
 GetByteOk returns a tuple with the Byte field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetByte
 
-`func (o *FormatTest) SetByte(v string)`
+`func (o *FormatTest) SetByte(v []byte)`
 
 SetByte sets Byte field to given value.
 

--- a/samples/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_format_test_.go
@@ -25,7 +25,7 @@ type FormatTest struct {
 	Float *float32 `json:"float,omitempty"`
 	Double *float64 `json:"double,omitempty"`
 	String *string `json:"string,omitempty"`
-	Byte string `json:"byte"`
+	Byte []byte `json:"byte"`
 	Binary **os.File `json:"binary,omitempty"`
 	Date string `json:"date"`
 	DateTime *time.Time `json:"dateTime,omitempty"`
@@ -38,7 +38,7 @@ type FormatTest struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewFormatTest(number float32, byte_ string, date string, password string, ) *FormatTest {
+func NewFormatTest(number float32, byte_ []byte, date string, password string, ) *FormatTest {
 	this := FormatTest{}
 	this.Number = number
 	this.Byte = byte_
@@ -272,9 +272,9 @@ func (o *FormatTest) SetString(v string) {
 }
 
 // GetByte returns the Byte field value
-func (o *FormatTest) GetByte() string {
+func (o *FormatTest) GetByte() []byte {
 	if o == nil  {
-		var ret string
+		var ret []byte
 		return ret
 	}
 
@@ -283,7 +283,7 @@ func (o *FormatTest) GetByte() string {
 
 // GetByteOk returns a tuple with the Byte field value
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetByteOk() (*string, bool) {
+func (o *FormatTest) GetByteOk() (*[]byte, bool) {
 	if o == nil  {
 		return nil, false
 	}
@@ -291,7 +291,7 @@ func (o *FormatTest) GetByteOk() (*string, bool) {
 }
 
 // SetByte sets field value
-func (o *FormatTest) SetByte(v string) {
+func (o *FormatTest) SetByte(v []byte) {
 	o.Byte = v
 }
 

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
@@ -1129,7 +1129,7 @@ type ApiTestEndpointParametersRequest struct {
 	number *float32
 	double *float64
 	patternWithoutDelimiter *string
-	byte_ *string
+	byte_ *[]byte
 	integer *int32
 	int32_ *int32
 	int64_ *int64
@@ -1154,7 +1154,7 @@ func (r ApiTestEndpointParametersRequest) PatternWithoutDelimiter(patternWithout
 	r.patternWithoutDelimiter = &patternWithoutDelimiter
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Byte_(byte_ string) ApiTestEndpointParametersRequest {
+func (r ApiTestEndpointParametersRequest) Byte_(byte_ []byte) ApiTestEndpointParametersRequest {
 	r.byte_ = &byte_
 	return r
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -563,7 +563,7 @@ func main() {
     number := float32(8.14) // float32 | None
     double := float64(1.2) // float64 | None
     patternWithoutDelimiter := "patternWithoutDelimiter_example" // string | None
-    byte_ := string(BYTE_ARRAY_DATA_HERE) // string | None
+    byte_ := []byte(BYTE_ARRAY_DATA_HERE) // []byte | None
     integer := int32(56) // int32 | None (optional)
     int32_ := int32(56) // int32 | None (optional)
     int64_ := int64(789) // int64 | None (optional)
@@ -599,7 +599,7 @@ Name | Type | Description  | Notes
  **number** | **float32** | None | 
  **double** | **float64** | None | 
  **patternWithoutDelimiter** | **string** | None | 
- **byte_** | **string** | None | 
+ **byte_** | **[]byte** | None | 
  **integer** | **int32** | None | 
  **int32_** | **int32** | None | 
  **int64_** | **int64** | None | 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FormatTest.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **Float** | Pointer to **float32** |  | [optional] 
 **Double** | Pointer to **float64** |  | [optional] 
 **String** | Pointer to **string** |  | [optional] 
-**Byte** | **string** |  | 
+**Byte** | [**[]byte**]([]byte.md) |  | 
 **Binary** | Pointer to ***os.File** |  | [optional] 
 **Date** | **string** |  | 
 **DateTime** | Pointer to **time.Time** |  | [optional] 
@@ -24,7 +24,7 @@ Name | Type | Description | Notes
 
 ### NewFormatTest
 
-`func NewFormatTest(number float32, byte_ string, date string, password string, ) *FormatTest`
+`func NewFormatTest(number float32, byte_ []byte, date string, password string, ) *FormatTest`
 
 NewFormatTest instantiates a new FormatTest object
 This constructor will assign default values to properties that have it defined,
@@ -211,20 +211,20 @@ HasString returns a boolean if a field has been set.
 
 ### GetByte
 
-`func (o *FormatTest) GetByte() string`
+`func (o *FormatTest) GetByte() []byte`
 
 GetByte returns the Byte field if non-nil, zero value otherwise.
 
 ### GetByteOk
 
-`func (o *FormatTest) GetByteOk() (*string, bool)`
+`func (o *FormatTest) GetByteOk() (*[]byte, bool)`
 
 GetByteOk returns a tuple with the Byte field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetByte
 
-`func (o *FormatTest) SetByte(v string)`
+`func (o *FormatTest) SetByte(v []byte)`
 
 SetByte sets Byte field to given value.
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
@@ -25,7 +25,7 @@ type FormatTest struct {
 	Float *float32 `json:"float,omitempty"`
 	Double *float64 `json:"double,omitempty"`
 	String *string `json:"string,omitempty"`
-	Byte string `json:"byte"`
+	Byte []byte `json:"byte"`
 	Binary **os.File `json:"binary,omitempty"`
 	Date string `json:"date"`
 	DateTime *time.Time `json:"dateTime,omitempty"`
@@ -44,7 +44,7 @@ type _FormatTest FormatTest
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewFormatTest(number float32, byte_ string, date string, password string, ) *FormatTest {
+func NewFormatTest(number float32, byte_ []byte, date string, password string, ) *FormatTest {
 	this := FormatTest{}
 	this.Number = number
 	this.Byte = byte_
@@ -278,9 +278,9 @@ func (o *FormatTest) SetString(v string) {
 }
 
 // GetByte returns the Byte field value
-func (o *FormatTest) GetByte() string {
+func (o *FormatTest) GetByte() []byte {
 	if o == nil  {
-		var ret string
+		var ret []byte
 		return ret
 	}
 
@@ -289,7 +289,7 @@ func (o *FormatTest) GetByte() string {
 
 // GetByteOk returns a tuple with the Byte field value
 // and a boolean to check if the value has been set.
-func (o *FormatTest) GetByteOk() (*string, bool) {
+func (o *FormatTest) GetByteOk() (*[]byte, bool) {
 	if o == nil  {
 		return nil, false
 	}
@@ -297,7 +297,7 @@ func (o *FormatTest) GetByteOk() (*string, bool) {
 }
 
 // SetByte sets field value
-func (o *FormatTest) SetByte(v string) {
+func (o *FormatTest) SetByte(v []byte) {
 	o.Byte = v
 }
 


### PR DESCRIPTION
Breaking changes in generated golang models 
Sorry for the bait and switch on the other RP, but i messed up my merging and wanted to correct it.
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
### Details
#### Changes
- Changes golang typeMapping item `byteArray` from `String` to `[]byte`
#### Verification
- Line 28 in model_format_test_.go
#### Impact
- The following openapi-model would change resulting golang type from `String` to `[]byte`
```
components:
  schemas:
    foo:
       type: string
       format: byte
```
Before:
```
Foo String `json:"foo"` 
```
After:
```
Foo []byte `json:"foo"`
```
#### Reviewers
@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01)
#### Resolves
Issue: https://github.com/OpenAPITools/openapi-generator/issues/8351
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run 
  ```
  mvn clean package
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  to update all Petstore samples related to your fix. 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
