### PR TITLE
Adds isNull to codegenX java core classes that represent schemas

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -95,6 +95,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
     public boolean isArray;
     public boolean hasChildren;
     public boolean isMap;
+    public boolean isNull;
     /**
      * Indicates the OAS schema specifies "deprecated: true".
      */
@@ -703,6 +704,16 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
     }
 
     @Override
+    public boolean getIsNull() {
+        return isNull;
+    }
+
+    @Override
+    public void setIsNull(boolean isNull) {
+        this.isNull = isNull;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof CodegenModel)) return false;
@@ -730,6 +741,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 isMap == that.isMap &&
                 isDeprecated == that.isDeprecated &&
                 hasOnlyReadOnly == that.hasOnlyReadOnly &&
+                isNull == that.isNull &&
                 getUniqueItems() == that.getUniqueItems() &&
                 getExclusiveMinimum() == that.getExclusiveMinimum() &&
                 getExclusiveMaximum() == that.getExclusiveMaximum() &&
@@ -794,7 +806,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 getDescription(), getClassVarName(), getModelJson(), getDataType(), getXmlPrefix(), getXmlNamespace(),
                 getXmlName(), getClassFilename(), getUnescapedDescription(), getDiscriminator(), getDefaultValue(),
                 getArrayModelType(), isAlias, isString, isInteger, isLong, isNumber, isNumeric, isFloat, isDouble,
-                isDate, isDateTime,
+                isDate, isDateTime, isNull,
                 getVars(), getAllVars(), getRequiredVars(), getOptionalVars(), getReadOnlyVars(), getReadWriteVars(),
                 getParentVars(), getAllowableValues(), getMandatory(), getAllMandatory(), getImports(), hasVars,
                 isEmptyVars(), hasMoreModels, hasEnums, isEnum, isNullable, hasRequired, hasOptional, isArray,
@@ -885,6 +897,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         sb.append(", items='").append(items).append('\'');
         sb.append(", additionalProperties='").append(additionalProperties).append('\'');
         sb.append(", isModel='").append(isModel).append('\'');
+        sb.append(", isNull='").append(isNull);
         sb.append('}');
         return sb.toString();
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -101,6 +101,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
     public Number multipleOf;
     private Integer maxProperties;
     private Integer minProperties;
