### PR TITLE
[dart][dart-dio] Improve prefixing of inner enums with classname

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
@@ -539,12 +539,18 @@ public class DartClientCodegen extends DefaultCodegen {
             // are prefix with the classname of the containing class in the template.
             // Here the datatypeWithEnum template variable gets updated to match that scheme.
             // Also taking into account potential collection types e.g. List<JustSymbolEnum> -> List<EnumArraysJustSymbolEnum>
+            final String enumName = model.classname + property.enumName;
             if (property.items != null) {
-                // basically inner items e.g. map of maps etc.
-                property.setDatatypeWithEnum(property.datatypeWithEnum.replace(property.items.datatypeWithEnum, model.classname + property.items.datatypeWithEnum));
+                // inner items e.g. enums in collections, only works for one level
+                // but same is the case for DefaultCodegen
+                property.setDatatypeWithEnum(property.datatypeWithEnum.replace(property.items.datatypeWithEnum, enumName));
+                property.items.setDatatypeWithEnum(enumName);
+                property.items.setEnumName(enumName);
             } else {
-                property.setDatatypeWithEnum(property.datatypeWithEnum.replace(property.enumName, model.classname + property.enumName));
+                // plain enum property
+                property.setDatatypeWithEnum(property.datatypeWithEnum.replace(property.enumName, enumName));
             }
+            property.setEnumName(enumName);
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
@@ -23,7 +23,7 @@ abstract class {{classname}} implements Built<{{classname}}, {{classname}}Builde
     {{classname}}._();
 
     static void _initializeBuilder({{{classname}}}Builder b) => b{{#vars}}{{#defaultValue}}
-        ..{{{name}}} = {{#isEnum}}{{^isContainer}}const {{{classname}}}{{{enumName}}}._({{/isContainer}}{{/isEnum}}{{{defaultValue}}}{{#isEnum}}{{^isContainer}}){{/isContainer}}{{/isEnum}}{{/defaultValue}}{{/vars}};
+        ..{{{name}}} = {{#isEnum}}{{^isContainer}}const {{{enumName}}}._({{/isContainer}}{{/isEnum}}{{{defaultValue}}}{{#isEnum}}{{^isContainer}}){{/isContainer}}{{/isEnum}}{{/defaultValue}}{{/vars}};
 
     factory {{classname}}([void updates({{classname}}Builder b)]) = _${{classname}};
     static Serializer<{{classname}}> get serializer => _${{#lambda.camelcase}}{{{classname}}}{{/lambda.camelcase}}Serializer;

--- a/modules/openapi-generator/src/main/resources/dart-dio/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/enum_inline.mustache
@@ -1,4 +1,4 @@
-class {{{classname}}}{{{enumName}}} extends EnumClass {
+class {{{enumName}}} extends EnumClass {
 
   {{#allowableValues}}
     {{#enumVars}}
@@ -6,14 +6,14 @@ class {{{classname}}}{{{enumName}}} extends EnumClass {
   /// {{{description}}}
       {{/description}}
   @BuiltValueEnumConst({{#isInteger}}wireNumber: {{{value}}}{{/isInteger}}{{^isInteger}}wireName: r{{#lambda.escapeBuiltValueEnum}}{{{value}}}{{/lambda.escapeBuiltValueEnum}}{{/isInteger}})
-  static const {{{classname}}}{{{enumName}}} {{name}} = _${{#lambda.camelcase}}{{{classname}}}{{{enumName}}}{{/lambda.camelcase}}_{{name}};
+  static const {{{enumName}}} {{name}} = _${{#lambda.camelcase}}{{{enumName}}}{{/lambda.camelcase}}_{{name}};
     {{/enumVars}}
   {{/allowableValues}}
 
-  static Serializer<{{{classname}}}{{{enumName}}}> get serializer => _${{#lambda.camelcase}}{{{classname}}}{{{enumName}}}{{/lambda.camelcase}}Serializer;
+  static Serializer<{{{enumName}}}> get serializer => _${{#lambda.camelcase}}{{{enumName}}}{{/lambda.camelcase}}Serializer;
 
-  const {{{classname}}}{{{enumName}}}._(String name): super(name);
+  const {{{enumName}}}._(String name): super(name);
 
-  static BuiltSet<{{{classname}}}{{{enumName}}}> get values => _${{#lambda.camelcase}}{{{classname}}}{{{enumName}}}{{/lambda.camelcase}}Values;
-  static {{{classname}}}{{{enumName}}} valueOf(String name) => _${{#lambda.camelcase}}{{{classname}}}{{{enumName}}}{{/lambda.camelcase}}ValueOf(name);
+  static BuiltSet<{{{enumName}}}> get values => _${{#lambda.camelcase}}{{{enumName}}}{{/lambda.camelcase}}Values;
+  static {{{enumName}}} valueOf(String name) => _${{#lambda.camelcase}}{{{enumName}}}{{/lambda.camelcase}}ValueOf(name);
 }

--- a/modules/openapi-generator/src/main/resources/dart2/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/class.mustache
@@ -2,7 +2,7 @@ class {{{classname}}} {
   /// Returns a new [{{{classname}}}] instance.
   {{{classname}}}({
   {{#vars}}
-    {{#required}}{{^defaultValue}}@required {{/defaultValue}}{{/required}}this.{{{name}}}{{^isNullable}}{{#defaultValue}} = {{#isEnum}}{{^isContainer}}const {{{classname}}}{{{enumName}}}._({{/isContainer}}{{/isEnum}}{{{defaultValue}}}{{#isEnum}}{{^isContainer}}){{/isContainer}}{{/isEnum}}{{/defaultValue}}{{/isNullable}},
+    {{#required}}{{^defaultValue}}@required {{/defaultValue}}{{/required}}this.{{{name}}}{{^isNullable}}{{#defaultValue}} = {{#isEnum}}{{^isContainer}}const {{{enumName}}}._({{/isContainer}}{{/isEnum}}{{{defaultValue}}}{{#isEnum}}{{^isContainer}}){{/isContainer}}{{/isEnum}}{{/defaultValue}}{{/isNullable}},
   {{/vars}}
   });
 
@@ -151,7 +151,7 @@ class {{{classname}}} {
     {{^complexType}}
       {{#isArray}}
         {{#isEnum}}
-        {{{name}}}: {{{classname}}}{{{items.datatypeWithEnum}}}.listFromJson(json[r'{{{baseName}}}']),
+        {{{name}}}: {{{items.datatypeWithEnum}}}.listFromJson(json[r'{{{baseName}}}']),
         {{/isEnum}}
         {{^isEnum}}
         {{{name}}}: json[r'{{{baseName}}}'] == null
@@ -176,7 +176,7 @@ class {{{classname}}} {
         {{{name}}}: json[r'{{{baseName}}}'],
     {{/isEnum}}
     {{#isEnum}}
-        {{{name}}}: {{{classname}}}{{{enumName}}}.fromJson(json[r'{{{baseName}}}']),
+        {{{name}}}: {{{enumName}}}.fromJson(json[r'{{{baseName}}}']),
     {{/isEnum}}
           {{/isNumber}}
         {{/isMap}}

--- a/modules/openapi-generator/src/main/resources/dart2/enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/enum_inline.mustache
@@ -1,7 +1,7 @@
 {{#description}}/// {{{description}}}{{/description}}
-class {{{classname}}}{{{enumName}}} {
+class {{{enumName}}} {
   /// Instantiate a new enum with the provided [value].
-  const {{{classname}}}{{{enumName}}}._(this.value);
+  const {{{enumName}}}._(this.value);
 
   /// The underlying value of this enum member.
   final {{{dataType}}} value;
@@ -13,12 +13,12 @@ class {{{classname}}}{{{enumName}}} {
 
   {{#allowableValues}}
     {{#enumVars}}
-  static const {{{name}}} = {{{classname}}}{{{enumName}}}._({{#isString}}r{{/isString}}{{{value}}});
+  static const {{{name}}} = {{{enumName}}}._({{#isString}}r{{/isString}}{{{value}}});
     {{/enumVars}}
   {{/allowableValues}}
 
-  /// List of all possible values in this [enum][{{{classname}}}{{{enumName}}}].
-  static const values = <{{{classname}}}{{{enumName}}}>[
+  /// List of all possible values in this [enum][{{{enumName}}}].
+  static const values = <{{{enumName}}}>[
   {{#allowableValues}}
     {{#enumVars}}
     {{{name}}},
@@ -26,27 +26,27 @@ class {{{classname}}}{{{enumName}}} {
   {{/allowableValues}}
   ];
 
-  static {{{classname}}}{{{enumName}}} fromJson(dynamic value) =>
-    {{{classname}}}{{{enumName}}}TypeTransformer().decode(value);
+  static {{{enumName}}} fromJson(dynamic value) =>
+    {{{enumName}}}TypeTransformer().decode(value);
 
-  static List<{{{classname}}}{{{enumName}}}> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
+  static List<{{{enumName}}}> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
     json == null || json.isEmpty
-      ? true == emptyIsNull ? null : <{{{classname}}}{{{enumName}}}>[]
+      ? true == emptyIsNull ? null : <{{{enumName}}}>[]
       : json
-          .map((value) => {{{classname}}}{{{enumName}}}.fromJson(value))
+          .map((value) => {{{enumName}}}.fromJson(value))
           .toList(growable: true == growable);
 }
 
-/// Transformation class that can [encode] an instance of [{{{classname}}}{{{enumName}}}] to {{{dataType}}},
-/// and [decode] dynamic data back to [{{{classname}}}{{{enumName}}}].
-class {{{classname}}}{{{enumName}}}TypeTransformer {
-  const {{{classname}}}{{{enumName}}}TypeTransformer._();
+/// Transformation class that can [encode] an instance of [{{{enumName}}}] to {{{dataType}}},
+/// and [decode] dynamic data back to [{{{enumName}}}].
+class {{{enumName}}}TypeTransformer {
+  const {{{enumName}}}TypeTransformer._();
 
-  factory {{{classname}}}{{{enumName}}}TypeTransformer() => _instance ??= {{{classname}}}{{{enumName}}}TypeTransformer._();
+  factory {{{enumName}}}TypeTransformer() => _instance ??= {{{enumName}}}TypeTransformer._();
 
-  {{{dataType}}} encode({{{classname}}}{{{enumName}}} data) => data.value;
+  {{{dataType}}} encode({{{enumName}}} data) => data.value;
 
-  /// Decodes a [dynamic value][data] to a {{{classname}}}{{{enumName}}}.
+  /// Decodes a [dynamic value][data] to a {{{enumName}}}.
   ///
   /// If [allowNull] is true and the [dynamic value][data] cannot be decoded successfully,
   /// then null is returned. However, if [allowNull] is false and the [dynamic value][data]
@@ -54,11 +54,11 @@ class {{{classname}}}{{{enumName}}}TypeTransformer {
   ///
   /// The [allowNull] is very handy when an API changes and a new enum value is added or removed,
   /// and users are still using an old app with the old code.
-  {{{classname}}}{{{enumName}}} decode(dynamic data, {bool allowNull}) {
+  {{{enumName}}} decode(dynamic data, {bool allowNull}) {
     switch (data) {
       {{#allowableValues}}
         {{#enumVars}}
-      case {{#isString}}r{{/isString}}{{{value}}}: return {{{classname}}}{{{enumName}}}.{{{name}}};
+      case {{#isString}}r{{/isString}}{{{value}}}: return {{{enumName}}}.{{{name}}};
         {{/enumVars}}
       {{/allowableValues}}
       default:
@@ -69,6 +69,6 @@ class {{{classname}}}{{{enumName}}}TypeTransformer {
     return null;
   }
 
-  /// Singleton [{{{classname}}}{{{enumName}}}TypeTransformer] instance.
-  static {{{classname}}}{{{enumName}}}TypeTransformer _instance;
+  /// Singleton [{{{enumName}}}TypeTransformer] instance.
+  static {{{enumName}}}TypeTransformer _instance;
 }

--- a/samples/client/petstore/dart-dio/petstore_client_lib/test/api_response_test.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/test/api_response_test.dart
@@ -6,17 +6,17 @@ void main() {
   final instance = ApiResponse();
 
   group(ApiResponse, () {
-    // int code (default value: null)
+    // int code
     test('to test the property `code`', () async {
       // TODO
     });
 
-    // String type (default value: null)
+    // String type
     test('to test the property `type`', () async {
       // TODO
     });
 
-    // String message (default value: null)
+    // String message
     test('to test the property `message`', () async {
       // TODO
     });

--- a/samples/client/petstore/dart-dio/petstore_client_lib/test/category_test.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/test/category_test.dart
@@ -6,12 +6,12 @@ void main() {
   final instance = Category();
 
   group(Category, () {
-    // int id (default value: null)
+    // int id
     test('to test the property `id`', () async {
       // TODO
     });
 
-    // String name (default value: null)
+    // String name
     test('to test the property `name`', () async {
       // TODO
     });

--- a/samples/client/petstore/dart-dio/petstore_client_lib/test/order_test.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/test/order_test.dart
@@ -6,28 +6,28 @@ void main() {
   final instance = Order();
 
   group(Order, () {
-    // int id (default value: null)
+    // int id
     test('to test the property `id`', () async {
       // TODO
     });
 
-    // int petId (default value: null)
+    // int petId
     test('to test the property `petId`', () async {
       // TODO
     });
 
-    // int quantity (default value: null)
+    // int quantity
     test('to test the property `quantity`', () async {
       // TODO
     });
 
-    // DateTime shipDate (default value: null)
+    // DateTime shipDate
     test('to test the property `shipDate`', () async {
       // TODO
     });
 
     // Order Status
-    // String status (default value: null)
+    // String status
     test('to test the property `status`', () async {
       // TODO
     });

--- a/samples/client/petstore/dart-dio/petstore_client_lib/test/pet_test.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/test/pet_test.dart
@@ -6,33 +6,33 @@ void main() {
   final instance = Pet();
 
   group(Pet, () {
-    // int id (default value: null)
+    // int id
     test('to test the property `id`', () async {
       // TODO
     });
 
-    // Category category (default value: null)
+    // Category category
     test('to test the property `category`', () async {
       // TODO
     });
 
-    // String name (default value: null)
+    // String name
     test('to test the property `name`', () async {
       // TODO
     });
 
-    // BuiltList<String> photoUrls (default value: const [])
+    // BuiltList<String> photoUrls
     test('to test the property `photoUrls`', () async {
       // TODO
     });
 
-    // BuiltList<Tag> tags (default value: const [])
+    // BuiltList<Tag> tags
     test('to test the property `tags`', () async {
       // TODO
     });
 
     // pet status in the store
-    // String status (default value: null)
+    // String status
     test('to test the property `status`', () async {
       // TODO
     });

--- a/samples/client/petstore/dart-dio/petstore_client_lib/test/tag_test.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/test/tag_test.dart
@@ -6,12 +6,12 @@ void main() {
   final instance = Tag();
 
   group(Tag, () {
-    // int id (default value: null)
+    // int id
     test('to test the property `id`', () async {
       // TODO
     });
 
-    // String name (default value: null)
+    // String name
     test('to test the property `name`', () async {
       // TODO
     });

--- a/samples/client/petstore/dart-dio/petstore_client_lib/test/user_test.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/test/user_test.dart
@@ -6,43 +6,43 @@ void main() {
   final instance = User();
 
   group(User, () {
-    // int id (default value: null)
+    // int id
     test('to test the property `id`', () async {
       // TODO
     });
 
-    // String username (default value: null)
+    // String username
     test('to test the property `username`', () async {
       // TODO
     });
 
-    // String firstName (default value: null)
+    // String firstName
     test('to test the property `firstName`', () async {
       // TODO
     });
 
-    // String lastName (default value: null)
+    // String lastName
     test('to test the property `lastName`', () async {
       // TODO
     });
 
-    // String email (default value: null)
+    // String email
     test('to test the property `email`', () async {
       // TODO
     });
 
-    // String password (default value: null)
+    // String password
     test('to test the property `password`', () async {
       // TODO
     });
 
-    // String phone (default value: null)
+    // String phone
     test('to test the property `phone`', () async {
       // TODO
     });
 
     // User Status
-    // int userStatus (default value: null)
+    // int userStatus
     test('to test the property `userStatus`', () async {
       // TODO
     });

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/model/map_test.dart
@@ -19,7 +19,7 @@ abstract class MapTest implements Built<MapTest, MapTestBuilder> {
 
     @nullable
     @BuiltValueField(wireName: r'map_of_enum_string')
-    BuiltMap<String, MapTestInnerEnum> get mapOfEnumString;
+    BuiltMap<String, MapTestMapOfEnumStringEnum> get mapOfEnumString;
     // enum mapOfEnumStringEnum {  UPPER,  lower,  };
 
     @nullable
@@ -39,18 +39,18 @@ abstract class MapTest implements Built<MapTest, MapTestBuilder> {
     static Serializer<MapTest> get serializer => _$mapTestSerializer;
 }
 
-class MapTestInnerEnum extends EnumClass {
+class MapTestMapOfEnumStringEnum extends EnumClass {
 
   @BuiltValueEnumConst(wireName: r'UPPER')
-  static const MapTestInnerEnum UPPER = _$mapTestInnerEnum_UPPER;
+  static const MapTestMapOfEnumStringEnum UPPER = _$mapTestMapOfEnumStringEnum_UPPER;
   @BuiltValueEnumConst(wireName: r'lower')
-  static const MapTestInnerEnum lower = _$mapTestInnerEnum_lower;
+  static const MapTestMapOfEnumStringEnum lower = _$mapTestMapOfEnumStringEnum_lower;
 
-  static Serializer<MapTestInnerEnum> get serializer => _$mapTestInnerEnumSerializer;
+  static Serializer<MapTestMapOfEnumStringEnum> get serializer => _$mapTestMapOfEnumStringEnumSerializer;
 
-  const MapTestInnerEnum._(String name): super(name);
+  const MapTestMapOfEnumStringEnum._(String name): super(name);
 
-  static BuiltSet<MapTestInnerEnum> get values => _$mapTestInnerEnumValues;
-  static MapTestInnerEnum valueOf(String name) => _$mapTestInnerEnumValueOf(name);
+  static BuiltSet<MapTestMapOfEnumStringEnum> get values => _$mapTestMapOfEnumStringEnumValues;
+  static MapTestMapOfEnumStringEnum valueOf(String name) => _$mapTestMapOfEnumStringEnumValueOf(name);
 }
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
@@ -20,7 +20,7 @@ class MapTest {
 
   Map<String, Map<String, String>> mapMapOfString;
 
-  Map<String, MapTestInnerEnum> mapOfEnumString;
+  Map<String, MapTestMapOfEnumStringEnum> mapOfEnumString;
 
   Map<String, bool> directMap;
 
@@ -105,9 +105,9 @@ class MapTest {
 }
 
 
-class MapTestInnerEnum {
+class MapTestMapOfEnumStringEnum {
   /// Instantiate a new enum with the provided [value].
-  const MapTestInnerEnum._(this.value);
+  const MapTestMapOfEnumStringEnum._(this.value);
 
   /// The underlying value of this enum member.
   final String value;
@@ -117,36 +117,36 @@ class MapTestInnerEnum {
 
   String toJson() => value;
 
-  static const UPPER = MapTestInnerEnum._(r'UPPER');
-  static const lower = MapTestInnerEnum._(r'lower');
+  static const UPPER = MapTestMapOfEnumStringEnum._(r'UPPER');
+  static const lower = MapTestMapOfEnumStringEnum._(r'lower');
 
-  /// List of all possible values in this [enum][MapTestInnerEnum].
-  static const values = <MapTestInnerEnum>[
+  /// List of all possible values in this [enum][MapTestMapOfEnumStringEnum].
+  static const values = <MapTestMapOfEnumStringEnum>[
     UPPER,
     lower,
   ];
 
-  static MapTestInnerEnum fromJson(dynamic value) =>
-    MapTestInnerEnumTypeTransformer().decode(value);
+  static MapTestMapOfEnumStringEnum fromJson(dynamic value) =>
+    MapTestMapOfEnumStringEnumTypeTransformer().decode(value);
 
-  static List<MapTestInnerEnum> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
+  static List<MapTestMapOfEnumStringEnum> listFromJson(List<dynamic> json, {bool emptyIsNull, bool growable,}) =>
     json == null || json.isEmpty
-      ? true == emptyIsNull ? null : <MapTestInnerEnum>[]
+      ? true == emptyIsNull ? null : <MapTestMapOfEnumStringEnum>[]
       : json
-          .map((value) => MapTestInnerEnum.fromJson(value))
+          .map((value) => MapTestMapOfEnumStringEnum.fromJson(value))
           .toList(growable: true == growable);
 }
 
-/// Transformation class that can [encode] an instance of [MapTestInnerEnum] to String,
-/// and [decode] dynamic data back to [MapTestInnerEnum].
-class MapTestInnerEnumTypeTransformer {
-  const MapTestInnerEnumTypeTransformer._();
+/// Transformation class that can [encode] an instance of [MapTestMapOfEnumStringEnum] to String,
+/// and [decode] dynamic data back to [MapTestMapOfEnumStringEnum].
+class MapTestMapOfEnumStringEnumTypeTransformer {
+  const MapTestMapOfEnumStringEnumTypeTransformer._();
 
-  factory MapTestInnerEnumTypeTransformer() => _instance ??= MapTestInnerEnumTypeTransformer._();
+  factory MapTestMapOfEnumStringEnumTypeTransformer() => _instance ??= MapTestMapOfEnumStringEnumTypeTransformer._();
 
-  String encode(MapTestInnerEnum data) => data.value;
+  String encode(MapTestMapOfEnumStringEnum data) => data.value;
 
-  /// Decodes a [dynamic value][data] to a MapTestInnerEnum.
+  /// Decodes a [dynamic value][data] to a MapTestMapOfEnumStringEnum.
   ///
   /// If [allowNull] is true and the [dynamic value][data] cannot be decoded successfully,
   /// then null is returned. However, if [allowNull] is false and the [dynamic value][data]
@@ -154,10 +154,10 @@ class MapTestInnerEnumTypeTransformer {
   ///
   /// The [allowNull] is very handy when an API changes and a new enum value is added or removed,
   /// and users are still using an old app with the old code.
-  MapTestInnerEnum decode(dynamic data, {bool allowNull}) {
+  MapTestMapOfEnumStringEnum decode(dynamic data, {bool allowNull}) {
     switch (data) {
-      case r'UPPER': return MapTestInnerEnum.UPPER;
-      case r'lower': return MapTestInnerEnum.lower;
+      case r'UPPER': return MapTestMapOfEnumStringEnum.UPPER;
+      case r'lower': return MapTestMapOfEnumStringEnum.lower;
       default:
         if (allowNull == false) {
           throw ArgumentError('Unknown enum value to decode: $data');
@@ -166,7 +166,7 @@ class MapTestInnerEnumTypeTransformer {
     return null;
   }
 
-  /// Singleton [MapTestInnerEnumTypeTransformer] instance.
-  static MapTestInnerEnumTypeTransformer _instance;
+  /// Singleton [MapTestMapOfEnumStringEnumTypeTransformer] instance.
+  static MapTestMapOfEnumStringEnumTypeTransformer _instance;
 }
 


### PR DESCRIPTION
* prevent further name conflicts by correctly naming the enum, until now there could potentially occur conflicts e.g. 2x `MapTestInnerEnum` by renaming the `items` child property
* correctly set `enumName` to match `datatypeWithEnum`

Follow-up for https://github.com/OpenAPITools/openapi-generator/pull/8220

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)