### PR TITLE
[C#][netcore] fix binary response

### DIFF
--- a/bin/utils/test_file_list.yaml
+++ b/bin/utils/test_file_list.yaml
@@ -1,6 +1,6 @@
 ---
 # csharp-netcore test files and image for upload
 - filename: "samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/Api/PetApiTests.cs"
-  sha256: b74ef9eefa4b41fd3233e083fe2355babf25a77f9073d28e1aa81ae2e0a5f1d0
+  sha256: aceebba316148a2a803a15ef4e13bbd0b0a1b8d15006cd88adb9b39a620ee451
 - filename: "samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/linux-logo.png"
   sha256: 0a67c32728197e942b13bdda064b73793f12f5c795f1e5cf35a3adf69c973230

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -472,6 +472,19 @@ namespace {{packageName}}.Client
                 response = client.Execute<T>(req);
             }
 
+            // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
+            if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
+            {
+                T instance = (T)Activator.CreateInstance(typeof(T));
+                MethodInfo method = typeof(T).GetMethod("FromJson");
+                method.Invoke(instance, new object[] { response.Content });
+                response.Data = instance;
+            }
+            else if (typeof(T).Name == "Stream") // for binary response
+            {
+                response.Data = (T)(object)new MemoryStream(response.RawBytes);
+            }
+
             InterceptResponse(req, response);
 
             var result = ToApiResponse(response);
@@ -582,6 +595,10 @@ namespace {{packageName}}.Client
                 MethodInfo method = typeof(T).GetMethod("FromJson");
                 method.Invoke(instance, new object[] { response.Content });
                 response.Data = instance;
+            }
+            else if (typeof(T).Name == "Stream") // for binary response
+            {
+                response.Data = (T)(object)new MemoryStream(response.RawBytes);
             }
 
             InterceptResponse(req, response);

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/Api/PetApiTests.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/Api/PetApiTests.cs
@@ -199,6 +199,19 @@ namespace Org.OpenAPITools.Test
             Assert.Equal("sample category name2", response.Category.Name);
         }
 
+        /* a simple test for binary response. no longer in use.
+        [Fact]
+        public void TestGetByIdBinaryResponse()
+        {
+            PetApi petApi = new PetApi(c1);
+            Stream response = petApi.GetPetByIdBinaryResponse(petId);
+            Assert.IsType<System.IO.MemoryStream>(response);
+            StreamReader reader = new StreamReader(response);
+            // the following will fail for sure
+            //Assert.Equal("someting", reader.ReadToEnd());
+        }
+        */
+
         /// <summary>
         /// Test GetPetByIdWithHttpInfoAsync
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -476,6 +476,19 @@ namespace Org.OpenAPITools.Client
                 response = client.Execute<T>(req);
             }
 
+            // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
+            if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
+            {
+                T instance = (T)Activator.CreateInstance(typeof(T));
+                MethodInfo method = typeof(T).GetMethod("FromJson");
+                method.Invoke(instance, new object[] { response.Content });
+                response.Data = instance;
+            }
+            else if (typeof(T).Name == "Stream") // for binary response
+            {
+                response.Data = (T)(object)new MemoryStream(response.RawBytes);
+            }
+
             InterceptResponse(req, response);
 
             var result = ToApiResponse(response);
@@ -585,6 +598,10 @@ namespace Org.OpenAPITools.Client
                 MethodInfo method = typeof(T).GetMethod("FromJson");
                 method.Invoke(instance, new object[] { response.Content });
                 response.Data = instance;
+            }
+            else if (typeof(T).Name == "Stream") // for binary response
+            {
+                response.Data = (T)(object)new MemoryStream(response.RawBytes);
             }
 
             InterceptResponse(req, response);


### PR DESCRIPTION
To fix https://github.com/OpenAPITools/openapi-generator/issues/8524 by supporting binary responses.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)


