### PR TITLE
refactor: erefactor/AutoRefactor - Diamond operator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AndroidClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AndroidClientCodegen.java
@@ -117,7 +117,7 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
                         "native", "super", "while", "null")
         );
 
-        languageSpecificPrimitives = new HashSet<String>(
+        languageSpecificPrimitives = new HashSet<>(
                 Arrays.asList(
                         "String",
                         "boolean",

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Apache2ConfigCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Apache2ConfigCodegen.java
@@ -94,13 +94,13 @@ public class Apache2ConfigCodegen extends DefaultCodegen implements CodegenConfi
     public Map<String, Object> postProcessOperationsWithModels(Map<String, Object> objs, List<Object> allModels) {
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         List<CodegenOperation> operationList = (List<CodegenOperation>) operations.get("operation");
-        List<CodegenOperation> newOpList = new ArrayList<CodegenOperation>();
+        List<CodegenOperation> newOpList = new ArrayList<>();
 
         for (CodegenOperation op : operationList) {
             String path = op.path;
 
             String[] items = path.split("/", -1);
-            List<String> splitPath = new ArrayList<String>();
+            List<String> splitPath = new ArrayList<>();
             for (String item : items) {
                 if (item.matches("^\\{(.*)\\}$")) {
                     item = "*";
@@ -116,7 +116,7 @@ public class Apache2ConfigCodegen extends DefaultCodegen implements CodegenConfi
                         foundInNewList = true;
                         List<CodegenOperation> currentOtherMethodList = (List<CodegenOperation>) op1.vendorExtensions.get("x-codegen-otherMethods");
                         if (currentOtherMethodList == null) {
-                            currentOtherMethodList = new ArrayList<CodegenOperation>();
+                            currentOtherMethodList = new ArrayList<>();
                         }
                         op.operationIdCamelCase = op1.operationIdCamelCase;
                         currentOtherMethodList.add(op);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ApexClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ApexClientCodegen.java
@@ -49,7 +49,7 @@ public class ApexClientCodegen extends AbstractApexCodegen {
     private String namedCredential;
     private String srcPath = "force-app/main/default/";
     private String sfdxConfigPath = "config/";
-    private HashMap<String, Object> primitiveDefaults = new HashMap<String, Object>();
+    private HashMap<String, Object> primitiveDefaults = new HashMap<>();
 
     public ApexClientCodegen() {
         super();
@@ -113,7 +113,7 @@ public class ApexClientCodegen extends AbstractApexCodegen {
                         "virtual", "void", "webservice", "when", "where", "while"
                 ));
 
-        languageSpecificPrimitives = new HashSet<String>(
+        languageSpecificPrimitives = new HashSet<>(
                 Arrays.asList("Blob", "Boolean", "Date", "Datetime", "Decimal", "Double", "ID",
                         "Integer", "Long", "Object", "String", "Time"
                 ));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AsciidocDocumentationCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AsciidocDocumentationCodegen.java
@@ -214,7 +214,7 @@ public class AsciidocDocumentationCodegen extends DefaultCodegen implements Code
         outputFolder = "generated-code" + File.separator + "asciidoc";
         embeddedTemplateDir = templateDir = "asciidoc-documentation";
 
-        defaultIncludes = new HashSet<String>();
+        defaultIncludes = new HashSet<>();
 
         cliOptions.add(new CliOption("appName", "short name of the application"));
         cliOptions.add(new CliOption("appDescription", "description of the application"));
@@ -261,10 +261,10 @@ public class AsciidocDocumentationCodegen extends DefaultCodegen implements Code
         additionalProperties.put(CodegenConstants.ARTIFACT_VERSION, artifactVersion);
 
         supportingFiles.add(new SupportingFile("index.mustache", "", "index.adoc"));
-        reservedWords = new HashSet<String>();
+        reservedWords = new HashSet<>();
 
-        languageSpecificPrimitives = new HashSet<String>();
-        importMapping = new HashMap<String, String>();
+        languageSpecificPrimitives = new HashSet<>();
+        importMapping = new HashMap<>();
 
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/BashClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/BashClientCodegen.java
@@ -206,7 +206,7 @@ public class BashClientCodegen extends DefaultCodegen implements CodegenConfig {
         /**
          * Bash reserved words.
          */
-        reservedWords = new HashSet<String>(
+        reservedWords = new HashSet<>(
                 Arrays.asList(
                         "case",
                         "do",

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
@@ -870,7 +870,7 @@ public class CLibcurlClientCodegen extends DefaultCodegen implements CodegenConf
         }
 
         // only procees the following type (or we can simply rely on the file extension to check if it's a .c or .h file)
-        Set<String> supportedFileType = new HashSet<String>(
+        Set<String> supportedFileType = new HashSet<>(
                 Arrays.asList(
                         "supporting-mustache",
                         "model-test",

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -243,7 +243,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
                 CodegenConstants.CASE_INSENSITIVE_RESPONSE_HEADERS_DESC,
                 this.caseInsensitiveResponseHeaders);
 
-        regexModifiers = new HashMap<Character, String>();
+        regexModifiers = new HashMap<>();
         regexModifiers.put('i', "IgnoreCase");
         regexModifiers.put('m', "Multiline");
         regexModifiers.put('s', "Singleline");
@@ -689,7 +689,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
             }
 
             String regex = pattern.substring(1, i).replace("'", "\'");
-            List<String> modifiers = new ArrayList<String>();
+            List<String> modifiers = new ArrayList<>();
 
             // perl requires an explicit modifier to be culture specific and .NET is the reverse.
             modifiers.add("CultureInvariant");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
@@ -123,7 +123,7 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
         );
 
         // mapped non-nullable type without ?
-        typeMapping = new HashMap<String, String>();
+        typeMapping = new HashMap<>();
         typeMapping.put("string", "string");
         typeMapping.put("binary", "byte[]");
         typeMapping.put("ByteArray", "byte[]");
@@ -491,7 +491,7 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
             }
 
             String regex = pattern.substring(1, i).replace("'", "\'").replace("\"", "\"\"");
-            List<String> modifiers = new ArrayList<String>();
+            List<String> modifiers = new ArrayList<>();
 
             // perl requires an explicit modifier to be culture specific and .NET is the reverse.
             modifiers.add("CultureInvariant");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ConfluenceWikiCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ConfluenceWikiCodegen.java
@@ -55,7 +55,7 @@ public class ConfluenceWikiCodegen extends DefaultCodegen implements CodegenConf
         outputFolder = "docs";
         embeddedTemplateDir = templateDir = "confluenceWikiDocs";
 
-        defaultIncludes = new HashSet<String>();
+        defaultIncludes = new HashSet<>();
 
         cliOptions.add(new CliOption("appName", "short name of the application"));
         cliOptions.add(new CliOption("appDescription", "description of the application"));
@@ -80,10 +80,10 @@ public class ConfluenceWikiCodegen extends DefaultCodegen implements CodegenConf
         additionalProperties.put(CodegenConstants.ARTIFACT_VERSION, artifactVersion);
 
         supportingFiles.add(new SupportingFile("index.mustache", "", "confluence-markup.txt"));
-        reservedWords = new HashSet<String>();
+        reservedWords = new HashSet<>();
 
-        languageSpecificPrimitives = new HashSet<String>();
-        importMapping = new HashMap<String, String>();
+        languageSpecificPrimitives = new HashSet<>();
+        importMapping = new HashMap<>();
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -117,10 +117,10 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
         supportingFiles.add(new SupportingFile("cmake.mustache", "", "CMakeLists.txt"));
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
 
-        languageSpecificPrimitives = new HashSet<String>(
+        languageSpecificPrimitives = new HashSet<>(
                 Arrays.asList("int", "char", "bool", "long", "float", "double", "int32_t", "int64_t"));
 
-        typeMapping = new HashMap<String, String>();
+        typeMapping = new HashMap<>();
         typeMapping.put("date", "std::string");
         typeMapping.put("DateTime", "std::string");
         typeMapping.put("string", "std::string");
@@ -137,7 +137,7 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
         typeMapping.put("URI", "std::string");
         typeMapping.put("ByteArray", "std::string");
 
-        super.importMapping = new HashMap<String, String>();
+        super.importMapping = new HashMap<>();
         importMapping.put("std::vector", "#include <vector>");
         importMapping.put("std::map", "#include <map>");
         importMapping.put("std::string", "#include <string>");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
@@ -23,13 +23,13 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
     protected static final String CPP_NAMESPACE_DESC = "C++ namespace (convention: name::space::for::api).";
     protected static final String CONTENT_COMPRESSION_ENABLED = "contentCompression";
     protected static final String CONTENT_COMPRESSION_ENABLED_DESC = "Enable Compressed Content Encoding for requests and responses";
-    protected Set<String> foundationClasses = new HashSet<String>();
+    protected Set<String> foundationClasses = new HashSet<>();
     protected String cppNamespace = "OpenAPI";
-    protected Map<String, String> namespaces = new HashMap<String, String>();
-    protected Set<String> systemIncludes = new HashSet<String>();
+    protected Map<String, String> namespaces = new HashMap<>();
+    protected Set<String> systemIncludes = new HashSet<>();
     protected boolean isContentCompressionEnabled = false;
 
-    protected Set<String> nonFrameworkPrimitives = new HashSet<String>();
+    protected Set<String> nonFrameworkPrimitives = new HashSet<>();
 
     public CppQt5AbstractCodegen() {
         super();
@@ -76,7 +76,7 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
          * Language Specific Primitives.  These types will not trigger imports by
          * the client generator
          */
-        languageSpecificPrimitives = new HashSet<String>(
+        languageSpecificPrimitives = new HashSet<>(
                 Arrays.asList(
                         "bool",
                         "qint32",
@@ -94,7 +94,7 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
                         "QByteArray")
         );
         languageSpecificPrimitives.addAll(foundationClasses);
-        super.typeMapping = new HashMap<String, String>();
+        super.typeMapping = new HashMap<>();
 
         typeMapping.put("date", "QDate");
         typeMapping.put("DateTime", "QDateTime");
@@ -116,8 +116,8 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
         typeMapping.put("URI", "QString");
         typeMapping.put("file", "QByteArray");
         typeMapping.put("binary", "QByteArray");
-        importMapping = new HashMap<String, String>();
-        namespaces = new HashMap<String, String>();
+        importMapping = new HashMap<>();
+        namespaces = new HashMap<>();
 
         systemIncludes.add("QString");
         systemIncludes.add("QList");
@@ -314,7 +314,7 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
         List<CodegenOperation> operations = (List<CodegenOperation>) objectMap.get("operation");
 
         List<Map<String, String>> imports = (List<Map<String, String>>) objs.get("imports");
-        Map<String, CodegenModel> codegenModels = new HashMap<String, CodegenModel>();
+        Map<String, CodegenModel> codegenModels = new HashMap<>();
 
         for (Object moObj : allModels) {
             CodegenModel mo = ((Map<String, CodegenModel>) moObj).get("model");
@@ -335,7 +335,7 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
                     imports.add(createMapping("import", operation.returnBaseType));
                 }
             }
-            List<CodegenParameter> params = new ArrayList<CodegenParameter>();
+            List<CodegenParameter> params = new ArrayList<>();
             if (operation.allParams != null) params.addAll(operation.allParams);
 
             // Check all parameter baseType if there is a necessity to include, include it if not
@@ -374,7 +374,7 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
     }
 
     private Map<String, String> createMapping(String key, String value) {
-        Map<String, String> customImport = new HashMap<String, String>();
+        Map<String, String> customImport = new HashMap<>();
         customImport.put(key, toModelImport(value));
         return customImport;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
@@ -158,10 +158,10 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
         supportingFiles.add(new SupportingFile("cmake-lists.mustache", "", "CMakeLists.txt"));
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
 
-        languageSpecificPrimitives = new HashSet<String>(
+        languageSpecificPrimitives = new HashSet<>(
                 Arrays.asList("int", "char", "bool", "long", "float", "double", "int32_t", "int64_t"));
 
-        typeMapping = new HashMap<String, String>();
+        typeMapping = new HashMap<>();
         typeMapping.put("date", "utility::datetime");
         typeMapping.put("DateTime", "utility::datetime");
         typeMapping.put("string", "utility::string_t");
@@ -178,7 +178,7 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
         typeMapping.put("URI", "utility::string_t");
         typeMapping.put("ByteArray", "utility::string_t");
 
-        super.importMapping = new HashMap<String, String>();
+        super.importMapping = new HashMap<>();
         importMapping.put("std::vector", "#include <vector>");
         importMapping.put("std::map", "#include <map>");
         importMapping.put("std::string", "#include <string>");
@@ -252,7 +252,7 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
         CodegenModel codegenModel = super.fromModel(name, model);
 
         Set<String> oldImports = codegenModel.imports;
-        codegenModel.imports = new HashSet<String>();
+        codegenModel.imports = new HashSet<>();
         for (String imp : oldImports) {
             String newImp = toModelImport(imp);
             if (!newImp.isEmpty()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestbedServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestbedServerCodegen.java
@@ -97,10 +97,10 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
 
-        languageSpecificPrimitives = new HashSet<String>(
+        languageSpecificPrimitives = new HashSet<>(
                 Arrays.asList("int", "char", "bool", "long", "float", "double", "int32_t", "int64_t"));
 
-        typeMapping = new HashMap<String, String>();
+        typeMapping = new HashMap<>();
         typeMapping.put("date", "std::string");
         typeMapping.put("DateTime", "std::string");
         typeMapping.put("string", "std::string");
@@ -117,7 +117,7 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
         typeMapping.put("URI", "std::string");
         typeMapping.put("ByteArray", "std::string");
 
-        super.importMapping = new HashMap<String, String>();
+        super.importMapping = new HashMap<>();
         importMapping.put("std::vector", "#include <vector>");
         importMapping.put("std::map", "#include <map>");
         importMapping.put("std::string", "#include <string>");
@@ -133,7 +133,7 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
         // Clean interfaces of ambiguity
         for (Entry<String, CodegenModel> cm : allModels.entrySet()) {
             if (cm.getValue().getInterfaces() != null && !cm.getValue().getInterfaces().isEmpty()) {
-                List<String> newIntf = new ArrayList<String>(cm.getValue().getInterfaces());
+                List<String> newIntf = new ArrayList<>(cm.getValue().getInterfaces());
 
                 for (String intf : allModels.get(cm.getKey()).getInterfaces()) {
                     if (allModels.get(intf).getInterfaces() != null && !allModels.get(intf).getInterfaces().isEmpty()) {
@@ -256,7 +256,7 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
         CodegenModel codegenModel = super.fromModel(name, model);
 
         Set<String> oldImports = codegenModel.imports;
-        codegenModel.imports = new HashSet<String>();
+        codegenModel.imports = new HashSet<>();
         for (String imp : oldImports) {
             String newImp = toModelImport(imp);
             if (!newImp.isEmpty()) {
@@ -285,7 +285,7 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
     public Map<String, Object> postProcessOperationsWithModels(Map<String, Object> objs, List<Object> allModels) {
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         List<CodegenOperation> operationList = (List<CodegenOperation>) operations.get("operation");
-        List<CodegenOperation> newOpList = new ArrayList<CodegenOperation>();
+        List<CodegenOperation> newOpList = new ArrayList<>();
 
         for (CodegenOperation op : operationList) {
             String path = op.path;
@@ -317,7 +317,7 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
                         foundInNewList = true;
                         List<CodegenOperation> currentOtherMethodList = (List<CodegenOperation>) op1.vendorExtensions.get("x-codegen-otherMethods");
                         if (currentOtherMethodList == null) {
-                            currentOtherMethodList = new ArrayList<CodegenOperation>();
+                            currentOtherMethodList = new ArrayList<>();
                         }
                         op.operationIdCamelCase = op1.operationIdCamelCase;
                         currentOtherMethodList.add(op);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTizenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTizenClientCodegen.java
@@ -71,7 +71,7 @@ public class CppTizenClientCodegen extends AbstractCppCodegen implements Codegen
         embeddedTemplateDir = templateDir = "cpp-tizen-client";
         modelPackage = "";
 
-        defaultIncludes = new HashSet<String>(
+        defaultIncludes = new HashSet<>(
                 Arrays.asList(
                         "bool",
                         "int",
@@ -79,7 +79,7 @@ public class CppTizenClientCodegen extends AbstractCppCodegen implements Codegen
                         "double",
                         "float")
         );
-        languageSpecificPrimitives = new HashSet<String>(
+        languageSpecificPrimitives = new HashSet<>(
                 Arrays.asList(
                         "bool",
                         "int",
@@ -105,7 +105,7 @@ public class CppTizenClientCodegen extends AbstractCppCodegen implements Codegen
                         "unsigned", "using", "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq"
                 ));
 
-        super.typeMapping = new HashMap<String, String>();
+        super.typeMapping = new HashMap<>();
 
         //typeMapping.put("Date", "DateTime");
         //typeMapping.put("DateTime", "DateTime");
@@ -128,7 +128,7 @@ public class CppTizenClientCodegen extends AbstractCppCodegen implements Codegen
         typeMapping.put("UUID", "std::string");
         typeMapping.put("URI", "std::string");
 
-        importMapping = new HashMap<String, String>();
+        importMapping = new HashMap<>();
 
         supportingFiles.clear();
         supportingFiles.add(new SupportingFile("helpers-header.mustache", sourceFolder, "Helpers.h"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppUE4ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppUE4ClientCodegen.java
@@ -39,14 +39,14 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
 
     protected String unrealModuleName = "OpenAPI";
     // Will be treated as pointer
-    protected Set<String> pointerClasses = new HashSet<String>();
+    protected Set<String> pointerClasses = new HashSet<>();
     // source folder where to write the files
     protected String privateFolder = "Private";
     protected String publicFolder = "Public";
     protected String apiVersion = "1.0.0";
-    protected Map<String, String> namespaces = new HashMap<String, String>();
+    protected Map<String, String> namespaces = new HashMap<>();
     // Will be included using the <> syntax, not used in Unreal's coding convention
-    protected Set<String> systemIncludes = new HashSet<String>();
+    protected Set<String> systemIncludes = new HashSet<>();
     protected String cppNamespace = unrealModuleName;
     protected boolean optionalProjectFileFlag = true;
 
@@ -132,7 +132,7 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
          * Language Specific Primitives.  These types will not trigger imports by
          * the client generator
          */
-        languageSpecificPrimitives = new HashSet<String>(
+        languageSpecificPrimitives = new HashSet<>(
                 Arrays.asList(
                         "bool",
                         "int32",
@@ -158,7 +158,7 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
             supportingFiles.add(new SupportingFile("module-source.mustache", privateFolder, unrealModuleName + "Module.cpp"));
         }
 
-        super.typeMapping = new HashMap<String, String>();
+        super.typeMapping = new HashMap<>();
 
         // Maps C++ types during call to getSchemaType, see DefaultCodegen.getSchemaType and not the types/formats
         // defined in openapi specification "array" is also used explicitly in the generator for containers
@@ -186,10 +186,10 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
         typeMapping.put("file", "HttpFileInput");
         typeMapping.put("UUID", "FGuid");
 
-        importMapping = new HashMap<String, String>();
+        importMapping = new HashMap<>();
         importMapping.put("HttpFileInput", "#include \"" + modelNamePrefix + "Helpers.h\"");
 
-        namespaces = new HashMap<String, String>();
+        namespaces = new HashMap<>();
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
@@ -130,7 +130,7 @@ public class CrystalClientCodegen extends DefaultCodegen {
         hideGenerationTimestamp = Boolean.TRUE;
 
         // reserved word. Ref: https://github.com/crystal-lang/crystal/wiki/Crystal-for-Rubyists#available-keywords
-        reservedWords = new HashSet<String>(
+        reservedWords = new HashSet<>(
                 Arrays.asList(
                         "abstract", "do", "if", "nil?", "select", "union",
                         "alias", "else", "in", "of", "self", "unless",
@@ -556,8 +556,8 @@ public class CrystalClientCodegen extends DefaultCodegen {
     public Map<String, Object> postProcessOperationsWithModels(Map<String, Object> objs, List<Object> allModels) {
         objs = super.postProcessOperationsWithModels(objs, allModels);
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
-        HashMap<String, CodegenModel> modelMaps = new HashMap<String, CodegenModel>();
-        HashMap<String, Integer> processedModelMaps = new HashMap<String, Integer>();
+        HashMap<String, CodegenModel> modelMaps = new HashMap<>();
+        HashMap<String, Integer> processedModelMaps = new HashMap<>();
 
         for (Object o : allModels) {
             HashMap<String, Object> h = (HashMap<String, Object>) o;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -116,7 +116,7 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
          * Reserved words.  Override this with reserved words specific to your language
          * Ref: https://github.com/itsgreggreg/elixir_quick_reference#reserved-words
          */
-        reservedWords = new HashSet<String>(
+        reservedWords = new HashSet<>(
                 Arrays.asList(
                         "nil",
                         "true",
@@ -164,7 +164,7 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
          * Language Specific Primitives.  These types will not trigger imports by
          * the client generator
          */
-        languageSpecificPrimitives = new HashSet<String>(
+        languageSpecificPrimitives = new HashSet<>(
                 Arrays.asList(
                         "Integer",
                         "Float",
@@ -180,7 +180,7 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
         );
 
         // ref: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
-        typeMapping = new HashMap<String, String>();
+        typeMapping = new HashMap<>();
         typeMapping.put("integer", "Integer");
         typeMapping.put("long", "Integer");
         typeMapping.put("number", "Float");
@@ -726,7 +726,7 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
             }
 
             sb.append("keyword()) :: ");
-            HashSet<String> uniqueResponseTypes = new HashSet<String>();
+            HashSet<String> uniqueResponseTypes = new HashSet<>();
             for (CodegenResponse response : this.responses) {
                 ExtendedCodegenResponse exResponse = (ExtendedCodegenResponse) response;
                 StringBuilder returnEntry = new StringBuilder("");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ErlangClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ErlangClientCodegen.java
@@ -311,7 +311,7 @@ public class ErlangClientCodegen extends DefaultCodegen implements CodegenConfig
     public Map<String, Object> postProcessOperationsWithModels(Map<String, Object> objs, List<Object> allModels) {
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         List<CodegenOperation> os = (List<CodegenOperation>) operations.get("operation");
-        List<ExtendedCodegenOperation> newOs = new ArrayList<ExtendedCodegenOperation>();
+        List<ExtendedCodegenOperation> newOs = new ArrayList<>();
         Pattern pattern = Pattern.compile("\\{([^\\}]+)\\}");
         for (CodegenOperation o : os) {
             // force http method to lower case
@@ -321,7 +321,7 @@ public class ErlangClientCodegen extends DefaultCodegen implements CodegenConfig
                 o.returnType = "[" + o.returnBaseType + "]";
             }
 
-            ArrayList<String> pathTemplateNames = new ArrayList<String>();
+            ArrayList<String> pathTemplateNames = new ArrayList<>();
             Matcher matcher = pattern.matcher(o.path);
             StringBuffer buffer = new StringBuffer();
             while (matcher.find()) {
@@ -385,7 +385,7 @@ public class ErlangClientCodegen extends DefaultCodegen implements CodegenConfig
     }
 
     class ExtendedCodegenOperation extends CodegenOperation {
-        private List<String> pathTemplateNames = new ArrayList<String>();
+        private List<String> pathTemplateNames = new ArrayList<>();
         private String replacedPathName;
         String arityRequired;
         String arityOptional;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/FlashClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/FlashClientCodegen.java
@@ -106,7 +106,7 @@ public class FlashClientCodegen extends DefaultCodegen implements CodegenConfig 
         typeMapping.put("URI", "String");
         typeMapping.put("binary", "File");
 
-        importMapping = new HashMap<String, String>();
+        importMapping = new HashMap<>();
         importMapping.put("File", "flash.filesystem.File");
 
         // from

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -431,8 +431,8 @@ public class GoClientCodegen extends AbstractGoCodegen {
     public Map<String, Object> postProcessOperationsWithModels(Map<String, Object> objs, List<Object> allModels) {
         objs = super.postProcessOperationsWithModels(objs, allModels);
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
-        HashMap<String, CodegenModel> modelMaps = new HashMap<String, CodegenModel>();
-        HashMap<String, Integer> processedModelMaps = new HashMap<String, Integer>();
+        HashMap<String, CodegenModel> modelMaps = new HashMap<>();
+        HashMap<String, Integer> processedModelMaps = new HashMap<>();
 
         for (Object o : allModels) {
             HashMap<String, Object> h = (HashMap<String, Object>) o;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
@@ -132,8 +132,8 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
     protected Map<String, Map<String, Object>> uniqueParamNameTypes = new HashMap<>();
     protected Map<String, Set<String>> modelMimeTypes = new HashMap<>();
     protected Map<String, String> knownMimeDataTypes = new HashMap<>();
-    protected Set<String> typeNames = new HashSet<String>();
-    protected Set<String> modelTypeNames = new HashSet<String>();
+    protected Set<String> typeNames = new HashSet<>();
+    protected Set<String> modelTypeNames = new HashSet<>();
 
     final private static Pattern CONTAINS_JSON_MIME_PATTERN = Pattern.compile("(?i)application/.*json(;.*)?");
 
@@ -231,7 +231,7 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
         supportingFiles.add(new SupportingFile("tests/PropMime.mustache", "tests", "PropMime.hs"));
         supportingFiles.add(new SupportingFile("tests/Test.mustache", "tests", "Test.hs"));
 
-        languageSpecificPrimitives = new HashSet<String>(
+        languageSpecificPrimitives = new HashSet<>(
                 Arrays.asList(
                         "Bool",
                         "String",
@@ -541,7 +541,7 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
         }
 
         if (!additionalProperties.containsKey(PROP_BASE_MODULE)) {
-            List<String> wordsCaps = new ArrayList<String>();
+            List<String> wordsCaps = new ArrayList<>();
             for (String word : baseTitle.split(" ")) {
                 wordsCaps.add(firstLetterToUpper(word));
             }
@@ -671,7 +671,7 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation op, Map<String, List<CodegenOperation>> operations) {
         List<CodegenOperation> opList = operations.get(tag);
         if (opList == null || opList.isEmpty()) {
-            opList = new ArrayList<CodegenOperation>();
+            opList = new ArrayList<>();
             operations.put(tag, opList);
         }
         // check for operationId uniqueness

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
@@ -169,7 +169,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
          * Language Specific Primitives.  These types will not trigger imports by
          * the client generator
          */
-        languageSpecificPrimitives = new HashSet<String>(
+        languageSpecificPrimitives = new HashSet<>(
                 Arrays.asList(
                         "Bool",
                         "String",
@@ -285,14 +285,14 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
         String[] words = title.split(" ");
 
         // The package name is made by appending the lowercased words of the title interspersed with dashes
-        List<String> wordsLower = new ArrayList<String>();
+        List<String> wordsLower = new ArrayList<>();
         for (String word : words) {
             wordsLower.add(word.toLowerCase(Locale.ROOT));
         }
         String cabalName = joinStrings("-", wordsLower);
 
         // The API name is made by appending the capitalized words of the title
-        List<String> wordsCaps = new ArrayList<String>();
+        List<String> wordsCaps = new ArrayList<>();
         for (String word : words) {
             wordsCaps.add(firstLetterToUpper(word));
         }
@@ -446,7 +446,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
     // IdType is provided by the capture params.
     private List<String> pathToServantRoute(String path, List<CodegenParameter> pathParams) {
         // Map the capture params by their names.
-        HashMap<String, String> captureTypes = new HashMap<String, String>();
+        HashMap<String, String> captureTypes = new HashMap<>();
         for (CodegenParameter param : pathParams) {
             captureTypes.put(param.baseName, param.dataType);
         }
@@ -462,7 +462,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
         }
 
         // Convert the path into a list of servant route components.
-        List<String> pathComponents = new ArrayList<String>();
+        List<String> pathComponents = new ArrayList<>();
         for (String piece : path.split("/")) {
             if (piece.startsWith("{") && piece.endsWith("}")) {
                 String name = piece.substring(1, piece.length() - 1);
@@ -479,7 +479,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
     // Extract the arguments that are passed in the route path parameters
     private List<String> pathToClientType(String path, List<CodegenParameter> pathParams) {
         // Map the capture params by their names.
-        HashMap<String, String> captureTypes = new HashMap<String, String>();
+        HashMap<String, String> captureTypes = new HashMap<>();
         for (CodegenParameter param : pathParams) {
             captureTypes.put(param.baseName, param.dataType);
         }
@@ -490,7 +490,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
         }
 
         // Convert the path into a list of servant route components.
-        List<String> type = new ArrayList<String>();
+        List<String> type = new ArrayList<>();
         for (String piece : path.split("/")) {
             if (piece.startsWith("{") && piece.endsWith("}")) {
                 String name = piece.substring(1, piece.length() - 1);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JMeterClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JMeterClientCodegen.java
@@ -132,7 +132,7 @@ public class JMeterClientCodegen extends DefaultCodegen implements CodegenConfig
         /*
          * Reserved words.  Override this with reserved words specific to your language
          */
-        reservedWords = new HashSet<String>(
+        reservedWords = new HashSet<>(
                 Arrays.asList(
                         "sample1",  // replace with static values
                         "sample2")

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
@@ -1249,16 +1249,16 @@ public class JavaCXFExtServerCodegen extends JavaCXFServerCodegen implements CXF
                 // did not include the ones we've just added to support the code in the operation bodies. Therefore it
                 // is necessary to recompute the imports and overwrite the existing ones. The code below was copied from
                 // the private DefaultGenerator.processOperations() method to achieve this end.
-                Set<String> allImports = new TreeSet<String>();
+                Set<String> allImports = new TreeSet<>();
                 for (CodegenOperation op : ops) {
                     allImports.addAll(op.imports);
                 }
                 allImports.add("List");
                 allImports.add("Map");
 
-                List<Map<String, String>> imports = new ArrayList<Map<String, String>>();
+                List<Map<String, String>> imports = new ArrayList<>();
                 for (String nextImport : allImports) {
-                    Map<String, String> im = new LinkedHashMap<String, String>();
+                    Map<String, String> im = new LinkedHashMap<>();
                     String mapping = importMapping().get(nextImport);
                     if (mapping == null) {
                         mapping = toModelImport(nextImport);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -786,7 +786,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                 // for enum model
                 if (Boolean.TRUE.equals(cm.isEnum) && cm.allowableValues != null) {
                     cm.imports.add(importMapping.get("SerializedName"));
-                    Map<String, String> item = new HashMap<String, String>();
+                    Map<String, String> item = new HashMap<>();
                     item.put("import", importMapping.get("SerializedName"));
                     imports.add(item);
                 }
@@ -832,10 +832,10 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 
                         // add import for Set, HashSet
                         cm.imports.add("Set");
-                        Map<String, String> importsSet = new HashMap<String, String>();
+                        Map<String, String> importsSet = new HashMap<>();
                         importsSet.put("import", "java.util.Set");
                         imports.add(importsSet);
-                        Map<String, String> importsHashSet = new HashMap<String, String>();
+                        Map<String, String> importsHashSet = new HashMap<>();
                         importsHashSet.put("import", "java.util.HashSet");
                         imports.add(importsHashSet);
                     }
@@ -849,7 +849,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                     imports2Classnames.put("JsonIgnore", "com.fasterxml.jackson.annotation.JsonIgnore");
                     for (Map.Entry<String, String> entry : imports2Classnames.entrySet()) {
                         cm.imports.add(entry.getKey());
-                        Map<String, String> importsItem = new HashMap<String, String>();
+                        Map<String, String> importsItem = new HashMap<>();
                         importsItem.put("import", entry.getValue());
                         imports.add(importsItem);
                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaInflectorServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaInflectorServerCodegen.java
@@ -128,7 +128,7 @@ public class JavaInflectorServerCodegen extends AbstractJavaCodegen {
         }
         List<CodegenOperation> opList = operations.get(basePath);
         if (opList == null) {
-            opList = new ArrayList<CodegenOperation>();
+            opList = new ArrayList<>();
             operations.put(basePath, opList);
         }
         opList.add(co);
@@ -197,7 +197,7 @@ public class JavaInflectorServerCodegen extends AbstractJavaCodegen {
             // for enum model
             if (Boolean.TRUE.equals(cm.isEnum) && cm.allowableValues != null) {
                 cm.imports.add(importMapping.get("JsonValue"));
-                Map<String, String> item = new HashMap<String, String>();
+                Map<String, String> item = new HashMap<>();
                 item.put("import", importMapping.get("JsonValue"));
                 imports.add(item);
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJerseyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJerseyServerCodegen.java
@@ -142,7 +142,7 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
             // for enum model
             if (Boolean.TRUE.equals(cm.isEnum) && cm.allowableValues != null) {
                 cm.imports.add(importMapping.get("JsonValue"));
-                Map<String, String> item = new HashMap<String, String>();
+                Map<String, String> item = new HashMap<>();
                 item.put("import", importMapping.get("JsonValue"));
                 imports.add(item);
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMSF4JServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMSF4JServerCodegen.java
@@ -135,7 +135,7 @@ public class JavaMSF4JServerCodegen extends AbstractJavaJAXRSServerCodegen {
             // for enum model
             if (Boolean.TRUE.equals(cm.isEnum) && cm.allowableValues != null) {
                 cm.imports.add(importMapping.get("JsonValue"));
-                Map<String, String> item = new HashMap<String, String>();
+                Map<String, String> item = new HashMap<>();
                 item.put("import", importMapping.get("JsonValue"));
                 imports.add(item);
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaPKMSTServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaPKMSTServerCodegen.java
@@ -443,7 +443,7 @@ public class JavaPKMSTServerCodegen extends AbstractJavaCodegen {
             // for enum model
             if (Boolean.TRUE.equals(cm.isEnum) && cm.allowableValues != null) {
                 cm.imports.add(this.importMapping.get("JsonValue"));
-                Map<String, String> item = new HashMap<String, String>();
+                Map<String, String> item = new HashMap<>();
                 item.put("import", this.importMapping.get("JsonValue"));
                 imports.add(item);
             }
@@ -548,9 +548,9 @@ public class JavaPKMSTServerCodegen extends AbstractJavaCodegen {
                 if (path.readOperations() != null) {
                     for (Operation operation : path.readOperations()) {
                         if (operation.getTags() != null) {
-                            List<Map<String, String>> tags = new ArrayList<Map<String, String>>();
+                            List<Map<String, String>> tags = new ArrayList<>();
                             for (String tag : operation.getTags()) {
-                                Map<String, String> value = new HashMap<String, String>();
+                                Map<String, String> value = new HashMap<>();
                                 value.put("tag", tag);
                                 tags.add(value);
                             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaResteasyEapServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaResteasyEapServerCodegen.java
@@ -151,7 +151,7 @@ public class JavaResteasyEapServerCodegen extends AbstractJavaJAXRSServerCodegen
             // for enum model
             if (Boolean.TRUE.equals(cm.isEnum) && cm.allowableValues != null) {
                 cm.imports.add(importMapping.get("JsonValue"));
-                Map<String, String> item = new HashMap<String, String>();
+                Map<String, String> item = new HashMap<>();
                 item.put("import", importMapping.get("JsonValue"));
                 imports.add(item);
             }


### PR DESCRIPTION
AutoRefactor cleanup 'UseDiamondOperatorCleanUp' applied by erefactor:

Refactors class instance creations to use the diamond operator
wherever possible.

For AutoRefactor see https://github.com/JnRouvignac/AutoRefactor
For erefactor see https://github.com/cal101/erefactor

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
