### PR TITLE
[scala-akka-client] Scala Akka client does not support arbitrary query string parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-akka-client/apiRequest.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/apiRequest.mustache
@@ -49,6 +49,8 @@ case class ApiRequest[U](
 
   def withPathParam(name: String, value: Any): ApiRequest[U] = copy[U](pathParams = pathParams + (name -> value))
 
+  def withQueryParam(values: Map[String, Any]): ApiRequest[U] = copy[U](queryParams = queryParams ++ values)
+
   def withQueryParam(name: String, value: Any): ApiRequest[U] = copy[U](queryParams = queryParams + (name -> value))
 
   def withHeaderParam(name: String, value: Any): ApiRequest[U] = copy[U](headerParams = headerParams + (name -> value))

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/paramCreation.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/paramCreation.mustache
@@ -1,1 +1,1 @@
-"{{baseName}}", {{#isContainer}}ArrayValues({{{paramName}}}{{#collectionFormat}}, {{collectionFormat.toUpperCase}}{{/collectionFormat}}){{/isContainer}}{{^isContainer}}{{{paramName}}}{{/isContainer}}
+{{#isMap}}{{baseName}}{{/isMap}}{{^isMap}}"{{baseName}}", {{#isContainer}}ArrayValues({{{paramName}}}{{#collectionFormat}}, {{collectionFormat.toUpperCase}}{{/collectionFormat}}){{/isContainer}}{{^isContainer}}{{{paramName}}}{{/isContainer}}{{/isMap}}

--- a/samples/client/petstore/scala-akka/README.md
+++ b/samples/client/petstore/scala-akka/README.md
@@ -69,6 +69,7 @@ Class | Method | HTTP request | Description
 *PetApi* | **deletePet** | **DELETE** /pet/{petId} | Deletes a pet
 *PetApi* | **findPetsByStatus** | **GET** /pet/findByStatus | Finds Pets by status
 *PetApi* | **findPetsByTags** | **GET** /pet/findByTags | Finds Pets by tags
+*PetApi* | **findPetsByFilters** | **GET** /pet/findPetsByFilters | Finds Pets by tags
 *PetApi* | **getPetById** | **GET** /pet/{petId} | Find pet by ID
 *PetApi* | **updatePet** | **PUT** /pet | Update an existing pet
 *PetApi* | **updatePetWithForm** | **POST** /pet/{petId} | Updates a pet in the store with form data

--- a/samples/client/petstore/scala-akka/README.md
+++ b/samples/client/petstore/scala-akka/README.md
@@ -69,7 +69,6 @@ Class | Method | HTTP request | Description
 *PetApi* | **deletePet** | **DELETE** /pet/{petId} | Deletes a pet
 *PetApi* | **findPetsByStatus** | **GET** /pet/findByStatus | Finds Pets by status
 *PetApi* | **findPetsByTags** | **GET** /pet/findByTags | Finds Pets by tags
-*PetApi* | **findPetsByFilters** | **GET** /pet/findPetsByFilters | Finds Pets by tags
 *PetApi* | **getPetById** | **GET** /pet/{petId} | Find pet by ID
 *PetApi* | **updatePet** | **PUT** /pet | Update an existing pet
 *PetApi* | **updatePetWithForm** | **POST** /pet/{petId} | Updates a pet in the store with form data

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -20,7 +20,7 @@ import org.openapitools.client.core.ApiKeyLocations._
 
 object PetApi {
 
-  def apply(baseUrl: String = "http://petstore.swagger.io/v2") = new PetApi(baseUrl)
+  def apply(baseUrl: String = "https://petstore.swagger.io/v2") = new PetApi(baseUrl)
 }
 
 class PetApi(baseUrl: String) {
@@ -83,7 +83,23 @@ class PetApi(baseUrl: String) {
       .withQueryParam("tags", ArrayValues(tags, CSV))
       .withSuccessResponse[Seq[Pet]](200)
       .withErrorResponse[Unit](400)
-      
+
+
+  /**
+   * Filter by multiple Pet properties via Map
+   *
+   * Expected answers:
+   *   code 200 : Seq[Pet] (successful operation)
+   *   code 400 :  (Invalid tag value)
+   *
+   * @param filters Pet properties to filter by
+   */
+  def findPetsByArbitraryFilters(filters: Map[String, Any]): ApiRequest[Seq[Pet]] =
+    ApiRequest[Seq[Pet]](ApiMethods.GET, baseUrl, "/pet/findByStatus", "application/json")
+      .withQueryParam(filters)
+      .withSuccessResponse[Seq[Pet]](200)
+      .withErrorResponse[Unit](400)
+
 
   /**
    * Returns a single pet

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -86,11 +86,11 @@ class PetApi(baseUrl: String) {
 
 
   /**
-   * Filter by multiple Pet properties via Map
+   * Filter by multiple Pet properties using Map
    *
    * Expected answers:
    *   code 200 : Seq[Pet] (successful operation)
-   *   code 400 :  (Invalid tag value)
+   *   code 400 :  (Invalid property)
    *
    * @param filters Pet properties to filter by
    */

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/ApiRequest.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/ApiRequest.scala
@@ -59,6 +59,8 @@ case class ApiRequest[U](
 
   def withPathParam(name: String, value: Any): ApiRequest[U] = copy[U](pathParams = pathParams + (name -> value))
 
+  def withQueryParam(values: Map[String, Any]): ApiRequest[U] = copy[U](queryParams = queryParams ++ values)
+
   def withQueryParam(name: String, value: Any): ApiRequest[U] = copy[U](queryParams = queryParams + (name -> value))
 
   def withHeaderParam(name: String, value: Any): ApiRequest[U] = copy[U](headerParams = headerParams + (name -> value))

--- a/samples/client/petstore/scala-akka/src/test/scala/PetApiTest.scala
+++ b/samples/client/petstore/scala-akka/src/test/scala/PetApiTest.scala
@@ -86,7 +86,6 @@ class PetApiTest extends AsyncFlatSpec with Matchers {
 
   it should "find pets by status" in {
     val request = api.findPetsByStatus(List("available"))
-
     invoker
       .execute(request)
       .map { apiResponse =>
@@ -119,5 +118,20 @@ class PetApiTest extends AsyncFlatSpec with Matchers {
       }
   }
   */
+
+  it should "find pets by arbitrary filter" in {
+    val request = api.findPetsByArbitraryFilters(Map("status" -> "available"))
+    invoker
+      .execute(request)
+      .map { apiResponse =>
+        apiResponse.code should be(200)
+        val pets = apiResponse.content
+        pets should not be empty
+
+        forAll(pets) { pet =>
+          pet.status should contain(PetEnums.Status.Available)
+        }
+      }
+  }
 }
 


### PR DESCRIPTION
Scala Akka client `ApiRequest` (mustache file) includes functionality to take Map type query string parameters. The `paramCreation`, has been modified to check the input and serialise the input as Map (when condition is satisfied) with the introduction of a simple conditional statement to check if it `isMap` type.

This PR is a solution for the issue #8606. 

### PR checklist
 
- [✅] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [✅] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [✅] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [✅] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [✅] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
