### PR TITLE
[typescript-angular] Fix configuration import in apiInterface.mustache when the configurationPrefix option is used

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/apiInterface.mustache
@@ -8,7 +8,7 @@ import { {{classname}} } from '../model/models';
 {{/imports}}
 
 
-import { Configuration }                                     from '../configuration';
+import { {{configurationClassName}} }                                     from '../configuration';
 
 {{#operations}}
 


### PR DESCRIPTION
Adjusted the configuration import in the ApiInterface, so it imports the correct class name (including the configurationPrefix), instead of statically importing 'Configuration'.

Fixes #8415 

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [ ] Run 
  ```
  mvn clean package
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  to update all Petstore samples related to your fix. 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
