### PR TITLE
[Go] Add additional AWS sigv4 configuration options to go client generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -359,7 +359,7 @@ func (c *APIClient) prepareRequest(
 		{{#withAWSV4Signature}}
 		// AWS Signature v4 Authentication
 		if auth, ok := ctx.Value(ContextAWSv4).(AWSv4); ok {
-			creds := awscredentials.NewStaticCredentials(auth.AccessKey, auth.SecretKey, "")
+			creds := awscredentials.NewStaticCredentials(auth.AccessKey, auth.SecretKey, auth.SessionToken)
 			signer := awsv4.NewSigner(creds)
 			var reader *strings.Reader
 			if body == nil {
@@ -367,8 +367,19 @@ func (c *APIClient) prepareRequest(
 			} else {
 				reader = strings.NewReader(body.String())
 			}
+
+			// Define default values for region and service to maintain backward compatibility 
+			region := auth.Region
+			if region == "" {
+				region = "eu-west-2"
+			}
+			service := auth.Service
+			if service == "" {
+				service = "oapi"
+			}
+
 			timestamp := time.Now()
-			_, err := signer.Sign(localVarRequest, reader, "oapi", "eu-west-2", timestamp)
+			_, err := signer.Sign(localVarRequest, reader, service, region, timestamp)
 			if err != nil {
 				return nil, err
 			}

--- a/modules/openapi-generator/src/main/resources/go/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/go/configuration.mustache
@@ -70,6 +70,9 @@ type APIKey struct {
 type AWSv4 struct {
 	AccessKey string
 	SecretKey string
+	SessionToken string
+	Region string
+	Service string
 }
 
 {{/withAWSV4Signature}}

--- a/modules/openapi-generator/src/main/resources/go/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_anyof.mustache
@@ -20,7 +20,7 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 	{{#-first}}
 	// use discriminator value to speed up the lookup
 	var jsonDict map[string]interface{}
-	err := json.Unmarshal(data, &jsonDict)
+	err = json.Unmarshal(data, &jsonDict)
 	if err != nil {
 		return fmt.Errorf("Failed to unmarshal JSON into map for the discrimintor lookup.")
 	}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Golang client generator allows to include the AWS v4 signature. However, It's not possible to provide AWS session token (required when we use temporary credentials) and some configuration parameters like region and service name are hardcoded.

This PR adds additional configuration options: SessionToken, Region and Service to the existing sigv4 implementation.

This change maintain backward compatibility. Old, hardcoded values for region and service name are used as a default ones.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01)