### PR TITLE
[kotlin-sping] use MultipartFile and FilePart for file upload

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -125,8 +125,6 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         typeMapping.put("array", "kotlin.collections.List");
         typeMapping.put("list", "kotlin.collections.List");
 
-        // use resource for file handling
-        typeMapping.put("file", "org.springframework.core.io.Resource");
 
         addOption(TITLE, "server title name or client service name", title);
         addOption(BASE_PACKAGE, "base package (invokerPackage) for generated code", basePackage);
@@ -352,6 +350,12 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
             this.setReactive(convertPropertyToBoolean(REACTIVE));
             // spring webflux doesn't support @ControllerAdvice
             this.setExceptionHandler(false);
+            // use FilePart for file handling
+            typeMapping.put("file", "org.springframework.http.codec.multipart.FilePart");
+        }
+        if (!additionalProperties.containsKey(REACTIVE) && library.equals(SPRING_BOOT)) {
+            // use MultipartFile for file handling
+            typeMapping.put("file", "org.springframework.web.multipart.MultipartFile");
         }
         writePropertyBack(REACTIVE, reactive);
         writePropertyBack(EXCEPTION_HANDLER, exceptionHandler);

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -180,7 +180,7 @@ interface PetApi {
     )
     fun uploadFile(@ApiParam(value = "ID of pet to update", required=true) @PathVariable("petId") petId: kotlin.Long
 ,@ApiParam(value = "Additional data to pass to server") @RequestParam(value="additionalMetadata", required=false) additionalMetadata: kotlin.String? 
-,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: org.springframework.core.io.Resource?
+,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: org.springframework.web.multipart.MultipartFile?
 ): ResponseEntity<ModelApiResponse> {
         return getDelegate().uploadFile(petId, additionalMetadata, file);
     }

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -171,7 +171,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
     )
     suspend fun uploadFile(@ApiParam(value = "ID of pet to update", required=true) @PathVariable("petId") petId: kotlin.Long
 ,@ApiParam(value = "Additional data to pass to server") @RequestParam(value="additionalMetadata", required=false) additionalMetadata: kotlin.String? 
-,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: org.springframework.core.io.Resource?
+,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: org.springframework.http.codec.multipart.FilePart?
 ): ResponseEntity<ModelApiResponse> {
         return ResponseEntity(service.uploadFile(petId, additionalMetadata, file), HttpStatus.valueOf(200))
     }

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/api/PetApiService.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/api/PetApiService.kt
@@ -19,5 +19,5 @@ interface PetApiService {
 
 	suspend fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?): Unit
 
-	suspend fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: org.springframework.core.io.Resource?): ModelApiResponse
+	suspend fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: org.springframework.http.codec.multipart.FilePart?): ModelApiResponse
 }

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/api/PetApiServiceImpl.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/api/PetApiServiceImpl.kt
@@ -35,7 +35,7 @@ class PetApiServiceImpl : PetApiService {
         TODO("Implement me")
     }
 
-    override suspend fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: org.springframework.core.io.Resource?): ModelApiResponse {
+    override suspend fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: org.springframework.http.codec.multipart.FilePart?): ModelApiResponse {
         TODO("Implement me")
     }
 }

--- a/samples/server/petstore/kotlin-springboot-reactive/src/test/kotlin/org/openapitools/api/PetApiTest.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/test/kotlin/org/openapitools/api/PetApiTest.kt
@@ -141,7 +141,7 @@ class PetApiTest {
     fun uploadFileTest() = runBlockingTest {
         val petId:kotlin.Long? = null
         val additionalMetadata:kotlin.String? = null
-        val file:org.springframework.core.io.Resource? = null
+        val file:org.springframework.http.codec.multipart.FilePart? = null
         val response: ResponseEntity<ModelApiResponse> = api.uploadFile(petId!!, additionalMetadata!!, file!!)
 
         // TODO: test validations

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -170,7 +170,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
     )
     fun uploadFile(@ApiParam(value = "ID of pet to update", required=true) @PathVariable("petId") petId: kotlin.Long
 ,@ApiParam(value = "Additional data to pass to server") @RequestParam(value="additionalMetadata", required=false) additionalMetadata: kotlin.String? 
-,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: org.springframework.core.io.Resource?
+,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: org.springframework.web.multipart.MultipartFile?
 ): ResponseEntity<ModelApiResponse> {
         return ResponseEntity(service.uploadFile(petId, additionalMetadata, file), HttpStatus.valueOf(200))
     }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiService.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiService.kt
@@ -18,5 +18,5 @@ interface PetApiService {
 
 	fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?): Unit
 
-	fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: org.springframework.core.io.Resource?): ModelApiResponse
+	fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: org.springframework.web.multipart.MultipartFile?): ModelApiResponse
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiServiceImpl.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiServiceImpl.kt
@@ -34,7 +34,7 @@ class PetApiServiceImpl : PetApiService {
         TODO("Implement me")
     }
 
-    override fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: org.springframework.core.io.Resource?): ModelApiResponse {
+    override fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: org.springframework.web.multipart.MultipartFile?): ModelApiResponse {
         TODO("Implement me")
     }
 }

--- a/samples/server/petstore/kotlin-springboot/src/test/kotlin/org/openapitools/api/PetApiTest.kt
+++ b/samples/server/petstore/kotlin-springboot/src/test/kotlin/org/openapitools/api/PetApiTest.kt
@@ -139,7 +139,7 @@ class PetApiTest {
     fun uploadFileTest() {
         val petId:kotlin.Long? = null
         val additionalMetadata:kotlin.String? = null
-        val file:org.springframework.core.io.Resource? = null
+        val file:org.springframework.web.multipart.MultipartFile? = null
         val response: ResponseEntity<ModelApiResponse> = api.uploadFile(petId!!, additionalMetadata!!, file!!)
 
         // TODO: test validations


### PR DESCRIPTION
related to #8333

for multipart/form with file the générature will use the following classes : 
- FilePart with spring web
- FilePart with spring webflux


@jimschubert @dr4ke616 @karismann  @Zomzog @andrewemery @4brunu  @yutaka0m

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, 
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
