### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove unnecessary casts

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -6379,7 +6379,7 @@ public class DefaultCodegen implements CodegenConfig {
 
         CodegenModel cm = new CodegenModel();
 
-        cm.discriminator = createDiscriminator("", (Schema) cs, openAPI);
+        cm.discriminator = createDiscriminator("", cs, openAPI);
         if (!this.getLegacyDiscriminatorBehavior()) {
             cm.addDiscriminatorMappedModelsImports();
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/InlineModelResolver.java
@@ -118,7 +118,7 @@ public class InlineModelResolver {
 
         Schema model = ModelUtils.getSchemaFromRequestBody(requestBody);
         if (model instanceof ObjectSchema) {
-            Schema obj = (Schema) model;
+            Schema obj = model;
             if (obj.getType() == null || "object".equals(obj.getType())) {
                 if (obj.getProperties() != null && obj.getProperties().size() > 0) {
                     flattenProperties(openAPI, obj.getProperties(), pathname);
@@ -213,7 +213,7 @@ public class InlineModelResolver {
 
             Schema model = parameter.getSchema();
             if (model instanceof ObjectSchema) {
-                Schema obj = (Schema) model;
+                Schema obj = model;
                 if (obj.getType() == null || "object".equals(obj.getType())) {
                     if (obj.getProperties() != null && obj.getProperties().size() > 0) {
                         flattenProperties(openAPI, obj.getProperties(), pathname);
@@ -431,7 +431,7 @@ public class InlineModelResolver {
                 flattenComposedChildren(openAPI, modelName + "_anyOf", m.getAnyOf());
                 flattenComposedChildren(openAPI, modelName + "_oneOf", m.getOneOf());
             } else if (model instanceof Schema) {
-                Schema m = (Schema) model;
+                Schema m = model;
                 Map<String, Schema> properties = m.getProperties();
                 flattenProperties(openAPI, properties, modelName);
                 fixStringModel(m);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ErlangClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ErlangClientCodegen.java
@@ -355,7 +355,7 @@ public class ErlangClientCodegen extends DefaultCodegen implements CodegenConfig
     String length(Object os) {
         int l = 1;
         for (CodegenParameter o : ((ExtendedCodegenOperation) os).allParams) {
-            CodegenParameter q = (CodegenParameter) o;
+            CodegenParameter q = o;
             if (q.required)
                 l++;
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
@@ -708,8 +708,8 @@ public class JavaCXFExtServerCodegen extends JavaCXFServerCodegen implements CXF
             // NOTE: use double to hold float values, to avoid numeric overflow.
             double min = var == null || var.minimum == null ? -Float.MAX_VALUE : Float.parseFloat(var.minimum);
             double max = var == null || var.maximum == null ? Float.MAX_VALUE : Float.parseFloat(var.maximum);
-            double exclusiveMin = (double) (var != null && var.exclusiveMinimum ? 1 : 0);
-            double inclusiveMax = (double) (var == null || !var.exclusiveMaximum ? 1 : 0);
+            double exclusiveMin = var != null && var.exclusiveMinimum ? 1 : 0;
+            double inclusiveMax = var == null || !var.exclusiveMaximum ? 1 : 0;
             float randomFloat = (float) (min + exclusiveMin
                     + ((max + inclusiveMax - min - exclusiveMin) * Math.random()));
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
@@ -71,7 +71,7 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
             if (obj == null || getClass() != obj.getClass())
                 return false;
             Parameter p = (Parameter) obj;
-            return key.equals(p.key) && value.equals((String) p.value);
+            return key.equals(p.key) && value.equals(p.value);
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KtormSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KtormSchemaCodegen.java
@@ -1152,7 +1152,7 @@ public class KtormSchemaCodegen extends AbstractKotlinCodegen {
                 this.identifierNamingConvention = naming;
                 break;
             default:
-                LOGGER.warn("\"" + (String) naming + "\" is invalid \"identifierNamingConvention\" argument. Current \"" + (String) this.identifierNamingConvention + "\" used instead.");
+                LOGGER.warn("\"" + naming + "\" is invalid \"identifierNamingConvention\" argument. Current \"" + this.identifierNamingConvention + "\" used instead.");
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MysqlSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MysqlSchemaCodegen.java
@@ -1196,7 +1196,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
                 this.identifierNamingConvention = naming;
                 break;
             default:
-                LOGGER.warn("\"" + (String) naming + "\" is invalid \"identifierNamingConvention\" argument. Current \"" + (String) this.identifierNamingConvention + "\" used instead.");
+                LOGGER.warn("\"" + naming + "\" is invalid \"identifierNamingConvention\" argument. Current \"" + this.identifierNamingConvention + "\" used instead.");
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlim4ServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlim4ServerCodegen.java
@@ -147,7 +147,7 @@ public class PhpSlim4ServerCodegen extends PhpSlimServerCodegen {
                 break;
             default:
                 this.psr7Implementation = "slim-psr7";
-                LOGGER.warn("\"" + (String) psr7Implementation + "\" is invalid \"psr7Implementation\" argument. Default \"slim-psr7\" used instead.");
+                LOGGER.warn("\"" + psr7Implementation + "\" is invalid \"psr7Implementation\" argument. Default \"slim-psr7\" used instead.");
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
@@ -628,7 +628,7 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
                 // Datetime time stamps in Swift are expressed as Seconds with Microsecond precision.
                 // In Java, we need to be creative to get the Timestamp in Microseconds as a long.
                 Instant instant = ((OffsetDateTime) p.getDefault()).toInstant();
-                long epochMicro = TimeUnit.SECONDS.toMicros(instant.getEpochSecond()) + ((long) instant.get(ChronoField.MICRO_OF_SECOND));
+                long epochMicro = TimeUnit.SECONDS.toMicros(instant.getEpochSecond()) + (instant.get(ChronoField.MICRO_OF_SECOND));
                 return "Date(timeIntervalSince1970: " + String.valueOf(epochMicro) + ".0 / 1_000_000)";
             } else if (ModelUtils.isStringSchema(p)) {
                 return "\"" + escapeText((String) p.getDefault()) + "\"";

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/mysql/MysqlSchemaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/mysql/MysqlSchemaCodegenTest.java
@@ -90,7 +90,7 @@ public class MysqlSchemaCodegenTest {
         Assert.assertFalse((Boolean) strProp.get("isFloat"));
         Assert.assertFalse((Boolean) strProp.get("isInteger"));
         Assert.assertFalse((Boolean) strProp.get("isNumeric"));
-        Assert.assertSame((String) strProp.get("argumentValue"), strArgument);
+        Assert.assertSame(strProp.get("argumentValue"), strArgument);
 
         Integer intArgument = 10;
         HashMap<String, Object> intProp = codegen.toCodegenMysqlDataTypeArgument(intArgument);
@@ -98,7 +98,7 @@ public class MysqlSchemaCodegenTest {
         Assert.assertFalse((Boolean) intProp.get("isFloat"));
         Assert.assertTrue((Boolean) intProp.get("isInteger"));
         Assert.assertTrue((Boolean) intProp.get("isNumeric"));
-        Assert.assertSame((Integer) intProp.get("argumentValue"), intArgument);
+        Assert.assertSame(intProp.get("argumentValue"), intArgument);
 
         Double floatArgument = 3.14;
         HashMap<String, Object> floatProp = codegen.toCodegenMysqlDataTypeArgument(floatArgument);
@@ -106,7 +106,7 @@ public class MysqlSchemaCodegenTest {
         Assert.assertTrue((Boolean) floatProp.get("isFloat"));
         Assert.assertFalse((Boolean) floatProp.get("isInteger"));
         Assert.assertTrue((Boolean) floatProp.get("isNumeric"));
-        Assert.assertSame((Double) floatProp.get("argumentValue"), floatArgument);
+        Assert.assertSame(floatProp.get("argumentValue"), floatArgument);
     }
 
     @Test


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveUnnecessaryCast' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.18/jdt.php
For erefactor see https://github.com/cal101/erefactor

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@OpenAPITools/generator-core-team
