### PR TITLE
Revert "[GO][Client] return GenericOpenAPIError instead of error in Execute() (#8137)"

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -3,7 +3,6 @@ package {{packageName}}
 
 {{#operations}}
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -36,7 +35,7 @@ type {{classname}} interface {
 	 * {{nickname}}Execute executes the request{{#returnType}}
 	 * @return {{{.}}}{{/returnType}}
 	 */
-	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, GenericOpenAPIError)
+	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error)
 	{{/operation}}
 }
 {{/generateInterfaces}}
@@ -61,7 +60,7 @@ func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Reques
 	return r
 }{{/isPathParam}}{{/allParams}}
 
-func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, GenericOpenAPIError) {
+func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
 	return r.ApiService.{{nickname}}Execute(r)
 }
 
@@ -86,14 +85,13 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#pathParam
  * Execute executes the request{{#returnType}}
  * @return {{{.}}}{{/returnType}}
  */
-func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, GenericOpenAPIError) {
+func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.Method{{httpMethod}}
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		{{#returnType}}
 		localVarReturnValue  {{{.}}}
 		{{/returnType}}
@@ -101,8 +99,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "{{{classname}}}Service.{{{nickname}}}")
 	if err != nil {
-		executionError.error = err.Error()
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "{{{path}}}"{{#pathParams}}
@@ -115,32 +112,27 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{#required}}
 	{{^isPathParam}}
 	if r.{{paramName}} == nil {
-		executionError.error = "{{paramName}} is required and must be specified"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} is required and must be specified")
 	}
 	{{/isPathParam}}
 	{{#minItems}}
 	if len({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) < {{minItems}} {
-		executionError.error = "{{paramName}} must have at least {{minItems}} elements"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minItems}} elements")
 	}
 	{{/minItems}}
 	{{#maxItems}}
 	if len({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) > {{maxItems}} {
-		executionError.error = "{{paramName}} must have less than {{maxItems}} elements"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxItems}} elements")
 	}
 	{{/maxItems}}
 	{{#minLength}}
 	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) < {{minLength}} {
-		executionError.error = "{{paramName}} must have at least {{minLength}} elements"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minLength}} elements")
 	}
 	{{/minLength}}
 	{{#maxLength}}
 	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) > {{maxLength}} {
-		executionError.error = "{{paramName}} must have less than {{maxLength}} elements"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxLength}} elements")
 	}
 	{{/maxLength}}
 	{{#minimum}}
@@ -151,8 +143,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{^isString}}
 	if {{^isPathParam}}*{{/isPathParam}}r.{{paramName}} < {{minimum}} {
 	{{/isString}}
-		executionError.error = "{{paramName}} must be greater than {{minimum}}"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be greater than {{minimum}}")
 	}
 	{{/minimum}}
 	{{#maximum}}
@@ -163,8 +154,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{^isString}}
 	if {{^isPathParam}}*{{/isPathParam}}r.{{paramName}} > {{maximum}} {
 	{{/isString}}
-		executionError.error = "{{paramName}} must be less than {{maximum}}"
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be less than {{maximum}}")
 	}
 	{{/maximum}}
 	{{/required}}
@@ -267,8 +257,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	if r.{{paramName}} != nil {
 		paramJson, err := parameterToJson(*r.{{paramName}})
 		if err != nil {
-			executionError.error = err.Error()
-			return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+			return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
 		}
 		localVarFormParams.Add("{{baseName}}", paramJson)
 	}
@@ -323,22 +312,18 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 {{/authMethods}}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, executionError
+		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -384,7 +369,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 
 	{{/returnType}}
-	return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, executionError
+	return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, nil
 }
 {{/operation}}
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/go/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api_doc.mustache
@@ -43,7 +43,7 @@ func main() {
     configuration := {{goImportAlias}}.NewConfiguration()
     api_client := {{goImportAlias}}.NewAPIClient(configuration)
     resp, r, err := api_client.{{classname}}.{{operationId}}(context.Background(){{#pathParams}}, {{paramName}}{{/pathParams}}){{#allParams}}{{^isPathParam}}.{{vendorExtensions.x-export-param-name}}({{paramName}}){{/isPathParam}}{{/allParams}}.Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `{{classname}}.{{operationId}}``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/auth_test.go
+++ b/samples/client/petstore/go/auth_test.go
@@ -43,7 +43,7 @@ func TestOAuth2(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -52,7 +52,7 @@ func TestOAuth2(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -78,7 +78,7 @@ func TestBasicAuth(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(auth).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -87,7 +87,7 @@ func TestBasicAuth(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -108,7 +108,7 @@ func TestAccessToken(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(nil).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -117,7 +117,7 @@ func TestAccessToken(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -138,7 +138,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -146,7 +146,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 	}
 
 	_, r, err = client.PetApi.GetPetById(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 
@@ -156,7 +156,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 	}
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -173,7 +173,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(nil).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -181,7 +181,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 	}
 
 	_, r, err = client.PetApi.GetPetById(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 
@@ -191,7 +191,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 	}
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -206,7 +206,7 @@ func TestDefaultHeader(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -215,7 +215,7 @@ func TestDefaultHeader(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(context.Background(), 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -230,7 +230,7 @@ func TestDefaultHeader(t *testing.T) {
 func TestHostOverride(t *testing.T) {
 	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while finding pets by status: %v", err)
 	}
 
@@ -242,7 +242,7 @@ func TestHostOverride(t *testing.T) {
 func TestSchemeOverride(t *testing.T) {
 	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while finding pets by status: %v", err)
 	}
 

--- a/samples/client/petstore/go/fake_api_test.go
+++ b/samples/client/petstore/go/fake_api_test.go
@@ -19,7 +19,7 @@ func TestPutBodyWithFileSchema(t *testing.T) {
 
 	r, err := client.FakeApi.TestBodyWithFileSchema(context.Background()).Body(schema).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {

--- a/samples/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_another_fake.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -37,7 +36,7 @@ type AnotherFakeApi interface {
 	 * Call123TestSpecialTagsExecute executes the request
 	 * @return Client
 	 */
-	Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, GenericOpenAPIError)
+	Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, error)
 }
 
 // AnotherFakeApiService AnotherFakeApi service
@@ -54,7 +53,7 @@ func (r ApiCall123TestSpecialTagsRequest) Body(body Client) ApiCall123TestSpecia
 	return r
 }
 
-func (r ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, error) {
 	return r.ApiService.Call123TestSpecialTagsExecute(r)
 }
 
@@ -75,21 +74,19 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context) Api
  * Execute executes the request
  * @return Client
  */
-func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Client
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AnotherFakeApiService.Call123TestSpecialTags")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/another-fake/dummy"
@@ -98,8 +95,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -123,22 +119,18 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -158,5 +150,5 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -39,7 +38,7 @@ type FakeApi interface {
 	/*
 	 * CreateXmlItemExecute executes the request
 	 */
-	CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_nethttp.Response, error)
 
 	/*
 	 * FakeOuterBooleanSerialize Method for FakeOuterBooleanSerialize
@@ -53,7 +52,7 @@ type FakeApi interface {
 	 * FakeOuterBooleanSerializeExecute executes the request
 	 * @return bool
 	 */
-	FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterCompositeSerialize Method for FakeOuterCompositeSerialize
@@ -67,7 +66,7 @@ type FakeApi interface {
 	 * FakeOuterCompositeSerializeExecute executes the request
 	 * @return OuterComposite
 	 */
-	FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterNumberSerialize Method for FakeOuterNumberSerialize
@@ -81,7 +80,7 @@ type FakeApi interface {
 	 * FakeOuterNumberSerializeExecute executes the request
 	 * @return float32
 	 */
-	FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterStringSerialize Method for FakeOuterStringSerialize
@@ -95,7 +94,7 @@ type FakeApi interface {
 	 * FakeOuterStringSerializeExecute executes the request
 	 * @return string
 	 */
-	FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, error)
 
 	/*
 	 * TestBodyWithFileSchema Method for TestBodyWithFileSchema
@@ -108,7 +107,7 @@ type FakeApi interface {
 	/*
 	 * TestBodyWithFileSchemaExecute executes the request
 	 */
-	TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestBodyWithQueryParams Method for TestBodyWithQueryParams
@@ -120,7 +119,7 @@ type FakeApi interface {
 	/*
 	 * TestBodyWithQueryParamsExecute executes the request
 	 */
-	TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestClientModel To test \"client\" model
@@ -134,7 +133,7 @@ type FakeApi interface {
 	 * TestClientModelExecute executes the request
 	 * @return Client
 	 */
-	TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, GenericOpenAPIError)
+	TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, error)
 
 	/*
 	 * TestEndpointParameters Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -150,7 +149,7 @@ type FakeApi interface {
 	/*
 	 * TestEndpointParametersExecute executes the request
 	 */
-	TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestEnumParameters To test enum parameters
@@ -163,7 +162,7 @@ type FakeApi interface {
 	/*
 	 * TestEnumParametersExecute executes the request
 	 */
-	TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestGroupParameters Fake endpoint to test group parameters (optional)
@@ -176,7 +175,7 @@ type FakeApi interface {
 	/*
 	 * TestGroupParametersExecute executes the request
 	 */
-	TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestInlineAdditionalProperties test inline additionalProperties
@@ -188,7 +187,7 @@ type FakeApi interface {
 	/*
 	 * TestInlineAdditionalPropertiesExecute executes the request
 	 */
-	TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestJsonFormData test json serialization of form data
@@ -200,7 +199,7 @@ type FakeApi interface {
 	/*
 	 * TestJsonFormDataExecute executes the request
 	 */
-	TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestQueryParameterCollectionFormat Method for TestQueryParameterCollectionFormat
@@ -213,7 +212,7 @@ type FakeApi interface {
 	/*
 	 * TestQueryParameterCollectionFormatExecute executes the request
 	 */
-	TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, error)
 }
 
 // FakeApiService FakeApi service
@@ -230,7 +229,7 @@ func (r ApiCreateXmlItemRequest) XmlItem(xmlItem XmlItem) ApiCreateXmlItemReques
 	return r
 }
 
-func (r ApiCreateXmlItemRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateXmlItemRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateXmlItemExecute(r)
 }
 
@@ -250,20 +249,18 @@ func (a *FakeApiService) CreateXmlItem(ctx _context.Context) ApiCreateXmlItemReq
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.CreateXmlItem")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/create_xml_item"
@@ -272,8 +269,7 @@ func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_neth
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.xmlItem == nil {
-		executionError.error = "xmlItem is required and must be specified"
-		return nil, executionError
+		return nil, reportError("xmlItem is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -297,22 +293,18 @@ func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_neth
 	localVarPostBody = r.xmlItem
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -323,7 +315,7 @@ func (a *FakeApiService) CreateXmlItemExecute(r ApiCreateXmlItemRequest) (*_neth
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterBooleanSerializeRequest struct {
@@ -337,7 +329,7 @@ func (r ApiFakeOuterBooleanSerializeRequest) Body(body bool) ApiFakeOuterBoolean
 	return r
 }
 
-func (r ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterBooleanSerializeExecute(r)
 }
 
@@ -358,21 +350,19 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context) ApiFake
  * Execute executes the request
  * @return bool
  */
-func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  bool
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterBooleanSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/boolean"
@@ -402,22 +392,18 @@ func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanS
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -437,7 +423,7 @@ func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanS
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterCompositeSerializeRequest struct {
@@ -451,7 +437,7 @@ func (r ApiFakeOuterCompositeSerializeRequest) Body(body OuterComposite) ApiFake
 	return r
 }
 
-func (r ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterCompositeSerializeExecute(r)
 }
 
@@ -472,21 +458,19 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context) ApiFa
  * Execute executes the request
  * @return OuterComposite
  */
-func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  OuterComposite
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterCompositeSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/composite"
@@ -516,22 +500,18 @@ func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompos
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -551,7 +531,7 @@ func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompos
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterNumberSerializeRequest struct {
@@ -565,7 +545,7 @@ func (r ApiFakeOuterNumberSerializeRequest) Body(body float32) ApiFakeOuterNumbe
 	return r
 }
 
-func (r ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterNumberSerializeExecute(r)
 }
 
@@ -586,21 +566,19 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context) ApiFakeO
  * Execute executes the request
  * @return float32
  */
-func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  float32
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterNumberSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/number"
@@ -630,22 +608,18 @@ func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSer
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -665,7 +639,7 @@ func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSer
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterStringSerializeRequest struct {
@@ -679,7 +653,7 @@ func (r ApiFakeOuterStringSerializeRequest) Body(body string) ApiFakeOuterString
 	return r
 }
 
-func (r ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterStringSerializeExecute(r)
 }
 
@@ -700,21 +674,19 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context) ApiFakeO
  * Execute executes the request
  * @return string
  */
-func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  string
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterStringSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/string"
@@ -744,22 +716,18 @@ func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSer
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -779,7 +747,7 @@ func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSer
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiTestBodyWithFileSchemaRequest struct {
@@ -793,7 +761,7 @@ func (r ApiTestBodyWithFileSchemaRequest) Body(body FileSchemaTestClass) ApiTest
 	return r
 }
 
-func (r ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestBodyWithFileSchemaExecute(r)
 }
 
@@ -813,20 +781,18 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context) ApiTestBod
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestBodyWithFileSchema")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/body-with-file-schema"
@@ -835,8 +801,7 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -860,22 +825,18 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -886,7 +847,7 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestBodyWithQueryParamsRequest struct {
@@ -905,7 +866,7 @@ func (r ApiTestBodyWithQueryParamsRequest) Body(body User) ApiTestBodyWithQueryP
 	return r
 }
 
-func (r ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestBodyWithQueryParamsExecute(r)
 }
 
@@ -924,20 +885,18 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context) ApiTestBo
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestBodyWithQueryParams")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/body-with-query-params"
@@ -946,12 +905,10 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.query == nil {
-		executionError.error = "query is required and must be specified"
-		return nil, executionError
+		return nil, reportError("query is required and must be specified")
 	}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	localVarQueryParams.Add("query", parameterToString(*r.query, ""))
@@ -976,22 +933,18 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1002,7 +955,7 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestClientModelRequest struct {
@@ -1016,7 +969,7 @@ func (r ApiTestClientModelRequest) Body(body Client) ApiTestClientModelRequest {
 	return r
 }
 
-func (r ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error) {
 	return r.ApiService.TestClientModelExecute(r)
 }
 
@@ -1037,21 +990,19 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context) ApiTestClientMode
  * Execute executes the request
  * @return Client
  */
-func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Client
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestClientModel")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1060,8 +1011,7 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1085,22 +1035,18 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1120,7 +1066,7 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiTestEndpointParametersRequest struct {
@@ -1199,7 +1145,7 @@ func (r ApiTestEndpointParametersRequest) Callback(callback string) ApiTestEndpo
 	return r
 }
 
-func (r ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestEndpointParametersExecute(r)
 }
 
@@ -1222,20 +1168,18 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context) ApiTestEnd
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestEndpointParameters")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1244,36 +1188,28 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.number == nil {
-		executionError.error = "number is required and must be specified"
-		return nil, executionError
+		return nil, reportError("number is required and must be specified")
 	}
 	if *r.number < 32.1 {
-		executionError.error = "number must be greater than 32.1"
-		return nil, executionError
+		return nil, reportError("number must be greater than 32.1")
 	}
 	if *r.number > 543.2 {
-		executionError.error = "number must be less than 543.2"
-		return nil, executionError
+		return nil, reportError("number must be less than 543.2")
 	}
 	if r.double == nil {
-		executionError.error = "double is required and must be specified"
-		return nil, executionError
+		return nil, reportError("double is required and must be specified")
 	}
 	if *r.double < 67.8 {
-		executionError.error = "double must be greater than 67.8"
-		return nil, executionError
+		return nil, reportError("double must be greater than 67.8")
 	}
 	if *r.double > 123.4 {
-		executionError.error = "double must be less than 123.4"
-		return nil, executionError
+		return nil, reportError("double must be less than 123.4")
 	}
 	if r.patternWithoutDelimiter == nil {
-		executionError.error = "patternWithoutDelimiter is required and must be specified"
-		return nil, executionError
+		return nil, reportError("patternWithoutDelimiter is required and must be specified")
 	}
 	if r.byte_ == nil {
-		executionError.error = "byte_ is required and must be specified"
-		return nil, executionError
+		return nil, reportError("byte_ is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1337,22 +1273,18 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1363,7 +1295,7 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestEnumParametersRequest struct {
@@ -1412,7 +1344,7 @@ func (r ApiTestEnumParametersRequest) EnumFormString(enumFormString string) ApiT
 	return r
 }
 
-func (r ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestEnumParametersExecute(r)
 }
 
@@ -1432,20 +1364,18 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context) ApiTestEnumPar
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestEnumParameters")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1497,22 +1427,18 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1523,7 +1449,7 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestGroupParametersRequest struct {
@@ -1562,7 +1488,7 @@ func (r ApiTestGroupParametersRequest) Int64Group(int64Group int64) ApiTestGroup
 	return r
 }
 
-func (r ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestGroupParametersExecute(r)
 }
 
@@ -1582,20 +1508,18 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context) ApiTestGroupP
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestGroupParameters")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1604,16 +1528,13 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.requiredStringGroup == nil {
-		executionError.error = "requiredStringGroup is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requiredStringGroup is required and must be specified")
 	}
 	if r.requiredBooleanGroup == nil {
-		executionError.error = "requiredBooleanGroup is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requiredBooleanGroup is required and must be specified")
 	}
 	if r.requiredInt64Group == nil {
-		executionError.error = "requiredInt64Group is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requiredInt64Group is required and must be specified")
 	}
 
 	localVarQueryParams.Add("required_string_group", parameterToString(*r.requiredStringGroup, ""))
@@ -1647,22 +1568,18 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1673,7 +1590,7 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestInlineAdditionalPropertiesRequest struct {
@@ -1687,7 +1604,7 @@ func (r ApiTestInlineAdditionalPropertiesRequest) Param(param map[string]string)
 	return r
 }
 
-func (r ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestInlineAdditionalPropertiesExecute(r)
 }
 
@@ -1706,20 +1623,18 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context) Ap
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestInlineAdditionalProperties")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/inline-additionalProperties"
@@ -1728,8 +1643,7 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.param == nil {
-		executionError.error = "param is required and must be specified"
-		return nil, executionError
+		return nil, reportError("param is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1753,22 +1667,18 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 	localVarPostBody = r.param
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1779,7 +1689,7 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestJsonFormDataRequest struct {
@@ -1798,7 +1708,7 @@ func (r ApiTestJsonFormDataRequest) Param2(param2 string) ApiTestJsonFormDataReq
 	return r
 }
 
-func (r ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestJsonFormDataExecute(r)
 }
 
@@ -1817,20 +1727,18 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context) ApiTestJsonFormD
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestJsonFormData")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/jsonFormData"
@@ -1839,12 +1747,10 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.param == nil {
-		executionError.error = "param is required and must be specified"
-		return nil, executionError
+		return nil, reportError("param is required and must be specified")
 	}
 	if r.param2 == nil {
-		executionError.error = "param2 is required and must be specified"
-		return nil, executionError
+		return nil, reportError("param2 is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1868,22 +1774,18 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 	localVarFormParams.Add("param2", parameterToString(*r.param2, ""))
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1894,7 +1796,7 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestQueryParameterCollectionFormatRequest struct {
@@ -1928,7 +1830,7 @@ func (r ApiTestQueryParameterCollectionFormatRequest) Context(context []string) 
 	return r
 }
 
-func (r ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestQueryParameterCollectionFormatExecute(r)
 }
 
@@ -1948,20 +1850,18 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestQueryParameterCollectionFormat")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/test-query-paramters"
@@ -1970,24 +1870,19 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.pipe == nil {
-		executionError.error = "pipe is required and must be specified"
-		return nil, executionError
+		return nil, reportError("pipe is required and must be specified")
 	}
 	if r.ioutil == nil {
-		executionError.error = "ioutil is required and must be specified"
-		return nil, executionError
+		return nil, reportError("ioutil is required and must be specified")
 	}
 	if r.http == nil {
-		executionError.error = "http is required and must be specified"
-		return nil, executionError
+		return nil, reportError("http is required and must be specified")
 	}
 	if r.url == nil {
-		executionError.error = "url is required and must be specified"
-		return nil, executionError
+		return nil, reportError("url is required and must be specified")
 	}
 	if r.context == nil {
-		executionError.error = "context is required and must be specified"
-		return nil, executionError
+		return nil, reportError("context is required and must be specified")
 	}
 
 	localVarQueryParams.Add("pipe", parameterToString(*r.pipe, "csv"))
@@ -2024,22 +1919,18 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -2050,5 +1941,5 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }

--- a/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -37,7 +36,7 @@ type FakeClassnameTags123Api interface {
 	 * TestClassnameExecute executes the request
 	 * @return Client
 	 */
-	TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, GenericOpenAPIError)
+	TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, error)
 }
 
 // FakeClassnameTags123ApiService FakeClassnameTags123Api service
@@ -54,7 +53,7 @@ func (r ApiTestClassnameRequest) Body(body Client) ApiTestClassnameRequest {
 	return r
 }
 
-func (r ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
 	return r.ApiService.TestClassnameExecute(r)
 }
 
@@ -75,21 +74,19 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context) Api
  * Execute executes the request
  * @return Client
  */
-func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Client
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeClassnameTags123ApiService.TestClassname")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake_classname_test"
@@ -98,8 +95,7 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -137,22 +133,18 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -172,5 +164,5 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/client/petstore/go/go-petstore/api_pet.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -37,7 +36,7 @@ type PetApi interface {
 	/*
 	 * AddPetExecute executes the request
 	 */
-	AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, GenericOpenAPIError)
+	AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, error)
 
 	/*
 	 * DeletePet Deletes a pet
@@ -50,7 +49,7 @@ type PetApi interface {
 	/*
 	 * DeletePetExecute executes the request
 	 */
-	DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, GenericOpenAPIError)
+	DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, error)
 
 	/*
 	 * FindPetsByStatus Finds Pets by status
@@ -64,7 +63,7 @@ type PetApi interface {
 	 * FindPetsByStatusExecute executes the request
 	 * @return []Pet
 	 */
-	FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError)
+	FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, error)
 
 	/*
 	 * FindPetsByTags Finds Pets by tags
@@ -78,7 +77,7 @@ type PetApi interface {
 	 * FindPetsByTagsExecute executes the request
 	 * @return []Pet
 	 */
-	FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError)
+	FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, error)
 
 	/*
 	 * GetPetById Find pet by ID
@@ -93,7 +92,7 @@ type PetApi interface {
 	 * GetPetByIdExecute executes the request
 	 * @return Pet
 	 */
-	GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, GenericOpenAPIError)
+	GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, error)
 
 	/*
 	 * UpdatePet Update an existing pet
@@ -105,7 +104,7 @@ type PetApi interface {
 	/*
 	 * UpdatePetExecute executes the request
 	 */