+    public boolean isNull;
 
     public CodegenParameter copy() {
         CodegenParameter output = new CodegenParameter();
@@ -147,6 +148,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
         output.minimum = this.minimum;
         output.pattern = this.pattern;
         output.additionalProperties = this.additionalProperties;
+        output.isNull = this.isNull;
 
         if (this._enum != null) {
             output._enum = new ArrayList<String>(this._enum);
@@ -200,7 +202,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
 
     @Override
     public int hashCode() {
-        return Objects.hash(isFormParam, isQueryParam, isPathParam, isHeaderParam, isCookieParam, isBodyParam, isContainer, isCollectionFormatMulti, isPrimitiveType, isModel, isExplode, baseName, paramName, dataType, datatypeWithEnum, dataFormat, collectionFormat, description, unescapedDescription, baseType, defaultValue, enumName, style, example, jsonSchema, isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isDecimal, isByteArray, isBinary, isBoolean, isDate, isDateTime, isUuid, isUri, isEmail, isFreeFormObject, isAnyType, isArray, isMap, isFile, isEnum, _enum, allowableValues, items, mostInnerItems, additionalProperties, vars, requiredVars, vendorExtensions, hasValidation, getMaxProperties(), getMinProperties(), isNullable, required, getMaximum(), getExclusiveMaximum(), getMinimum(), getExclusiveMinimum(), getMaxLength(), getMinLength(), getPattern(), getMaxItems(), getMinItems(), getUniqueItems(), contentType, multipleOf);
+        return Objects.hash(isFormParam, isQueryParam, isPathParam, isHeaderParam, isCookieParam, isBodyParam, isContainer, isCollectionFormatMulti, isPrimitiveType, isModel, isExplode, baseName, paramName, dataType, datatypeWithEnum, dataFormat, collectionFormat, description, unescapedDescription, baseType, defaultValue, enumName, style, example, jsonSchema, isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isDecimal, isByteArray, isBinary, isBoolean, isDate, isDateTime, isUuid, isUri, isEmail, isFreeFormObject, isAnyType, isArray, isMap, isFile, isEnum, _enum, allowableValues, items, mostInnerItems, additionalProperties, vars, requiredVars, vendorExtensions, hasValidation, getMaxProperties(), getMinProperties(), isNullable, required, getMaximum(), getExclusiveMaximum(), getMinimum(), getExclusiveMinimum(), getMaxLength(), getMinLength(), getPattern(), getMaxItems(), getMinItems(), getUniqueItems(), contentType, multipleOf, isNull);
     }
 
     @Override
@@ -244,6 +246,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
                 hasValidation == that.hasValidation &&
                 isNullable == that.isNullable &&
                 required == that.required &&
+                isNull == that.isNull &&
                 getExclusiveMaximum() == that.getExclusiveMaximum() &&
                 getExclusiveMinimum() == that.getExclusiveMinimum() &&
                 getUniqueItems() == that.getUniqueItems() &&
@@ -357,6 +360,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
         sb.append(", uniqueItems=").append(uniqueItems);
         sb.append(", contentType=").append(contentType);
         sb.append(", multipleOf=").append(multipleOf);
+        sb.append(", isNull=").append(isNull);
         sb.append('}');
         return sb.toString();
     }
@@ -567,6 +571,16 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
     @Override
     public void setRequiredVars(List<CodegenProperty> requiredVars) {
         this.requiredVars = requiredVars;
+    }
+
+    @Override
+    public boolean getIsNull() {
+        return isNull;
+    }
+
+    @Override
+    public void setIsNull(boolean isNull) {
+        this.isNull = isNull;
     }
 }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -132,6 +132,7 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
     public boolean isUuid;
     public boolean isUri;
     public boolean isEmail;
