### PR TITLE
Style fix: use correct package name in tests

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpNetCoreClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpNetCoreClientCodegenTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.openapitools.codegen.csharp;
+package org.openapitools.codegen.csharpnetcore;
 
 import org.openapitools.codegen.languages.CSharpNetCoreClientCodegen;
 import org.testng.Assert;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Corrects package name in tests (copy-paste mistake), as pointed out here https://github.com/OpenAPITools/openapi-generator/commit/ee2f0e04a95e8b0eb6cec07b77515369bd062585#r45960427

@mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
