### PR TITLE
[Rust Server] Generate operations where tags require sanitization

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1095,9 +1095,12 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation
             co, Map<String, List<CodegenOperation>> operations) {
         // only generate operation for the first tag of the tags
-        if (tag != null && co.tags.size() > 1 && !tag.equals(co.tags.get(0).getName())) {
-            LOGGER.info("generated skip additional tag `" + tag + "` with operationId=" + co.operationId);
-            return;
+        if (tag != null && co.tags.size() > 1) {
+            String expectedTag = sanitizeTag(co.tags.get(0).getName());
+            if (!tag.equals(expectedTag)) {
+                LOGGER.info("generated skip additional tag `" + tag + "` with operationId=" + co.operationId);
+                return;
+            }
         }
         super.addOperationToGroup(tag, resourcePath, operation, co, operations);
     }

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -365,7 +365,7 @@ paths:
           type: string
         required: true
     get:
-      tags: [Repo, Info]
+      tags: [repo, Info]
       operationId: GetRepoInfo
       responses:
         "200":

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -389,7 +389,7 @@ paths:
                 $ref: '#/components/schemas/StringObject'
           description: OK
       tags:
-      - Repo
+      - repo
       - Info
   /repos:
     post:


### PR DESCRIPTION
Fix an issue where operations don't get generated if the first tag's sanitised name isn't equal to it's actual name.

This builds on the fix in https://github.com/OpenAPITools/openapi-generator/pull/5928 which caused operations to get multiply generated if they had more than one tag.

That code is flawed because the tag is passed to us sanitised, but we are comparing against a non-sanitised list.

This worked for the tests because for the tests, the tag is the same before and after sanitisation.

I've tweaked one of the sample tests so that it hits this condition (`repo` != `Repo`) and ensures that the operation is still generate

### Rust Server Technical Committee

@frol @farcaller @paladinzh

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.