### PR TITLE
[Rust Server] Cargo Metadata Configuration

### DIFF
--- a/bin/configs/rust-server-petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/bin/configs/rust-server-petstore-with-fake-endpoints-models-for-testing.yaml
@@ -6,3 +6,4 @@ generateAliasAsModel: true
 additionalProperties:
   hideGenerationTimestamp: "true"
   packageName: petstore-with-fake-endpoints-models-for-testing
+  publishRustRegistry: crates-io

--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -7,6 +7,18 @@ description = "{{{appDescription}}}"
 {{/appDescription}}
 license = "Unlicense"
 edition = "2018"
+{{#publishRustRegistry}}
+publish = ["{{publishRustRegistry}}"]
+{{/publishRustRegistry}}
+{{#repositoryUrl}}
+repository = "{{repositoryUrl}}"
+{{/repositoryUrl}}
+{{#documentationUrl}}
+documentation = "{{documentationUrl}}"
+{{/documentationUrl}}
+{{#homePageUrl}}
+homepage = "{{homePageUrl}}
+{{/homePageUrl}}
 
 [features]
 default = ["client", "server"]

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -5,6 +5,7 @@ authors = []
 description = "This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\"
 license = "Unlicense"
 edition = "2018"
+publish = ["crates-io"]
 
 [features]
 default = ["client", "server"]


### PR DESCRIPTION
Allow configuration of various pieces of Cargo metadata:

- Rust Registry to publish to
- Repository URL
- Documentation URL
- Homepage

This work was developed on behalf of @Metaswitch

### Rust Server Technical Committee

@frol @farcaller @paladinzh

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