+    public boolean isNull;
     /**
      * The type is a free-form object, i.e. it is a map of string to values with no declared properties.
      * A OAS free-form schema may include the 'additionalProperties' attribute, which puts a constraint
@@ -677,6 +678,16 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
     }
 
     @Override
+    public boolean getIsNull() {
+        return isNull;
+    }
+
+    @Override
+    public void setIsNull(boolean isNull) {
+        this.isNull = isNull;
+    }
+
+    @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("CodegenProperty{");
         sb.append("openApiType='").append(openApiType).append('\'');
@@ -764,6 +775,7 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
         sb.append(", xmlName='").append(xmlName).append('\'');
         sb.append(", xmlNamespace='").append(xmlNamespace).append('\'');
         sb.append(", isXmlWrapped=").append(isXmlWrapped);
+        sb.append(", isNull=").append(isNull);
         sb.append('}');
         return sb.toString();
     }
@@ -812,6 +824,7 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
                 isInherited == that.isInherited &&
                 isXmlAttribute == that.isXmlAttribute &&
                 isXmlWrapped == that.isXmlWrapped &&
+                isNull == that.isNull &&
                 Objects.equals(openApiType, that.openApiType) &&
                 Objects.equals(baseName, that.baseName) &&
                 Objects.equals(complexType, that.complexType) &&
@@ -873,6 +886,6 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
                 items, mostInnerItems, additionalProperties, vars, requiredVars,
                 vendorExtensions, hasValidation, isInherited, discriminatorValue, nameInCamelCase,
                 nameInSnakeCase, enumName, maxItems, minItems, isXmlAttribute, xmlPrefix, xmlName,
-                xmlNamespace, isXmlWrapped);
+                xmlNamespace, isXmlWrapped, isNull);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
@@ -57,6 +57,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
     public boolean isArray;
     public boolean isBinary = false;
     public boolean isFile = false;
+    public boolean isNull;
     public Object schema;
     public String jsonSchema;
     public Map<String, Object> vendorExtensions = new HashMap<String, Object>();
@@ -84,7 +85,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
                 isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isDecimal, isByteArray, isBoolean, isDate,
                 isDateTime, isUuid, isEmail, isModel, isFreeFormObject, isAnyType, isDefault, simpleType, primitiveType,
                 isMap, isArray, isBinary, isFile, schema, jsonSchema, vendorExtensions, items, additionalProperties,
-                vars, requiredVars,
+                vars, requiredVars, isNull,
                 getMaxProperties(), getMinProperties(), uniqueItems, getMaxItems(), getMinItems(), getMaxLength(),
                 getMinLength(), exclusiveMinimum, exclusiveMaximum, getMinimum(), getMaximum(), getPattern(),
                 is1xx, is2xx, is3xx, is4xx, is5xx);
@@ -122,6 +123,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
                 isFile == that.isFile &&
                 items == that.items &&
                 additionalProperties == that.additionalProperties &&
+                isNull == that.isNull &&
                 is1xx == that.is1xx &&
                 is2xx == that.is2xx &&
                 is3xx == that.is3xx &&
@@ -423,6 +425,7 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
         sb.append(", additionalProperties='").append(additionalProperties).append('\'');
         sb.append(", vars='").append(vars).append('\'');
         sb.append(", requiredVars='").append(requiredVars).append('\'');
+        sb.append(", isNull='").append(isNull);
         sb.append('}');
         return sb.toString();
     }
@@ -442,5 +445,15 @@ public class CodegenResponse implements IJsonSchemaValidationProperties {
         if (code != null && code.length() == 3 && "XX".equalsIgnoreCase(code.substring(1)))
             return true;
         return false;
+    }
+
+    @Override
+    public boolean getIsNull() {
+        return isNull;
+    }
+
+    @Override
+    public void setIsNull(boolean isNull) {
+        this.isNull = isNull;
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2306,6 +2306,8 @@ public class DefaultCodegen implements CodegenConfig {
             m.arrayModelType = arrayProperty.complexType;
             addParentContainer(m, name, schema);
             ModelUtils.syncValidationProperties(schema, m);
+        } else if (ModelUtils.isNullType(schema)) {
+            m.isNull = true;
         } else if (schema instanceof ComposedSchema) {
             final ComposedSchema composed = (ComposedSchema) schema;
             Map<String, Schema> properties = new LinkedHashMap<String, Schema>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3281,6 +3281,8 @@ public class DefaultCodegen implements CodegenConfig {
                 innerSchema = new StringSchema().description("//TODO automatically added by openapi-generator due to undefined type");
                 p.setAdditionalProperties(innerSchema);
             }
+        } else if (ModelUtils.isNullType(p)) {
+            property.isNull = true;
         }
 
         //Inline enum case:
@@ -4046,6 +4048,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (r.schema != null) {
             Map<String, Schema> allSchemas = null;
             CodegenProperty cp = fromProperty("response", responseSchema);
+            r.isNull = cp.isNull;
 
             if (ModelUtils.isArraySchema(responseSchema)) {
                 ArraySchema as = (ArraySchema) responseSchema;
@@ -4319,6 +4322,8 @@ public class DefaultCodegen implements CodegenConfig {
                     imports.add(codegenProperty.baseType);
                     codegenProperty = codegenProperty.items;
                 }
+            } else if (ModelUtils.isNullType(parameterSchema)) {
+                codegenParameter.isNull = true;
             }
 /* TODO revise the logic below
             } else {
@@ -6148,6 +6153,7 @@ public class DefaultCodegen implements CodegenConfig {
                 } else {
                     codegenParameter.baseName = bodyParameterName;
                 }
+                codegenParameter.isNull = codegenProperty.isNull;
                 codegenParameter.isPrimitiveType = true;
                 codegenParameter.baseType = codegenProperty.baseType;
                 codegenParameter.dataType = codegenProperty.dataType;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
@@ -90,4 +90,8 @@ public interface IJsonSchemaValidationProperties {
     List<CodegenProperty> getRequiredVars();
 
     void setRequiredVars(List<CodegenProperty> requiredVars);
+
+    boolean getIsNull();
+
+    void setIsNull(boolean isNull);
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -2557,6 +2557,11 @@ public class DefaultCodegenTest {
         assertEquals(cm.isString, false);
         assertEquals(cm.isDate, true);
 
+        modelName = "NullModel";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.isNull, true);
+
         modelName = "ObjectWithDateWithValidation";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         cm = codegen.fromModel(modelName, sc);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -2562,6 +2562,18 @@ public class DefaultCodegenTest {
         cm = codegen.fromModel(modelName, sc);
         assertEquals(cm.isNull, true);
 
+        modelName = "ObjectWithTypeNullProperties";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.getVars().get(0).isNull, true);
+        assertEquals(cm.getVars().get(1).getItems().isNull, true);
+        assertEquals(cm.getAdditionalProperties().isNull, true);
+
+        modelName = "ArrayOfNulls";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.getItems().isNull, true);
+
         modelName = "ObjectWithDateWithValidation";
         sc = openAPI.getComponents().getSchemas().get(modelName);
         cm = codegen.fromModel(modelName, sc);
@@ -2623,6 +2635,20 @@ public class DefaultCodegenTest {
         assertEquals(co.bodyParams.get(0).isDateTime, true);
         assertEquals(co.responses.get(0).isString, false);
         assertEquals(co.responses.get(0).isDateTime, true);
+
+        path = "/null/{param}";
+        operation = openAPI.getPaths().get(path).getPost();
+        co = codegen.fromOperation(path, "POST", operation, null);
+        assertEquals(co.pathParams.get(0).isNull, true);
+        assertEquals(co.bodyParams.get(0).isNull, true);
+        assertEquals(co.responses.get(0).isNull, true);
+
+        path = "/ref_null/{param}";
+        operation = openAPI.getPaths().get(path).getPost();
+        co = codegen.fromOperation(path, "POST", operation, null);
+        assertEquals(co.pathParams.get(0).isNull, true);
+        assertEquals(co.bodyParams.get(0).isNull, true);
+        assertEquals(co.responses.get(0).isNull, true);
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/issue_7651.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_7651.yaml
@@ -120,6 +120,54 @@ paths:
                 type: string
                 format: date-time
                 pattern: '^2020.*'
+  /null/{param}:
+    post:
+      tags:
+        - isX
+      operationId: null
+      parameters:
+        - name: param
+          in: path
+          required: true
+          schema:
+            type: 'null'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: 'null'
+        required: true
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                type: 'null'
+  /ref_null/{param}:
+    post:
+      tags:
+        - isX
+      operationId: null
+      parameters:
+        - name: param
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/NullModel'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NullModel'
+        required: true
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NullModel'
 components:
   schemas:
     NullModel:
@@ -135,7 +183,7 @@ components:
             type: 'null'
       additionalProperties:
         type: 'null'
-    ArrayModelOfNulls:
+    ArrayOfNulls:
       type: array
       items:
         type: 'null'

--- a/modules/openapi-generator/src/test/resources/3_0/issue_7651.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_7651.yaml
@@ -122,6 +122,23 @@ paths:
                 pattern: '^2020.*'
 components:
   schemas:
+    NullModel:
+      type: 'null'
+    ObjectWithTypeNullProperties:
+      type: object
+      properties:
+        nullProp:
+          type: 'null'
+        listOfNulls:
+          type: array
+          items:
+            type: 'null'
+      additionalProperties:
+        type: 'null'
+    ArrayModelOfNulls:
+      type: array
+      items:
+        type: 'null'
     DateWithValidation:
       type: string
       format: date

--- a/samples/openapi3/client/petstore/python/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/python/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-unset
+5.0.1-SNAPSHOT

--- a/samples/openapi3/client/petstore/python/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/python/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.0.1-SNAPSHOT
+unset


### PR DESCRIPTION
Adds isNull to codegenModel codegenParameter codegenProperty codegenResponse
This is different than nullable: True
isNull should be set to true for schemas of type null like:
```
  schema:
    type: 'null'
```
Note: this is a v3.1 feature
Adding this property and these getIsNull setIsNull methods is a feature break out for https://github.com/OpenAPITools/openapi-generator/issues/7651

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
