### PR TITLE
[Qt5][C++] Adding Parameter Styling Support for Qt5

### DIFF
--- a/docs/generators/cpp-qt5-client.md
+++ b/docs/generators/cpp-qt5-client.md
@@ -206,7 +206,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |XMLStructureDefinitions|✗|OAS2,OAS3
 |MultiServer|✓|OAS3
 |ParameterizedServer|✓|OAS3
-|ParameterStyling|✗|OAS3
+|ParameterStyling|✓|OAS3
 |Callbacks|✗|OAS3
 |LinkObjects|✗|OAS3
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5ClientCodegen.java
@@ -46,6 +46,7 @@ public class CppQt5ClientCodegen extends CppQt5AbstractCodegen implements Codege
         .includeSecurityFeatures(SecurityFeature.BasicAuth)
         .includeSecurityFeatures(SecurityFeature.ApiKey)
         .includeSecurityFeatures(SecurityFeature.BearerToken)
+        .includeGlobalFeatures(GlobalFeature.ParameterStyling)
         );
 
         // set the output folder here

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -139,15 +139,73 @@ void {{classname}}::abortRequests(){
     emit abortRequestsSignal();
 }
 
+QString {{classname}}::getParamStylePrefix(QString style){
+
+        if(style == "matrix"){ 
+            return ";";
+        }else if(style == "label"){
+            return ".";
+        }else if(style == "form"){
+            return "&"; 
+        }else if(style == "simple"){
+            return "";
+        }else if(style == "spaceDelimited"){
+            return "&"; 
+        }else if(style == "pipeDelimited"){
+            return "&"; 
+        }else
+            return "none";
+}
+
+QString {{classname}}::getParamStyleSuffix(QString style){
+
+        if(style == "matrix"){ 
+            return "=";
+        }else if(style == "label"){
+            return "";
+        }else if(style == "form"){
+            return "=";
+        }else if(style == "simple"){
+            return "";
+        }else if(style == "spaceDelimited"){
+            return "=";
+        }else if(style == "pipeDelimited"){
+            return "=";
+        }else
+            return "none";
+}
+
+QString {{classname}}::getParamStyleDelimiter(QString style, QString name, bool isExplode){
+
+        if(style == "matrix"){ 
+            return (isExplode) ? ";" + name + "=" : ",";
+
+        }else if(style == "label"){
+            return (isExplode) ? "." : ",";
+
+        }else if(style == "form"){
+            return (isExplode) ? "&" + name + "=" : ","; 
+
+        }else if(style == "simple"){
+            return ",";
+        }else if(style == "spaceDelimited"){
+            return (isExplode) ? "&" + name + "=" : " ";
+
+        }else if(style == "pipeDelimited"){
+            return (isExplode) ? "&" + name + "=" : "|";
+
+        }else if(style == "deepObject"){
+            return (isExplode) ? "&" : "none";
+
+        }else
+            return "none";
+}
+
 {{#operations}}
 {{#operation}}
 void {{classname}}::{{nickname}}({{#allParams}}const {{{dataType}}} &{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) {
     QString fullPath = QString(_serverConfigs["{{nickname}}"][_serverIndices.value("{{nickname}}")].URL()+"{{{path}}}");
-    {{#pathParams}}
-    QString {{paramName}}PathParam("{");
-    {{paramName}}PathParam.append("{{baseName}}").append("}");
-    fullPath.replace({{paramName}}PathParam, QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue({{paramName}})));
-    {{/pathParams}}{{#authMethods}}{{#isApiKey}}{{#isKeyInHeader}}
+    {{#authMethods}}{{#isApiKey}}{{#isKeyInHeader}}
     if(_apiKeys.contains("{{name}}")){
         addHeaders("{{name}}",_apiKeys.find("{{name}}").value());
     }
@@ -168,18 +226,148 @@ void {{classname}}::{{nickname}}({{#allParams}}const {{{dataType}}} &{{paramName
         b64.append(_username.toUtf8() + ":" + _password.toUtf8());
         addHeaders("Authorization","Basic " + b64.toBase64());
     }{{/isBasicBasic}}{{/authMethods}}
-{{#queryParams}}{{^collectionFormat}}
+    {{#pathParams}}
+    QString {{paramName}}PathParam("{");
+    {{paramName}}PathParam.append("{{baseName}}").append("}");
+    QString pathPrefix, pathSuffix, pathDelimiter;
+    QString pathStyle = "{{style}}";    
+    if(pathStyle == "") 
+        pathStyle = "simple";
+    pathPrefix = getParamStylePrefix(pathStyle);
+    pathSuffix = getParamStyleSuffix(pathStyle);
+    pathDelimiter = getParamStyleDelimiter(pathStyle, "{{baseName}}", {{isExplode}});
+    {{^collectionFormat}}
+    {{^isPrimitiveType}}
+    QString paramString = (pathStyle == "matrix" && {{isExplode}}) ? pathPrefix : pathPrefix+"{{baseName}}"+pathSuffix;
+    QJsonObject parameter = {{paramName}}.asJsonObject();
+    qint32 count = 0;
+    foreach(const QString& key, parameter.keys()) {
+        if (count > 0) {
+            pathDelimiter = (pathStyle == "matrix" && {{isExplode}}) ? ";" : getParamStyleDelimiter(pathStyle, key, {{isExplode}});
+            paramString.append(pathDelimiter);
+        }
+        QString assignOperator = ({{isExplode}}) ? "=" : ",";
+        switch(parameter.value(key).type()) {
+            case QJsonValue::String:
+            {
+                paramString.append(key+assignOperator+parameter.value(key).toString());
+                break;
+            }
+            case QJsonValue::Double:
+            {
+                paramString.append(key+assignOperator+QString::number(parameter.value(key).toDouble()));
+                break;
+            }
+            case QJsonValue::Bool:
+            {
+                paramString.append(key+assignOperator+QVariant(parameter.value(key).toBool()).toString());
+                break;
+            }
+            case QJsonValue::Array:
+            {
+                paramString.append(key+assignOperator+QVariant(parameter.value(key).toArray()).toString());
+                break;
+            }
+            case QJsonValue::Object:
+            {
+                paramString.append(key+assignOperator+QVariant(parameter.value(key).toObject()).toString());
+                break;
+            }
+            case QJsonValue::Null:
+            case QJsonValue::Undefined:
+                break;
+        }
+        count++;
+    }
+    fullPath.replace({{paramName}}PathParam, QUrl::toPercentEncoding(paramString));
+    {{/isPrimitiveType}}
+    {{#isPrimitiveType}}
+    QString paramString = (pathStyle == "matrix") ? pathPrefix+"{{baseName}}"+pathSuffix : pathPrefix;
+    fullPath.replace({{paramName}}PathParam, paramString+QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue({{paramName}})));
+{{/isPrimitiveType}}{{/collectionFormat}}{{#collectionFormat}}
+    if ({{{paramName}}}.size() > 0) {
+            QString paramString = (pathStyle == "matrix") ? pathPrefix+"{{baseName}}"+pathSuffix : pathPrefix;
+            qint32 count = 0;
+            foreach ({{{baseType}}} t, {{paramName}}) {
+                if (count > 0) {
+                    fullPath.append(pathDelimiter);
+                }
+                fullPath.append(QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue(t)));
+                count++;
+            }
+              fullPath.replace({{paramName}}PathParam, paramString);
+    }
+{{/collectionFormat}}{{/pathParams}}
+    {{#hasQueryParams}}
+    QString queryPrefix, querySuffix, queryDelimiter, queryStyle;
+    {{/hasQueryParams}}
+{{#queryParams}}
+    queryStyle = "{{style}}";
+    if(queryStyle == "") 
+        queryStyle = "form";
+    queryPrefix = getParamStylePrefix(queryStyle);
+    querySuffix = getParamStyleSuffix(queryStyle);
+    queryDelimiter = getParamStyleDelimiter(queryStyle, "{{baseName}}", {{isExplode}}); 
+{{^collectionFormat}} 
     if (fullPath.indexOf("?") > 0)
-        fullPath.append("&");
+        fullPath.append(queryPrefix);
     else
         fullPath.append("?");
-    fullPath.append(QUrl::toPercentEncoding("{{baseName}}")).append("=").append(QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue({{paramName}})));
-{{/collectionFormat}}{{#collectionFormat}}
+    {{^isPrimitiveType}}
+    QString paramString = (queryStyle == "form" && {{isExplode}}) ? "" : (queryStyle == "form" && !({{isExplode}})) ? "{{baseName}}"+querySuffix : "";
+    QJsonObject parameter = {{paramName}}.asJsonObject();
+    qint32 count = 0;
+    foreach(const QString& key, parameter.keys()) {
+        if (count > 0) {
+            queryDelimiter =  ((queryStyle == "form" || queryStyle == "deepObject") && {{isExplode}}) ? "&" : getParamStyleDelimiter(queryStyle, key, {{isExplode}});
+            paramString.append(queryDelimiter);
+        }
+        QString assignOperator;
+        if (queryStyle == "form")
+            assignOperator = ({{isExplode}}) ? "=" : ",";
+        else if (queryStyle == "deepObject")
+            assignOperator = ({{isExplode}}) ? "=" : "none";
+        switch(parameter.value(key).type()) {
+            case QJsonValue::String:
+            {
+                paramString.append(((queryStyle == "form") ? key : QString("{{baseName}}").append("[").append(key).append("]"))+assignOperator+parameter.value(key).toString());
+                break;
+            }
+            case QJsonValue::Double:
+            {
+                paramString.append(((queryStyle == "form") ? key : QString("{{baseName}}").append("[").append(key).append("]"))+assignOperator+QString::number(parameter.value(key).toDouble()));
+                break;
+            }
+            case QJsonValue::Bool:
+            {
+                paramString.append(((queryStyle == "form") ? key : QString("{{baseName}}").append("[").append(key).append("]"))+assignOperator+QVariant(parameter.value(key).toBool()).toString());
+                break;
+            }
+            case QJsonValue::Array:
+            {
+                paramString.append(((queryStyle == "form") ? key : QString("{{baseName}}").append("[").append(key).append("]"))+assignOperator+QVariant(parameter.value(key).toArray()).toString());
+                break;
+            }
+            case QJsonValue::Object:
+            {
+                paramString.append(((queryStyle == "form") ? key : QString("{{baseName}}").append("[").append(key).append("]"))+assignOperator+QVariant(parameter.value(key).toObject()).toString());
+                break;
+            }
+            case QJsonValue::Null:
+            case QJsonValue::Undefined:
+                break;
+        }
+        count++;
+    }
+    fullPath.append(paramString);
+    {{/isPrimitiveType}}{{#isPrimitiveType}}
+    fullPath.append(QUrl::toPercentEncoding("{{baseName}}")).append(querySuffix).append(QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue({{paramName}})));
+{{/isPrimitiveType}}{{/collectionFormat}}{{#collectionFormat}}
     if ({{{paramName}}}.size() > 0) {
         if (QString("{{collectionFormat}}").indexOf("multi") == 0) {
             foreach ({{{baseType}}} t, {{paramName}}) {
                 if (fullPath.indexOf("?") > 0)
-                    fullPath.append("&");
+                    fullPath.append(queryPrefix);
                 else
                     fullPath.append("?");
                 fullPath.append("{{{baseName}}}=").append(::{{cppNamespace}}::toStringValue(t));
@@ -188,28 +376,67 @@ void {{classname}}::{{nickname}}({{#allParams}}const {{{dataType}}} &{{paramName
             if (fullPath.indexOf("?") > 0)
                 fullPath.append("&");
             else
-                fullPath.append("?");
-            fullPath.append("{{baseName}}=");
+                fullPath.append("?").append(queryPrefix).append("{{baseName}}").append(querySuffix);
             qint32 count = 0;
             foreach ({{{baseType}}} t, {{paramName}}) {
                 if (count > 0) {
-                    fullPath.append(" ");
+                    fullPath.append(({{isExplode}})? queryDelimiter : QUrl::toPercentEncoding(queryDelimiter));
                 }
                 fullPath.append(::{{cppNamespace}}::toStringValue(t));
+                count++;
             }
         } else if (QString("{{collectionFormat}}").indexOf("tsv") == 0) {
             if (fullPath.indexOf("?") > 0)
                 fullPath.append("&");
             else
-                fullPath.append("?");
-            fullPath.append("{{baseName}}=");
+                fullPath.append("?").append(queryPrefix).append("{{baseName}}").append(querySuffix);
             qint32 count = 0;
             foreach ({{{baseType}}} t, {{paramName}}) {
                 if (count > 0) {
                     fullPath.append("\t");
                 }
                 fullPath.append(::{{cppNamespace}}::toStringValue(t));
+                count++;
             }
+        } else if (QString("{{collectionFormat}}").indexOf("csv") == 0) {
+            if (fullPath.indexOf("?") > 0)
+                fullPath.append("&");
+            else
+                fullPath.append("?").append(queryPrefix).append("{{baseName}}").append(querySuffix);
+            qint32 count = 0;
+            foreach ({{{baseType}}} t, {{paramName}}) {
+                if (count > 0) {
+                    fullPath.append(queryDelimiter);
+                }
+                fullPath.append(::{{cppNamespace}}::toStringValue(t));
+                count++;
+            }
+        } else if (QString("{{collectionFormat}}").indexOf("pipes") == 0) {
+            if (fullPath.indexOf("?") > 0)
+                fullPath.append("&");
+            else
+                fullPath.append("?").append(queryPrefix).append("{{baseName}}").append(querySuffix);
+            qint32 count = 0;
+            foreach ({{{baseType}}} t, {{paramName}}) {
+                if (count > 0) {
+                    fullPath.append(queryDelimiter);
+                }
+                fullPath.append(::{{cppNamespace}}::toStringValue(t));
+                count++;
+            }
+        } else if (QString("{{collectionFormat}}").indexOf("deepObject") == 0) {
+            if (fullPath.indexOf("?") > 0)
+                fullPath.append("&");
+            else
+                fullPath.append("?").append(queryPrefix).append("{{baseName}}").append(querySuffix);
+            qint32 count = 0;
+            foreach ({{{baseType}}} t, {{paramName}}) {
+                if (count > 0) {
+                    fullPath.append(queryDelimiter);
+                }
+                fullPath.append(::{{cppNamespace}}::toStringValue(t));
+                count++;
+            }   
         }
     }
 {{/collectionFormat}}{{/queryParams}}
@@ -219,7 +446,18 @@ void {{classname}}::{{nickname}}({{#allParams}}const {{{dataType}}} &{{paramName
     worker->setResponseCompressionEnabled(isResponseCompressionEnabled);
     worker->setRequestCompressionEnabled(isRequestCompressionEnabled);{{/contentCompression}}
     {{prefix}}HttpRequestInput input(fullPath, "{{httpMethod}}");
-{{#formParams}}{{^isFile}}
+
+{{#formParams}}
+    {{#first}}
+    QString formPrefix,formSuffix, formDelimiter;
+    QString formStyle = "{{style}}";
+    if(formStyle == "") 
+        formStyle = "form";
+    formPrefix = getParamStylePrefix(formStyle);
+    formSuffix = getParamStyleSuffix(formStyle);
+    formDelimiter = getParamStyleDelimiter(formStyle, "{{baseName}}", {{isExplode}});
+    {{/first}}
+{{^isFile}}
     input.add_var("{{baseName}}", ::{{cppNamespace}}::toStringValue({{paramName}}));{{/isFile}}{{#isFile}}
     input.add_file("{{baseName}}", {{paramName}}.local_filename, {{paramName}}.request_filename, {{paramName}}.mime_type);{{/isFile}}{{/formParams}}{{#bodyParams}}{{#isContainer}}{{#isArray}}
     QJsonDocument doc(::{{cppNamespace}}::toJsonValue({{paramName}}).toArray());{{/isArray}}{{#isMap}}
@@ -232,11 +470,130 @@ void {{classname}}::{{nickname}}({{#allParams}}const {{{dataType}}} &{{paramName
     QByteArray output = {{paramName}}.asByteArray();{{/isFile}}
     input.request_body.append(output);
 {{/isContainer}}{{/bodyParams}}{{#headerParams}}
+{{^collectionFormat}}{{^isPrimitiveType}}
+    QString headerString;
+    QJsonObject parameter = {{paramName}}.asJsonObject();
+    qint32 count = 0;
+    foreach(const QString& key, parameter.keys()) {
+        if (count > 0) {
+            headerString.append(",");
+        }
+        QString assignOperator = ({{isExplode}}) ? "=" : ",";
+        switch(parameter.value(key).type()) {
+            case QJsonValue::String:
+            {
+                headerString.append(key+assignOperator+parameter.value(key).toString());
+                break;
+            }
+            case QJsonValue::Double:
+            {
+                headerString.append(key+assignOperator+QString::number(parameter.value(key).toDouble()));
+                break;
+            }
+            case QJsonValue::Bool:
+            {
+                headerString.append(key+assignOperator+QVariant(parameter.value(key).toBool()).toString());
+                break;
+            }
+            case QJsonValue::Array:
+            {
+                headerString.append(key+assignOperator+QVariant(parameter.value(key).toArray()).toString());
+                break;
+            }
+            case QJsonValue::Object:
+            {
+                headerString.append(key+assignOperator+QVariant(parameter.value(key).toObject()).toString());
+                break;
+            }
+            case QJsonValue::Null:
+            case QJsonValue::Undefined:
+                break;
+        }
+        count++;
+    }
+    input.headers.insert("{{baseName}}", headerString);
+{{/isPrimitiveType}}{{#isPrimitiveType}}
     if (!::{{cppNamespace}}::toStringValue({{paramName}}).isEmpty()) {
         input.headers.insert("{{baseName}}", ::{{cppNamespace}}::toStringValue({{paramName}}));
     }
+{{/isPrimitiveType}}{{/collectionFormat}}{{#collectionFormat}}
+    QString headerString;
+    if ({{{paramName}}}.size() > 0) {
+    qint32 count = 0;
+    foreach ({{{baseType}}} t, {{paramName}}) {
+        if (count > 0) {
+            headerString.append(",");
+        }
+        headerString.append(::{{cppNamespace}}::toStringValue(t));
+        count++;
+    }
+    input.headers.insert("{{baseName}}", headerString);
+    }
+{{/collectionFormat}}
 {{/headerParams}}
-
+{{#cookieParams}}
+if(QString("{{style}}").indexOf("form") == 0){
+{{^collectionFormat}}{{^isPrimitiveType}}{{^isExplode}}
+    QString cookieString = "{{baseName}}=";
+    QJsonObject parameter = {{paramName}}.asJsonObject();
+    qint32 count = 0;
+    foreach(const QString& key, parameter.keys()) {
+        if (count > 0) {
+            cookieString.append(",");
+        }
+        switch(parameter.value(key).type()) {
+            case QJsonValue::String:
+            {
+                cookieString.append(key+","+parameter.value(key).toString());
+                break;
+            }
+            case QJsonValue::Double:
+            {
+                cookieString.append(key+","+QString::number(parameter.value(key).toDouble()));
+                break;
+            }
+            case QJsonValue::Bool:
+            {
+                cookieString.append(key+","+QVariant(parameter.value(key).toBool()).toString());
+                break;
+            }
+            case QJsonValue::Array:
+            {
+                cookieString.append(key+","+QVariant(parameter.value(key).toArray()).toString());
+                break;
+            }
+            case QJsonValue::Object:
+            {
+                cookieString.append(key+","+QVariant(parameter.value(key).toObject()).toString());
+                break;
+            }
+            case QJsonValue::Null:
+            case QJsonValue::Undefined:
+                break;
+        }
+        count++;
+    }
+    input.headers.insert("Cookie", cookieString);
+{{/isExplode}}{{/isPrimitiveType}}{{#isPrimitiveType}}
+    if (!::{{cppNamespace}}::toStringValue({{paramName}}).isEmpty()) {
+        input.headers.insert("Cookie", "{{baseName}}="+::{{cppNamespace}}::toStringValue({{paramName}}));
+    }
+{{/isPrimitiveType}}{{/collectionFormat}}{{#collectionFormat}}{{^isExplode}}
+    QString cookieString = "{{baseName}}=";
+    if ({{{paramName}}}.size() > 0) {
+    qint32 count = 0;
+    foreach ({{{baseType}}} t, {{paramName}}) {
+        if (count > 0) {
+            cookieString.append(",");
+        }
+        cookieString.append(::{{cppNamespace}}::toStringValue(t));
+        count++;
+    }
+    input.headers.insert("Cookie", cookieString);
+    }
+{{/isExplode}}{{/collectionFormat}}
+}
+{{/cookieParams}}
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &{{prefix}}HttpRequestWorker::on_execution_finished, this, &{{classname}}::{{nickname}}Callback);

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
@@ -43,6 +43,9 @@ public:
     void enableRequestCompression();
     void enableResponseCompression();
     void abortRequests();
+    QString getParamStylePrefix(QString style);
+    QString getParamStyleSuffix(QString style);
+    QString getParamStyleDelimiter(QString style, QString name, bool isExplode);
 {{#operations}}{{#operation}}
     void {{nickname}}({{#allParams}}const {{{dataType}}} &{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});{{/operation}}{{/operations}}
 

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
@@ -53,6 +53,9 @@ public:
     void enableRequestCompression();
     void enableResponseCompression();
     void abortRequests();
+    QString getParamStylePrefix(QString style);
+    QString getParamStyleSuffix(QString style);
+    QString getParamStyleDelimiter(QString style, QString name, bool isExplode);
 
     void addPet(const PFXPet &body);
     void deletePet(const qint64 &pet_id, const QString &api_key);

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
@@ -133,12 +133,83 @@ void PFXStoreApi::abortRequests(){
     emit abortRequestsSignal();
 }
 
+QString PFXStoreApi::getParamStylePrefix(QString style){
+
+        if(style == "matrix"){ 
+            return ";";
+        }else if(style == "label"){
+            return ".";
+        }else if(style == "form"){
+            return "&"; 
+        }else if(style == "simple"){
+            return "";
+        }else if(style == "spaceDelimited"){
+            return "&"; 
+        }else if(style == "pipeDelimited"){
+            return "&"; 
+        }else
+            return "none";
+}
+
+QString PFXStoreApi::getParamStyleSuffix(QString style){
+
+        if(style == "matrix"){ 
+            return "=";
+        }else if(style == "label"){
+            return "";
+        }else if(style == "form"){
+            return "=";
+        }else if(style == "simple"){
+            return "";
+        }else if(style == "spaceDelimited"){
+            return "=";
+        }else if(style == "pipeDelimited"){
+            return "=";
+        }else
+            return "none";
+}
+
+QString PFXStoreApi::getParamStyleDelimiter(QString style, QString name, bool isExplode){
+
+        if(style == "matrix"){ 
+            return (isExplode) ? ";" + name + "=" : ",";
+
+        }else if(style == "label"){
+            return (isExplode) ? "." : ",";
+
+        }else if(style == "form"){
+            return (isExplode) ? "&" + name + "=" : ","; 
+
+        }else if(style == "simple"){
+            return ",";
+        }else if(style == "spaceDelimited"){
+            return (isExplode) ? "&" + name + "=" : " ";
+
+        }else if(style == "pipeDelimited"){
+            return (isExplode) ? "&" + name + "=" : "|";
+
+        }else if(style == "deepObject"){
+            return (isExplode) ? "&" : "none";
+
+        }else
+            return "none";
+}
+
 void PFXStoreApi::deleteOrder(const QString &order_id) {
     QString fullPath = QString(_serverConfigs["deleteOrder"][_serverIndices.value("deleteOrder")].URL()+"/store/order/{orderId}");
+    
     QString order_idPathParam("{");
     order_idPathParam.append("orderId").append("}");
-    fullPath.replace(order_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(order_id)));
-    
+    QString pathPrefix, pathSuffix, pathDelimiter;
+    QString pathStyle = "";    
+    if(pathStyle == "") 
+        pathStyle = "simple";
+    pathPrefix = getParamStylePrefix(pathStyle);
+    pathSuffix = getParamStyleSuffix(pathStyle);
+    pathDelimiter = getParamStyleDelimiter(pathStyle, "orderId", false);
+    QString paramString = (pathStyle == "matrix") ? pathPrefix+"orderId"+pathSuffix : pathPrefix;
+    fullPath.replace(order_idPathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(order_id)));
+
 
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
@@ -176,11 +247,12 @@ void PFXStoreApi::deleteOrderCallback(PFXHttpRequestWorker *worker) {
 
 void PFXStoreApi::getInventory() {
     QString fullPath = QString(_serverConfigs["getInventory"][_serverIndices.value("getInventory")].URL()+"/store/inventory");
-
+    
     if(_apiKeys.contains("api_key")){
         addHeaders("api_key",_apiKeys.find("api_key").value());
     }
     
+
 
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
@@ -228,10 +300,19 @@ void PFXStoreApi::getInventoryCallback(PFXHttpRequestWorker *worker) {
 
 void PFXStoreApi::getOrderById(const qint64 &order_id) {
     QString fullPath = QString(_serverConfigs["getOrderById"][_serverIndices.value("getOrderById")].URL()+"/store/order/{orderId}");
+    
     QString order_idPathParam("{");
     order_idPathParam.append("orderId").append("}");
-    fullPath.replace(order_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(order_id)));
-    
+    QString pathPrefix, pathSuffix, pathDelimiter;
+    QString pathStyle = "";    
+    if(pathStyle == "") 
+        pathStyle = "simple";
+    pathPrefix = getParamStylePrefix(pathStyle);
+    pathSuffix = getParamStyleSuffix(pathStyle);
+    pathDelimiter = getParamStyleDelimiter(pathStyle, "orderId", false);
+    QString paramString = (pathStyle == "matrix") ? pathPrefix+"orderId"+pathSuffix : pathPrefix;
+    fullPath.replace(order_idPathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(order_id)));
+
 
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
@@ -270,6 +351,7 @@ void PFXStoreApi::getOrderByIdCallback(PFXHttpRequestWorker *worker) {
 
 void PFXStoreApi::placeOrder(const PFXOrder &body) {
     QString fullPath = QString(_serverConfigs["placeOrder"][_serverIndices.value("placeOrder")].URL()+"/store/order");
+    
 
 
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
@@ -277,9 +359,9 @@ void PFXStoreApi::placeOrder(const PFXOrder &body) {
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
+
     QByteArray output = body.asJson().toUtf8();
     input.request_body.append(output);
-
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXStoreApi::placeOrderCallback);

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
@@ -52,6 +52,9 @@ public:
     void enableRequestCompression();
     void enableResponseCompression();
     void abortRequests();
+    QString getParamStylePrefix(QString style);
+    QString getParamStyleSuffix(QString style);
+    QString getParamStyleDelimiter(QString style, QString name, bool isExplode);
 
     void deleteOrder(const QString &order_id);
     void getInventory();

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
@@ -145,8 +145,71 @@ void PFXUserApi::abortRequests(){
     emit abortRequestsSignal();
 }
 
+QString PFXUserApi::getParamStylePrefix(QString style){
+
+        if(style == "matrix"){ 
+            return ";";
+        }else if(style == "label"){
+            return ".";
+        }else if(style == "form"){
+            return "&"; 
+        }else if(style == "simple"){
+            return "";
+        }else if(style == "spaceDelimited"){
+            return "&"; 
+        }else if(style == "pipeDelimited"){
+            return "&"; 
+        }else
+            return "none";
+}
+
+QString PFXUserApi::getParamStyleSuffix(QString style){
+
+        if(style == "matrix"){ 
+            return "=";
+        }else if(style == "label"){
+            return "";
+        }else if(style == "form"){
+            return "=";
+        }else if(style == "simple"){
+            return "";
+        }else if(style == "spaceDelimited"){
+            return "=";
+        }else if(style == "pipeDelimited"){
+            return "=";
+        }else
+            return "none";
+}
+
+QString PFXUserApi::getParamStyleDelimiter(QString style, QString name, bool isExplode){
+
+        if(style == "matrix"){ 
+            return (isExplode) ? ";" + name + "=" : ",";
+
+        }else if(style == "label"){
+            return (isExplode) ? "." : ",";
+
+        }else if(style == "form"){
+            return (isExplode) ? "&" + name + "=" : ","; 
+
+        }else if(style == "simple"){
+            return ",";
+        }else if(style == "spaceDelimited"){
+            return (isExplode) ? "&" + name + "=" : " ";
+
+        }else if(style == "pipeDelimited"){
+            return (isExplode) ? "&" + name + "=" : "|";
+
+        }else if(style == "deepObject"){
+            return (isExplode) ? "&" : "none";
+
+        }else
+            return "none";
+}
+
 void PFXUserApi::createUser(const PFXUser &body) {
     QString fullPath = QString(_serverConfigs["createUser"][_serverIndices.value("createUser")].URL()+"/user");
+    
 
 
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
@@ -154,9 +217,9 @@ void PFXUserApi::createUser(const PFXUser &body) {
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
+
     QByteArray output = body.asJson().toUtf8();
     input.request_body.append(output);
-
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::createUserCallback);
@@ -188,6 +251,7 @@ void PFXUserApi::createUserCallback(PFXHttpRequestWorker *worker) {
 
 void PFXUserApi::createUsersWithArrayInput(const QList<PFXUser> &body) {
     QString fullPath = QString(_serverConfigs["createUsersWithArrayInput"][_serverIndices.value("createUsersWithArrayInput")].URL()+"/user/createWithArray");
+    
 
 
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
@@ -195,10 +259,10 @@ void PFXUserApi::createUsersWithArrayInput(const QList<PFXUser> &body) {
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
+
     QJsonDocument doc(::test_namespace::toJsonValue(body).toArray());
     QByteArray bytes = doc.toJson();
     input.request_body.append(bytes);
-
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::createUsersWithArrayInputCallback);
@@ -230,6 +294,7 @@ void PFXUserApi::createUsersWithArrayInputCallback(PFXHttpRequestWorker *worker)
 
 void PFXUserApi::createUsersWithListInput(const QList<PFXUser> &body) {
     QString fullPath = QString(_serverConfigs["createUsersWithListInput"][_serverIndices.value("createUsersWithListInput")].URL()+"/user/createWithList");
+    
 
 
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
@@ -237,10 +302,10 @@ void PFXUserApi::createUsersWithListInput(const QList<PFXUser> &body) {
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
+
     QJsonDocument doc(::test_namespace::toJsonValue(body).toArray());
     QByteArray bytes = doc.toJson();
     input.request_body.append(bytes);
-
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::createUsersWithListInputCallback);
@@ -272,10 +337,19 @@ void PFXUserApi::createUsersWithListInputCallback(PFXHttpRequestWorker *worker) 
 
 void PFXUserApi::deleteUser(const QString &username) {
     QString fullPath = QString(_serverConfigs["deleteUser"][_serverIndices.value("deleteUser")].URL()+"/user/{username}");
+    
     QString usernamePathParam("{");
     usernamePathParam.append("username").append("}");
-    fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
-    
+    QString pathPrefix, pathSuffix, pathDelimiter;
+    QString pathStyle = "";    
+    if(pathStyle == "") 
+        pathStyle = "simple";
+    pathPrefix = getParamStylePrefix(pathStyle);
+    pathSuffix = getParamStyleSuffix(pathStyle);
+    pathDelimiter = getParamStyleDelimiter(pathStyle, "username", false);
+    QString paramString = (pathStyle == "matrix") ? pathPrefix+"username"+pathSuffix : pathPrefix;
+    fullPath.replace(usernamePathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
+
 
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
@@ -313,10 +387,19 @@ void PFXUserApi::deleteUserCallback(PFXHttpRequestWorker *worker) {
 
 void PFXUserApi::getUserByName(const QString &username) {
     QString fullPath = QString(_serverConfigs["getUserByName"][_serverIndices.value("getUserByName")].URL()+"/user/{username}");
+    
     QString usernamePathParam("{");
     usernamePathParam.append("username").append("}");
-    fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
-    
+    QString pathPrefix, pathSuffix, pathDelimiter;
+    QString pathStyle = "";    
+    if(pathStyle == "") 
+        pathStyle = "simple";
+    pathPrefix = getParamStylePrefix(pathStyle);
+    pathSuffix = getParamStyleSuffix(pathStyle);
+    pathDelimiter = getParamStyleDelimiter(pathStyle, "username", false);
+    QString paramString = (pathStyle == "matrix") ? pathPrefix+"username"+pathSuffix : pathPrefix;
+    fullPath.replace(usernamePathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
+
 
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
@@ -355,19 +438,33 @@ void PFXUserApi::getUserByNameCallback(PFXHttpRequestWorker *worker) {
 
 void PFXUserApi::loginUser(const QString &username, const QString &password) {
     QString fullPath = QString(_serverConfigs["loginUser"][_serverIndices.value("loginUser")].URL()+"/user/login");
+    
 
-
+    QString queryPrefix, querySuffix, queryDelimiter, queryStyle;
+    queryStyle = "";
+    if(queryStyle == "") 
+        queryStyle = "form";
+    queryPrefix = getParamStylePrefix(queryStyle);
+    querySuffix = getParamStyleSuffix(queryStyle);
+    queryDelimiter = getParamStyleDelimiter(queryStyle, "username", false); 
     if (fullPath.indexOf("?") > 0)
-        fullPath.append("&");
+        fullPath.append(queryPrefix);
     else
         fullPath.append("?");
-    fullPath.append(QUrl::toPercentEncoding("username")).append("=").append(QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
 
+    fullPath.append(QUrl::toPercentEncoding("username")).append(querySuffix).append(QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
+    queryStyle = "";
+    if(queryStyle == "") 
+        queryStyle = "form";
+    queryPrefix = getParamStylePrefix(queryStyle);
+    querySuffix = getParamStyleSuffix(queryStyle);
+    queryDelimiter = getParamStyleDelimiter(queryStyle, "password", false); 
     if (fullPath.indexOf("?") > 0)
-        fullPath.append("&");
+        fullPath.append(queryPrefix);
     else
         fullPath.append("?");
-    fullPath.append(QUrl::toPercentEncoding("password")).append("=").append(QUrl::toPercentEncoding(::test_namespace::toStringValue(password)));
+
+    fullPath.append(QUrl::toPercentEncoding("password")).append(querySuffix).append(QUrl::toPercentEncoding(::test_namespace::toStringValue(password)));
 
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
@@ -407,6 +504,7 @@ void PFXUserApi::loginUserCallback(PFXHttpRequestWorker *worker) {
 
 void PFXUserApi::logoutUser() {
     QString fullPath = QString(_serverConfigs["logoutUser"][_serverIndices.value("logoutUser")].URL()+"/user/logout");
+    
 
 
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
@@ -445,19 +543,28 @@ void PFXUserApi::logoutUserCallback(PFXHttpRequestWorker *worker) {
 
 void PFXUserApi::updateUser(const QString &username, const PFXUser &body) {
     QString fullPath = QString(_serverConfigs["updateUser"][_serverIndices.value("updateUser")].URL()+"/user/{username}");
+    
     QString usernamePathParam("{");
     usernamePathParam.append("username").append("}");
-    fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
-    
+    QString pathPrefix, pathSuffix, pathDelimiter;
+    QString pathStyle = "";    
+    if(pathStyle == "") 
+        pathStyle = "simple";
+    pathPrefix = getParamStylePrefix(pathStyle);
+    pathSuffix = getParamStyleSuffix(pathStyle);
+    pathDelimiter = getParamStyleDelimiter(pathStyle, "username", false);
+    QString paramString = (pathStyle == "matrix") ? pathPrefix+"username"+pathSuffix : pathPrefix;
+    fullPath.replace(usernamePathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
+
 
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "PUT");
 
+
     QByteArray output = body.asJson().toUtf8();
     input.request_body.append(output);
-
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::updateUserCallback);

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
@@ -52,6 +52,9 @@ public:
     void enableRequestCompression();
     void enableResponseCompression();
     void abortRequests();
+    QString getParamStylePrefix(QString style);
+    QString getParamStyleSuffix(QString style);
+    QString getParamStyleDelimiter(QString style, QString name, bool isExplode);
 
     void createUser(const PFXUser &body);
     void createUsersWithArrayInput(const QList<PFXUser> &body);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

NOTE:  all changes are from #8565. I did a fresh PR because the rebase on the old PR was a bad idea.

This PR will enable parameter styling support following the [OpenAPI Specification 3.0.3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#ParameterObject). 
The field `allowReserved` is missing because it is not available in the mustache template. I created an issue addressing this  #8564. Once this issue is fixed, I will provide additional commits to support the `allowReserved` feature.

PING @wing328 @ravinikam (2017/07) @stkrwork (2017/07) @etherealjoy (2018/02) @MartinDelille (2018/03) @muttleyxd (2019/08)
