### PR TITLE
[Java] fix bug that dateLibrary java8 does works now with xml

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -241,6 +241,11 @@
             <artifactId>jackson-dataformat-xml</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.threeten-jaxb</groupId>
+            <artifactId>threeten-jaxb-core</artifactId>
+            <version>1.2</version>
+        </dependency>
 
         {{/withXml}}
         {{^java8}}

--- a/modules/openapi-generator/src/main/resources/Java/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/model.mustache
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.dataformat.xml.annotation.*;
 {{/jackson}}
 {{#withXml}}
 import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.*;
+import io.github.threetenjaxb.core.*;
 {{/withXml}}
 {{#parcelableModel}}
 import android.os.Parcelable;

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -52,6 +52,9 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
   @XmlElementWrapper({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
       {{/isXmlWrapped}}
     {{/isContainer}}
+  {{#isDateTime}}
+  @XmlJavaTypeAdapter(OffsetDateTimeXmlAdapter.class)
+  {{/isDateTime}}
   {{/isXmlAttribute}}
   {{/withXml}}
   {{#gson}}


### PR DESCRIPTION
Commit solves the problem, described here - https://github.com/OpenAPITools/openapi-generator/issues/8134