### PR TITLE
Update Swift styleguide link in contribution guidelines

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,7 +73,7 @@ Code change should conform to the programming style guide of the respective lang
 - Ruby: https://github.com/bbatsov/ruby-style-guide
 - Rust: https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md (the default [rustfmt](https://github.com/rust-lang-nursery/rustfmt) configuration)
 - Scala: http://docs.scala-lang.org/style/
-- Swift: [Apple Developer](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/Swift_Programming_Language/TheBasics.html)
+- Swift: https://swift.org/documentation/api-design-guidelines/
 - TypeScript: https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines
 
 For other languages, feel free to suggest.


### PR DESCRIPTION
The link to Swift style guide (called API design guidelines in Swift) is not the right one. It is a link to old language guide.

Mentioning the Swift commitee here: @jgavris @ehyche @Edubits @jaz-ah @4brunu

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
