### PR TITLE
[cpp-qt5-client] Fix qt5.15 check

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpFileElement.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpFileElement.cpp.mustache
@@ -57,13 +57,13 @@ QJsonValue {{prefix}}HttpFileElement::asJsonValue() const {
     if (!result) {
         qDebug() << "Error opening file " << local_filename;
     }
-#if QT_VERSION >= 0x051500
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     return QJsonDocument::fromJson(bArray.data()).object();
 #else
-    return QJsonDocument::fromBinaryData(bArray.data()).object(); 
+    return QJsonDocument::fromBinaryData(bArray.data()).object();
 #endif
 }
-    
+
 bool {{prefix}}HttpFileElement::fromStringValue(const QString &instr) {
     QFile file(local_filename);
     bool result = false;
@@ -86,7 +86,7 @@ bool {{prefix}}HttpFileElement::fromJsonValue(const QJsonValue &jval) {
         file.remove();
     }
     result = file.open(QIODevice::WriteOnly);
-#if QT_VERSION >= 0x051500
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     file.write(QJsonDocument(jval.toObject()).toJson());
 #else
     file.write(QJsonDocument(jval.toObject()).toBinaryData());

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
@@ -7,7 +7,7 @@
 #include <QUrl>
 #include <QUuid>
 #include <QtGlobal>
-#if QT_VERSION >= 0x051500
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     #define SKIP_EMPTY_PARTS Qt::SkipEmptyParts
 #else
     #define SKIP_EMPTY_PARTS QString::SkipEmptyParts
@@ -52,7 +52,7 @@ void {{prefix}}HttpRequestInput::add_file(QString variable_name, QString local_f
 {{prefix}}HttpRequestWorker::{{prefix}}HttpRequestWorker(QObject *parent, QNetworkAccessManager *_manager)
     : QObject(parent), manager(_manager), timeOutTimer(this), isResponseCompressionEnabled(false), isRequestCompressionEnabled(false), httpResponseCode(-1) {
 
-#if QT_VERSION >= 0x051500
+#if QT_VERSION >= QT_VERSION(5, 15, 0)
     randomGenerator = QRandomGenerator(QDateTime::currentDateTime().toSecsSinceEpoch());
 #else
     qsrand(QDateTime::currentDateTime().toTime_t());
@@ -216,7 +216,7 @@ void {{prefix}}HttpRequestWorker::execute({{prefix}}HttpRequestInput *input) {
         // variable layout is MULTIPART
 
         boundary = QString("__-----------------------%1%2")
-                    #if QT_VERSION >= 0x051500
+                    #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
                             .arg(QDateTime::currentDateTime().toSecsSinceEpoch())
                             .arg(randomGenerator.generate());
                     #else
@@ -546,7 +546,7 @@ QByteArray {{prefix}}HttpRequestWorker::compress(const QByteArray& input, int le
     return output;{{/contentCompression}}{{^contentCompression}}
     Q_UNUSED(input);
     Q_UNUSED(level);
-    Q_UNUSED(compressType);        
+    Q_UNUSED(compressType);
     return QByteArray();{{/contentCompression}}
 }
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
@@ -52,7 +52,7 @@ void {{prefix}}HttpRequestInput::add_file(QString variable_name, QString local_f
 {{prefix}}HttpRequestWorker::{{prefix}}HttpRequestWorker(QObject *parent, QNetworkAccessManager *_manager)
     : QObject(parent), manager(_manager), timeOutTimer(this), isResponseCompressionEnabled(false), isRequestCompressionEnabled(false), httpResponseCode(-1) {
 
-#if QT_VERSION >= QT_VERSION(5, 15, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     randomGenerator = QRandomGenerator(QDateTime::currentDateTime().toSecsSinceEpoch());
 #else
     qsrand(QDateTime::currentDateTime().toTime_t());

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
@@ -14,7 +14,7 @@
 #include <QObject>
 #include <QString>
 #include <QTimer>
-#if QT_VERSION >= 0x051500
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     #include <QRandomGenerator>
 #endif
 
@@ -89,7 +89,7 @@ private:
     bool isResponseCompressionEnabled;
     bool isRequestCompressionEnabled;
     int  httpResponseCode;
-#if QT_VERSION >= 0x051500
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     QRandomGenerator randomGenerator;
 #endif
 

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpFileElement.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpFileElement.cpp
@@ -65,13 +65,13 @@ QJsonValue PFXHttpFileElement::asJsonValue() const {
     if (!result) {
         qDebug() << "Error opening file " << local_filename;
     }
-#if QT_VERSION >= 0x051500
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     return QJsonDocument::fromJson(bArray.data()).object();
 #else
-    return QJsonDocument::fromBinaryData(bArray.data()).object(); 
+    return QJsonDocument::fromBinaryData(bArray.data()).object();
 #endif
 }
-    
+
 bool PFXHttpFileElement::fromStringValue(const QString &instr) {
     QFile file(local_filename);
     bool result = false;
@@ -94,7 +94,7 @@ bool PFXHttpFileElement::fromJsonValue(const QJsonValue &jval) {
         file.remove();
     }
     result = file.open(QIODevice::WriteOnly);
-#if QT_VERSION >= 0x051500
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     file.write(QJsonDocument(jval.toObject()).toJson());
 #else
     file.write(QJsonDocument(jval.toObject()).toBinaryData());

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
@@ -17,7 +17,7 @@
 #include <QUrl>
 #include <QUuid>
 #include <QtGlobal>
-#if QT_VERSION >= 0x051500
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     #define SKIP_EMPTY_PARTS Qt::SkipEmptyParts
 #else
     #define SKIP_EMPTY_PARTS QString::SkipEmptyParts
@@ -59,7 +59,7 @@ void PFXHttpRequestInput::add_file(QString variable_name, QString local_filename
 PFXHttpRequestWorker::PFXHttpRequestWorker(QObject *parent, QNetworkAccessManager *_manager)
     : QObject(parent), manager(_manager), timeOutTimer(this), isResponseCompressionEnabled(false), isRequestCompressionEnabled(false), httpResponseCode(-1) {
 
-#if QT_VERSION >= 0x051500
+#if QT_VERSION >= QT_VERSION(5, 15, 0)
     randomGenerator = QRandomGenerator(QDateTime::currentDateTime().toSecsSinceEpoch());
 #else
     qsrand(QDateTime::currentDateTime().toTime_t());
@@ -223,7 +223,7 @@ void PFXHttpRequestWorker::execute(PFXHttpRequestInput *input) {
         // variable layout is MULTIPART
 
         boundary = QString("__-----------------------%1%2")
-                    #if QT_VERSION >= 0x051500
+                    #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
                             .arg(QDateTime::currentDateTime().toSecsSinceEpoch())
                             .arg(randomGenerator.generate());
                     #else
@@ -480,7 +480,7 @@ QByteArray PFXHttpRequestWorker::compress(const QByteArray& input, int level, PF
     
     Q_UNUSED(input);
     Q_UNUSED(level);
-    Q_UNUSED(compressType);        
+    Q_UNUSED(compressType);
     return QByteArray();
 }
 

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
@@ -59,7 +59,7 @@ void PFXHttpRequestInput::add_file(QString variable_name, QString local_filename
 PFXHttpRequestWorker::PFXHttpRequestWorker(QObject *parent, QNetworkAccessManager *_manager)
     : QObject(parent), manager(_manager), timeOutTimer(this), isResponseCompressionEnabled(false), isRequestCompressionEnabled(false), httpResponseCode(-1) {
 
-#if QT_VERSION >= QT_VERSION(5, 15, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     randomGenerator = QRandomGenerator(QDateTime::currentDateTime().toSecsSinceEpoch());
 #else
     qsrand(QDateTime::currentDateTime().toTime_t());

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.h
@@ -24,7 +24,7 @@
 #include <QObject>
 #include <QString>
 #include <QTimer>
-#if QT_VERSION >= 0x051500
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     #include <QRandomGenerator>
 #endif
 
@@ -97,7 +97,7 @@ private:
     bool isResponseCompressionEnabled;
     bool isRequestCompressionEnabled;
     int  httpResponseCode;
-#if QT_VERSION >= 0x051500
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     QRandomGenerator randomGenerator;
 #endif
 


### PR DESCRIPTION
The Qt 5.15 check doesn't works: it checked again Qt 5.21.0 (my mistake by the way). This PR fix it.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@ravinikam @stkrwork @etherealjoy @muttleyxd