### PR TITLE
Raise an error when passing None authentication values in Python

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -618,6 +618,8 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
+                if auth_setting['value'] is None:
+                    raise ApiValueError('Invalid authentication parameter value')
                 if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -618,12 +618,12 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if auth_setting['value'] is None:
-                    raise ApiValueError('Invalid authentication parameter value')
                 if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     if auth_setting['type'] != 'http-signature':
+                        if auth_setting['value'] is None:
+                            raise ApiValueError('Invalid authentication parameter value')
                         headers[auth_setting['key']] = auth_setting['value']
 {{#hasHttpSignatureMethods}}
                     else:

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -606,12 +606,12 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if auth_setting['value'] is None:
-                    raise ApiValueError('Invalid authentication parameter value')
                 if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     if auth_setting['type'] != 'http-signature':
+                        if auth_setting['value'] is None:
+                            raise ApiValueError('Invalid authentication parameter value')
                         headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':
                     querys.append((auth_setting['key'], auth_setting['value']))

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -606,6 +606,8 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
+                if auth_setting['value'] is None:
+                    raise ApiValueError('Invalid authentication parameter value')
                 if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/api_client.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/api_client.py
@@ -606,12 +606,12 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if auth_setting['value'] is None:
-                    raise ApiValueError('Invalid authentication parameter value')
                 if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     if auth_setting['type'] != 'http-signature':
+                        if auth_setting['value'] is None:
+                            raise ApiValueError('Invalid authentication parameter value')
                         headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':
                     querys.append((auth_setting['key'], auth_setting['value']))

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/api_client.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/api_client.py
@@ -606,6 +606,8 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
+                if auth_setting['value'] is None:
+                    raise ApiValueError('Invalid authentication parameter value')
                 if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api_client.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api_client.py
@@ -606,12 +606,12 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if auth_setting['value'] is None:
-                    raise ApiValueError('Invalid authentication parameter value')
                 if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     if auth_setting['type'] != 'http-signature':
+                        if auth_setting['value'] is None:
+                            raise ApiValueError('Invalid authentication parameter value')
                         headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':
                     querys.append((auth_setting['key'], auth_setting['value']))

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api_client.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api_client.py
@@ -606,6 +606,8 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
+                if auth_setting['value'] is None:
+                    raise ApiValueError('Invalid authentication parameter value')
                 if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -606,6 +606,8 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
+                if auth_setting['value'] is None:
+                    raise ApiValueError('Invalid authentication parameter value')
                 if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -606,12 +606,12 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if auth_setting['value'] is None:
-                    raise ApiValueError('Invalid authentication parameter value')
                 if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     if auth_setting['type'] != 'http-signature':
+                        if auth_setting['value'] is None:
+                            raise ApiValueError('Invalid authentication parameter value')
                         headers[auth_setting['key']] = auth_setting['value']
                     else:
                         # The HTTP signature scheme requires multiple HTTP headers


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

When using a client that gets value from the environment, it's very easy
to end up with None in api_key, which gives a pretty error about
bytes-like object down in the HTTP code. This raises an error earlier.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.