### PR TITLE
[Java][native] extend native ApiClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
@@ -148,8 +148,28 @@ public class ApiClient {
    * Ctor.
    */
   public ApiClient() {
-    builder = HttpClient.newBuilder();
-    mapper = new ObjectMapper();
+    this.builder = createDefaultHttpClientBuilder();
+    this.mapper = createDefaultObjectMapper();
+    updateBaseUri(getDefaultBaseUri());
+    interceptor = null;
+    readTimeout = null;
+    responseInterceptor = null;
+  }
+
+  /**
+   * Ctor.
+   */
+  public ApiClient(HttpClient.Builder builder, ObjectMapper mapper, String baseUri) {
+    this.builder = builder;
+    this.mapper = mapper;
+    updateBaseUri(baseUri);
+    interceptor = null;
+    readTimeout = null;
+    responseInterceptor = null;
+  }
+
+  protected ObjectMapper createDefaultObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
@@ -158,17 +178,25 @@ public class ApiClient {
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.registerModule(new JavaTimeModule());
     {{#openApiNullable}}
-    JsonNullableModule jnm = new JsonNullableModule();
-    mapper.registerModule(jnm);
+    mapper.registerModule(new JsonNullableModule());
     {{/openApiNullable}}
-    URI baseURI = URI.create("{{{basePath}}}");
-    scheme = baseURI.getScheme();
-    host = baseURI.getHost();
-    port = baseURI.getPort();
-    basePath = baseURI.getRawPath();
-    interceptor = null;
-    readTimeout = null;
-    responseInterceptor = null;
+    return mapper;
+  }
+
+  protected String getDefaultBaseUri() {
+    return "{{{basePath}}}";
+  }
+
+  protected HttpClient.Builder createDefaultHttpClientBuilder() {
+    return HttpClient.newBuilder();
+  }
+
+  public void updateBaseUri(String baseUri) {
+    URI uri = URI.create(baseUri);
+    scheme = uri.getScheme();
+    host = uri.getHost();
+    port = uri.getPort();
+    basePath = uri.getRawPath();
   }
 
   /**

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiClient.java
@@ -157,8 +157,28 @@ public class ApiClient {
    * Ctor.
    */
   public ApiClient() {
-    builder = HttpClient.newBuilder();
-    mapper = new ObjectMapper();
+    this.builder = createDefaultHttpClientBuilder();
+    this.mapper = createDefaultObjectMapper();
+    updateBaseUri(getDefaultBaseUri());
+    interceptor = null;
+    readTimeout = null;
+    responseInterceptor = null;
+  }
+
+  /**
+   * Ctor.
+   */
+  public ApiClient(HttpClient.Builder builder, ObjectMapper mapper, String baseUri) {
+    this.builder = builder;
+    this.mapper = mapper;
+    updateBaseUri(baseUri);
+    interceptor = null;
+    readTimeout = null;
+    responseInterceptor = null;
+  }
+
+  protected ObjectMapper createDefaultObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
@@ -166,16 +186,24 @@ public class ApiClient {
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.registerModule(new JavaTimeModule());
-    JsonNullableModule jnm = new JsonNullableModule();
-    mapper.registerModule(jnm);
-    URI baseURI = URI.create("http://petstore.swagger.io:80/v2");
-    scheme = baseURI.getScheme();
-    host = baseURI.getHost();
-    port = baseURI.getPort();
-    basePath = baseURI.getRawPath();
-    interceptor = null;
-    readTimeout = null;
-    responseInterceptor = null;
+    mapper.registerModule(new JsonNullableModule());
+    return mapper;
+  }
+
+  protected String getDefaultBaseUri() {
+    return "http://petstore.swagger.io:80/v2";
+  }
+
+  protected HttpClient.Builder createDefaultHttpClientBuilder() {
+    return HttpClient.newBuilder();
+  }
+
+  public void updateBaseUri(String baseUri) {
+    URI uri = URI.create(baseUri);
+    scheme = uri.getScheme();
+    host = uri.getHost();
+    port = uri.getPort();
+    basePath = uri.getRawPath();
   }
 
   /**

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -157,8 +157,28 @@ public class ApiClient {
    * Ctor.
    */
   public ApiClient() {
-    builder = HttpClient.newBuilder();
-    mapper = new ObjectMapper();
+    this.builder = createDefaultHttpClientBuilder();
+    this.mapper = createDefaultObjectMapper();
+    updateBaseUri(getDefaultBaseUri());
+    interceptor = null;
+    readTimeout = null;
+    responseInterceptor = null;
+  }
+
+  /**
+   * Ctor.
+   */
+  public ApiClient(HttpClient.Builder builder, ObjectMapper mapper, String baseUri) {
+    this.builder = builder;
+    this.mapper = mapper;
+    updateBaseUri(baseUri);
+    interceptor = null;
+    readTimeout = null;
+    responseInterceptor = null;
+  }
+
+  protected ObjectMapper createDefaultObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
@@ -166,16 +186,24 @@ public class ApiClient {
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.registerModule(new JavaTimeModule());
-    JsonNullableModule jnm = new JsonNullableModule();
-    mapper.registerModule(jnm);
-    URI baseURI = URI.create("http://petstore.swagger.io:80/v2");
-    scheme = baseURI.getScheme();
-    host = baseURI.getHost();
-    port = baseURI.getPort();
-    basePath = baseURI.getRawPath();
-    interceptor = null;
-    readTimeout = null;
-    responseInterceptor = null;
+    mapper.registerModule(new JsonNullableModule());
+    return mapper;
+  }
+
+  protected String getDefaultBaseUri() {
+    return "http://petstore.swagger.io:80/v2";
+  }
+
+  protected HttpClient.Builder createDefaultHttpClientBuilder() {
+    return HttpClient.newBuilder();
+  }
+
+  public void updateBaseUri(String baseUri) {
+    URI uri = URI.create(baseUri);
+    scheme = uri.getScheme();
+    host = uri.getHost();
+    port = uri.getPort();
+    basePath = uri.getRawPath();
   }
 
   /**

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -157,8 +157,28 @@ public class ApiClient {
    * Ctor.
    */
   public ApiClient() {
-    builder = HttpClient.newBuilder();
-    mapper = new ObjectMapper();
+    this.builder = createDefaultHttpClientBuilder();
+    this.mapper = createDefaultObjectMapper();
+    updateBaseUri(getDefaultBaseUri());
+    interceptor = null;
+    readTimeout = null;
+    responseInterceptor = null;
+  }
+
+  /**
+   * Ctor.
+   */
+  public ApiClient(HttpClient.Builder builder, ObjectMapper mapper, String baseUri) {
+    this.builder = builder;
+    this.mapper = mapper;
+    updateBaseUri(baseUri);
+    interceptor = null;
+    readTimeout = null;
+    responseInterceptor = null;
+  }
+
+  protected ObjectMapper createDefaultObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
@@ -166,16 +186,24 @@ public class ApiClient {
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.registerModule(new JavaTimeModule());
-    JsonNullableModule jnm = new JsonNullableModule();
-    mapper.registerModule(jnm);
-    URI baseURI = URI.create("http://petstore.swagger.io:80/v2");
-    scheme = baseURI.getScheme();
-    host = baseURI.getHost();
-    port = baseURI.getPort();
-    basePath = baseURI.getRawPath();
-    interceptor = null;
-    readTimeout = null;
-    responseInterceptor = null;
+    mapper.registerModule(new JsonNullableModule());
+    return mapper;
+  }
+
+  protected String getDefaultBaseUri() {
+    return "http://petstore.swagger.io:80/v2";
+  }
+
+  protected HttpClient.Builder createDefaultHttpClientBuilder() {
+    return HttpClient.newBuilder();
+  }
+
+  public void updateBaseUri(String baseUri) {
+    URI uri = URI.create(baseUri);
+    scheme = uri.getScheme();
+    host = uri.getHost();
+    port = uri.getPort();
+    basePath = uri.getRawPath();
   }
 
   /**


### PR DESCRIPTION
Issue https://github.com/OpenAPITools/openapi-generator/issues/8541
Give ability to extend `ApiClient` for `java-native` library

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
