### PR TITLE
[Rust Server] Reinstate tests

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -15,7 +15,7 @@ client = [
     "mime_0_2",
 {{/apiUsesMultipart}}
 {{#apiUsesMultipartFormData}}
-    "multipart", "multipart/client", "swagger/multipart",
+    "multipart", "multipart/client", "swagger/multipart_form",
 {{/apiUsesMultipartFormData}}
 {{#apiUsesMultipartRelated}}
     "hyper_0_10", "mime_multipart",

--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -60,7 +60,7 @@ openssl = {version = "0.10", optional = true }
 async-trait = "0.1.24"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = "5.0.0-alpha-1"
+swagger = "5.0.2"
 log = "0.4.0"
 mime = "0.3"
 

--- a/modules/openapi-generator/src/main/resources/rust-server/server-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-operation.mustache
@@ -39,7 +39,7 @@
 {{/hasAuthMethods}}
 {{#vendorExtensions}}
   {{#x-consumes-multipart}}
-                let boundary = match swagger::multipart::boundary(&headers) {
+                let boundary = match swagger::multipart::form::boundary(&headers) {
                     Some(boundary) => boundary.to_string(),
                     None => return Ok(Response::builder()
                                 .status(StatusCode::BAD_REQUEST)

--- a/pom.xml
+++ b/pom.xml
@@ -1189,7 +1189,7 @@
                 <module>samples/server/petstore/php-slim4</module>
                 <module>samples/server/petstore/php-laravel</module>
                 <module>samples/server/petstore/php-lumen</module>
-                <!--<module>samples/server/petstore/rust-server</module>-->
+                <module>samples/server/petstore/rust-server</module>
                 <!-- clients -->
                 <!--<module>samples/client/petstore/perl</module>
                 <module>samples/client/petstore/bash</module>-->

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 default = ["client", "server"]
 client = [
     "mime_0_2",
-    "multipart", "multipart/client", "swagger/multipart",
+    "multipart", "multipart/client", "swagger/multipart_form",
     "hyper_0_10", "mime_multipart",
     "hyper", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -35,7 +35,7 @@ openssl = {version = "0.10", optional = true }
 async-trait = "0.1.24"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = "5.0.0-alpha-1"
+swagger = "5.0.2"
 log = "0.4.0"
 mime = "0.3"
 

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/server/mod.rs
@@ -286,7 +286,7 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
 
             // MultipartRequestPost - POST /multipart_request
             &hyper::Method::POST if path.matched(paths::ID_MULTIPART_REQUEST) => {
-                let boundary = match swagger::multipart::boundary(&headers) {
+                let boundary = match swagger::multipart::form::boundary(&headers) {
                     Some(boundary) => boundary.to_string(),
                     None => return Ok(Response::builder()
                                 .status(StatusCode::BAD_REQUEST)

--- a/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
@@ -29,7 +29,7 @@ openssl = {version = "0.10", optional = true }
 async-trait = "0.1.24"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = "5.0.0-alpha-1"
+swagger = "5.0.2"
 log = "0.4.0"
 mime = "0.3"
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -31,7 +31,7 @@ openssl = {version = "0.10", optional = true }
 async-trait = "0.1.24"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = "5.0.0-alpha-1"
+swagger = "5.0.2"
 log = "0.4.0"
 mime = "0.3"
 

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -29,7 +29,7 @@ openssl = {version = "0.10", optional = true }
 async-trait = "0.1.24"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = "5.0.0-alpha-1"
+swagger = "5.0.2"
 log = "0.4.0"
 mime = "0.3"
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -34,7 +34,7 @@ openssl = {version = "0.10", optional = true }
 async-trait = "0.1.24"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = "5.0.0-alpha-1"
+swagger = "5.0.2"
 log = "0.4.0"
 mime = "0.3"
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 default = ["client", "server"]
 client = [
     "mime_0_2",
-    "multipart", "multipart/client", "swagger/multipart",
+    "multipart", "multipart/client", "swagger/multipart_form",
     "serde_urlencoded",
     "hyper", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -1989,7 +1989,7 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                     }
                 }
 
-                let boundary = match swagger::multipart::boundary(&headers) {
+                let boundary = match swagger::multipart::form::boundary(&headers) {
                     Some(boundary) => boundary.to_string(),
                     None => return Ok(Response::builder()
                                 .status(StatusCode::BAD_REQUEST)

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -29,7 +29,7 @@ openssl = {version = "0.10", optional = true }
 async-trait = "0.1.24"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
-swagger = "5.0.0-alpha-1"
+swagger = "5.0.2"
 log = "0.4.0"
 mime = "0.3"
 


### PR DESCRIPTION
This reverts https://github.com/OpenAPITools/openapi-generator/pull/8440 and updates swagger-rs to fix the tests - I'm surprised this wasn't picked up by CI automatically.

### Rust Server Technical Committee

@frol @farcaller @paladinzh

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
