### PR TITLE
[cpp-qtt5-client] Remove unused parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -9,12 +9,8 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
-{{classname}}::{{classname}}(const QString &scheme, const QString &host, int port, const QString &basePath, const int timeOut)
-    : _scheme(scheme),
-      _host(host),
-      _port(port),
-      _basePath(basePath),
-      _timeOut(timeOut),
+{{classname}}::{{classname}}(const int timeOut)
+    : _timeOut(timeOut),
       _manager(nullptr),
       isResponseCompressionEnabled(false),
       isRequestCompressionEnabled(false) {
@@ -79,18 +75,6 @@ void {{classname}}::setServerIndex(const QString &operation, int serverIndex){
         _serverIndices[operation] = serverIndex;
 }
 
-void {{classname}}::setScheme(const QString &scheme) {
-    _scheme = scheme;
-}
-
-void {{classname}}::setHost(const QString &host) {
-    _host = host;
-}
-
-void {{classname}}::setPort(int port) {
-    _port = port;
-}
-
 void {{classname}}::setApiKey(const QString &apiKeyName, const QString &apiKey){
     _apiKeys.insert(apiKeyName,apiKey);
 }
@@ -105,10 +89,6 @@ void {{classname}}::setUsername(const QString &username) {
 
 void {{classname}}::setPassword(const QString &password) {
     _password = password;
-}
-
-void {{classname}}::setBasePath(const QString &basePath) {
-    _basePath = basePath;
 }
 
 void {{classname}}::setTimeOut(const int timeOut) {

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
@@ -22,20 +22,16 @@ class {{classname}} : public QObject {
     Q_OBJECT
 
 public:
-    {{classname}}(const QString &scheme = "{{scheme}}", const QString &host = "{{serverHost}}", int port = {{#serverPort}}{{serverPort}}{{/serverPort}}{{^serverPort}}0{{/serverPort}}, const QString &basePath = "{{basePathWithoutHost}}", const int timeOut = 0);
+    {{classname}}(const int timeOut = 0);
     ~{{classname}}();
 
     void initializeServerConfigs();
     int setDefaultServerValue(int serverIndex,const QString &operation, const QString &variable,const QString &val);
     void setServerIndex(const QString &operation, int serverIndex);
-    void setScheme(const QString &scheme);
-    void setHost(const QString &host);
-    void setPort(int port);
     void setApiKey(const QString &apiKeyName, const QString &apiKey);
     void setBearerToken(const QString &token);
     void setUsername(const QString &username);
     void setPassword(const QString &password);
-    void setBasePath(const QString &basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
@@ -50,9 +46,6 @@ public:
     void {{nickname}}({{#allParams}}const {{{dataType}}} &{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});{{/operation}}{{/operations}}
 
 private:
-    QString _scheme, _host;
-    int _port;
-    QString _basePath;
     QMap<QString,int> _serverIndices;
     QMap<QString,QList<{{prefix}}ServerConfiguration>> _serverConfigs;
     QMap<QString, QString> _apiKeys;

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
@@ -17,12 +17,8 @@
 
 namespace test_namespace {
 
-PFXPetApi::PFXPetApi(const QString &scheme, const QString &host, int port, const QString &basePath, const int timeOut)
-    : _scheme(scheme),
-      _host(host),
-      _port(port),
-      _basePath(basePath),
-      _timeOut(timeOut),
+PFXPetApi::PFXPetApi(const int timeOut)
+    : _timeOut(timeOut),
       _manager(nullptr),
       isResponseCompressionEnabled(false),
       isRequestCompressionEnabled(false) {
@@ -85,18 +81,6 @@ void PFXPetApi::setServerIndex(const QString &operation, int serverIndex){
         _serverIndices[operation] = serverIndex;
 }
 
-void PFXPetApi::setScheme(const QString &scheme) {
-    _scheme = scheme;
-}
-
-void PFXPetApi::setHost(const QString &host) {
-    _host = host;
-}
-
-void PFXPetApi::setPort(int port) {
-    _port = port;
-}
-
 void PFXPetApi::setApiKey(const QString &apiKeyName, const QString &apiKey){
     _apiKeys.insert(apiKeyName,apiKey);
 }
@@ -111,10 +95,6 @@ void PFXPetApi::setUsername(const QString &username) {
 
 void PFXPetApi::setPassword(const QString &password) {
     _password = password;
-}
-
-void PFXPetApi::setBasePath(const QString &basePath) {
-    _basePath = basePath;
 }
 
 void PFXPetApi::setTimeOut(const int timeOut) {

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
@@ -32,20 +32,16 @@ class PFXPetApi : public QObject {
     Q_OBJECT
 
 public:
-    PFXPetApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 0, const QString &basePath = "/v2", const int timeOut = 0);
+    PFXPetApi(const int timeOut = 0);
     ~PFXPetApi();
 
     void initializeServerConfigs();
     int setDefaultServerValue(int serverIndex,const QString &operation, const QString &variable,const QString &val);
     void setServerIndex(const QString &operation, int serverIndex);
-    void setScheme(const QString &scheme);
-    void setHost(const QString &host);
-    void setPort(int port);
     void setApiKey(const QString &apiKeyName, const QString &apiKey);
     void setBearerToken(const QString &token);
     void setUsername(const QString &username);
     void setPassword(const QString &password);
-    void setBasePath(const QString &basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
@@ -67,9 +63,6 @@ public:
     void uploadFile(const qint64 &pet_id, const QString &additional_metadata, const PFXHttpFileElement &file);
 
 private:
-    QString _scheme, _host;
-    int _port;
-    QString _basePath;
     QMap<QString,int> _serverIndices;
     QMap<QString,QList<PFXServerConfiguration>> _serverConfigs;
     QMap<QString, QString> _apiKeys;

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
@@ -17,12 +17,8 @@
 
 namespace test_namespace {
 
-PFXStoreApi::PFXStoreApi(const QString &scheme, const QString &host, int port, const QString &basePath, const int timeOut)
-    : _scheme(scheme),
-      _host(host),
-      _port(port),
-      _basePath(basePath),
-      _timeOut(timeOut),
+PFXStoreApi::PFXStoreApi(const int timeOut)
+    : _timeOut(timeOut),
       _manager(nullptr),
       isResponseCompressionEnabled(false),
       isRequestCompressionEnabled(false) {
@@ -73,18 +69,6 @@ void PFXStoreApi::setServerIndex(const QString &operation, int serverIndex){
         _serverIndices[operation] = serverIndex;
 }
 
-void PFXStoreApi::setScheme(const QString &scheme) {
-    _scheme = scheme;
-}
-
-void PFXStoreApi::setHost(const QString &host) {
-    _host = host;
-}
-
-void PFXStoreApi::setPort(int port) {
-    _port = port;
-}
-
 void PFXStoreApi::setApiKey(const QString &apiKeyName, const QString &apiKey){
     _apiKeys.insert(apiKeyName,apiKey);
 }
@@ -99,10 +83,6 @@ void PFXStoreApi::setUsername(const QString &username) {
 
 void PFXStoreApi::setPassword(const QString &password) {
     _password = password;
-}
-
-void PFXStoreApi::setBasePath(const QString &basePath) {
-    _basePath = basePath;
 }
 
 void PFXStoreApi::setTimeOut(const int timeOut) {

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
@@ -31,20 +31,16 @@ class PFXStoreApi : public QObject {
     Q_OBJECT
 
 public:
-    PFXStoreApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 0, const QString &basePath = "/v2", const int timeOut = 0);
+    PFXStoreApi(const int timeOut = 0);
     ~PFXStoreApi();
 
     void initializeServerConfigs();
     int setDefaultServerValue(int serverIndex,const QString &operation, const QString &variable,const QString &val);
     void setServerIndex(const QString &operation, int serverIndex);
-    void setScheme(const QString &scheme);
-    void setHost(const QString &host);
-    void setPort(int port);
     void setApiKey(const QString &apiKeyName, const QString &apiKey);
     void setBearerToken(const QString &token);
     void setUsername(const QString &username);
     void setPassword(const QString &password);
-    void setBasePath(const QString &basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
@@ -62,9 +58,6 @@ public:
     void placeOrder(const PFXOrder &body);
 
 private:
-    QString _scheme, _host;
-    int _port;
-    QString _basePath;
     QMap<QString,int> _serverIndices;
     QMap<QString,QList<PFXServerConfiguration>> _serverConfigs;
     QMap<QString, QString> _apiKeys;

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
@@ -17,12 +17,8 @@
 
 namespace test_namespace {
 
-PFXUserApi::PFXUserApi(const QString &scheme, const QString &host, int port, const QString &basePath, const int timeOut)
-    : _scheme(scheme),
-      _host(host),
-      _port(port),
-      _basePath(basePath),
-      _timeOut(timeOut),
+PFXUserApi::PFXUserApi(const int timeOut)
+    : _timeOut(timeOut),
       _manager(nullptr),
       isResponseCompressionEnabled(false),
       isRequestCompressionEnabled(false) {
@@ -85,18 +81,6 @@ void PFXUserApi::setServerIndex(const QString &operation, int serverIndex){
         _serverIndices[operation] = serverIndex;
 }
 
-void PFXUserApi::setScheme(const QString &scheme) {
-    _scheme = scheme;
-}
-
-void PFXUserApi::setHost(const QString &host) {
-    _host = host;
-}
-
-void PFXUserApi::setPort(int port) {
-    _port = port;
-}
-
 void PFXUserApi::setApiKey(const QString &apiKeyName, const QString &apiKey){
     _apiKeys.insert(apiKeyName,apiKey);
 }
@@ -111,10 +95,6 @@ void PFXUserApi::setUsername(const QString &username) {
 
 void PFXUserApi::setPassword(const QString &password) {
     _password = password;
-}
-
-void PFXUserApi::setBasePath(const QString &basePath) {
-    _basePath = basePath;
 }
 
 void PFXUserApi::setTimeOut(const int timeOut) {

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
@@ -31,20 +31,16 @@ class PFXUserApi : public QObject {
     Q_OBJECT
 
 public:
-    PFXUserApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 0, const QString &basePath = "/v2", const int timeOut = 0);
+    PFXUserApi(const int timeOut = 0);
     ~PFXUserApi();
 
     void initializeServerConfigs();
     int setDefaultServerValue(int serverIndex,const QString &operation, const QString &variable,const QString &val);
     void setServerIndex(const QString &operation, int serverIndex);
-    void setScheme(const QString &scheme);
-    void setHost(const QString &host);
-    void setPort(int port);
     void setApiKey(const QString &apiKeyName, const QString &apiKey);
     void setBearerToken(const QString &token);
     void setUsername(const QString &username);
     void setPassword(const QString &password);
-    void setBasePath(const QString &basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
@@ -66,9 +62,6 @@ public:
     void updateUser(const QString &username, const PFXUser &body);
 
 private:
-    QString _scheme, _host;
-    int _port;
-    QString _basePath;
     QMap<QString,int> _serverIndices;
     QMap<QString,QList<PFXServerConfiguration>> _serverConfigs;
     QMap<QString, QString> _apiKeys;


### PR DESCRIPTION
Using the latest version of openapi-generator, I noticed that some parameters were missing. What about removing them?

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@ravinikam @stkrwork @etherealjoy @muttleyxd
