### PR TITLE
Use issubclass for checking validity of input class

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_utils.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_utils.mustache
@@ -1051,7 +1051,7 @@ def is_valid_type(input_class_simple, valid_classes):
     Returns:
         bool
     """
-    valid_type = input_class_simple in valid_classes
+    valid_type = issubclass(input_class_simple, valid_classes)
     if not valid_type and (
             issubclass(input_class_simple, OpenApiModel) or
             input_class_simple is none_type):

--- a/samples/client/petstore/python/petstore_api/model_utils.py
+++ b/samples/client/petstore/python/petstore_api/model_utils.py
@@ -1333,7 +1333,7 @@ def is_valid_type(input_class_simple, valid_classes):
     Returns:
         bool
     """
-    valid_type = input_class_simple in valid_classes
+    valid_type = issubclass(input_class_simple, valid_classes)
     if not valid_type and (
             issubclass(input_class_simple, OpenApiModel) or
             input_class_simple is none_type):

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/model_utils.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/model_utils.py
@@ -1333,7 +1333,7 @@ def is_valid_type(input_class_simple, valid_classes):
     Returns:
         bool
     """
-    valid_type = input_class_simple in valid_classes
+    valid_type = issubclass(input_class_simple, valid_classes)
     if not valid_type and (
             issubclass(input_class_simple, OpenApiModel) or
             input_class_simple is none_type):

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/model_utils.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/model_utils.py
@@ -1333,7 +1333,7 @@ def is_valid_type(input_class_simple, valid_classes):
     Returns:
         bool
     """
-    valid_type = input_class_simple in valid_classes
+    valid_type = issubclass(input_class_simple, valid_classes)
     if not valid_type and (
             issubclass(input_class_simple, OpenApiModel) or
             input_class_simple is none_type):

--- a/samples/openapi3/client/petstore/python/petstore_api/model_utils.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model_utils.py
@@ -1333,7 +1333,7 @@ def is_valid_type(input_class_simple, valid_classes):
     Returns:
         bool
     """
-    valid_type = input_class_simple in valid_classes
+    valid_type = issubclass(input_class_simple, valid_classes)
     if not valid_type and (
             issubclass(input_class_simple, OpenApiModel) or
             input_class_simple is none_type):


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


### Description

Since Python generator cannot handle `anyOf`, `oneOf` properly, it generates model's `openapi_types` with `object` for properties using `anyOf` or `oneOf`.

But it checks a type of value with `in` operator so we can't event set property with `str` value! 