### PR TITLE
[REQ] [GO] Added enumClassPrefix option to go-gin-server.  Used same appro…

### DIFF
--- a/docs/generators/go-gin-server.md
+++ b/docs/generators/go-gin-server.md
@@ -8,11 +8,11 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Option | Description | Values | Default |
 | ------ | ----------- | ------ | ------- |
 |apiPath|Name of the folder that contains the Go source code| |go|
+|enumClassPrefix|Prefix enum with class name| |false|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |packageName|Go package name (convention: lowercase).| |openapi|
 |packageVersion|Go package version.| |1.0.0|
 |serverPort|The network port the generated server binds to| |8080|
-|enumClassPrefix|Prefix enum with class name| |false|
 
 ## IMPORT MAPPING
 

--- a/docs/generators/go-gin-server.md
+++ b/docs/generators/go-gin-server.md
@@ -12,6 +12,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |packageName|Go package name (convention: lowercase).| |openapi|
 |packageVersion|Go package version.| |1.0.0|
 |serverPort|The network port the generated server binds to| |8080|
+|enumClassPrefix|Prefix enum with class name| |false|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoGinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoGinServerCodegen.java
@@ -116,6 +116,8 @@ public class GoGinServerCodegen extends AbstractGoCodegen {
         optServerPort.setType("int");
         optServerPort.defaultValue(Integer.toString(serverPort));
         cliOptions.add(optServerPort);
+
+        cliOptions.add(CliOption.newBoolean(CodegenConstants.ENUM_CLASS_PREFIX, CodegenConstants.ENUM_CLASS_PREFIX_DESC));
     }
 
     @Override
@@ -163,6 +165,13 @@ public class GoGinServerCodegen extends AbstractGoCodegen {
             this.apiPath = (String)additionalProperties.get("apiPath");
         } else {
             additionalProperties.put("apiPath", apiPath);
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.ENUM_CLASS_PREFIX)) {
+            setEnumClassPrefix(Boolean.parseBoolean(additionalProperties.get(CodegenConstants.ENUM_CLASS_PREFIX).toString()));
+            if (enumClassPrefix) {
+                additionalProperties.put(CodegenConstants.ENUM_CLASS_PREFIX, true);
+            }
         }
 
         modelPackage = packageName;

--- a/modules/openapi-generator/src/main/resources/go-gin-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-gin-server/model.mustache
@@ -5,13 +5,13 @@ package {{packageName}}
 {{/-first}}	"{{import}}"{{#-last}}
 )
 {{/-last}}{{/imports}}{{#model}}{{#isEnum}}{{#description}}// {{{classname}}} : {{{description}}}{{/description}}
-type {{{name}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
+type {{{classname}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/format}}
 
-// List of {{{name}}}
+// List of {{{classname}}}
 const (
 	{{#allowableValues}}
 	{{#enumVars}}
-	{{name}} {{{classname}}} = {{{value}}}
+	{{#enumClassPrefix}}{{{classname.toUpperCase}}}_{{/enumClassPrefix}}{{name}} {{{classname}}} = {{{value}}}
 	{{/enumVars}}
 	{{/allowableValues}}
 ){{/isEnum}}{{^isEnum}}{{#description}}


### PR DESCRIPTION
#8680  (go-server)

Added enumClassPrefix option for go-gin-server target.   This option already exists in go-server.   
Fixed a bug in the model.mustache where  name is used in the type declaration and classname is used in the definition

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

generated code before:

```
`type ComparisonOperator_anyOf string

// List of ComparisonOperator_anyOf
const (
        EQ ComparisonOperatorAnyOf = "EQ"
        NEQ ComparisonOperatorAnyOf = "NEQ"
        GT ComparisonOperatorAnyOf = "GT"
        GTE ComparisonOperatorAnyOf = "GTE"
        LT ComparisonOperatorAnyOf = "LT"
        LTE ComparisonOperatorAnyOf = "LTE"
)`
```

generated code after:

```
`type ComparisonOperatorAnyOf string

// List of ComparisonOperatorAnyOf
const (
        COMPARISONOPERATORANYOF_EQ ComparisonOperatorAnyOf = "EQ"
        COMPARISONOPERATORANYOF_NEQ ComparisonOperatorAnyOf = "NEQ"
        COMPARISONOPERATORANYOF_GT ComparisonOperatorAnyOf = "GT"
        COMPARISONOPERATORANYOF_GTE ComparisonOperatorAnyOf = "GTE"
        COMPARISONOPERATORANYOF_LT ComparisonOperatorAnyOf = "LT"
        COMPARISONOPERATORANYOF_LTE ComparisonOperatorAnyOf = "LTE"
)`
```
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01)