-	UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, GenericOpenAPIError)
+	UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, error)
 
 	/*
 	 * UpdatePetWithForm Updates a pet in the store with form data
@@ -118,7 +117,7 @@ type PetApi interface {
 	/*
 	 * UpdatePetWithFormExecute executes the request
 	 */
-	UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, GenericOpenAPIError)
+	UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, error)
 
 	/*
 	 * UploadFile uploads an image
@@ -132,7 +131,7 @@ type PetApi interface {
 	 * UploadFileExecute executes the request
 	 * @return ApiResponse
 	 */
-	UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError)
+	UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, error)
 
 	/*
 	 * UploadFileWithRequiredFile uploads an image (required)
@@ -146,7 +145,7 @@ type PetApi interface {
 	 * UploadFileWithRequiredFileExecute executes the request
 	 * @return ApiResponse
 	 */
-	UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError)
+	UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, error)
 }
 
 // PetApiService PetApi service
@@ -163,7 +162,7 @@ func (r ApiAddPetRequest) Body(body Pet) ApiAddPetRequest {
 	return r
 }
 
-func (r ApiAddPetRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiAddPetRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.AddPetExecute(r)
 }
 
@@ -182,20 +181,18 @@ func (a *PetApiService) AddPet(ctx _context.Context) ApiAddPetRequest {
 /*
  * Execute executes the request
  */
-func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.AddPet")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet"
@@ -204,8 +201,7 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, G
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -229,22 +225,18 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, G
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -255,7 +247,7 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, G
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiDeletePetRequest struct {
@@ -270,7 +262,7 @@ func (r ApiDeletePetRequest) ApiKey(apiKey string) ApiDeletePetRequest {
 	return r
 }
 
-func (r ApiDeletePetRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiDeletePetRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeletePetExecute(r)
 }
 
@@ -291,20 +283,18 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64) ApiDeletePe
 /*
  * Execute executes the request
  */
-func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.DeletePet")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
@@ -336,22 +326,18 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -362,7 +348,7 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiFindPetsByStatusRequest struct {
@@ -376,7 +362,7 @@ func (r ApiFindPetsByStatusRequest) Status(status []string) ApiFindPetsByStatusR
 	return r
 }
 
-func (r ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	return r.ApiService.FindPetsByStatusExecute(r)
 }
 
@@ -397,21 +383,19 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context) ApiFindPetsByStat
  * Execute executes the request
  * @return []Pet
  */
-func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  []Pet
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.FindPetsByStatus")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/findByStatus"
@@ -420,8 +404,7 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.status == nil {
-		executionError.error = "status is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("status is required and must be specified")
 	}
 
 	localVarQueryParams.Add("status", parameterToString(*r.status, "csv"))
@@ -444,22 +427,18 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -479,7 +458,7 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFindPetsByTagsRequest struct {
@@ -493,7 +472,7 @@ func (r ApiFindPetsByTagsRequest) Tags(tags []string) ApiFindPetsByTagsRequest {
 	return r
 }
 
-func (r ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	return r.ApiService.FindPetsByTagsExecute(r)
 }
 
@@ -514,21 +493,19 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context) ApiFindPetsByTagsRe
  * Execute executes the request
  * @return []Pet
  */
-func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  []Pet
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.FindPetsByTags")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/findByTags"
@@ -537,8 +514,7 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.tags == nil {
-		executionError.error = "tags is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("tags is required and must be specified")
 	}
 
 	localVarQueryParams.Add("tags", parameterToString(*r.tags, "csv"))
@@ -561,22 +537,18 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -596,7 +568,7 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetPetByIdRequest struct {
@@ -606,7 +578,7 @@ type ApiGetPetByIdRequest struct {
 }
 
 
-func (r ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
 	return r.ApiService.GetPetByIdExecute(r)
 }
 
@@ -629,21 +601,19 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) ApiGetPetB
  * Execute executes the request
  * @return Pet
  */
-func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Pet
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.GetPetById")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
@@ -686,22 +656,18 @@ func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethtt
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -721,7 +687,7 @@ func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethtt
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiUpdatePetRequest struct {
@@ -735,7 +701,7 @@ func (r ApiUpdatePetRequest) Body(body Pet) ApiUpdatePetRequest {
 	return r
 }
 
-func (r ApiUpdatePetRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.UpdatePetExecute(r)
 }
 
@@ -754,20 +720,18 @@ func (a *PetApiService) UpdatePet(ctx _context.Context) ApiUpdatePetRequest {
 /*
  * Execute executes the request
  */
-func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UpdatePet")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet"
@@ -776,8 +740,7 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -801,22 +764,18 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -827,7 +786,7 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiUpdatePetWithFormRequest struct {
@@ -847,7 +806,7 @@ func (r ApiUpdatePetWithFormRequest) Status(status string) ApiUpdatePetWithFormR
 	return r
 }
 
-func (r ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.UpdatePetWithFormExecute(r)
 }
 
@@ -868,20 +827,18 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64) Api
 /*
  * Execute executes the request
  */
-func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UpdatePetWithForm")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
@@ -916,22 +873,18 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -942,7 +895,7 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiUploadFileRequest struct {
@@ -962,7 +915,7 @@ func (r ApiUploadFileRequest) File(file *os.File) ApiUploadFileRequest {
 	return r
 }
 
-func (r ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
 	return r.ApiService.UploadFileExecute(r)
 }
 
@@ -984,21 +937,19 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64) ApiUploadF
  * Execute executes the request
  * @return ApiResponse
  */
-func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  ApiResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UploadFile")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}/uploadImage"
@@ -1041,22 +992,18 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1076,7 +1023,7 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiUploadFileWithRequiredFileRequest struct {
@@ -1096,7 +1043,7 @@ func (r ApiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetad
 	return r
 }
 
-func (r ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
 	return r.ApiService.UploadFileWithRequiredFileExecute(r)
 }
 
@@ -1118,21 +1065,19 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
  * Execute executes the request
  * @return ApiResponse
  */
-func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  ApiResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UploadFileWithRequiredFile")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/{petId}/uploadImageWithRequiredFile"
@@ -1142,8 +1087,7 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.requiredFile == nil {
-		executionError.error = "requiredFile is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("requiredFile is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1176,22 +1120,18 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1211,5 +1151,5 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/client/petstore/go/go-petstore/api_store.go
+++ b/samples/client/petstore/go/go-petstore/api_store.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -38,7 +37,7 @@ type StoreApi interface {
 	/*
 	 * DeleteOrderExecute executes the request
 	 */
-	DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, GenericOpenAPIError)
+	DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, error)
 
 	/*
 	 * GetInventory Returns pet inventories by status
@@ -52,7 +51,7 @@ type StoreApi interface {
 	 * GetInventoryExecute executes the request
 	 * @return map[string]int32
 	 */
-	GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, GenericOpenAPIError)
+	GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, error)
 
 	/*
 	 * GetOrderById Find purchase order by ID
@@ -67,7 +66,7 @@ type StoreApi interface {
 	 * GetOrderByIdExecute executes the request
 	 * @return Order
 	 */
