### PR TITLE
make shebangs portable

### DIFF
--- a/bin/utils/export_docs_generators.sh
+++ b/bin/utils/export_docs_generators.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT="$0"
 echo "# START SCRIPT: ${SCRIPT}"

--- a/bin/utils/export_generator.sh
+++ b/bin/utils/export_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT="$0"
 


### PR DESCRIPTION
change the shebangs for the scripts that generate samples to locate bash via `/usr/bin/env`
Some systems, like nixOS, don't use the linux filesystem hierarchy standard and/or have a bash binary in that path. `/usr/bin/env` is available on most systems even that don't go with the regular FHS and will locate the interpreter using the user's $PATH instead. for more info: https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my