### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove redundant semicolons

### DIFF
--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplateProcessor.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplateProcessor.java
@@ -53,5 +53,5 @@ public interface TemplateProcessor {
      * @param path The path which has caused an error
      * @param context The reason for the error
      */
-    default void error(Path path, String context) { };
+    default void error(Path path, String context) { }
 }

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
@@ -295,7 +295,7 @@ public class WorkflowSettings {
         private String ignoreFileOverride;
 
         // NOTE: All collections must be mutable in the builder, and copied to a new immutable collection in .build()
-        private Map<String, String> globalProperties = new HashMap<>();;
+        private Map<String, String> globalProperties = new HashMap<>();
 
         private Builder() {
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
@@ -604,7 +604,7 @@ public class PowerShellClientCodegen extends DefaultCodegen implements CodegenCo
        this.iconUri = iconUri;
    }
 
-   public void setSkipVerbParsing(boolean skipVerbParsing) { this.skipVerbParsing = skipVerbParsing; };
+   public void setSkipVerbParsing(boolean skipVerbParsing) { this.skipVerbParsing = skipVerbParsing; }
 
     @Override
     public void processOpts() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -40,8 +40,8 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     private static String CLASS_NAME_SUFFIX_PATTERN = "^[a-zA-Z0-9]*$";
     private static String FILE_NAME_SUFFIX_PATTERN = "^[a-zA-Z0-9.-]*$";
 
-    public static enum QUERY_PARAM_OBJECT_FORMAT_TYPE {dot, json, key};
-    public static enum PROVIDED_IN_LEVEL {none, root, any, platform}; 
+    public static enum QUERY_PARAM_OBJECT_FORMAT_TYPE {dot, json, key}
+    public static enum PROVIDED_IN_LEVEL {none, root, any, platform} 
 
     private static final String DEFAULT_IMPORT_PREFIX = "./";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/JsonCache.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/JsonCache.java
@@ -122,8 +122,6 @@ public interface JsonCache {
             OVERWRITE_EXISTING
         }
 
-        ;
-
         /**
          * If the cache is dirty, saves the object graph in JSON format to the specified file.
          *

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -2726,7 +2726,7 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         String modelName = "ObjectWithPropertiesThatHaveValidations";
-        Schema sc = openAPI.getComponents().getSchemas().get(modelName);;
+        Schema sc = openAPI.getComponents().getSchemas().get(modelName);
         CodegenModel cm = codegen.fromModel(modelName, sc);
 
         List<CodegenProperty> props = cm.getVars();


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveRedundantSemicolons' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.18/jdt.php
For erefactor see https://github.com/cal101/erefactor

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@OpenAPITools/generator-core-team