-	GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, GenericOpenAPIError)
+	GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, error)
 
 	/*
 	 * PlaceOrder Place an order for a pet
@@ -80,7 +79,7 @@ type StoreApi interface {
 	 * PlaceOrderExecute executes the request
 	 * @return Order
 	 */
-	PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, GenericOpenAPIError)
+	PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, error)
 }
 
 // StoreApiService StoreApi service
@@ -93,7 +92,7 @@ type ApiDeleteOrderRequest struct {
 }
 
 
-func (r ApiDeleteOrderRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteOrderExecute(r)
 }
 
@@ -115,20 +114,18 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) ApiD
 /*
  * Execute executes the request
  */
-func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.DeleteOrder")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
@@ -157,22 +154,18 @@ func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -183,7 +176,7 @@ func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetInventoryRequest struct {
@@ -192,7 +185,7 @@ type ApiGetInventoryRequest struct {
 }
 
 
-func (r ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, error) {
 	return r.ApiService.GetInventoryExecute(r)
 }
 
@@ -213,21 +206,19 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) ApiGetInventoryRequ
  * Execute executes the request
  * @return map[string]int32
  */
-func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  map[string]int32
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.GetInventory")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/inventory"
@@ -269,22 +260,18 @@ func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[str
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -304,7 +291,7 @@ func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[str
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetOrderByIdRequest struct {
@@ -314,7 +301,7 @@ type ApiGetOrderByIdRequest struct {
 }
 
 
-func (r ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
 	return r.ApiService.GetOrderByIdExecute(r)
 }
 
@@ -337,21 +324,19 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) ApiG
  * Execute executes the request
  * @return Order
  */
-func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Order
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.GetOrderById")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
@@ -361,12 +346,10 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.orderId < 1 {
-		executionError.error = "orderId must be greater than 1"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("orderId must be greater than 1")
 	}
 	if r.orderId > 5 {
-		executionError.error = "orderId must be less than 5"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("orderId must be less than 5")
 	}
 
 	// to determine the Content-Type header
@@ -388,22 +371,18 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -423,7 +402,7 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPlaceOrderRequest struct {
@@ -437,7 +416,7 @@ func (r ApiPlaceOrderRequest) Body(body Order) ApiPlaceOrderRequest {
 	return r
 }
 
-func (r ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
 	return r.ApiService.PlaceOrderExecute(r)
 }
 
@@ -457,21 +436,19 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context) ApiPlaceOrderRequest 
  * Execute executes the request
  * @return Order
  */
-func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Order
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.PlaceOrder")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order"
@@ -480,8 +457,7 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -505,22 +481,18 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -540,5 +512,5 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/client/petstore/go/go-petstore/api_user.go
+++ b/samples/client/petstore/go/go-petstore/api_user.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -37,7 +36,7 @@ type UserApi interface {
 	/*
 	 * CreateUserExecute executes the request
 	 */
-	CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, error)
 
 	/*
 	 * CreateUsersWithArrayInput Creates list of users with given input array
@@ -49,7 +48,7 @@ type UserApi interface {
 	/*
 	 * CreateUsersWithArrayInputExecute executes the request
 	 */
-	CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, error)
 
 	/*
 	 * CreateUsersWithListInput Creates list of users with given input array
@@ -61,7 +60,7 @@ type UserApi interface {
 	/*
 	 * CreateUsersWithListInputExecute executes the request
 	 */
-	CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, error)
 
 	/*
 	 * DeleteUser Delete user
@@ -75,7 +74,7 @@ type UserApi interface {
 	/*
 	 * DeleteUserExecute executes the request
 	 */
-	DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, error)
 
 	/*
 	 * GetUserByName Get user by user name
@@ -89,7 +88,7 @@ type UserApi interface {
 	 * GetUserByNameExecute executes the request
 	 * @return User
 	 */
-	GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, GenericOpenAPIError)
+	GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, error)
 
 	/*
 	 * LoginUser Logs user into the system
@@ -102,7 +101,7 @@ type UserApi interface {
 	 * LoginUserExecute executes the request
 	 * @return string
 	 */
-	LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, GenericOpenAPIError)
+	LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, error)
 
 	/*
 	 * LogoutUser Logs out current logged in user session
@@ -114,7 +113,7 @@ type UserApi interface {
 	/*
 	 * LogoutUserExecute executes the request
 	 */
-	LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, error)
 
 	/*
 	 * UpdateUser Updated user
@@ -128,7 +127,7 @@ type UserApi interface {
 	/*
 	 * UpdateUserExecute executes the request
 	 */
-	UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, error)
 }
 
 // UserApiService UserApi service
@@ -145,7 +144,7 @@ func (r ApiCreateUserRequest) Body(body User) ApiCreateUserRequest {
 	return r
 }
 
-func (r ApiCreateUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateUserExecute(r)
 }
 
@@ -165,20 +164,18 @@ func (a *UserApiService) CreateUser(ctx _context.Context) ApiCreateUserRequest {
 /*
  * Execute executes the request
  */
-func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user"
@@ -187,8 +184,7 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -212,22 +208,18 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -238,7 +230,7 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiCreateUsersWithArrayInputRequest struct {
@@ -252,7 +244,7 @@ func (r ApiCreateUsersWithArrayInputRequest) Body(body []User) ApiCreateUsersWit
 	return r
 }
 
-func (r ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateUsersWithArrayInputExecute(r)
 }
 
@@ -271,20 +263,18 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context) ApiCrea
 /*
  * Execute executes the request
  */
-func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUsersWithArrayInput")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/createWithArray"
@@ -293,8 +283,7 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -318,22 +307,18 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -344,7 +329,7 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiCreateUsersWithListInputRequest struct {
@@ -358,7 +343,7 @@ func (r ApiCreateUsersWithListInputRequest) Body(body []User) ApiCreateUsersWith
 	return r
 }
 
-func (r ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateUsersWithListInputExecute(r)
 }
 
@@ -377,20 +362,18 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context) ApiCreat
 /*
  * Execute executes the request
  */
-func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUsersWithListInput")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/createWithList"
@@ -399,8 +382,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -424,22 +406,18 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -450,7 +428,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiDeleteUserRequest struct {
@@ -460,7 +438,7 @@ type ApiDeleteUserRequest struct {
 }
 
 
-func (r ApiDeleteUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteUserExecute(r)
 }
 
@@ -482,20 +460,18 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) ApiDe
 /*
  * Execute executes the request
  */
-func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.DeleteUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
@@ -524,22 +500,18 @@ func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Re
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -550,7 +522,7 @@ func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetUserByNameRequest struct {
@@ -560,7 +532,7 @@ type ApiGetUserByNameRequest struct {
 }
 
 
-func (r ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
 	return r.ApiService.GetUserByNameExecute(r)
 }
 
@@ -582,21 +554,19 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) Ap
  * Execute executes the request
  * @return User
  */
