### PR TITLE
[ plugin docs ] Update gradle plugin version to 5.0.0

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -76,7 +76,7 @@ buildscript {
     maven { url "https://repo1.maven.org/maven2" }
   }
   dependencies {
-    classpath "org.openapitools:openapi-generator-gradle-plugin:3.3.4"
+    classpath "org.openapitools:openapi-generator-gradle-plugin:4.3.1"
   }
 }
 
@@ -111,9 +111,6 @@ openApiGenerate {
     apiPackage = "org.openapi.example.api"
     invokerPackage = "org.openapi.example.invoker"
     modelPackage = "org.openapi.example.model"
-    modelFilesConstrainedTo = [
-            "Error"
-    ]
     configOptions = [
         dateLibrary: "java8"
     ]

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -15,7 +15,7 @@ Add to your `build->plugins` section (default phase is `generate-sources` phase)
 <plugin>
     <groupId>org.openapitools</groupId>
     <artifactId>openapi-generator-maven-plugin</artifactId>
-    <version>4.3.1</version>
+    <version>5.0.0</version>
     <executions>
         <execution>
             <goals>
@@ -76,7 +76,7 @@ buildscript {
     maven { url "https://repo1.maven.org/maven2" }
   }
   dependencies {
-    classpath "org.openapitools:openapi-generator-gradle-plugin:4.3.1"
+    classpath "org.openapitools:openapi-generator-gradle-plugin:5.0.0"
   }
 }
 


### PR DESCRIPTION
1. Updated gradle plugin version to 5.0.0 (the latest stable release)
2. Removed modelFilesConstrainedTo  in the gradle sample to generate code for dummies who are pasting and running.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
