### PR TITLE
[JS] the replace statement in parseDate is too greedy (#8632)

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
@@ -576,7 +576,7 @@
    */
 {{/emitJSDoc}}  exports.parseDate = function(str) {
     if (isNaN(str)) {
-      return new Date(str.replace(/T/i, ' '));
+      return new Date(str.replace(/(\d)(T)(\d)/i, '$1 $3'));
     }
     return new Date(+str);
   };

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -556,7 +556,7 @@ class ApiClient {
     */{{/emitJSDoc}}
     static parseDate(str) {
         if (isNaN(str)) {
-            return new Date(str);
+            return new Date(str.replace(/(\d)(T)(\d)/i, '$1 $3'));
         }
         return new Date(+str);
     }

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -512,7 +512,7 @@ class ApiClient {
     */
     static parseDate(str) {
         if (isNaN(str)) {
-            return new Date(str);
+            return new Date(str.replace(/(\d)(T)(\d)/i, '$1 $3'));
         }
         return new Date(+str);
     }

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -513,7 +513,7 @@ class ApiClient {
     */
     static parseDate(str) {
         if (isNaN(str)) {
-            return new Date(str);
+            return new Date(str.replace(/(\d)(T)(\d)/i, '$1 $3'));
         }
         return new Date(+str);
     }


### PR DESCRIPTION
Fix for #8632

* updated the regex used in the String.replace for parseDate() to more precisely target ISO-8601
* added the replace function call to the ES6 mustache file

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jfiala @wing328 