-func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  User
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.GetUserByName")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
@@ -625,22 +595,18 @@ func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -660,7 +626,7 @@ func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiLoginUserRequest struct {
@@ -679,7 +645,7 @@ func (r ApiLoginUserRequest) Password(password string) ApiLoginUserRequest {
 	return r
 }
 
-func (r ApiLoginUserRequest) Execute() (string, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
 	return r.ApiService.LoginUserExecute(r)
 }
 
@@ -699,21 +665,19 @@ func (a *UserApiService) LoginUser(ctx _context.Context) ApiLoginUserRequest {
  * Execute executes the request
  * @return string
  */
-func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  string
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.LoginUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/login"
@@ -722,12 +686,10 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.username == nil {
-		executionError.error = "username is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("username is required and must be specified")
 	}
 	if r.password == nil {
-		executionError.error = "password is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("password is required and must be specified")
 	}
 
 	localVarQueryParams.Add("username", parameterToString(*r.username, ""))
@@ -751,22 +713,18 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -786,7 +744,7 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiLogoutUserRequest struct {
@@ -795,7 +753,7 @@ type ApiLogoutUserRequest struct {
 }
 
 
-func (r ApiLogoutUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.LogoutUserExecute(r)
 }
 
@@ -814,20 +772,18 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) ApiLogoutUserRequest {
 /*
  * Execute executes the request
  */
-func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.LogoutUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/logout"
@@ -855,22 +811,18 @@ func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Re
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -881,7 +833,7 @@ func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiUpdateUserRequest struct {
@@ -896,7 +848,7 @@ func (r ApiUpdateUserRequest) Body(body User) ApiUpdateUserRequest {
 	return r
 }
 
-func (r ApiUpdateUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.UpdateUserExecute(r)
 }
 
@@ -918,20 +870,18 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string) ApiUp
 /*
  * Execute executes the request
  */
-func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.UpdateUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
@@ -941,8 +891,7 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		executionError.error = "body is required and must be specified"
-		return nil, executionError
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -966,22 +915,18 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -992,5 +937,5 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }

--- a/samples/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
@@ -34,7 +34,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.AnotherFakeApi.Call123TestSpecialTags(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `AnotherFakeApi.Call123TestSpecialTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -47,7 +47,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.CreateXmlItem(context.Background()).XmlItem(xmlItem).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.CreateXmlItem``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -111,7 +111,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterBooleanSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterBooleanSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -177,7 +177,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterCompositeSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterCompositeSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -243,7 +243,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterNumberSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterNumberSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -309,7 +309,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterStringSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterStringSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -375,7 +375,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestBodyWithFileSchema(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithFileSchema``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -438,7 +438,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestBodyWithQueryParams(context.Background()).Query(query).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithQueryParams``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -503,7 +503,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestClientModel(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestClientModel``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -583,7 +583,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestEndpointParameters(context.Background()).Number(number).Double(double).PatternWithoutDelimiter(patternWithoutDelimiter).Byte_(byte_).Integer(integer).Int32_(int32_).Int64_(int64_).Float(float).String_(string_).Binary(binary).Date(date).DateTime(dateTime).Password(password).Callback(callback).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEndpointParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -667,7 +667,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestEnumParameters(context.Background()).EnumHeaderStringArray(enumHeaderStringArray).EnumHeaderString(enumHeaderString).EnumQueryStringArray(enumQueryStringArray).EnumQueryString(enumQueryString).EnumQueryInteger(enumQueryInteger).EnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEnumParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -743,7 +743,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestGroupParameters(context.Background()).RequiredStringGroup(requiredStringGroup).RequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).BooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestGroupParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -810,7 +810,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestInlineAdditionalProperties(context.Background()).Param(param).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestInlineAdditionalProperties``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -873,7 +873,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestJsonFormData(context.Background()).Param(param).Param2(param2).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestJsonFormData``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -942,7 +942,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestQueryParameterCollectionFormat(context.Background()).Pipe(pipe).Ioutil(ioutil).Http(http).Url(url).Context(context).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestQueryParameterCollectionFormat``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
@@ -34,7 +34,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeClassnameTags123Api.TestClassname(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeClassnameTags123Api.TestClassname``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/PetApi.md
@@ -40,7 +40,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.AddPet(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.AddPet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -103,7 +103,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.DeletePet(context.Background(), petId).ApiKey(apiKey).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.DeletePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -172,7 +172,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.FindPetsByStatus(context.Background()).Status(status).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByStatus``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -238,7 +238,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.FindPetsByTags(context.Background()).Tags(tags).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -304,7 +304,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.GetPetById(context.Background(), petId).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.GetPetById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -372,7 +372,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UpdatePet(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -436,7 +436,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UpdatePetWithForm(context.Background(), petId).Name(name).Status(status).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePetWithForm``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -506,7 +506,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UploadFile(context.Background(), petId).AdditionalMetadata(additionalMetadata).File(file).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -578,7 +578,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UploadFileWithRequiredFile(context.Background(), petId).RequiredFile(requiredFile).AdditionalMetadata(additionalMetadata).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFileWithRequiredFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -37,7 +37,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.DeleteOrder(context.Background(), orderId).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.DeleteOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -104,7 +104,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.GetInventory(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetInventory``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -166,7 +166,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.GetOrderById(context.Background(), orderId).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetOrderById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -234,7 +234,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.PlaceOrder(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.PlaceOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/UserApi.md
@@ -41,7 +41,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.CreateUser(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -103,7 +103,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.CreateUsersWithArrayInput(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithArrayInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -165,7 +165,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.CreateUsersWithListInput(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithListInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -229,7 +229,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.DeleteUser(context.Background(), username).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.DeleteUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -295,7 +295,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.GetUserByName(context.Background(), username).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.GetUserByName``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -364,7 +364,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.LoginUser(context.Background()).Username(username).Password(password).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LoginUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -428,7 +428,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.LogoutUser(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LogoutUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -489,7 +489,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.UpdateUser(context.Background(), username).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.UpdateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/client/petstore/go/mock/mock_api_pet.go
+++ b/samples/client/petstore/go/mock/mock_api_pet.go
@@ -20,70 +20,70 @@ func (m *MockPetApi) AddPet(ctx context.Context) sw.ApiAddPetRequest {
 	return sw.ApiAddPetRequest{ApiService: m}
 }
 
-func (m *MockPetApi) AddPetExecute(r sw.ApiAddPetRequest) (*http.Response, sw.GenericOpenAPIError) {
-	return &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) AddPetExecute(r sw.ApiAddPetRequest) (*http.Response, error) {
+	return &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) DeletePet(ctx context.Context, petId int64) sw.ApiDeletePetRequest {
 	return sw.ApiDeletePetRequest{ApiService: m}
 }
 
-func (m *MockPetApi) DeletePetExecute(r sw.ApiDeletePetRequest) (*http.Response, sw.GenericOpenAPIError) {
-	return &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) DeletePetExecute(r sw.ApiDeletePetRequest) (*http.Response, error) {
+	return &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) FindPetsByStatus(ctx context.Context) sw.ApiFindPetsByStatusRequest {
 	return sw.ApiFindPetsByStatusRequest{ApiService: m}
 }
 
-func (m *MockPetApi) FindPetsByStatusExecute(r sw.ApiFindPetsByStatusRequest) ([]sw.Pet, *http.Response, sw.GenericOpenAPIError) {
-	return []sw.Pet{}, &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) FindPetsByStatusExecute(r sw.ApiFindPetsByStatusRequest) ([]sw.Pet, *http.Response, error) {
+	return []sw.Pet{}, &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) FindPetsByTags(ctx context.Context) sw.ApiFindPetsByTagsRequest {
 	return sw.ApiFindPetsByTagsRequest{ApiService: m}
 }
 
-func (m *MockPetApi) FindPetsByTagsExecute(r sw.ApiFindPetsByTagsRequest) ([]sw.Pet, *http.Response, sw.GenericOpenAPIError) {
-	return []sw.Pet{}, &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) FindPetsByTagsExecute(r sw.ApiFindPetsByTagsRequest) ([]sw.Pet, *http.Response, error) {
+	return []sw.Pet{}, &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) GetPetById(ctx context.Context, petId int64) sw.ApiGetPetByIdRequest {
 	return sw.ApiGetPetByIdRequest{ApiService: m}
 }
 
-func (m *MockPetApi) GetPetByIdExecute(r sw.ApiGetPetByIdRequest) (sw.Pet, *http.Response, sw.GenericOpenAPIError) {
-	return sw.Pet{}, &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) GetPetByIdExecute(r sw.ApiGetPetByIdRequest) (sw.Pet, *http.Response, error) {
+	return sw.Pet{}, &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) UpdatePet(ctx context.Context) sw.ApiUpdatePetRequest {
 	return sw.ApiUpdatePetRequest{ApiService: m}
 }
 
-func (m *MockPetApi) UpdatePetExecute(r sw.ApiUpdatePetRequest) (*http.Response, sw.GenericOpenAPIError) {
-	return &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) UpdatePetExecute(r sw.ApiUpdatePetRequest) (*http.Response, error) {
+	return &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) UpdatePetWithForm(ctx context.Context, petId int64) sw.ApiUpdatePetWithFormRequest {
 	return sw.ApiUpdatePetWithFormRequest{ApiService: m}
 }
 
-func (m *MockPetApi) UpdatePetWithFormExecute(r sw.ApiUpdatePetWithFormRequest) (*http.Response, sw.GenericOpenAPIError) {
-	return &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) UpdatePetWithFormExecute(r sw.ApiUpdatePetWithFormRequest) (*http.Response, error) {
+	return &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) UploadFile(ctx context.Context, petId int64) sw.ApiUploadFileRequest {
 	return sw.ApiUploadFileRequest{ApiService: m}
 }
 
-func (m *MockPetApi) UploadFileExecute(r sw.ApiUploadFileRequest) (sw.ApiResponse, *http.Response, sw.GenericOpenAPIError) {
-	return sw.ApiResponse{}, &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) UploadFileExecute(r sw.ApiUploadFileRequest) (sw.ApiResponse, *http.Response, error) {
+	return sw.ApiResponse{}, &http.Response{StatusCode:200}, nil
 }
 
 func (m *MockPetApi) UploadFileWithRequiredFile(ctx context.Context, petId int64) sw.ApiUploadFileWithRequiredFileRequest {
 	return sw.ApiUploadFileWithRequiredFileRequest{ApiService: m}
 }
 
-func (m *MockPetApi) UploadFileWithRequiredFileExecute(r sw.ApiUploadFileWithRequiredFileRequest) (sw.ApiResponse, *http.Response, sw.GenericOpenAPIError) {
-	return sw.ApiResponse{}, &http.Response{StatusCode:200}, sw.GenericOpenAPIError{}
+func (m *MockPetApi) UploadFileWithRequiredFileExecute(r sw.ApiUploadFileWithRequiredFileRequest) (sw.ApiResponse, *http.Response, error) {
+	return sw.ApiResponse{}, &http.Response{StatusCode:200}, nil
 }

--- a/samples/client/petstore/go/pet_api_test.go
+++ b/samples/client/petstore/go/pet_api_test.go
@@ -34,7 +34,7 @@ func TestAddPet(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Body(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -54,7 +54,7 @@ func TestAddPetMock(t *testing.T) {
 func TestFindPetsByStatusWithMissingParam(t *testing.T) {
 	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while testing TestFindPetsByStatusWithMissingParam: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -69,12 +69,13 @@ func TestGetPetById(t *testing.T) {
 func TestGetPetByIdWithInvalidID(t *testing.T) {
 	resp, r, err := client.PetApi.GetPetById(context.Background(), 999999999).Execute()
 	if r != nil && r.StatusCode == 404 {
-		assertedError := err
+		assertedError, ok := err.(sw.GenericOpenAPIError)
 		a := assert.New(t)
+		a.True(ok)
 		a.Contains(string(assertedError.Body()), "type")
 
 		a.Contains(assertedError.Error(), "Not Found")
-	} else if err.Error() != "" {
+	} else if err != nil {
 		t.Fatalf("Error while getting pet by invalid id: %v", err)
 		t.Log(r)
 	} else {
@@ -84,7 +85,7 @@ func TestGetPetByIdWithInvalidID(t *testing.T) {
 
 func TestUpdatePetWithForm(t *testing.T) {
 	r, err := client.PetApi.UpdatePetWithForm(context.Background(), 12830).Name("golang").Status("available").Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while updating pet by id: %v", err)
 		t.Log(r)
 	}
@@ -99,7 +100,7 @@ func TestUpdatePetWithForm(t *testing.T) {
 func TestFindPetsByTag(t *testing.T) {
 	var found = false
 	resp, r, err := client.PetApi.FindPetsByTags(context.Background()).Tags([]string{"tag2"}).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting pet by tag: %v", err)
 		t.Log(r)
 	} else {
@@ -128,7 +129,7 @@ func TestFindPetsByTag(t *testing.T) {
 
 func TestFindPetsByStatus(t *testing.T) {
 	resp, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status([]string{"available"}).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting pet by id: %v", err)
 		t.Log(r)
 	} else {
@@ -155,7 +156,7 @@ func TestUploadFile(t *testing.T) {
 
 	_, r, err := client.PetApi.UploadFile(context.Background(), 12830).AdditionalMetadata("golang").File(file).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)
 	}
 
@@ -173,7 +174,7 @@ func TestUploadFileRequired(t *testing.T) {
 
 	_, r, err := client.PetApi.UploadFileWithRequiredFile(context.Background(), 12830).RequiredFile(file).AdditionalMetadata("golang").Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)
 	}
 
@@ -185,7 +186,7 @@ func TestUploadFileRequired(t *testing.T) {
 func TestDeletePet(t *testing.T) {
 	r, err := client.PetApi.DeletePet(context.Background(), 12830).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -275,7 +276,7 @@ func waitOnFunctions(t *testing.T, errc chan error, n int) {
 func deletePet(t *testing.T, id int64) {
 	r, err := client.PetApi.DeletePet(context.Background(), id).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -286,7 +287,7 @@ func deletePet(t *testing.T, id int64) {
 func isPetCorrect(t *testing.T, id int64, name string, status string) {
 	assert := assert.New(t)
 	resp, r, err := client.PetApi.GetPetById(context.Background(), id).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting pet by id: %v", err)
 	} else {
 		assert.Equal(*resp.Id, int64(id), "Pet id should be equal")

--- a/samples/client/petstore/go/store_api_test.go
+++ b/samples/client/petstore/go/store_api_test.go
@@ -20,7 +20,7 @@ func TestPlaceOrder(t *testing.T) {
 
 	_, r, err := client.StoreApi.PlaceOrder(context.Background()).Body(newOrder).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		// Skip parsing time error due to error in Petstore Test Server
 		// https://github.com/OpenAPITools/openapi-generator/issues/1292
 		if regexp.

--- a/samples/client/petstore/go/user_api_test.go
+++ b/samples/client/petstore/go/user_api_test.go
@@ -22,7 +22,7 @@ func TestCreateUser(t *testing.T) {
 
 	apiResponse, err := client.UserApi.CreateUser(context.Background()).Body(newUser).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding user: %v", err)
 	}
 	if apiResponse.StatusCode != 200 {
@@ -56,7 +56,7 @@ func TestCreateUsersWithArrayInput(t *testing.T) {
 	}
 
 	apiResponse, err := client.UserApi.CreateUsersWithArrayInput(context.Background()).Body(newUsers).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding users: %v", err)
 	}
 	if apiResponse.StatusCode != 200 {
@@ -82,7 +82,7 @@ func TestGetUserByName(t *testing.T) {
 	assert := assert.New(t)
 
 	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher").Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting user by id: %v", err)
 	} else {
 		assert.Equal(*resp.Id, int64(1000), "User id should be equal")
@@ -99,7 +99,7 @@ func TestGetUserByNameWithInvalidID(t *testing.T) {
 	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "999999999").Execute()
 	if apiResponse != nil && apiResponse.StatusCode == 404 {
 		return // This is a pass condition. API will return with a 404 error.
-	} else if err.Error() != "" {
+	} else if err != nil {
 		t.Fatalf("Error while getting user by invalid id: %v", err)
 		t.Log(apiResponse)
 	} else {
@@ -124,7 +124,7 @@ func TestUpdateUser(t *testing.T) {
 		UserStatus: sw.PtrInt32(1)}
 
 	apiResponse, err := client.UserApi.UpdateUser(context.Background(), "gopher").Body(newUser).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting user by id: %v", err)
 	}
 	if apiResponse.StatusCode != 200 {
@@ -133,7 +133,7 @@ func TestUpdateUser(t *testing.T) {
 
 	//verify changings are correct
 	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher").Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting user by id: %v", err)
 	} else {
 		assert.Equal(*resp.Id, int64(1000), "User id should be equal")

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/api_usage.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/api_usage.go
@@ -11,7 +11,6 @@
 package x_auth_id_alias
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -32,7 +31,7 @@ type ApiAnyKeyRequest struct {
 }
 
 
-func (r ApiAnyKeyRequest) Execute() (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiAnyKeyRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
 	return r.ApiService.AnyKeyExecute(r)
 }
 
@@ -53,21 +52,19 @@ func (a *UsageApiService) AnyKey(ctx _context.Context) ApiAnyKeyRequest {
  * Execute executes the request
  * @return map[string]interface{}
  */
-func (a *UsageApiService) AnyKeyExecute(r ApiAnyKeyRequest) (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UsageApiService) AnyKeyExecute(r ApiAnyKeyRequest) (map[string]interface{}, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  map[string]interface{}
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.AnyKey")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/any"
@@ -123,22 +120,18 @@ func (a *UsageApiService) AnyKeyExecute(r ApiAnyKeyRequest) (map[string]interfac
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -158,7 +151,7 @@ func (a *UsageApiService) AnyKeyExecute(r ApiAnyKeyRequest) (map[string]interfac
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiBothKeysRequest struct {
@@ -167,7 +160,7 @@ type ApiBothKeysRequest struct {
 }
 
 
-func (r ApiBothKeysRequest) Execute() (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiBothKeysRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
 	return r.ApiService.BothKeysExecute(r)
 }
 
@@ -188,21 +181,19 @@ func (a *UsageApiService) BothKeys(ctx _context.Context) ApiBothKeysRequest {
  * Execute executes the request
  * @return map[string]interface{}
  */
-func (a *UsageApiService) BothKeysExecute(r ApiBothKeysRequest) (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UsageApiService) BothKeysExecute(r ApiBothKeysRequest) (map[string]interface{}, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  map[string]interface{}
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.BothKeys")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/both"
@@ -258,22 +249,18 @@ func (a *UsageApiService) BothKeysExecute(r ApiBothKeysRequest) (map[string]inte
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -293,7 +280,7 @@ func (a *UsageApiService) BothKeysExecute(r ApiBothKeysRequest) (map[string]inte
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiKeyInHeaderRequest struct {
@@ -302,7 +289,7 @@ type ApiKeyInHeaderRequest struct {
 }
 
 
-func (r ApiKeyInHeaderRequest) Execute() (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiKeyInHeaderRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
 	return r.ApiService.KeyInHeaderExecute(r)
 }
 
@@ -323,21 +310,19 @@ func (a *UsageApiService) KeyInHeader(ctx _context.Context) ApiKeyInHeaderReques
  * Execute executes the request
  * @return map[string]interface{}
  */
-func (a *UsageApiService) KeyInHeaderExecute(r ApiKeyInHeaderRequest) (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UsageApiService) KeyInHeaderExecute(r ApiKeyInHeaderRequest) (map[string]interface{}, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  map[string]interface{}
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.KeyInHeader")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/header"
@@ -379,22 +364,18 @@ func (a *UsageApiService) KeyInHeaderExecute(r ApiKeyInHeaderRequest) (map[strin
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -414,7 +395,7 @@ func (a *UsageApiService) KeyInHeaderExecute(r ApiKeyInHeaderRequest) (map[strin
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiKeyInQueryRequest struct {
@@ -423,7 +404,7 @@ type ApiKeyInQueryRequest struct {
 }
 
 
-func (r ApiKeyInQueryRequest) Execute() (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiKeyInQueryRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
 	return r.ApiService.KeyInQueryExecute(r)
 }
 
@@ -444,21 +425,19 @@ func (a *UsageApiService) KeyInQuery(ctx _context.Context) ApiKeyInQueryRequest 
  * Execute executes the request
  * @return map[string]interface{}
  */
-func (a *UsageApiService) KeyInQueryExecute(r ApiKeyInQueryRequest) (map[string]interface{}, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UsageApiService) KeyInQueryExecute(r ApiKeyInQueryRequest) (map[string]interface{}, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  map[string]interface{}
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsageApiService.KeyInQuery")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/query"
@@ -500,22 +479,18 @@ func (a *UsageApiService) KeyInQueryExecute(r ApiKeyInQueryRequest) (map[string]
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -535,5 +510,5 @@ func (a *UsageApiService) KeyInQueryExecute(r ApiKeyInQueryRequest) (map[string]
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/docs/UsageApi.md
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/docs/UsageApi.md
@@ -36,7 +36,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UsageApi.AnyKey(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.AnyKey``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -97,7 +97,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UsageApi.BothKeys(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.BothKeys``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -158,7 +158,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UsageApi.KeyInHeader(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.KeyInHeader``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -219,7 +219,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UsageApi.KeyInQuery(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UsageApi.KeyInQuery``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/auth_test.go
+++ b/samples/openapi3/client/petstore/go/auth_test.go
@@ -43,7 +43,7 @@ func TestOAuth2(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -52,7 +52,7 @@ func TestOAuth2(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -78,7 +78,7 @@ func TestBasicAuth(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(auth).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -87,7 +87,7 @@ func TestBasicAuth(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -108,7 +108,7 @@ func TestAccessToken(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(nil).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -117,7 +117,7 @@ func TestAccessToken(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -138,7 +138,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -146,7 +146,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 	}
 
 	_, r, err = client.PetApi.GetPetById(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 
@@ -156,7 +156,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 	}
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -173,7 +173,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(nil).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -181,7 +181,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 	}
 
 	_, r, err = client.PetApi.GetPetById(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 
@@ -191,7 +191,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 	}
 
 	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -206,7 +206,7 @@ func TestDefaultHeader(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -215,7 +215,7 @@ func TestDefaultHeader(t *testing.T) {
 
 	r, err = client.PetApi.DeletePet(context.Background(), 12992).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -230,7 +230,7 @@ func TestDefaultHeader(t *testing.T) {
 func TestHostOverride(t *testing.T) {
 	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while finding pets by status: %v", err)
 	}
 
@@ -242,7 +242,7 @@ func TestHostOverride(t *testing.T) {
 func TestSchemeOverride(t *testing.T) {
 	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while finding pets by status: %v", err)
 	}
 

--- a/samples/openapi3/client/petstore/go/fake_api_test.go
+++ b/samples/openapi3/client/petstore/go/fake_api_test.go
@@ -19,7 +19,7 @@ func TestPutBodyWithFileSchema(t *testing.T) {
 
 	r, err := client.FakeApi.TestBodyWithFileSchema(context.Background()).FileSchemaTestClass(schema).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {

--- a/samples/openapi3/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_another_fake.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -37,7 +36,7 @@ type AnotherFakeApi interface {
 	 * Call123TestSpecialTagsExecute executes the request
 	 * @return Client
 	 */
-	Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, GenericOpenAPIError)
+	Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, error)
 }
 
 // AnotherFakeApiService AnotherFakeApi service
@@ -54,7 +53,7 @@ func (r ApiCall123TestSpecialTagsRequest) Client(client Client) ApiCall123TestSp
 	return r
 }
 
-func (r ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, error) {
 	return r.ApiService.Call123TestSpecialTagsExecute(r)
 }
 
@@ -75,21 +74,19 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context) Api
  * Execute executes the request
  * @return Client
  */
-func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSpecialTagsRequest) (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Client
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AnotherFakeApiService.Call123TestSpecialTags")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/another-fake/dummy"
@@ -98,8 +95,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.client == nil {
-		executionError.error = "client is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("client is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -123,22 +119,18 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 	localVarPostBody = r.client
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -158,5 +150,5 @@ func (a *AnotherFakeApiService) Call123TestSpecialTagsExecute(r ApiCall123TestSp
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_default.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_default.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -36,7 +35,7 @@ type DefaultApi interface {
 	 * FooGetExecute executes the request
 	 * @return InlineResponseDefault
 	 */
-	FooGetExecute(r ApiFooGetRequest) (InlineResponseDefault, *_nethttp.Response, GenericOpenAPIError)
+	FooGetExecute(r ApiFooGetRequest) (InlineResponseDefault, *_nethttp.Response, error)
 }
 
 // DefaultApiService DefaultApi service
@@ -48,7 +47,7 @@ type ApiFooGetRequest struct {
 }
 
 
-func (r ApiFooGetRequest) Execute() (InlineResponseDefault, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFooGetRequest) Execute() (InlineResponseDefault, *_nethttp.Response, error) {
 	return r.ApiService.FooGetExecute(r)
 }
 
@@ -68,21 +67,19 @@ func (a *DefaultApiService) FooGet(ctx _context.Context) ApiFooGetRequest {
  * Execute executes the request
  * @return InlineResponseDefault
  */
-func (a *DefaultApiService) FooGetExecute(r ApiFooGetRequest) (InlineResponseDefault, *_nethttp.Response, GenericOpenAPIError) {
+func (a *DefaultApiService) FooGetExecute(r ApiFooGetRequest) (InlineResponseDefault, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  InlineResponseDefault
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DefaultApiService.FooGet")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/foo"
@@ -110,22 +107,18 @@ func (a *DefaultApiService) FooGetExecute(r ApiFooGetRequest) (InlineResponseDef
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -152,5 +145,5 @@ func (a *DefaultApiService) FooGetExecute(r ApiFooGetRequest) (InlineResponseDef
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -39,7 +38,7 @@ type FakeApi interface {
 	 * FakeHealthGetExecute executes the request
 	 * @return HealthCheckResult
 	 */
-	FakeHealthGetExecute(r ApiFakeHealthGetRequest) (HealthCheckResult, *_nethttp.Response, GenericOpenAPIError)
+	FakeHealthGetExecute(r ApiFakeHealthGetRequest) (HealthCheckResult, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterBooleanSerialize Method for FakeOuterBooleanSerialize
@@ -53,7 +52,7 @@ type FakeApi interface {
 	 * FakeOuterBooleanSerializeExecute executes the request
 	 * @return bool
 	 */
-	FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterCompositeSerialize Method for FakeOuterCompositeSerialize
@@ -67,7 +66,7 @@ type FakeApi interface {
 	 * FakeOuterCompositeSerializeExecute executes the request
 	 * @return OuterComposite
 	 */
-	FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterNumberSerialize Method for FakeOuterNumberSerialize
@@ -81,7 +80,7 @@ type FakeApi interface {
 	 * FakeOuterNumberSerializeExecute executes the request
 	 * @return float32
 	 */
-	FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, error)
 
 	/*
 	 * FakeOuterStringSerialize Method for FakeOuterStringSerialize
@@ -95,7 +94,7 @@ type FakeApi interface {
 	 * FakeOuterStringSerializeExecute executes the request
 	 * @return string
 	 */
-	FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, GenericOpenAPIError)
+	FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, error)
 
 	/*
 	 * TestBodyWithFileSchema Method for TestBodyWithFileSchema
@@ -108,7 +107,7 @@ type FakeApi interface {
 	/*
 	 * TestBodyWithFileSchemaExecute executes the request
 	 */
-	TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestBodyWithQueryParams Method for TestBodyWithQueryParams
@@ -120,7 +119,7 @@ type FakeApi interface {
 	/*
 	 * TestBodyWithQueryParamsExecute executes the request
 	 */
-	TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestClientModel To test \"client\" model
@@ -134,7 +133,7 @@ type FakeApi interface {
 	 * TestClientModelExecute executes the request
 	 * @return Client
 	 */
-	TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, GenericOpenAPIError)
+	TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, error)
 
 	/*
 	 * TestEndpointParameters Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -151,7 +150,7 @@ type FakeApi interface {
 	/*
 	 * TestEndpointParametersExecute executes the request
 	 */
-	TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestEnumParameters To test enum parameters
@@ -164,7 +163,7 @@ type FakeApi interface {
 	/*
 	 * TestEnumParametersExecute executes the request
 	 */
-	TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestGroupParameters Fake endpoint to test group parameters (optional)
@@ -177,7 +176,7 @@ type FakeApi interface {
 	/*
 	 * TestGroupParametersExecute executes the request
 	 */
-	TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestInlineAdditionalProperties test inline additionalProperties
@@ -189,7 +188,7 @@ type FakeApi interface {
 	/*
 	 * TestInlineAdditionalPropertiesExecute executes the request
 	 */
-	TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestJsonFormData test json serialization of form data
@@ -201,7 +200,7 @@ type FakeApi interface {
 	/*
 	 * TestJsonFormDataExecute executes the request
 	 */
-	TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, error)
 
 	/*
 	 * TestQueryParameterCollectionFormat Method for TestQueryParameterCollectionFormat
@@ -214,7 +213,7 @@ type FakeApi interface {
 	/*
 	 * TestQueryParameterCollectionFormatExecute executes the request
 	 */
-	TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, GenericOpenAPIError)
+	TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, error)
 }
 
 // FakeApiService FakeApi service
@@ -226,7 +225,7 @@ type ApiFakeHealthGetRequest struct {
 }
 
 
-func (r ApiFakeHealthGetRequest) Execute() (HealthCheckResult, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeHealthGetRequest) Execute() (HealthCheckResult, *_nethttp.Response, error) {
 	return r.ApiService.FakeHealthGetExecute(r)
 }
 
@@ -246,21 +245,19 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) ApiFakeHealthGetReq
  * Execute executes the request
  * @return HealthCheckResult
  */
-func (a *FakeApiService) FakeHealthGetExecute(r ApiFakeHealthGetRequest) (HealthCheckResult, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeHealthGetExecute(r ApiFakeHealthGetRequest) (HealthCheckResult, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  HealthCheckResult
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeHealthGet")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/health"
@@ -288,22 +285,18 @@ func (a *FakeApiService) FakeHealthGetExecute(r ApiFakeHealthGetRequest) (Health
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -323,7 +316,7 @@ func (a *FakeApiService) FakeHealthGetExecute(r ApiFakeHealthGetRequest) (Health
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterBooleanSerializeRequest struct {
@@ -337,7 +330,7 @@ func (r ApiFakeOuterBooleanSerializeRequest) Body(body bool) ApiFakeOuterBoolean
 	return r
 }
 
-func (r ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterBooleanSerializeExecute(r)
 }
 
@@ -358,21 +351,19 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context) ApiFake
  * Execute executes the request
  * @return bool
  */
-func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanSerializeRequest) (bool, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  bool
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterBooleanSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/boolean"
@@ -402,22 +393,18 @@ func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanS
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -437,7 +424,7 @@ func (a *FakeApiService) FakeOuterBooleanSerializeExecute(r ApiFakeOuterBooleanS
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterCompositeSerializeRequest struct {
@@ -451,7 +438,7 @@ func (r ApiFakeOuterCompositeSerializeRequest) OuterComposite(outerComposite Out
 	return r
 }
 
-func (r ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterCompositeSerializeExecute(r)
 }
 
@@ -472,21 +459,19 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context) ApiFa
  * Execute executes the request
  * @return OuterComposite
  */
-func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompositeSerializeRequest) (OuterComposite, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  OuterComposite
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterCompositeSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/composite"
@@ -516,22 +501,18 @@ func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompos
 	localVarPostBody = r.outerComposite
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -551,7 +532,7 @@ func (a *FakeApiService) FakeOuterCompositeSerializeExecute(r ApiFakeOuterCompos
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterNumberSerializeRequest struct {
@@ -565,7 +546,7 @@ func (r ApiFakeOuterNumberSerializeRequest) Body(body float32) ApiFakeOuterNumbe
 	return r
 }
 
-func (r ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterNumberSerializeExecute(r)
 }
 
@@ -586,21 +567,19 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context) ApiFakeO
  * Execute executes the request
  * @return float32
  */
-func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSerializeRequest) (float32, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  float32
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterNumberSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/number"
@@ -630,22 +609,18 @@ func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSer
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -665,7 +640,7 @@ func (a *FakeApiService) FakeOuterNumberSerializeExecute(r ApiFakeOuterNumberSer
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFakeOuterStringSerializeRequest struct {
@@ -679,7 +654,7 @@ func (r ApiFakeOuterStringSerializeRequest) Body(body string) ApiFakeOuterString
 	return r
 }
 
-func (r ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, error) {
 	return r.ApiService.FakeOuterStringSerializeExecute(r)
 }
 
@@ -700,21 +675,19 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context) ApiFakeO
  * Execute executes the request
  * @return string
  */
-func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSerializeRequest) (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  string
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterStringSerialize")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/string"
@@ -744,22 +717,18 @@ func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSer
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -779,7 +748,7 @@ func (a *FakeApiService) FakeOuterStringSerializeExecute(r ApiFakeOuterStringSer
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiTestBodyWithFileSchemaRequest struct {
@@ -793,7 +762,7 @@ func (r ApiTestBodyWithFileSchemaRequest) FileSchemaTestClass(fileSchemaTestClas
 	return r
 }
 
-func (r ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestBodyWithFileSchemaExecute(r)
 }
 
@@ -813,20 +782,18 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context) ApiTestBod
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSchemaRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestBodyWithFileSchema")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/body-with-file-schema"
@@ -835,8 +802,7 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.fileSchemaTestClass == nil {
-		executionError.error = "fileSchemaTestClass is required and must be specified"
-		return nil, executionError
+		return nil, reportError("fileSchemaTestClass is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -860,22 +826,18 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 	localVarPostBody = r.fileSchemaTestClass
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -886,7 +848,7 @@ func (a *FakeApiService) TestBodyWithFileSchemaExecute(r ApiTestBodyWithFileSche
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestBodyWithQueryParamsRequest struct {
@@ -905,7 +867,7 @@ func (r ApiTestBodyWithQueryParamsRequest) User(user User) ApiTestBodyWithQueryP
 	return r
 }
 
-func (r ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestBodyWithQueryParamsExecute(r)
 }
 
@@ -924,20 +886,18 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context) ApiTestBo
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryParamsRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestBodyWithQueryParams")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/body-with-query-params"
@@ -946,12 +906,10 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.query == nil {
-		executionError.error = "query is required and must be specified"
-		return nil, executionError
+		return nil, reportError("query is required and must be specified")
 	}
 	if r.user == nil {
-		executionError.error = "user is required and must be specified"
-		return nil, executionError
+		return nil, reportError("user is required and must be specified")
 	}
 
 	localVarQueryParams.Add("query", parameterToString(*r.query, ""))
@@ -976,22 +934,18 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 	localVarPostBody = r.user
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1002,7 +956,7 @@ func (a *FakeApiService) TestBodyWithQueryParamsExecute(r ApiTestBodyWithQueryPa
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestClientModelRequest struct {
@@ -1016,7 +970,7 @@ func (r ApiTestClientModelRequest) Client(client Client) ApiTestClientModelReque
 	return r
 }
 
-func (r ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error) {
 	return r.ApiService.TestClientModelExecute(r)
 }
 
@@ -1037,21 +991,19 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context) ApiTestClientMode
  * Execute executes the request
  * @return Client
  */
-func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Client
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestClientModel")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1060,8 +1012,7 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.client == nil {
-		executionError.error = "client is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("client is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1085,22 +1036,18 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 	localVarPostBody = r.client
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1120,7 +1067,7 @@ func (a *FakeApiService) TestClientModelExecute(r ApiTestClientModelRequest) (Cl
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiTestEndpointParametersRequest struct {
@@ -1199,7 +1146,7 @@ func (r ApiTestEndpointParametersRequest) Callback(callback string) ApiTestEndpo
 	return r
 }
 
-func (r ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestEndpointParametersExecute(r)
 }
 
@@ -1223,20 +1170,18 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context) ApiTestEnd
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParametersRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestEndpointParameters")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1245,36 +1190,28 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.number == nil {
-		executionError.error = "number is required and must be specified"
-		return nil, executionError
+		return nil, reportError("number is required and must be specified")
 	}
 	if *r.number < 32.1 {
-		executionError.error = "number must be greater than 32.1"
-		return nil, executionError
+		return nil, reportError("number must be greater than 32.1")
 	}
 	if *r.number > 543.2 {
-		executionError.error = "number must be less than 543.2"
-		return nil, executionError
+		return nil, reportError("number must be less than 543.2")
 	}
 	if r.double == nil {
-		executionError.error = "double is required and must be specified"
-		return nil, executionError
+		return nil, reportError("double is required and must be specified")
 	}
 	if *r.double < 67.8 {
-		executionError.error = "double must be greater than 67.8"
-		return nil, executionError
+		return nil, reportError("double must be greater than 67.8")
 	}
 	if *r.double > 123.4 {
-		executionError.error = "double must be less than 123.4"
-		return nil, executionError
+		return nil, reportError("double must be less than 123.4")
 	}
 	if r.patternWithoutDelimiter == nil {
-		executionError.error = "patternWithoutDelimiter is required and must be specified"
-		return nil, executionError
+		return nil, reportError("patternWithoutDelimiter is required and must be specified")
 	}
 	if r.byte_ == nil {
-		executionError.error = "byte_ is required and must be specified"
-		return nil, executionError
+		return nil, reportError("byte_ is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1338,22 +1275,18 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1364,7 +1297,7 @@ func (a *FakeApiService) TestEndpointParametersExecute(r ApiTestEndpointParamete
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestEnumParametersRequest struct {
@@ -1413,7 +1346,7 @@ func (r ApiTestEnumParametersRequest) EnumFormString(enumFormString string) ApiT
 	return r
 }
 
-func (r ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestEnumParametersExecute(r)
 }
 
@@ -1433,20 +1366,18 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context) ApiTestEnumPar
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestEnumParameters")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1506,22 +1437,18 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1532,7 +1459,7 @@ func (a *FakeApiService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestGroupParametersRequest struct {
@@ -1571,7 +1498,7 @@ func (r ApiTestGroupParametersRequest) Int64Group(int64Group int64) ApiTestGroup
 	return r
 }
 
-func (r ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestGroupParametersExecute(r)
 }
 
@@ -1591,20 +1518,18 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context) ApiTestGroupP
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestGroupParameters")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
@@ -1613,16 +1538,13 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.requiredStringGroup == nil {
-		executionError.error = "requiredStringGroup is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requiredStringGroup is required and must be specified")
 	}
 	if r.requiredBooleanGroup == nil {
-		executionError.error = "requiredBooleanGroup is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requiredBooleanGroup is required and must be specified")
 	}
 	if r.requiredInt64Group == nil {
-		executionError.error = "requiredInt64Group is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requiredInt64Group is required and must be specified")
 	}
 
 	localVarQueryParams.Add("required_string_group", parameterToString(*r.requiredStringGroup, ""))
@@ -1656,22 +1578,18 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1682,7 +1600,7 @@ func (a *FakeApiService) TestGroupParametersExecute(r ApiTestGroupParametersRequ
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestInlineAdditionalPropertiesRequest struct {
@@ -1696,7 +1614,7 @@ func (r ApiTestInlineAdditionalPropertiesRequest) RequestBody(requestBody map[st
 	return r
 }
 
-func (r ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestInlineAdditionalPropertiesExecute(r)
 }
 
@@ -1715,20 +1633,18 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context) Ap
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAdditionalPropertiesRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestInlineAdditionalProperties")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/inline-additionalProperties"
@@ -1737,8 +1653,7 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.requestBody == nil {
-		executionError.error = "requestBody is required and must be specified"
-		return nil, executionError
+		return nil, reportError("requestBody is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1762,22 +1677,18 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 	localVarPostBody = r.requestBody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1788,7 +1699,7 @@ func (a *FakeApiService) TestInlineAdditionalPropertiesExecute(r ApiTestInlineAd
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestJsonFormDataRequest struct {
@@ -1807,7 +1718,7 @@ func (r ApiTestJsonFormDataRequest) Param2(param2 string) ApiTestJsonFormDataReq
 	return r
 }
 
-func (r ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestJsonFormDataExecute(r)
 }
 
@@ -1826,20 +1737,18 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context) ApiTestJsonFormD
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestJsonFormData")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/jsonFormData"
@@ -1848,12 +1757,10 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.param == nil {
-		executionError.error = "param is required and must be specified"
-		return nil, executionError
+		return nil, reportError("param is required and must be specified")
 	}
 	if r.param2 == nil {
-		executionError.error = "param2 is required and must be specified"
-		return nil, executionError
+		return nil, reportError("param2 is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1877,22 +1784,18 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 	localVarFormParams.Add("param2", parameterToString(*r.param2, ""))
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1903,7 +1806,7 @@ func (a *FakeApiService) TestJsonFormDataExecute(r ApiTestJsonFormDataRequest) (
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiTestQueryParameterCollectionFormatRequest struct {
@@ -1937,7 +1840,7 @@ func (r ApiTestQueryParameterCollectionFormatRequest) Context(context []string) 
 	return r
 }
 
-func (r ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.TestQueryParameterCollectionFormatExecute(r)
 }
 
@@ -1957,20 +1860,18 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 /*
  * Execute executes the request
  */
-func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQueryParameterCollectionFormatRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestQueryParameterCollectionFormat")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/test-query-paramters"
@@ -1979,24 +1880,19 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.pipe == nil {
-		executionError.error = "pipe is required and must be specified"
-		return nil, executionError
+		return nil, reportError("pipe is required and must be specified")
 	}
 	if r.ioutil == nil {
-		executionError.error = "ioutil is required and must be specified"
-		return nil, executionError
+		return nil, reportError("ioutil is required and must be specified")
 	}
 	if r.http == nil {
-		executionError.error = "http is required and must be specified"
-		return nil, executionError
+		return nil, reportError("http is required and must be specified")
 	}
 	if r.url == nil {
-		executionError.error = "url is required and must be specified"
-		return nil, executionError
+		return nil, reportError("url is required and must be specified")
 	}
 	if r.context == nil {
-		executionError.error = "context is required and must be specified"
-		return nil, executionError
+		return nil, reportError("context is required and must be specified")
 	}
 
 	{
@@ -2043,22 +1939,18 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -2069,5 +1961,5 @@ func (a *FakeApiService) TestQueryParameterCollectionFormatExecute(r ApiTestQuer
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -37,7 +36,7 @@ type FakeClassnameTags123Api interface {
 	 * TestClassnameExecute executes the request
 	 * @return Client
 	 */
-	TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, GenericOpenAPIError)
+	TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, error)
 }
 
 // FakeClassnameTags123ApiService FakeClassnameTags123Api service
@@ -54,7 +53,7 @@ func (r ApiTestClassnameRequest) Client(client Client) ApiTestClassnameRequest {
 	return r
 }
 
-func (r ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
 	return r.ApiService.TestClassnameExecute(r)
 }
 
@@ -75,21 +74,19 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context) Api
  * Execute executes the request
  * @return Client
  */
-func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, GenericOpenAPIError) {
+func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassnameRequest) (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Client
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "FakeClassnameTags123ApiService.TestClassname")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake_classname_test"
@@ -98,8 +95,7 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.client == nil {
-		executionError.error = "client is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("client is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -137,22 +133,18 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -172,5 +164,5 @@ func (a *FakeClassnameTags123ApiService) TestClassnameExecute(r ApiTestClassname
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -37,7 +36,7 @@ type PetApi interface {
 	/*
 	 * AddPetExecute executes the request
 	 */
-	AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, GenericOpenAPIError)
+	AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, error)
 
 	/*
 	 * DeletePet Deletes a pet
@@ -50,7 +49,7 @@ type PetApi interface {
 	/*
 	 * DeletePetExecute executes the request
 	 */
-	DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, GenericOpenAPIError)
+	DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, error)
 
 	/*
 	 * FindPetsByStatus Finds Pets by status
@@ -64,7 +63,7 @@ type PetApi interface {
 	 * FindPetsByStatusExecute executes the request
 	 * @return []Pet
 	 */
-	FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError)
+	FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, error)
 
 	/*
 	 * FindPetsByTags Finds Pets by tags
@@ -78,7 +77,7 @@ type PetApi interface {
 	 * FindPetsByTagsExecute executes the request
 	 * @return []Pet
 	 */
-	FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError)
+	FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, error)
 
 	/*
 	 * GetPetById Find pet by ID
@@ -93,7 +92,7 @@ type PetApi interface {
 	 * GetPetByIdExecute executes the request
 	 * @return Pet
 	 */
-	GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, GenericOpenAPIError)
+	GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, error)
 
 	/*
 	 * UpdatePet Update an existing pet
@@ -105,7 +104,7 @@ type PetApi interface {
 	/*
 	 * UpdatePetExecute executes the request
 	 */
-	UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, GenericOpenAPIError)
+	UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, error)
 
 	/*
 	 * UpdatePetWithForm Updates a pet in the store with form data
@@ -118,7 +117,7 @@ type PetApi interface {
 	/*
 	 * UpdatePetWithFormExecute executes the request
 	 */
-	UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, GenericOpenAPIError)
+	UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, error)
 
 	/*
 	 * UploadFile uploads an image
@@ -132,7 +131,7 @@ type PetApi interface {
 	 * UploadFileExecute executes the request
 	 * @return ApiResponse
 	 */
-	UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError)
+	UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, error)
 
 	/*
 	 * UploadFileWithRequiredFile uploads an image (required)
@@ -146,7 +145,7 @@ type PetApi interface {
 	 * UploadFileWithRequiredFileExecute executes the request
 	 * @return ApiResponse
 	 */
-	UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError)
+	UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, error)
 }
 
 // PetApiService PetApi service
@@ -163,7 +162,7 @@ func (r ApiAddPetRequest) Pet(pet Pet) ApiAddPetRequest {
 	return r
 }
 
-func (r ApiAddPetRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiAddPetRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.AddPetExecute(r)
 }
 
@@ -182,20 +181,18 @@ func (a *PetApiService) AddPet(ctx _context.Context) ApiAddPetRequest {
 /*
  * Execute executes the request
  */
-func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.AddPet")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet"
@@ -204,8 +201,7 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, G
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.pet == nil {
-		executionError.error = "pet is required and must be specified"
-		return nil, executionError
+		return nil, reportError("pet is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -229,22 +225,18 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, G
 	localVarPostBody = r.pet
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -255,7 +247,7 @@ func (a *PetApiService) AddPetExecute(r ApiAddPetRequest) (*_nethttp.Response, G
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiDeletePetRequest struct {
@@ -270,7 +262,7 @@ func (r ApiDeletePetRequest) ApiKey(apiKey string) ApiDeletePetRequest {
 	return r
 }
 
-func (r ApiDeletePetRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiDeletePetRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeletePetExecute(r)
 }
 
@@ -291,20 +283,18 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64) ApiDeletePe
 /*
  * Execute executes the request
  */
-func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.DeletePet")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
@@ -336,22 +326,18 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -362,7 +348,7 @@ func (a *PetApiService) DeletePetExecute(r ApiDeletePetRequest) (*_nethttp.Respo
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiFindPetsByStatusRequest struct {
@@ -376,7 +362,7 @@ func (r ApiFindPetsByStatusRequest) Status(status []string) ApiFindPetsByStatusR
 	return r
 }
 
-func (r ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	return r.ApiService.FindPetsByStatusExecute(r)
 }
 
@@ -397,21 +383,19 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context) ApiFindPetsByStat
  * Execute executes the request
  * @return []Pet
  */
-func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([]Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  []Pet
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.FindPetsByStatus")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/findByStatus"
@@ -420,8 +404,7 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.status == nil {
-		executionError.error = "status is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("status is required and must be specified")
 	}
 
 	localVarQueryParams.Add("status", parameterToString(*r.status, "csv"))
@@ -444,22 +427,18 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -479,7 +458,7 @@ func (a *PetApiService) FindPetsByStatusExecute(r ApiFindPetsByStatusRequest) ([
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiFindPetsByTagsRequest struct {
@@ -493,7 +472,7 @@ func (r ApiFindPetsByTagsRequest) Tags(tags []string) ApiFindPetsByTagsRequest {
 	return r
 }
 
-func (r ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	return r.ApiService.FindPetsByTagsExecute(r)
 }
 
@@ -514,21 +493,19 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context) ApiFindPetsByTagsRe
  * Execute executes the request
  * @return []Pet
  */
-func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  []Pet
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.FindPetsByTags")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/findByTags"
@@ -537,8 +514,7 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.tags == nil {
-		executionError.error = "tags is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("tags is required and must be specified")
 	}
 
 	localVarQueryParams.Add("tags", parameterToString(*r.tags, "csv"))
@@ -561,22 +537,18 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -596,7 +568,7 @@ func (a *PetApiService) FindPetsByTagsExecute(r ApiFindPetsByTagsRequest) ([]Pet
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetPetByIdRequest struct {
@@ -606,7 +578,7 @@ type ApiGetPetByIdRequest struct {
 }
 
 
-func (r ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
 	return r.ApiService.GetPetByIdExecute(r)
 }
 
@@ -629,21 +601,19 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) ApiGetPetB
  * Execute executes the request
  * @return Pet
  */
-func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Pet
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.GetPetById")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
@@ -686,22 +656,18 @@ func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethtt
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -721,7 +687,7 @@ func (a *PetApiService) GetPetByIdExecute(r ApiGetPetByIdRequest) (Pet, *_nethtt
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiUpdatePetRequest struct {
@@ -735,7 +701,7 @@ func (r ApiUpdatePetRequest) Pet(pet Pet) ApiUpdatePetRequest {
 	return r
 }
 
-func (r ApiUpdatePetRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.UpdatePetExecute(r)
 }
 
@@ -754,20 +720,18 @@ func (a *PetApiService) UpdatePet(ctx _context.Context) ApiUpdatePetRequest {
 /*
  * Execute executes the request
  */
-func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UpdatePet")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet"
@@ -776,8 +740,7 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.pet == nil {
-		executionError.error = "pet is required and must be specified"
-		return nil, executionError
+		return nil, reportError("pet is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -801,22 +764,18 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 	localVarPostBody = r.pet
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -827,7 +786,7 @@ func (a *PetApiService) UpdatePetExecute(r ApiUpdatePetRequest) (*_nethttp.Respo
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiUpdatePetWithFormRequest struct {
@@ -847,7 +806,7 @@ func (r ApiUpdatePetWithFormRequest) Status(status string) ApiUpdatePetWithFormR
 	return r
 }
 
-func (r ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.UpdatePetWithFormExecute(r)
 }
 
@@ -868,20 +827,18 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64) Api
 /*
  * Execute executes the request
  */
-func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UpdatePetWithForm")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
@@ -916,22 +873,18 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -942,7 +895,7 @@ func (a *PetApiService) UpdatePetWithFormExecute(r ApiUpdatePetWithFormRequest) 
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiUploadFileRequest struct {
@@ -962,7 +915,7 @@ func (r ApiUploadFileRequest) File(file *os.File) ApiUploadFileRequest {
 	return r
 }
 
-func (r ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
 	return r.ApiService.UploadFileExecute(r)
 }
 
@@ -984,21 +937,19 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64) ApiUploadF
  * Execute executes the request
  * @return ApiResponse
  */
-func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  ApiResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UploadFile")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}/uploadImage"
@@ -1041,22 +992,18 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1076,7 +1023,7 @@ func (a *PetApiService) UploadFileExecute(r ApiUploadFileRequest) (ApiResponse, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiUploadFileWithRequiredFileRequest struct {
@@ -1096,7 +1043,7 @@ func (r ApiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetad
 	return r
 }
 
-func (r ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
 	return r.ApiService.UploadFileWithRequiredFileExecute(r)
 }
 
@@ -1118,21 +1065,19 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
  * Execute executes the request
  * @return ApiResponse
  */
-func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, GenericOpenAPIError) {
+func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithRequiredFileRequest) (ApiResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  ApiResponse
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UploadFileWithRequiredFile")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/{petId}/uploadImageWithRequiredFile"
@@ -1142,8 +1087,7 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.requiredFile == nil {
-		executionError.error = "requiredFile is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("requiredFile is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1176,22 +1120,18 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -1211,5 +1151,5 @@ func (a *PetApiService) UploadFileWithRequiredFileExecute(r ApiUploadFileWithReq
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_store.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_store.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -38,7 +37,7 @@ type StoreApi interface {
 	/*
 	 * DeleteOrderExecute executes the request
 	 */
-	DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, GenericOpenAPIError)
+	DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, error)
 
 	/*
 	 * GetInventory Returns pet inventories by status
@@ -52,7 +51,7 @@ type StoreApi interface {
 	 * GetInventoryExecute executes the request
 	 * @return map[string]int32
 	 */
-	GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, GenericOpenAPIError)
+	GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, error)
 
 	/*
 	 * GetOrderById Find purchase order by ID
@@ -67,7 +66,7 @@ type StoreApi interface {
 	 * GetOrderByIdExecute executes the request
 	 * @return Order
 	 */
-	GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, GenericOpenAPIError)
+	GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, error)
 
 	/*
 	 * PlaceOrder Place an order for a pet
@@ -80,7 +79,7 @@ type StoreApi interface {
 	 * PlaceOrderExecute executes the request
 	 * @return Order
 	 */
-	PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, GenericOpenAPIError)
+	PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, error)
 }
 
 // StoreApiService StoreApi service
@@ -93,7 +92,7 @@ type ApiDeleteOrderRequest struct {
 }
 
 
-func (r ApiDeleteOrderRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteOrderExecute(r)
 }
 
@@ -115,20 +114,18 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) ApiD
 /*
  * Execute executes the request
  */
-func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.DeleteOrder")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
@@ -157,22 +154,18 @@ func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -183,7 +176,7 @@ func (a *StoreApiService) DeleteOrderExecute(r ApiDeleteOrderRequest) (*_nethttp
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetInventoryRequest struct {
@@ -192,7 +185,7 @@ type ApiGetInventoryRequest struct {
 }
 
 
-func (r ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, error) {
 	return r.ApiService.GetInventoryExecute(r)
 }
 
@@ -213,21 +206,19 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) ApiGetInventoryRequ
  * Execute executes the request
  * @return map[string]int32
  */
-func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[string]int32, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  map[string]int32
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.GetInventory")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/inventory"
@@ -269,22 +260,18 @@ func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[str
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -304,7 +291,7 @@ func (a *StoreApiService) GetInventoryExecute(r ApiGetInventoryRequest) (map[str
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetOrderByIdRequest struct {
@@ -314,7 +301,7 @@ type ApiGetOrderByIdRequest struct {
 }
 
 
-func (r ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
 	return r.ApiService.GetOrderByIdExecute(r)
 }
 
@@ -337,21 +324,19 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) ApiG
  * Execute executes the request
  * @return Order
  */
-func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Order
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.GetOrderById")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
@@ -361,12 +346,10 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.orderId < 1 {
-		executionError.error = "orderId must be greater than 1"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("orderId must be greater than 1")
 	}
 	if r.orderId > 5 {
-		executionError.error = "orderId must be less than 5"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("orderId must be less than 5")
 	}
 
 	// to determine the Content-Type header
@@ -388,22 +371,18 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -423,7 +402,7 @@ func (a *StoreApiService) GetOrderByIdExecute(r ApiGetOrderByIdRequest) (Order, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPlaceOrderRequest struct {
@@ -437,7 +416,7 @@ func (r ApiPlaceOrderRequest) Order(order Order) ApiPlaceOrderRequest {
 	return r
 }
 
-func (r ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
 	return r.ApiService.PlaceOrderExecute(r)
 }
 
@@ -457,21 +436,19 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context) ApiPlaceOrderRequest 
  * Execute executes the request
  * @return Order
  */
-func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, GenericOpenAPIError) {
+func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  Order
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.PlaceOrder")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order"
@@ -480,8 +457,7 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.order == nil {
-		executionError.error = "order is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("order is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -505,22 +481,18 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 	localVarPostBody = r.order
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -540,5 +512,5 @@ func (a *StoreApiService) PlaceOrderExecute(r ApiPlaceOrderRequest) (Order, *_ne
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/api_user.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_user.go
@@ -11,7 +11,6 @@
 package petstore
 
 import (
-	"bytes"
 	_context "context"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
@@ -37,7 +36,7 @@ type UserApi interface {
 	/*
 	 * CreateUserExecute executes the request
 	 */
-	CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, error)
 
 	/*
 	 * CreateUsersWithArrayInput Creates list of users with given input array
@@ -49,7 +48,7 @@ type UserApi interface {
 	/*
 	 * CreateUsersWithArrayInputExecute executes the request
 	 */
-	CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, error)
 
 	/*
 	 * CreateUsersWithListInput Creates list of users with given input array
@@ -61,7 +60,7 @@ type UserApi interface {
 	/*
 	 * CreateUsersWithListInputExecute executes the request
 	 */
-	CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, GenericOpenAPIError)
+	CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, error)
 
 	/*
 	 * DeleteUser Delete user
@@ -75,7 +74,7 @@ type UserApi interface {
 	/*
 	 * DeleteUserExecute executes the request
 	 */
-	DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, error)
 
 	/*
 	 * GetUserByName Get user by user name
@@ -89,7 +88,7 @@ type UserApi interface {
 	 * GetUserByNameExecute executes the request
 	 * @return User
 	 */
-	GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, GenericOpenAPIError)
+	GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, error)
 
 	/*
 	 * LoginUser Logs user into the system
@@ -102,7 +101,7 @@ type UserApi interface {
 	 * LoginUserExecute executes the request
 	 * @return string
 	 */
-	LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, GenericOpenAPIError)
+	LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, error)
 
 	/*
 	 * LogoutUser Logs out current logged in user session
@@ -114,7 +113,7 @@ type UserApi interface {
 	/*
 	 * LogoutUserExecute executes the request
 	 */
-	LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, error)
 
 	/*
 	 * UpdateUser Updated user
@@ -128,7 +127,7 @@ type UserApi interface {
 	/*
 	 * UpdateUserExecute executes the request
 	 */
-	UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, GenericOpenAPIError)
+	UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, error)
 }
 
 // UserApiService UserApi service
@@ -145,7 +144,7 @@ func (r ApiCreateUserRequest) User(user User) ApiCreateUserRequest {
 	return r
 }
 
-func (r ApiCreateUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateUserExecute(r)
 }
 
@@ -165,20 +164,18 @@ func (a *UserApiService) CreateUser(ctx _context.Context) ApiCreateUserRequest {
 /*
  * Execute executes the request
  */
-func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user"
@@ -187,8 +184,7 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.user == nil {
-		executionError.error = "user is required and must be specified"
-		return nil, executionError
+		return nil, reportError("user is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -212,22 +208,18 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 	localVarPostBody = r.user
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -238,7 +230,7 @@ func (a *UserApiService) CreateUserExecute(r ApiCreateUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiCreateUsersWithArrayInputRequest struct {
@@ -252,7 +244,7 @@ func (r ApiCreateUsersWithArrayInputRequest) User(user []User) ApiCreateUsersWit
 	return r
 }
 
-func (r ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateUsersWithArrayInputExecute(r)
 }
 
@@ -271,20 +263,18 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context) ApiCrea
 /*
  * Execute executes the request
  */
-func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithArrayInputRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUsersWithArrayInput")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/createWithArray"
@@ -293,8 +283,7 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.user == nil {
-		executionError.error = "user is required and must be specified"
-		return nil, executionError
+		return nil, reportError("user is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -318,22 +307,18 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 	localVarPostBody = r.user
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -344,7 +329,7 @@ func (a *UserApiService) CreateUsersWithArrayInputExecute(r ApiCreateUsersWithAr
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiCreateUsersWithListInputRequest struct {
@@ -358,7 +343,7 @@ func (r ApiCreateUsersWithListInputRequest) User(user []User) ApiCreateUsersWith
 	return r
 }
 
-func (r ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.CreateUsersWithListInputExecute(r)
 }
 
@@ -377,20 +362,18 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context) ApiCreat
 /*
  * Execute executes the request
  */
-func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithListInputRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUsersWithListInput")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/createWithList"
@@ -399,8 +382,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.user == nil {
-		executionError.error = "user is required and must be specified"
-		return nil, executionError
+		return nil, reportError("user is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -424,22 +406,18 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 	localVarPostBody = r.user
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -450,7 +428,7 @@ func (a *UserApiService) CreateUsersWithListInputExecute(r ApiCreateUsersWithLis
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiDeleteUserRequest struct {
@@ -460,7 +438,7 @@ type ApiDeleteUserRequest struct {
 }
 
 
-func (r ApiDeleteUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.DeleteUserExecute(r)
 }
 
@@ -482,20 +460,18 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) ApiDe
 /*
  * Execute executes the request
  */
-func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.DeleteUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
@@ -524,22 +500,18 @@ func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Re
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -550,7 +522,7 @@ func (a *UserApiService) DeleteUserExecute(r ApiDeleteUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetUserByNameRequest struct {
@@ -560,7 +532,7 @@ type ApiGetUserByNameRequest struct {
 }
 
 
-func (r ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
 	return r.ApiService.GetUserByNameExecute(r)
 }
 
@@ -582,21 +554,19 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) Ap
  * Execute executes the request
  * @return User
  */
-func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  User
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.GetUserByName")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
@@ -625,22 +595,18 @@ func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -660,7 +626,7 @@ func (a *UserApiService) GetUserByNameExecute(r ApiGetUserByNameRequest) (User, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiLoginUserRequest struct {
@@ -679,7 +645,7 @@ func (r ApiLoginUserRequest) Password(password string) ApiLoginUserRequest {
 	return r
 }
 
-func (r ApiLoginUserRequest) Execute() (string, *_nethttp.Response, GenericOpenAPIError) {
+func (r ApiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
 	return r.ApiService.LoginUserExecute(r)
 }
 
@@ -699,21 +665,19 @@ func (a *UserApiService) LoginUser(ctx _context.Context) ApiLoginUserRequest {
  * Execute executes the request
  * @return string
  */
-func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 		localVarReturnValue  string
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.LoginUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/login"
@@ -722,12 +686,10 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.username == nil {
-		executionError.error = "username is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("username is required and must be specified")
 	}
 	if r.password == nil {
-		executionError.error = "password is required and must be specified"
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, reportError("password is required and must be specified")
 	}
 
 	localVarQueryParams.Add("username", parameterToString(*r.username, ""))
@@ -751,22 +713,18 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, nil, executionError
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarReturnValue, localVarHTTPResponse, executionError
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -786,7 +744,7 @@ func (a *UserApiService) LoginUserExecute(r ApiLoginUserRequest) (string, *_neth
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, executionError
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiLogoutUserRequest struct {
@@ -795,7 +753,7 @@ type ApiLogoutUserRequest struct {
 }
 
 
-func (r ApiLogoutUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.LogoutUserExecute(r)
 }
 
@@ -814,20 +772,18 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) ApiLogoutUserRequest {
 /*
  * Execute executes the request
  */
-func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.LogoutUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/logout"
@@ -855,22 +811,18 @@ func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Re
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -881,7 +833,7 @@ func (a *UserApiService) LogoutUserExecute(r ApiLogoutUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }
 
 type ApiUpdateUserRequest struct {
@@ -896,7 +848,7 @@ func (r ApiUpdateUserRequest) User(user User) ApiUpdateUserRequest {
 	return r
 }
 
-func (r ApiUpdateUserRequest) Execute() (*_nethttp.Response, GenericOpenAPIError) {
+func (r ApiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.UpdateUserExecute(r)
 }
 
@@ -918,20 +870,18 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string) ApiUp
 /*
  * Execute executes the request
  */
-func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, GenericOpenAPIError) {
+func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		executionError       GenericOpenAPIError
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.UpdateUser")
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
@@ -941,8 +891,7 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.user == nil {
-		executionError.error = "user is required and must be specified"
-		return nil, executionError
+		return nil, reportError("user is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -966,22 +915,18 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 	localVarPostBody = r.user
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		executionError.error = err.Error()
-		return nil, executionError
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
 	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		executionError.error = err.Error()
-		return localVarHTTPResponse, executionError
+		return localVarHTTPResponse, err
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
@@ -992,5 +937,5 @@ func (a *UserApiService) UpdateUserExecute(r ApiUpdateUserRequest) (*_nethttp.Re
 		return localVarHTTPResponse, newErr
 	}
 
-	return localVarHTTPResponse, executionError
+	return localVarHTTPResponse, nil
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
@@ -34,7 +34,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.AnotherFakeApi.Call123TestSpecialTags(context.Background()).Client(client).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `AnotherFakeApi.Call123TestSpecialTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/DefaultApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/DefaultApi.md
@@ -31,7 +31,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.DefaultApi.FooGet(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `DefaultApi.FooGet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -44,7 +44,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeHealthGet(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeHealthGet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -106,7 +106,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterBooleanSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterBooleanSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -172,7 +172,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterCompositeSerialize(context.Background()).OuterComposite(outerComposite).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterCompositeSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -238,7 +238,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterNumberSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterNumberSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -304,7 +304,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.FakeOuterStringSerialize(context.Background()).Body(body).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.FakeOuterStringSerialize``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -370,7 +370,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestBodyWithFileSchema(context.Background()).FileSchemaTestClass(fileSchemaTestClass).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithFileSchema``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -433,7 +433,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestBodyWithQueryParams(context.Background()).Query(query).User(user).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestBodyWithQueryParams``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -498,7 +498,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestClientModel(context.Background()).Client(client).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestClientModel``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -578,7 +578,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestEndpointParameters(context.Background()).Number(number).Double(double).PatternWithoutDelimiter(patternWithoutDelimiter).Byte_(byte_).Integer(integer).Int32_(int32_).Int64_(int64_).Float(float).String_(string_).Binary(binary).Date(date).DateTime(dateTime).Password(password).Callback(callback).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEndpointParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -662,7 +662,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestEnumParameters(context.Background()).EnumHeaderStringArray(enumHeaderStringArray).EnumHeaderString(enumHeaderString).EnumQueryStringArray(enumQueryStringArray).EnumQueryString(enumQueryString).EnumQueryInteger(enumQueryInteger).EnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestEnumParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -738,7 +738,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestGroupParameters(context.Background()).RequiredStringGroup(requiredStringGroup).RequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).BooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestGroupParameters``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -805,7 +805,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestInlineAdditionalProperties(context.Background()).RequestBody(requestBody).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestInlineAdditionalProperties``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -868,7 +868,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestJsonFormData(context.Background()).Param(param).Param2(param2).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestJsonFormData``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -937,7 +937,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeApi.TestQueryParameterCollectionFormat(context.Background()).Pipe(pipe).Ioutil(ioutil).Http(http).Url(url).Context(context).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeApi.TestQueryParameterCollectionFormat``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
@@ -34,7 +34,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.FakeClassnameTags123Api.TestClassname(context.Background()).Client(client).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `FakeClassnameTags123Api.TestClassname``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
@@ -40,7 +40,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.AddPet(context.Background()).Pet(pet).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.AddPet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -103,7 +103,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.DeletePet(context.Background(), petId).ApiKey(apiKey).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.DeletePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -172,7 +172,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.FindPetsByStatus(context.Background()).Status(status).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByStatus``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -238,7 +238,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.FindPetsByTags(context.Background()).Tags(tags).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.FindPetsByTags``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -304,7 +304,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.GetPetById(context.Background(), petId).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.GetPetById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -372,7 +372,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UpdatePet(context.Background()).Pet(pet).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePet``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -436,7 +436,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UpdatePetWithForm(context.Background(), petId).Name(name).Status(status).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UpdatePetWithForm``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -506,7 +506,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UploadFile(context.Background(), petId).AdditionalMetadata(additionalMetadata).File(file).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -578,7 +578,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.PetApi.UploadFileWithRequiredFile(context.Background(), petId).RequiredFile(requiredFile).AdditionalMetadata(additionalMetadata).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `PetApi.UploadFileWithRequiredFile``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -37,7 +37,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.DeleteOrder(context.Background(), orderId).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.DeleteOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -104,7 +104,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.GetInventory(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetInventory``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -166,7 +166,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.GetOrderById(context.Background(), orderId).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.GetOrderById``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -234,7 +234,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.StoreApi.PlaceOrder(context.Background()).Order(order).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `StoreApi.PlaceOrder``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/UserApi.md
@@ -41,7 +41,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.CreateUser(context.Background()).User(user).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -103,7 +103,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.CreateUsersWithArrayInput(context.Background()).User(user).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithArrayInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -165,7 +165,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.CreateUsersWithListInput(context.Background()).User(user).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.CreateUsersWithListInput``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -229,7 +229,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.DeleteUser(context.Background(), username).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.DeleteUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -295,7 +295,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.GetUserByName(context.Background(), username).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.GetUserByName``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -364,7 +364,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.LoginUser(context.Background()).Username(username).Password(password).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LoginUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -428,7 +428,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.LogoutUser(context.Background()).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.LogoutUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
@@ -489,7 +489,7 @@ func main() {
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)
     resp, r, err := api_client.UserApi.UpdateUser(context.Background(), username).User(user).Execute()
-    if err.Error() != "" {
+    if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `UserApi.UpdateUser``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }

--- a/samples/openapi3/client/petstore/go/http_signature_test.go
+++ b/samples/openapi3/client/petstore/go/http_signature_test.go
@@ -282,11 +282,11 @@ func executeHttpSignatureAuth(t *testing.T, authConfig *sw.HttpSignatureAuth, ex
 		authConfig.SigningScheme, authConfig.SigningAlgorithm, authConfig.SignatureMaxValidity, authConfig.SignedHeaders)
 
 	r, err2 := apiClient.PetApi.AddPet(authCtx).Pet(newPet).Execute()
-	if expectSuccess && err2.Error() != "" {
+	if expectSuccess && err2 != nil {
 		t.Fatalf("Error while adding pet: %v", err2)
 	}
 	if !expectSuccess {
-		if err2.Error() == "" {
+		if err2 == nil {
 			t.Fatalf("Error was expected, but no error was generated")
 		} else {
 			// Do not continue. Error is expected.
@@ -298,7 +298,7 @@ func executeHttpSignatureAuth(t *testing.T, authConfig *sw.HttpSignatureAuth, ex
 	}
 
 	_, r, err = apiClient.PetApi.GetPetById(authCtx, 12992).Execute()
-	if expectSuccess && err.Error() != "" {
+	if expectSuccess && err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 

--- a/samples/openapi3/client/petstore/go/pet_api_test.go
+++ b/samples/openapi3/client/petstore/go/pet_api_test.go
@@ -33,7 +33,7 @@ func TestAddPet(t *testing.T) {
 
 	r, err := client.PetApi.AddPet(context.Background()).Pet(newPet).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -44,7 +44,7 @@ func TestAddPet(t *testing.T) {
 func TestFindPetsByStatusWithMissingParam(t *testing.T) {
 	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while testing TestFindPetsByStatusWithMissingParam: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -59,12 +59,13 @@ func TestGetPetById(t *testing.T) {
 func TestGetPetByIdWithInvalidID(t *testing.T) {
 	resp, r, err := client.PetApi.GetPetById(context.Background(), 999999999).Execute()
 	if r != nil && r.StatusCode == 404 {
-		assertedError:= err
+		assertedError, ok := err.(sw.GenericOpenAPIError)
 		a := assert.New(t)
+		a.True(ok)
 		a.Contains(string(assertedError.Body()), "type")
 
 		a.Contains(assertedError.Error(), "Not Found")
-	} else if err.Error() != "" {
+	} else if err != nil {
 		t.Fatalf("Error while getting pet by invalid id: %v", err)
 		t.Log(r)
 	} else {
@@ -74,7 +75,7 @@ func TestGetPetByIdWithInvalidID(t *testing.T) {
 
 func TestUpdatePetWithForm(t *testing.T) {
 	r, err := client.PetApi.UpdatePetWithForm(context.Background(), 12830).Name("golang").Status("available").Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while updating pet by id: %v", err)
 		t.Log(r)
 	}
@@ -89,7 +90,7 @@ func TestUpdatePetWithForm(t *testing.T) {
 func TestFindPetsByTag(t *testing.T) {
 	var found = false
 	resp, r, err := client.PetApi.FindPetsByTags(context.Background()).Tags([]string{"tag2"}).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting pet by tag: %v", err)
 		t.Log(r)
 	} else {
@@ -118,7 +119,7 @@ func TestFindPetsByTag(t *testing.T) {
 
 func TestFindPetsByStatus(t *testing.T) {
 	resp, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status([]string{"available"}).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting pet by id: %v", err)
 		t.Log(r)
 	} else {
@@ -145,7 +146,7 @@ func TestUploadFile(t *testing.T) {
 
 	_, r, err := client.PetApi.UploadFile(context.Background(), 12830).AdditionalMetadata("golang").File(file).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)
 	}
 
@@ -163,7 +164,7 @@ func TestUploadFileRequired(t *testing.T) {
 
 	_, r, err := client.PetApi.UploadFileWithRequiredFile(context.Background(), 12830).RequiredFile(file).AdditionalMetadata("golang").Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)
 	}
 
@@ -175,7 +176,7 @@ func TestUploadFileRequired(t *testing.T) {
 func TestDeletePet(t *testing.T) {
 	r, err := client.PetApi.DeletePet(context.Background(), 12830).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -265,7 +266,7 @@ func waitOnFunctions(t *testing.T, errc chan error, n int) {
 func deletePet(t *testing.T, id int64) {
 	r, err := client.PetApi.DeletePet(context.Background(), id).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
 	if r.StatusCode != 200 {
@@ -276,7 +277,7 @@ func deletePet(t *testing.T, id int64) {
 func isPetCorrect(t *testing.T, id int64, name string, status string) {
 	assert := assert.New(t)
 	resp, r, err := client.PetApi.GetPetById(context.Background(), id).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting pet by id: %v", err)
 	} else {
 		assert.Equal(*resp.Id, int64(id), "Pet id should be equal")

--- a/samples/openapi3/client/petstore/go/store_api_test.go
+++ b/samples/openapi3/client/petstore/go/store_api_test.go
@@ -20,7 +20,7 @@ func TestPlaceOrder(t *testing.T) {
 
 	_, r, err := client.StoreApi.PlaceOrder(context.Background()).Order(newOrder).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		// Skip parsing time error due to error in Petstore Test Server
 		// https://github.com/OpenAPITools/openapi-generator/issues/1292
 		if regexp.

--- a/samples/openapi3/client/petstore/go/user_api_test.go
+++ b/samples/openapi3/client/petstore/go/user_api_test.go
@@ -22,7 +22,7 @@ func TestCreateUser(t *testing.T) {
 
 	apiResponse, err := client.UserApi.CreateUser(context.Background()).User(newUser).Execute()
 
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding user: %v", err)
 	}
 	if apiResponse.StatusCode != 200 {
@@ -56,7 +56,7 @@ func TestCreateUsersWithArrayInput(t *testing.T) {
 	}
 
 	apiResponse, err := client.UserApi.CreateUsersWithArrayInput(context.Background()).User(newUsers).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while adding users: %v", err)
 	}
 	if apiResponse.StatusCode != 200 {
@@ -83,7 +83,7 @@ func TestGetUserByName(t *testing.T) {
 	assert := assert.New(t)
 
 	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher").Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting user by id: %v", err)
 	} else {
 		assert.Equal(*resp.Id, int64(1000), "User id should be equal")
@@ -100,7 +100,7 @@ func TestGetUserByNameWithInvalidID(t *testing.T) {
 	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "999999999").Execute()
 	if apiResponse != nil && apiResponse.StatusCode == 404 {
 		return // This is a pass condition. API will return with a 404 error.
-	} else if err.Error() != "" {
+	} else if err != nil {
 		t.Fatalf("Error while getting user by invalid id: %v", err)
 		t.Log(apiResponse)
 	} else {
@@ -125,7 +125,7 @@ func TestUpdateUser(t *testing.T) {
 		UserStatus: sw.PtrInt32(1)}
 
 	apiResponse, err := client.UserApi.UpdateUser(context.Background(), "gopher").User(newUser).Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while deleting user by id: %v", err)
 	}
 	if apiResponse.StatusCode != 200 {
@@ -134,7 +134,7 @@ func TestUpdateUser(t *testing.T) {
 
 	//verify changings are correct
 	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher").Execute()
-	if err.Error() != "" {
+	if err != nil {
 		t.Fatalf("Error while getting user by id: %v", err)
 	} else {
 		assert.Equal(*resp.Id, int64(1000), "User id should be equal")


### PR DESCRIPTION
This reverts commit 1562afea3980484a7f1819c4f51b0d53a44a009f.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run 
  ```
  mvn clean package
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  to update all Petstore samples related to your fix. 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01)


