### PR TITLE
[PYTHON] use customized default Configuration() objects if available

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-legacy/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/model.mustache
@@ -61,7 +61,7 @@ class {{classname}}(object):
     def __init__(self{{#vars}}, {{name}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}{{/vars}}, local_vars_configuration=None):  # noqa: E501
         """{{classname}} - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 {{#vars}}{{#-first}}
 {{/-first}}

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -61,7 +61,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration()
+            configuration = Configuration.get_default_copy()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_any_type.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_any_type.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesAnyType(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesAnyType - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_array.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_array.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesArray(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesArray - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_boolean.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_boolean.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesBoolean(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesBoolean - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_class.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_class.py
@@ -63,7 +63,7 @@ class AdditionalPropertiesClass(object):
     def __init__(self, map_string=None, map_number=None, map_integer=None, map_boolean=None, map_array_integer=None, map_array_anytype=None, map_map_string=None, map_map_anytype=None, anytype_1=None, anytype_2=None, anytype_3=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._map_string = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_integer.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_integer.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesInteger(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesInteger - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_number.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_number.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesNumber(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesNumber - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_object.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_object.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesObject(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesObject - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_string.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/additional_properties_string.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesString(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesString - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/animal.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/animal.py
@@ -51,7 +51,7 @@ class Animal(object):
     def __init__(self, class_name=None, color='red', local_vars_configuration=None):  # noqa: E501
         """Animal - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._class_name = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/api_response.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/api_response.py
@@ -47,7 +47,7 @@ class ApiResponse(object):
     def __init__(self, code=None, type=None, message=None, local_vars_configuration=None):  # noqa: E501
         """ApiResponse - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._code = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/array_of_array_of_number_only.py
@@ -43,7 +43,7 @@ class ArrayOfArrayOfNumberOnly(object):
     def __init__(self, array_array_number=None, local_vars_configuration=None):  # noqa: E501
         """ArrayOfArrayOfNumberOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._array_array_number = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/array_of_number_only.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/array_of_number_only.py
@@ -43,7 +43,7 @@ class ArrayOfNumberOnly(object):
     def __init__(self, array_number=None, local_vars_configuration=None):  # noqa: E501
         """ArrayOfNumberOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._array_number = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/array_test.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/array_test.py
@@ -47,7 +47,7 @@ class ArrayTest(object):
     def __init__(self, array_of_string=None, array_array_of_integer=None, array_array_of_model=None, local_vars_configuration=None):  # noqa: E501
         """ArrayTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._array_of_string = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/big_cat.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/big_cat.py
@@ -43,7 +43,7 @@ class BigCat(object):
     def __init__(self, kind=None, local_vars_configuration=None):  # noqa: E501
         """BigCat - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._kind = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/big_cat_all_of.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/big_cat_all_of.py
@@ -43,7 +43,7 @@ class BigCatAllOf(object):
     def __init__(self, kind=None, local_vars_configuration=None):  # noqa: E501
         """BigCatAllOf - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._kind = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/capitalization.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/capitalization.py
@@ -53,7 +53,7 @@ class Capitalization(object):
     def __init__(self, small_camel=None, capital_camel=None, small_snake=None, capital_snake=None, sca_eth_flow_points=None, att_name=None, local_vars_configuration=None):  # noqa: E501
         """Capitalization - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._small_camel = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/cat.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/cat.py
@@ -43,7 +43,7 @@ class Cat(object):
     def __init__(self, declawed=None, local_vars_configuration=None):  # noqa: E501
         """Cat - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._declawed = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/cat_all_of.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/cat_all_of.py
@@ -43,7 +43,7 @@ class CatAllOf(object):
     def __init__(self, declawed=None, local_vars_configuration=None):  # noqa: E501
         """CatAllOf - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._declawed = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/category.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/category.py
@@ -45,7 +45,7 @@ class Category(object):
     def __init__(self, id=None, name='default-name', local_vars_configuration=None):  # noqa: E501
         """Category - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/class_model.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/class_model.py
@@ -43,7 +43,7 @@ class ClassModel(object):
     def __init__(self, _class=None, local_vars_configuration=None):  # noqa: E501
         """ClassModel - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self.__class = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/client.py
@@ -43,7 +43,7 @@ class Client(object):
     def __init__(self, client=None, local_vars_configuration=None):  # noqa: E501
         """Client - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._client = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/dog.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/dog.py
@@ -43,7 +43,7 @@ class Dog(object):
     def __init__(self, breed=None, local_vars_configuration=None):  # noqa: E501
         """Dog - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._breed = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/dog_all_of.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/dog_all_of.py
@@ -43,7 +43,7 @@ class DogAllOf(object):
     def __init__(self, breed=None, local_vars_configuration=None):  # noqa: E501
         """DogAllOf - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._breed = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/enum_arrays.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/enum_arrays.py
@@ -45,7 +45,7 @@ class EnumArrays(object):
     def __init__(self, just_symbol=None, array_enum=None, local_vars_configuration=None):  # noqa: E501
         """EnumArrays - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._just_symbol = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/enum_class.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/enum_class.py
@@ -50,7 +50,7 @@ class EnumClass(object):
     def __init__(self, local_vars_configuration=None):  # noqa: E501
         """EnumClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
         self.discriminator = None
 

--- a/samples/client/petstore/python-asyncio/petstore_api/models/enum_test.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/enum_test.py
@@ -51,7 +51,7 @@ class EnumTest(object):
     def __init__(self, enum_string=None, enum_string_required=None, enum_integer=None, enum_number=None, outer_enum=None, local_vars_configuration=None):  # noqa: E501
         """EnumTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._enum_string = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/file.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/file.py
@@ -43,7 +43,7 @@ class File(object):
     def __init__(self, source_uri=None, local_vars_configuration=None):  # noqa: E501
         """File - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._source_uri = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/file_schema_test_class.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/file_schema_test_class.py
@@ -45,7 +45,7 @@ class FileSchemaTestClass(object):
     def __init__(self, file=None, files=None, local_vars_configuration=None):  # noqa: E501
         """FileSchemaTestClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._file = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/format_test.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/format_test.py
@@ -69,7 +69,7 @@ class FormatTest(object):
     def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, string=None, byte=None, binary=None, date=None, date_time=None, uuid=None, password=None, big_decimal=None, local_vars_configuration=None):  # noqa: E501
         """FormatTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._integer = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/has_only_read_only.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/has_only_read_only.py
@@ -45,7 +45,7 @@ class HasOnlyReadOnly(object):
     def __init__(self, bar=None, foo=None, local_vars_configuration=None):  # noqa: E501
         """HasOnlyReadOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._bar = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/list.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/list.py
@@ -43,7 +43,7 @@ class List(object):
     def __init__(self, _123_list=None, local_vars_configuration=None):  # noqa: E501
         """List - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self.__123_list = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/map_test.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/map_test.py
@@ -49,7 +49,7 @@ class MapTest(object):
     def __init__(self, map_map_of_string=None, map_of_enum_string=None, direct_map=None, indirect_map=None, local_vars_configuration=None):  # noqa: E501
         """MapTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._map_map_of_string = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -47,7 +47,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(object):
     def __init__(self, uuid=None, date_time=None, map=None, local_vars_configuration=None):  # noqa: E501
         """MixedPropertiesAndAdditionalPropertiesClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._uuid = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/model200_response.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/model200_response.py
@@ -45,7 +45,7 @@ class Model200Response(object):
     def __init__(self, name=None, _class=None, local_vars_configuration=None):  # noqa: E501
         """Model200Response - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/model_return.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/model_return.py
@@ -43,7 +43,7 @@ class ModelReturn(object):
     def __init__(self, _return=None, local_vars_configuration=None):  # noqa: E501
         """ModelReturn - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self.__return = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/name.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/name.py
@@ -49,7 +49,7 @@ class Name(object):
     def __init__(self, name=None, snake_case=None, _property=None, _123_number=None, local_vars_configuration=None):  # noqa: E501
         """Name - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/number_only.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/number_only.py
@@ -43,7 +43,7 @@ class NumberOnly(object):
     def __init__(self, just_number=None, local_vars_configuration=None):  # noqa: E501
         """NumberOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._just_number = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/order.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/order.py
@@ -53,7 +53,7 @@ class Order(object):
     def __init__(self, id=None, pet_id=None, quantity=None, ship_date=None, status=None, complete=False, local_vars_configuration=None):  # noqa: E501
         """Order - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/outer_composite.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/outer_composite.py
@@ -47,7 +47,7 @@ class OuterComposite(object):
     def __init__(self, my_number=None, my_string=None, my_boolean=None, local_vars_configuration=None):  # noqa: E501
         """OuterComposite - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._my_number = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/outer_enum.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/outer_enum.py
@@ -50,7 +50,7 @@ class OuterEnum(object):
     def __init__(self, local_vars_configuration=None):  # noqa: E501
         """OuterEnum - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
         self.discriminator = None
 

--- a/samples/client/petstore/python-asyncio/petstore_api/models/pet.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/pet.py
@@ -53,7 +53,7 @@ class Pet(object):
     def __init__(self, id=None, category=None, name=None, photo_urls=None, tags=None, status=None, local_vars_configuration=None):  # noqa: E501
         """Pet - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/read_only_first.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/read_only_first.py
@@ -45,7 +45,7 @@ class ReadOnlyFirst(object):
     def __init__(self, bar=None, baz=None, local_vars_configuration=None):  # noqa: E501
         """ReadOnlyFirst - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._bar = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/special_model_name.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/special_model_name.py
@@ -43,7 +43,7 @@ class SpecialModelName(object):
     def __init__(self, special_property_name=None, local_vars_configuration=None):  # noqa: E501
         """SpecialModelName - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._special_property_name = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/tag.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/tag.py
@@ -45,7 +45,7 @@ class Tag(object):
     def __init__(self, id=None, name=None, local_vars_configuration=None):  # noqa: E501
         """Tag - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/type_holder_default.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/type_holder_default.py
@@ -51,7 +51,7 @@ class TypeHolderDefault(object):
     def __init__(self, string_item='what', number_item=None, integer_item=None, bool_item=True, array_item=None, local_vars_configuration=None):  # noqa: E501
         """TypeHolderDefault - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._string_item = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/type_holder_example.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/type_holder_example.py
@@ -53,7 +53,7 @@ class TypeHolderExample(object):
     def __init__(self, string_item=None, number_item=None, float_item=None, integer_item=None, bool_item=None, array_item=None, local_vars_configuration=None):  # noqa: E501
         """TypeHolderExample - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._string_item = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/user.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/user.py
@@ -57,7 +57,7 @@ class User(object):
     def __init__(self, id=None, username=None, first_name=None, last_name=None, email=None, password=None, phone=None, user_status=None, local_vars_configuration=None):  # noqa: E501
         """User - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-asyncio/petstore_api/models/xml_item.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/xml_item.py
@@ -99,7 +99,7 @@ class XmlItem(object):
     def __init__(self, attribute_string=None, attribute_number=None, attribute_integer=None, attribute_boolean=None, wrapped_array=None, name_string=None, name_number=None, name_integer=None, name_boolean=None, name_array=None, name_wrapped_array=None, prefix_string=None, prefix_number=None, prefix_integer=None, prefix_boolean=None, prefix_array=None, prefix_wrapped_array=None, namespace_string=None, namespace_number=None, namespace_integer=None, namespace_boolean=None, namespace_array=None, namespace_wrapped_array=None, prefix_ns_string=None, prefix_ns_number=None, prefix_ns_integer=None, prefix_ns_boolean=None, prefix_ns_array=None, prefix_ns_wrapped_array=None, local_vars_configuration=None):  # noqa: E501
         """XmlItem - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._attribute_string = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_any_type.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_any_type.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesAnyType(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesAnyType - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_array.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_array.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesArray(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesArray - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_boolean.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_boolean.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesBoolean(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesBoolean - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_class.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_class.py
@@ -63,7 +63,7 @@ class AdditionalPropertiesClass(object):
     def __init__(self, map_string=None, map_number=None, map_integer=None, map_boolean=None, map_array_integer=None, map_array_anytype=None, map_map_string=None, map_map_anytype=None, anytype_1=None, anytype_2=None, anytype_3=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._map_string = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_integer.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_integer.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesInteger(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesInteger - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_number.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_number.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesNumber(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesNumber - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_object.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_object.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesObject(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesObject - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_string.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/additional_properties_string.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesString(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesString - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/animal.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/animal.py
@@ -51,7 +51,7 @@ class Animal(object):
     def __init__(self, class_name=None, color='red', local_vars_configuration=None):  # noqa: E501
         """Animal - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._class_name = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/api_response.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/api_response.py
@@ -47,7 +47,7 @@ class ApiResponse(object):
     def __init__(self, code=None, type=None, message=None, local_vars_configuration=None):  # noqa: E501
         """ApiResponse - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._code = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/array_of_array_of_number_only.py
@@ -43,7 +43,7 @@ class ArrayOfArrayOfNumberOnly(object):
     def __init__(self, array_array_number=None, local_vars_configuration=None):  # noqa: E501
         """ArrayOfArrayOfNumberOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._array_array_number = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/array_of_number_only.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/array_of_number_only.py
@@ -43,7 +43,7 @@ class ArrayOfNumberOnly(object):
     def __init__(self, array_number=None, local_vars_configuration=None):  # noqa: E501
         """ArrayOfNumberOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._array_number = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/array_test.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/array_test.py
@@ -47,7 +47,7 @@ class ArrayTest(object):
     def __init__(self, array_of_string=None, array_array_of_integer=None, array_array_of_model=None, local_vars_configuration=None):  # noqa: E501
         """ArrayTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._array_of_string = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/big_cat.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/big_cat.py
@@ -43,7 +43,7 @@ class BigCat(object):
     def __init__(self, kind=None, local_vars_configuration=None):  # noqa: E501
         """BigCat - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._kind = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/big_cat_all_of.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/big_cat_all_of.py
@@ -43,7 +43,7 @@ class BigCatAllOf(object):
     def __init__(self, kind=None, local_vars_configuration=None):  # noqa: E501
         """BigCatAllOf - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._kind = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/capitalization.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/capitalization.py
@@ -53,7 +53,7 @@ class Capitalization(object):
     def __init__(self, small_camel=None, capital_camel=None, small_snake=None, capital_snake=None, sca_eth_flow_points=None, att_name=None, local_vars_configuration=None):  # noqa: E501
         """Capitalization - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._small_camel = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/cat.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/cat.py
@@ -43,7 +43,7 @@ class Cat(object):
     def __init__(self, declawed=None, local_vars_configuration=None):  # noqa: E501
         """Cat - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._declawed = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/cat_all_of.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/cat_all_of.py
@@ -43,7 +43,7 @@ class CatAllOf(object):
     def __init__(self, declawed=None, local_vars_configuration=None):  # noqa: E501
         """CatAllOf - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._declawed = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/category.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/category.py
@@ -45,7 +45,7 @@ class Category(object):
     def __init__(self, id=None, name='default-name', local_vars_configuration=None):  # noqa: E501
         """Category - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/class_model.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/class_model.py
@@ -43,7 +43,7 @@ class ClassModel(object):
     def __init__(self, _class=None, local_vars_configuration=None):  # noqa: E501
         """ClassModel - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self.__class = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/client.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/client.py
@@ -43,7 +43,7 @@ class Client(object):
     def __init__(self, client=None, local_vars_configuration=None):  # noqa: E501
         """Client - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._client = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/dog.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/dog.py
@@ -43,7 +43,7 @@ class Dog(object):
     def __init__(self, breed=None, local_vars_configuration=None):  # noqa: E501
         """Dog - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._breed = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/dog_all_of.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/dog_all_of.py
@@ -43,7 +43,7 @@ class DogAllOf(object):
     def __init__(self, breed=None, local_vars_configuration=None):  # noqa: E501
         """DogAllOf - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._breed = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/enum_arrays.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/enum_arrays.py
@@ -45,7 +45,7 @@ class EnumArrays(object):
     def __init__(self, just_symbol=None, array_enum=None, local_vars_configuration=None):  # noqa: E501
         """EnumArrays - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._just_symbol = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/enum_class.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/enum_class.py
@@ -50,7 +50,7 @@ class EnumClass(object):
     def __init__(self, local_vars_configuration=None):  # noqa: E501
         """EnumClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
         self.discriminator = None
 

--- a/samples/client/petstore/python-legacy/petstore_api/models/enum_test.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/enum_test.py
@@ -51,7 +51,7 @@ class EnumTest(object):
     def __init__(self, enum_string=None, enum_string_required=None, enum_integer=None, enum_number=None, outer_enum=None, local_vars_configuration=None):  # noqa: E501
         """EnumTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._enum_string = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/file.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/file.py
@@ -43,7 +43,7 @@ class File(object):
     def __init__(self, source_uri=None, local_vars_configuration=None):  # noqa: E501
         """File - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._source_uri = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/file_schema_test_class.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/file_schema_test_class.py
@@ -45,7 +45,7 @@ class FileSchemaTestClass(object):
     def __init__(self, file=None, files=None, local_vars_configuration=None):  # noqa: E501
         """FileSchemaTestClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._file = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/format_test.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/format_test.py
@@ -69,7 +69,7 @@ class FormatTest(object):
     def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, string=None, byte=None, binary=None, date=None, date_time=None, uuid=None, password=None, big_decimal=None, local_vars_configuration=None):  # noqa: E501
         """FormatTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._integer = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/has_only_read_only.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/has_only_read_only.py
@@ -45,7 +45,7 @@ class HasOnlyReadOnly(object):
     def __init__(self, bar=None, foo=None, local_vars_configuration=None):  # noqa: E501
         """HasOnlyReadOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._bar = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/list.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/list.py
@@ -43,7 +43,7 @@ class List(object):
     def __init__(self, _123_list=None, local_vars_configuration=None):  # noqa: E501
         """List - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self.__123_list = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/map_test.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/map_test.py
@@ -49,7 +49,7 @@ class MapTest(object):
     def __init__(self, map_map_of_string=None, map_of_enum_string=None, direct_map=None, indirect_map=None, local_vars_configuration=None):  # noqa: E501
         """MapTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._map_map_of_string = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -47,7 +47,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(object):
     def __init__(self, uuid=None, date_time=None, map=None, local_vars_configuration=None):  # noqa: E501
         """MixedPropertiesAndAdditionalPropertiesClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._uuid = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/model200_response.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/model200_response.py
@@ -45,7 +45,7 @@ class Model200Response(object):
     def __init__(self, name=None, _class=None, local_vars_configuration=None):  # noqa: E501
         """Model200Response - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/model_return.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/model_return.py
@@ -43,7 +43,7 @@ class ModelReturn(object):
     def __init__(self, _return=None, local_vars_configuration=None):  # noqa: E501
         """ModelReturn - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self.__return = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/name.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/name.py
@@ -49,7 +49,7 @@ class Name(object):
     def __init__(self, name=None, snake_case=None, _property=None, _123_number=None, local_vars_configuration=None):  # noqa: E501
         """Name - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/number_only.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/number_only.py
@@ -43,7 +43,7 @@ class NumberOnly(object):
     def __init__(self, just_number=None, local_vars_configuration=None):  # noqa: E501
         """NumberOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._just_number = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/order.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/order.py
@@ -53,7 +53,7 @@ class Order(object):
     def __init__(self, id=None, pet_id=None, quantity=None, ship_date=None, status=None, complete=False, local_vars_configuration=None):  # noqa: E501
         """Order - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/outer_composite.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/outer_composite.py
@@ -47,7 +47,7 @@ class OuterComposite(object):
     def __init__(self, my_number=None, my_string=None, my_boolean=None, local_vars_configuration=None):  # noqa: E501
         """OuterComposite - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._my_number = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/outer_enum.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/outer_enum.py
@@ -50,7 +50,7 @@ class OuterEnum(object):
     def __init__(self, local_vars_configuration=None):  # noqa: E501
         """OuterEnum - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
         self.discriminator = None
 

--- a/samples/client/petstore/python-legacy/petstore_api/models/pet.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/pet.py
@@ -53,7 +53,7 @@ class Pet(object):
     def __init__(self, id=None, category=None, name=None, photo_urls=None, tags=None, status=None, local_vars_configuration=None):  # noqa: E501
         """Pet - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/read_only_first.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/read_only_first.py
@@ -45,7 +45,7 @@ class ReadOnlyFirst(object):
     def __init__(self, bar=None, baz=None, local_vars_configuration=None):  # noqa: E501
         """ReadOnlyFirst - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._bar = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/special_model_name.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/special_model_name.py
@@ -43,7 +43,7 @@ class SpecialModelName(object):
     def __init__(self, special_property_name=None, local_vars_configuration=None):  # noqa: E501
         """SpecialModelName - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._special_property_name = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/tag.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/tag.py
@@ -45,7 +45,7 @@ class Tag(object):
     def __init__(self, id=None, name=None, local_vars_configuration=None):  # noqa: E501
         """Tag - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/type_holder_default.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/type_holder_default.py
@@ -51,7 +51,7 @@ class TypeHolderDefault(object):
     def __init__(self, string_item='what', number_item=None, integer_item=None, bool_item=True, array_item=None, local_vars_configuration=None):  # noqa: E501
         """TypeHolderDefault - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._string_item = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/type_holder_example.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/type_holder_example.py
@@ -53,7 +53,7 @@ class TypeHolderExample(object):
     def __init__(self, string_item=None, number_item=None, float_item=None, integer_item=None, bool_item=None, array_item=None, local_vars_configuration=None):  # noqa: E501
         """TypeHolderExample - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._string_item = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/user.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/user.py
@@ -57,7 +57,7 @@ class User(object):
     def __init__(self, id=None, username=None, first_name=None, last_name=None, email=None, password=None, phone=None, user_status=None, local_vars_configuration=None):  # noqa: E501
         """User - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-legacy/petstore_api/models/xml_item.py
+++ b/samples/client/petstore/python-legacy/petstore_api/models/xml_item.py
@@ -99,7 +99,7 @@ class XmlItem(object):
     def __init__(self, attribute_string=None, attribute_number=None, attribute_integer=None, attribute_boolean=None, wrapped_array=None, name_string=None, name_number=None, name_integer=None, name_boolean=None, name_array=None, name_wrapped_array=None, prefix_string=None, prefix_number=None, prefix_integer=None, prefix_boolean=None, prefix_array=None, prefix_wrapped_array=None, namespace_string=None, namespace_number=None, namespace_integer=None, namespace_boolean=None, namespace_array=None, namespace_wrapped_array=None, prefix_ns_string=None, prefix_ns_number=None, prefix_ns_integer=None, prefix_ns_boolean=None, prefix_ns_array=None, prefix_ns_wrapped_array=None, local_vars_configuration=None):  # noqa: E501
         """XmlItem - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._attribute_string = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_any_type.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_any_type.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesAnyType(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesAnyType - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_array.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_array.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesArray(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesArray - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_boolean.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_boolean.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesBoolean(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesBoolean - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_class.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_class.py
@@ -63,7 +63,7 @@ class AdditionalPropertiesClass(object):
     def __init__(self, map_string=None, map_number=None, map_integer=None, map_boolean=None, map_array_integer=None, map_array_anytype=None, map_map_string=None, map_map_anytype=None, anytype_1=None, anytype_2=None, anytype_3=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._map_string = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_integer.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_integer.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesInteger(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesInteger - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_number.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_number.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesNumber(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesNumber - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_object.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_object.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesObject(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesObject - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_string.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/additional_properties_string.py
@@ -43,7 +43,7 @@ class AdditionalPropertiesString(object):
     def __init__(self, name=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesString - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/animal.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/animal.py
@@ -51,7 +51,7 @@ class Animal(object):
     def __init__(self, class_name=None, color='red', local_vars_configuration=None):  # noqa: E501
         """Animal - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._class_name = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/api_response.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/api_response.py
@@ -47,7 +47,7 @@ class ApiResponse(object):
     def __init__(self, code=None, type=None, message=None, local_vars_configuration=None):  # noqa: E501
         """ApiResponse - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._code = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/array_of_array_of_number_only.py
@@ -43,7 +43,7 @@ class ArrayOfArrayOfNumberOnly(object):
     def __init__(self, array_array_number=None, local_vars_configuration=None):  # noqa: E501
         """ArrayOfArrayOfNumberOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._array_array_number = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/array_of_number_only.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/array_of_number_only.py
@@ -43,7 +43,7 @@ class ArrayOfNumberOnly(object):
     def __init__(self, array_number=None, local_vars_configuration=None):  # noqa: E501
         """ArrayOfNumberOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._array_number = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/array_test.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/array_test.py
@@ -47,7 +47,7 @@ class ArrayTest(object):
     def __init__(self, array_of_string=None, array_array_of_integer=None, array_array_of_model=None, local_vars_configuration=None):  # noqa: E501
         """ArrayTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._array_of_string = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/big_cat.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/big_cat.py
@@ -43,7 +43,7 @@ class BigCat(object):
     def __init__(self, kind=None, local_vars_configuration=None):  # noqa: E501
         """BigCat - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._kind = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/big_cat_all_of.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/big_cat_all_of.py
@@ -43,7 +43,7 @@ class BigCatAllOf(object):
     def __init__(self, kind=None, local_vars_configuration=None):  # noqa: E501
         """BigCatAllOf - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._kind = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/capitalization.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/capitalization.py
@@ -53,7 +53,7 @@ class Capitalization(object):
     def __init__(self, small_camel=None, capital_camel=None, small_snake=None, capital_snake=None, sca_eth_flow_points=None, att_name=None, local_vars_configuration=None):  # noqa: E501
         """Capitalization - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._small_camel = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/cat.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/cat.py
@@ -43,7 +43,7 @@ class Cat(object):
     def __init__(self, declawed=None, local_vars_configuration=None):  # noqa: E501
         """Cat - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._declawed = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/cat_all_of.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/cat_all_of.py
@@ -43,7 +43,7 @@ class CatAllOf(object):
     def __init__(self, declawed=None, local_vars_configuration=None):  # noqa: E501
         """CatAllOf - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._declawed = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/category.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/category.py
@@ -45,7 +45,7 @@ class Category(object):
     def __init__(self, id=None, name='default-name', local_vars_configuration=None):  # noqa: E501
         """Category - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/class_model.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/class_model.py
@@ -43,7 +43,7 @@ class ClassModel(object):
     def __init__(self, _class=None, local_vars_configuration=None):  # noqa: E501
         """ClassModel - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self.__class = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/client.py
@@ -43,7 +43,7 @@ class Client(object):
     def __init__(self, client=None, local_vars_configuration=None):  # noqa: E501
         """Client - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._client = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/dog.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/dog.py
@@ -43,7 +43,7 @@ class Dog(object):
     def __init__(self, breed=None, local_vars_configuration=None):  # noqa: E501
         """Dog - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._breed = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/dog_all_of.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/dog_all_of.py
@@ -43,7 +43,7 @@ class DogAllOf(object):
     def __init__(self, breed=None, local_vars_configuration=None):  # noqa: E501
         """DogAllOf - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._breed = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/enum_arrays.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/enum_arrays.py
@@ -45,7 +45,7 @@ class EnumArrays(object):
     def __init__(self, just_symbol=None, array_enum=None, local_vars_configuration=None):  # noqa: E501
         """EnumArrays - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._just_symbol = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/enum_class.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/enum_class.py
@@ -50,7 +50,7 @@ class EnumClass(object):
     def __init__(self, local_vars_configuration=None):  # noqa: E501
         """EnumClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
         self.discriminator = None
 

--- a/samples/client/petstore/python-tornado/petstore_api/models/enum_test.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/enum_test.py
@@ -51,7 +51,7 @@ class EnumTest(object):
     def __init__(self, enum_string=None, enum_string_required=None, enum_integer=None, enum_number=None, outer_enum=None, local_vars_configuration=None):  # noqa: E501
         """EnumTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._enum_string = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/file.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/file.py
@@ -43,7 +43,7 @@ class File(object):
     def __init__(self, source_uri=None, local_vars_configuration=None):  # noqa: E501
         """File - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._source_uri = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/file_schema_test_class.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/file_schema_test_class.py
@@ -45,7 +45,7 @@ class FileSchemaTestClass(object):
     def __init__(self, file=None, files=None, local_vars_configuration=None):  # noqa: E501
         """FileSchemaTestClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._file = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/format_test.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/format_test.py
@@ -69,7 +69,7 @@ class FormatTest(object):
     def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, string=None, byte=None, binary=None, date=None, date_time=None, uuid=None, password=None, big_decimal=None, local_vars_configuration=None):  # noqa: E501
         """FormatTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._integer = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/has_only_read_only.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/has_only_read_only.py
@@ -45,7 +45,7 @@ class HasOnlyReadOnly(object):
     def __init__(self, bar=None, foo=None, local_vars_configuration=None):  # noqa: E501
         """HasOnlyReadOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._bar = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/list.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/list.py
@@ -43,7 +43,7 @@ class List(object):
     def __init__(self, _123_list=None, local_vars_configuration=None):  # noqa: E501
         """List - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self.__123_list = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/map_test.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/map_test.py
@@ -49,7 +49,7 @@ class MapTest(object):
     def __init__(self, map_map_of_string=None, map_of_enum_string=None, direct_map=None, indirect_map=None, local_vars_configuration=None):  # noqa: E501
         """MapTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._map_map_of_string = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -47,7 +47,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(object):
     def __init__(self, uuid=None, date_time=None, map=None, local_vars_configuration=None):  # noqa: E501
         """MixedPropertiesAndAdditionalPropertiesClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._uuid = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/model200_response.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/model200_response.py
@@ -45,7 +45,7 @@ class Model200Response(object):
     def __init__(self, name=None, _class=None, local_vars_configuration=None):  # noqa: E501
         """Model200Response - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/model_return.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/model_return.py
@@ -43,7 +43,7 @@ class ModelReturn(object):
     def __init__(self, _return=None, local_vars_configuration=None):  # noqa: E501
         """ModelReturn - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self.__return = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/name.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/name.py
@@ -49,7 +49,7 @@ class Name(object):
     def __init__(self, name=None, snake_case=None, _property=None, _123_number=None, local_vars_configuration=None):  # noqa: E501
         """Name - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/number_only.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/number_only.py
@@ -43,7 +43,7 @@ class NumberOnly(object):
     def __init__(self, just_number=None, local_vars_configuration=None):  # noqa: E501
         """NumberOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._just_number = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/order.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/order.py
@@ -53,7 +53,7 @@ class Order(object):
     def __init__(self, id=None, pet_id=None, quantity=None, ship_date=None, status=None, complete=False, local_vars_configuration=None):  # noqa: E501
         """Order - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/outer_composite.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/outer_composite.py
@@ -47,7 +47,7 @@ class OuterComposite(object):
     def __init__(self, my_number=None, my_string=None, my_boolean=None, local_vars_configuration=None):  # noqa: E501
         """OuterComposite - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._my_number = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/outer_enum.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/outer_enum.py
@@ -50,7 +50,7 @@ class OuterEnum(object):
     def __init__(self, local_vars_configuration=None):  # noqa: E501
         """OuterEnum - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
         self.discriminator = None
 

--- a/samples/client/petstore/python-tornado/petstore_api/models/pet.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/pet.py
@@ -53,7 +53,7 @@ class Pet(object):
     def __init__(self, id=None, category=None, name=None, photo_urls=None, tags=None, status=None, local_vars_configuration=None):  # noqa: E501
         """Pet - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/read_only_first.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/read_only_first.py
@@ -45,7 +45,7 @@ class ReadOnlyFirst(object):
     def __init__(self, bar=None, baz=None, local_vars_configuration=None):  # noqa: E501
         """ReadOnlyFirst - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._bar = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/special_model_name.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/special_model_name.py
@@ -43,7 +43,7 @@ class SpecialModelName(object):
     def __init__(self, special_property_name=None, local_vars_configuration=None):  # noqa: E501
         """SpecialModelName - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._special_property_name = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/tag.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/tag.py
@@ -45,7 +45,7 @@ class Tag(object):
     def __init__(self, id=None, name=None, local_vars_configuration=None):  # noqa: E501
         """Tag - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/type_holder_default.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/type_holder_default.py
@@ -51,7 +51,7 @@ class TypeHolderDefault(object):
     def __init__(self, string_item='what', number_item=None, integer_item=None, bool_item=True, array_item=None, local_vars_configuration=None):  # noqa: E501
         """TypeHolderDefault - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._string_item = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/type_holder_example.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/type_holder_example.py
@@ -53,7 +53,7 @@ class TypeHolderExample(object):
     def __init__(self, string_item=None, number_item=None, float_item=None, integer_item=None, bool_item=None, array_item=None, local_vars_configuration=None):  # noqa: E501
         """TypeHolderExample - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._string_item = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/user.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/user.py
@@ -57,7 +57,7 @@ class User(object):
     def __init__(self, id=None, username=None, first_name=None, last_name=None, email=None, password=None, phone=None, user_status=None, local_vars_configuration=None):  # noqa: E501
         """User - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/client/petstore/python-tornado/petstore_api/models/xml_item.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/xml_item.py
@@ -99,7 +99,7 @@ class XmlItem(object):
     def __init__(self, attribute_string=None, attribute_number=None, attribute_integer=None, attribute_boolean=None, wrapped_array=None, name_string=None, name_number=None, name_integer=None, name_boolean=None, name_array=None, name_wrapped_array=None, prefix_string=None, prefix_number=None, prefix_integer=None, prefix_boolean=None, prefix_array=None, prefix_wrapped_array=None, namespace_string=None, namespace_number=None, namespace_integer=None, namespace_boolean=None, namespace_array=None, namespace_wrapped_array=None, prefix_ns_string=None, prefix_ns_number=None, prefix_ns_integer=None, prefix_ns_boolean=None, prefix_ns_array=None, prefix_ns_wrapped_array=None, local_vars_configuration=None):  # noqa: E501
         """XmlItem - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._attribute_string = None

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -66,7 +66,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration()
+            configuration = Configuration.get_default_copy()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/api_client.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/api_client.py
@@ -66,7 +66,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration()
+            configuration = Configuration.get_default_copy()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api_client.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api_client.py
@@ -66,7 +66,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration()
+            configuration = Configuration.get_default_copy()
         self.configuration = configuration
         self.pool_threads = pool_threads
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/additional_properties_class.py
@@ -45,7 +45,7 @@ class AdditionalPropertiesClass(object):
     def __init__(self, map_property=None, map_of_map_property=None, local_vars_configuration=None):  # noqa: E501
         """AdditionalPropertiesClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._map_property = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/animal.py
@@ -50,7 +50,7 @@ class Animal(object):
     def __init__(self, class_name=None, color='red', local_vars_configuration=None):  # noqa: E501
         """Animal - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._class_name = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/api_response.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/api_response.py
@@ -47,7 +47,7 @@ class ApiResponse(object):
     def __init__(self, code=None, type=None, message=None, local_vars_configuration=None):  # noqa: E501
         """ApiResponse - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._code = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/array_of_array_of_number_only.py
@@ -43,7 +43,7 @@ class ArrayOfArrayOfNumberOnly(object):
     def __init__(self, array_array_number=None, local_vars_configuration=None):  # noqa: E501
         """ArrayOfArrayOfNumberOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._array_array_number = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/array_of_number_only.py
@@ -43,7 +43,7 @@ class ArrayOfNumberOnly(object):
     def __init__(self, array_number=None, local_vars_configuration=None):  # noqa: E501
         """ArrayOfNumberOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._array_number = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/array_test.py
@@ -47,7 +47,7 @@ class ArrayTest(object):
     def __init__(self, array_of_string=None, array_array_of_integer=None, array_array_of_model=None, local_vars_configuration=None):  # noqa: E501
         """ArrayTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._array_of_string = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/capitalization.py
@@ -53,7 +53,7 @@ class Capitalization(object):
     def __init__(self, small_camel=None, capital_camel=None, small_snake=None, capital_snake=None, sca_eth_flow_points=None, att_name=None, local_vars_configuration=None):  # noqa: E501
         """Capitalization - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._small_camel = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/cat.py
@@ -43,7 +43,7 @@ class Cat(object):
     def __init__(self, declawed=None, local_vars_configuration=None):  # noqa: E501
         """Cat - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._declawed = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/cat_all_of.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/cat_all_of.py
@@ -43,7 +43,7 @@ class CatAllOf(object):
     def __init__(self, declawed=None, local_vars_configuration=None):  # noqa: E501
         """CatAllOf - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._declawed = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/category.py
@@ -45,7 +45,7 @@ class Category(object):
     def __init__(self, id=None, name='default-name', local_vars_configuration=None):  # noqa: E501
         """Category - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/class_model.py
@@ -43,7 +43,7 @@ class ClassModel(object):
     def __init__(self, _class=None, local_vars_configuration=None):  # noqa: E501
         """ClassModel - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self.__class = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/client.py
@@ -43,7 +43,7 @@ class Client(object):
     def __init__(self, client=None, local_vars_configuration=None):  # noqa: E501
         """Client - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._client = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/dog.py
@@ -43,7 +43,7 @@ class Dog(object):
     def __init__(self, breed=None, local_vars_configuration=None):  # noqa: E501
         """Dog - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._breed = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/dog_all_of.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/dog_all_of.py
@@ -43,7 +43,7 @@ class DogAllOf(object):
     def __init__(self, breed=None, local_vars_configuration=None):  # noqa: E501
         """DogAllOf - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._breed = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/enum_arrays.py
@@ -45,7 +45,7 @@ class EnumArrays(object):
     def __init__(self, just_symbol=None, array_enum=None, local_vars_configuration=None):  # noqa: E501
         """EnumArrays - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._just_symbol = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/enum_class.py
@@ -50,7 +50,7 @@ class EnumClass(object):
     def __init__(self, local_vars_configuration=None):  # noqa: E501
         """EnumClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
         self.discriminator = None
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/enum_test.py
@@ -57,7 +57,7 @@ class EnumTest(object):
     def __init__(self, enum_string=None, enum_string_required=None, enum_integer=None, enum_number=None, outer_enum=None, outer_enum_integer=None, outer_enum_default_value=None, outer_enum_integer_default_value=None, local_vars_configuration=None):  # noqa: E501
         """EnumTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._enum_string = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/file.py
@@ -43,7 +43,7 @@ class File(object):
     def __init__(self, source_uri=None, local_vars_configuration=None):  # noqa: E501
         """File - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._source_uri = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/file_schema_test_class.py
@@ -45,7 +45,7 @@ class FileSchemaTestClass(object):
     def __init__(self, file=None, files=None, local_vars_configuration=None):  # noqa: E501
         """FileSchemaTestClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._file = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/foo.py
@@ -43,7 +43,7 @@ class Foo(object):
     def __init__(self, bar='bar', local_vars_configuration=None):  # noqa: E501
         """Foo - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._bar = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/format_test.py
@@ -73,7 +73,7 @@ class FormatTest(object):
     def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, decimal=None, string=None, byte=None, binary=None, date=None, date_time=None, uuid=None, password=None, pattern_with_digits=None, pattern_with_digits_and_delimiter=None, local_vars_configuration=None):  # noqa: E501
         """FormatTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._integer = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/has_only_read_only.py
@@ -45,7 +45,7 @@ class HasOnlyReadOnly(object):
     def __init__(self, bar=None, foo=None, local_vars_configuration=None):  # noqa: E501
         """HasOnlyReadOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._bar = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/health_check_result.py
@@ -43,7 +43,7 @@ class HealthCheckResult(object):
     def __init__(self, nullable_message=None, local_vars_configuration=None):  # noqa: E501
         """HealthCheckResult - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._nullable_message = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_object.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_object.py
@@ -45,7 +45,7 @@ class InlineObject(object):
     def __init__(self, name=None, status=None, local_vars_configuration=None):  # noqa: E501
         """InlineObject - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_object1.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_object1.py
@@ -45,7 +45,7 @@ class InlineObject1(object):
     def __init__(self, additional_metadata=None, file=None, local_vars_configuration=None):  # noqa: E501
         """InlineObject1 - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._additional_metadata = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_object2.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_object2.py
@@ -45,7 +45,7 @@ class InlineObject2(object):
     def __init__(self, enum_form_string_array=None, enum_form_string='-efg', local_vars_configuration=None):  # noqa: E501
         """InlineObject2 - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._enum_form_string_array = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_object3.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_object3.py
@@ -69,7 +69,7 @@ class InlineObject3(object):
     def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, string=None, pattern_without_delimiter=None, byte=None, binary=None, date=None, date_time=None, password=None, callback=None, local_vars_configuration=None):  # noqa: E501
         """InlineObject3 - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._integer = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_object4.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_object4.py
@@ -45,7 +45,7 @@ class InlineObject4(object):
     def __init__(self, param=None, param2=None, local_vars_configuration=None):  # noqa: E501
         """InlineObject4 - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._param = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_object5.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_object5.py
@@ -45,7 +45,7 @@ class InlineObject5(object):
     def __init__(self, additional_metadata=None, required_file=None, local_vars_configuration=None):  # noqa: E501
         """InlineObject5 - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._additional_metadata = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_response_default.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/inline_response_default.py
@@ -43,7 +43,7 @@ class InlineResponseDefault(object):
     def __init__(self, string=None, local_vars_configuration=None):  # noqa: E501
         """InlineResponseDefault - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._string = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/list.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/list.py
@@ -43,7 +43,7 @@ class List(object):
     def __init__(self, _123_list=None, local_vars_configuration=None):  # noqa: E501
         """List - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self.__123_list = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/map_test.py
@@ -49,7 +49,7 @@ class MapTest(object):
     def __init__(self, map_map_of_string=None, map_of_enum_string=None, direct_map=None, indirect_map=None, local_vars_configuration=None):  # noqa: E501
         """MapTest - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._map_map_of_string = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -47,7 +47,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(object):
     def __init__(self, uuid=None, date_time=None, map=None, local_vars_configuration=None):  # noqa: E501
         """MixedPropertiesAndAdditionalPropertiesClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._uuid = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/model200_response.py
@@ -45,7 +45,7 @@ class Model200Response(object):
     def __init__(self, name=None, _class=None, local_vars_configuration=None):  # noqa: E501
         """Model200Response - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/model_return.py
@@ -43,7 +43,7 @@ class ModelReturn(object):
     def __init__(self, _return=None, local_vars_configuration=None):  # noqa: E501
         """ModelReturn - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self.__return = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/name.py
@@ -49,7 +49,7 @@ class Name(object):
     def __init__(self, name=None, snake_case=None, _property=None, _123_number=None, local_vars_configuration=None):  # noqa: E501
         """Name - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._name = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/nullable_class.py
@@ -65,7 +65,7 @@ class NullableClass(object):
     def __init__(self, integer_prop=None, number_prop=None, boolean_prop=None, string_prop=None, date_prop=None, datetime_prop=None, array_nullable_prop=None, array_and_items_nullable_prop=None, array_items_nullable=None, object_nullable_prop=None, object_and_items_nullable_prop=None, object_items_nullable=None, local_vars_configuration=None):  # noqa: E501
         """NullableClass - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._integer_prop = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/number_only.py
@@ -43,7 +43,7 @@ class NumberOnly(object):
     def __init__(self, just_number=None, local_vars_configuration=None):  # noqa: E501
         """NumberOnly - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._just_number = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/order.py
@@ -53,7 +53,7 @@ class Order(object):
     def __init__(self, id=None, pet_id=None, quantity=None, ship_date=None, status=None, complete=False, local_vars_configuration=None):  # noqa: E501
         """Order - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/outer_composite.py
@@ -47,7 +47,7 @@ class OuterComposite(object):
     def __init__(self, my_number=None, my_string=None, my_boolean=None, local_vars_configuration=None):  # noqa: E501
         """OuterComposite - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._my_number = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/outer_enum.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/outer_enum.py
@@ -50,7 +50,7 @@ class OuterEnum(object):
     def __init__(self, local_vars_configuration=None):  # noqa: E501
         """OuterEnum - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
         self.discriminator = None
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/outer_enum_default_value.py
@@ -50,7 +50,7 @@ class OuterEnumDefaultValue(object):
     def __init__(self, local_vars_configuration=None):  # noqa: E501
         """OuterEnumDefaultValue - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
         self.discriminator = None
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/outer_enum_integer.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/outer_enum_integer.py
@@ -50,7 +50,7 @@ class OuterEnumInteger(object):
     def __init__(self, local_vars_configuration=None):  # noqa: E501
         """OuterEnumInteger - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
         self.discriminator = None
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/outer_enum_integer_default_value.py
@@ -50,7 +50,7 @@ class OuterEnumIntegerDefaultValue(object):
     def __init__(self, local_vars_configuration=None):  # noqa: E501
         """OuterEnumIntegerDefaultValue - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
         self.discriminator = None
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/pet.py
@@ -53,7 +53,7 @@ class Pet(object):
     def __init__(self, id=None, category=None, name=None, photo_urls=None, tags=None, status=None, local_vars_configuration=None):  # noqa: E501
         """Pet - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/read_only_first.py
@@ -45,7 +45,7 @@ class ReadOnlyFirst(object):
     def __init__(self, bar=None, baz=None, local_vars_configuration=None):  # noqa: E501
         """ReadOnlyFirst - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._bar = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/special_model_name.py
@@ -43,7 +43,7 @@ class SpecialModelName(object):
     def __init__(self, special_property_name=None, local_vars_configuration=None):  # noqa: E501
         """SpecialModelName - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._special_property_name = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/tag.py
@@ -45,7 +45,7 @@ class Tag(object):
     def __init__(self, id=None, name=None, local_vars_configuration=None):  # noqa: E501
         """Tag - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/models/user.py
@@ -57,7 +57,7 @@ class User(object):
     def __init__(self, id=None, username=None, first_name=None, last_name=None, email=None, password=None, phone=None, user_status=None, local_vars_configuration=None):  # noqa: E501
         """User - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
-            local_vars_configuration = Configuration()
+            local_vars_configuration = Configuration.get_default_copy()
         self.local_vars_configuration = local_vars_configuration
 
         self._id = None

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -66,7 +66,7 @@ class ApiClient(object):
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1):
         if configuration is None:
-            configuration = Configuration()
+            configuration = Configuration.get_default_copy()
         self.configuration = configuration
         self.pool_threads = pool_threads
 


### PR DESCRIPTION
To be reviewed by the Python Technical Committee:  
@taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @Jyhess @arun-nalla @spacether

For the Python variants, the generated `PACKAGENAME.configuration.Configuration` class allows the programmer to save the data from pre-configured instance of it as the default to be used for future instances.
However, this requires the classes to be instantiated using `Configuration.get_default_copy()`, rather than just `Configuration()`.
This PR changes the templates/samples to use the `Configuration.get_default_copy()` wherever a naked `Configuration()` was found.
This has the effect of making the programmer's stored Configuration be used (such as to override the client-side verification setting), if the programmer set one, and the hard-coded defaults used otherwise.

Related Issue: #8499

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
