### PR TITLE
--http-user-agent arg support in javascript generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript-Apollo/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript-Apollo/api.mustache
@@ -53,7 +53,8 @@ export default class <&classname> extends ApiClient {
       let queryParams = {<#queryParams>
         '<baseName>': <#collectionFormat>this.buildCollectionParam(<#required><paramName></required><^required>opts['<paramName>']</required>, '<collectionFormat>')</collectionFormat><^collectionFormat><#required><paramName></required><^required>opts['<paramName>']</required></collectionFormat><^-last>,</-last></queryParams>
       };
-      let headerParams = {<#headerParams>
+      let headerParams = {
+        'User-Agent': '<#httpUserAgent><.></httpUserAgent><^httpUserAgent>OpenAPI-Generator/<&projectVersion>/Javascript</httpUserAgent>',<#headerParams>
         '<baseName>': <#required><paramName></required><^required>opts['<paramName>']</required><^-last>,</-last></headerParams>
       };
       let formParams = {<#formParams>

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -52,7 +52,9 @@ class ApiClient {
          * @type {Array.<String>}
          * @default {}
          */{{/emitJSDoc}}
-        this.defaultHeaders = {};
+        this.defaultHeaders = {
+            'User-Agent': '{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{projectVersion}}/Javascript{{/httpUserAgent}}'
+        };
 
         /**
          * The default HTTP timeout for all API calls.

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -53,7 +53,9 @@ class ApiClient {
          * @type {Array.<String>}
          * @default {}
          */
-        this.defaultHeaders = {};
+        this.defaultHeaders = {
+            'User-Agent': 'OpenAPI-Generator/1.0.0/Javascript'
+        };
 
         /**
          * The default HTTP timeout for all API calls.

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -53,7 +53,9 @@ class ApiClient {
          * @type {Array.<String>}
          * @default {}
          */
-        this.defaultHeaders = {};
+        this.defaultHeaders = {
+            'User-Agent': 'OpenAPI-Generator/1.0.0/Javascript'
+        };
 
         /**
          * The default HTTP timeout for all API calls.


### PR DESCRIPTION
It adds a `User-Agent` header in javascript and javascript-apollo generators allowing usage of `--http-user-agent` argument.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
