### PR TITLE
[PHP] Use a valid php type for maps

### DIFF
--- a/docs/generators/php-laravel.md
+++ b/docs/generators/php-laravel.md
@@ -33,7 +33,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Type/Alias | Instantiated By |
 | ---------- | --------------- |
 |array|array|
-|map|map|
+|map|array|
 
 
 ## LANGUAGE PRIMITIVES

--- a/docs/generators/php-lumen.md
+++ b/docs/generators/php-lumen.md
@@ -33,7 +33,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Type/Alias | Instantiated By |
 | ---------- | --------------- |
 |array|array|
-|map|map|
+|map|array|
 
 
 ## LANGUAGE PRIMITIVES

--- a/docs/generators/php-mezzio-ph.md
+++ b/docs/generators/php-mezzio-ph.md
@@ -33,7 +33,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Type/Alias | Instantiated By |
 | ---------- | --------------- |
 |array|array|
-|map|map|
+|map|array|
 
 
 ## LANGUAGE PRIMITIVES

--- a/docs/generators/php-slim-deprecated.md
+++ b/docs/generators/php-slim-deprecated.md
@@ -33,7 +33,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Type/Alias | Instantiated By |
 | ---------- | --------------- |
 |array|array|
-|map|map|
+|map|array|
 
 
 ## LANGUAGE PRIMITIVES

--- a/docs/generators/php-slim4.md
+++ b/docs/generators/php-slim4.md
@@ -34,7 +34,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Type/Alias | Instantiated By |
 | ---------- | --------------- |
 |array|array|
-|map|map|
+|map|array|
 
 
 ## LANGUAGE PRIMITIVES

--- a/docs/generators/php-symfony.md
+++ b/docs/generators/php-symfony.md
@@ -39,7 +39,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Type/Alias | Instantiated By |
 | ---------- | --------------- |
 |array|array|
-|map|map|
+|map|array|
 
 
 ## LANGUAGE PRIMITIVES

--- a/docs/generators/php.md
+++ b/docs/generators/php.md
@@ -34,7 +34,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | Type/Alias | Instantiated By |
 | ---------- | --------------- |
 |array|array|
-|map|map|
+|map|array|
 
 
 ## LANGUAGE PRIMITIVES

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -98,7 +98,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         );
 
         instantiationTypes.put("array", "array");
-        instantiationTypes.put("map", "map");
+        instantiationTypes.put("map", "array");
 
 
         // provide primitives to mustache template
@@ -119,7 +119,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         typeMapping.put("Date", "\\DateTime");
         typeMapping.put("DateTime", "\\DateTime");
         typeMapping.put("file", "\\SplFileObject");
-        typeMapping.put("map", "map");
+        typeMapping.put("map", "array");
         typeMapping.put("array", "array");
         typeMapping.put("list", "array");
         typeMapping.put("object", "object");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -307,7 +307,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
                 LOGGER.warn(p.getName() + "(map property) does not have a proper inner type defined. Default to string");
                 inner = new StringSchema().description("TODO default missing map inner type to string");
             }
-            return getSchemaType(p) + "[string," + getTypeDeclaration(inner) + "]";
+            return getSchemaType(p) + "<string," + getTypeDeclaration(inner) + ">";
         } else if (StringUtils.isNotBlank(p.get$ref())) { // model
             String type = super.getTypeDeclaration(p);
             return (!languageSpecificPrimitives.contains(type))

--- a/modules/openapi-generator/src/main/resources/php-laravel/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/model.mustache
@@ -10,7 +10,7 @@ namespace {{modelPackage}};
 class {{classname}} {
 
     {{#vars}}
-    /** @var {{dataType}} ${{name}} {{#description}}{{description}}{{/description}}*/
+    /** @var {{{dataType}}} ${{name}} {{#description}}{{description}}{{/description}}*/
     private ${{name}};
 
     {{/vars}}

--- a/modules/openapi-generator/src/main/resources/php-mezzio-ph/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-mezzio-ph/api.mustache
@@ -45,10 +45,10 @@ class {{classname}}
 {{^isPrimitiveType}}
 {{#isContainer}}
      * TODO check if attribute is valid and can handle your container type
-     * @PHA\Attribute(name=PHAttribute\Transfer::class, options={"type":"{{dataType}}","objectAttr":"bodyData"})
+     * @PHA\Attribute(name=PHAttribute\Transfer::class, options={"type":"{{{dataType}}}","objectAttr":"bodyData"})
 {{/isContainer}}
 {{^isContainer}}
-     * @PHA\Attribute(name=PHAttribute\Transfer::class, options={"type":{{dataType}}::class,"objectAttr":"bodyData"})
+     * @PHA\Attribute(name=PHAttribute\Transfer::class, options={"type":{{{dataType}}}::class,"objectAttr":"bodyData"})
 {{/isContainer}}
 {{/isPrimitiveType}}
 {{/bodyParam}}
@@ -64,7 +64,7 @@ class {{classname}}
 {{#returnContainer}}
      * TODO check if generated return container type is valid
 {{/returnContainer}}
-     * @return {{returnType}}
+     * @return {{{returnType}}}
 {{/returnType}}
      */
     public function {{operationId}}(ServerRequestInterface $request){{#returnType}}: {{#returnContainer}}array{{/returnContainer}}{{^returnContainer}}{{returnType}}{{/returnContainer}}{{/returnType}}
@@ -78,7 +78,7 @@ class {{classname}}
 {{/vendorExtensions}}
 {{#bodyParam}}
 {{^isPrimitiveType}}
-        /** @var {{dataType}} $bodyData */
+        /** @var {{{dataType}}} $bodyData */
         $bodyData = $request->getAttribute("bodyData");
 {{/isPrimitiveType}}
 {{/bodyParam}}

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -278,7 +278,7 @@ class ObjectSerializer
             return $values;
         }
 
-        if (substr($class, 0, 4) === 'map[') { // for associative array e.g. map[string,int]
+        if (preg_match('/^(array<|map\[)/', $class)) { // for associative array e.g. array<string,int>
             $data = is_string($data) ? json_decode($data) : $data;
             settype($data, 'array');
             $inner = substr($class, 4, -1);

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -131,7 +131,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{dataType}} ${{paramName}}{{#description}} {{description}}{{/description}}{{^description}} {{paramName}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}}{{^description}} {{paramName}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/allParams}}
      *
      * @throws \{{invokerPackage}}\ApiException on non-2xx response
@@ -169,7 +169,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{dataType}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/allParams}}
      *
      * @throws \{{invokerPackage}}\ApiException on non-2xx response
@@ -216,14 +216,14 @@ use {{invokerPackage}}\ObjectSerializer;
             {{/-first}}
             {{#dataType}}
                 {{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
-                    if ('{{dataType}}' === '\SplFileObject') {
+                    if ('{{{dataType}}}' === '\SplFileObject') {
                         $content = $responseBody; //stream goes to serializer
                     } else {
                         $content = (string) $responseBody;
                     }
 
                     return [
-                        ObjectSerializer::deserialize($content, '{{dataType}}', []),
+                        ObjectSerializer::deserialize($content, '{{{dataType}}}', []),
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
@@ -233,7 +233,7 @@ use {{invokerPackage}}\ObjectSerializer;
             {{/-last}}
         {{/responses}}
 
-            $returnType = '{{returnType}}';
+            $returnType = '{{{returnType}}}';
             $responseBody = $response->getBody();
             if ($returnType === '\SplFileObject') {
                 $content = $responseBody; //stream goes to serializer
@@ -259,7 +259,7 @@ use {{invokerPackage}}\ObjectSerializer;
                 {{^isWildcard}}case {{code}}:{{/isWildcard}}{{#isWildcard}}default:{{/isWildcard}}
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
-                        '{{dataType}}',
+                        '{{{dataType}}}',
                         $e->getResponseHeaders()
                     );
                     $e->setResponseObject($data);
@@ -294,7 +294,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{dataType}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/allParams}}
      *
      * @throws \InvalidArgumentException
@@ -333,7 +333,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{dataType}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/allParams}}
      *
      * @throws \InvalidArgumentException
@@ -341,7 +341,7 @@ use {{invokerPackage}}\ObjectSerializer;
      */
     public function {{operationId}}AsyncWithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {
-        $returnType = '{{returnType}}';
+        $returnType = '{{{returnType}}}';
         $request = $this->{{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^-last}}, {{/-last}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});
 
         return $this->client
@@ -400,7 +400,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{dataType}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/allParams}}
      *
      * @throws \InvalidArgumentException

--- a/modules/openapi-generator/src/main/resources/php/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api_doc.mustache
@@ -57,7 +57,7 @@ Note: the input parameter is an associative array with the keys listed as the pa
 {{/vendorExtensions.x-group-parameters}}
 {{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#-last}}Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}
-{{#allParams}} **{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**](../Model/{{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} |{{^required}} [optional]{{/required}}{{#defaultValue}} [default to {{defaultValue}}]{{/defaultValue}}
+{{#allParams}} **{{paramName}}** | {{#isFile}}**{{{dataType}}}**{{/isFile}}{{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{{dataType}}}**](../Model/{{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} |{{^required}} [optional]{{/required}}{{#defaultValue}} [default to {{defaultValue}}]{{/defaultValue}}
 {{/allParams}}
 
 ### Return type

--- a/modules/openapi-generator/src/main/resources/php/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_doc.mustache
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} |{{^required}} [optional]{{/required}}{{#isReadOnly}} [readonly]{{/isReadOnly}}{{#defaultValue}} [default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} |{{^required}} [optional]{{/required}}{{#isReadOnly}} [readonly]{{/isReadOnly}}{{#defaultValue}} [default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md){{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -269,7 +269,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
     /**
      * Gets {{name}}
      *
-     * @return {{dataType}}{{^required}}|null{{/required}}
+     * @return {{{dataType}}}{{^required}}|null{{/required}}
      */
     public function {{getter}}()
     {
@@ -279,7 +279,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
     /**
      * Sets {{name}}
      *
-     * @param {{dataType}}{{^required}}|null{{/required}} ${{name}}{{#description}} {{{description}}}{{/description}}{{^description}} {{{name}}}{{/description}}
+     * @param {{{dataType}}}{{^required}}|null{{/required}} ${{name}}{{#description}} {{{description}}}{{/description}}{{^description}} {{{name}}}{{/description}}
      *
      * @return self
      */

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
@@ -143,9 +143,9 @@ public class PhpModelTest {
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "translations");
-        Assert.assertEquals(property1.dataType, "map[string,string]");
+        Assert.assertEquals(property1.dataType, "array[string,string]");
         Assert.assertEquals(property1.name, "translations");
-        Assert.assertEquals(property1.baseType, "map");
+        Assert.assertEquals(property1.baseType, "array");
         Assert.assertEquals(property1.containerType, "map");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
@@ -223,9 +223,9 @@ public class PhpModelTest {
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "children");
         Assert.assertEquals(property1.complexType, "Children");
-        Assert.assertEquals(property1.dataType, "map[string,\\OpenAPI\\Client\\Model\\Children]");
+        Assert.assertEquals(property1.dataType, "array[string,\\OpenAPI\\Client\\Model\\Children]");
         Assert.assertEquals(property1.name, "children");
-        Assert.assertEquals(property1.baseType, "map");
+        Assert.assertEquals(property1.baseType, "array");
         Assert.assertEquals(property1.containerType, "map");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
@@ -143,7 +143,7 @@ public class PhpModelTest {
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "translations");
-        Assert.assertEquals(property1.dataType, "array[string,string]");
+        Assert.assertEquals(property1.dataType, "array<string,string>");
         Assert.assertEquals(property1.name, "translations");
         Assert.assertEquals(property1.baseType, "array");
         Assert.assertEquals(property1.containerType, "map");
@@ -223,7 +223,7 @@ public class PhpModelTest {
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "children");
         Assert.assertEquals(property1.complexType, "Children");
-        Assert.assertEquals(property1.dataType, "array[string,\\OpenAPI\\Client\\Model\\Children]");
+        Assert.assertEquals(property1.dataType, "array<string,\\OpenAPI\\Client\\Model\\Children>");
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "array");
         Assert.assertEquals(property1.containerType, "map");

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -769,7 +769,7 @@ $apiInstance = new OpenAPI\Client\Api\FakeApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$request_body = array('key' => 'request_body_example'); // map[string,string] | request body
+$request_body = array('key' => 'request_body_example'); // array[string,string] | request body
 
 try {
     $apiInstance->testInlineAdditionalProperties($request_body);
@@ -782,7 +782,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **request_body** | [**map[string,string]**](../Model/string.md)| request body |
+ **request_body** | [**array[string,string]**](../Model/string.md)| request body |
 
 ### Return type
 

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -769,7 +769,7 @@ $apiInstance = new OpenAPI\Client\Api\FakeApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$request_body = array('key' => 'request_body_example'); // array[string,string] | request body
+$request_body = array('key' => 'request_body_example'); // array<string,string> | request body
 
 try {
     $apiInstance->testInlineAdditionalProperties($request_body);
@@ -782,7 +782,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **request_body** | [**array[string,string]**](../Model/string.md)| request body |
+ **request_body** | [**array<string,string>**](../Model/string.md)| request body |
 
 ### Return type
 

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/StoreApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/StoreApi.md
@@ -68,7 +68,7 @@ No authorization required
 ## `getInventory()`
 
 ```php
-getInventory(): map[string,int]
+getInventory(): array[string,int]
 ```
 
 Returns pet inventories by status
@@ -109,7 +109,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-**map[string,int]**
+**array[string,int]**
 
 ### Authorization
 

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/StoreApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/StoreApi.md
@@ -68,7 +68,7 @@ No authorization required
 ## `getInventory()`
 
 ```php
-getInventory(): array[string,int]
+getInventory(): array<string,int>
 ```
 
 Returns pet inventories by status
@@ -109,7 +109,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-**array[string,int]**
+**array<string,int>**
 
 ### Authorization
 

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/AdditionalPropertiesClass.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**map_property** | **array[string,string]** |  | [optional]
-**map_of_map_property** | [**array[string,array[string,string]]**](array.md) |  | [optional]
+**map_property** | **array<string,string>** |  | [optional]
+**map_of_map_property** | [**array<string,array<string,string>>**](array.md) |  | [optional]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/AdditionalPropertiesClass.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**map_property** | **map[string,string]** |  | [optional]
-**map_of_map_property** | [**map[string,map[string,string]]**](map.md) |  | [optional]
+**map_property** | **array[string,string]** |  | [optional]
+**map_of_map_property** | [**array[string,array[string,string]]**](array.md) |  | [optional]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/MapTest.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/MapTest.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**map_map_of_string** | [**map[string,map[string,string]]**](map.md) |  | [optional]
-**map_of_enum_string** | **map[string,string]** |  | [optional]
-**direct_map** | **map[string,bool]** |  | [optional]
-**indirect_map** | **map[string,bool]** |  | [optional]
+**map_map_of_string** | [**array[string,array[string,string]]**](array.md) |  | [optional]
+**map_of_enum_string** | **array[string,string]** |  | [optional]
+**direct_map** | **array[string,bool]** |  | [optional]
+**indirect_map** | **array[string,bool]** |  | [optional]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/MapTest.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/MapTest.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**map_map_of_string** | [**array[string,array[string,string]]**](array.md) |  | [optional]
-**map_of_enum_string** | **array[string,string]** |  | [optional]
-**direct_map** | **array[string,bool]** |  | [optional]
-**indirect_map** | **array[string,bool]** |  | [optional]
+**map_map_of_string** | [**array<string,array<string,string>>**](array.md) |  | [optional]
+**map_of_enum_string** | **array<string,string>** |  | [optional]
+**direct_map** | **array<string,bool>** |  | [optional]
+**indirect_map** | **array<string,bool>** |  | [optional]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -6,6 +6,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **uuid** | **string** |  | [optional]
 **date_time** | [**\DateTime**](\DateTime.md) |  | [optional]
-**map** | [**array[string,\OpenAPI\Client\Model\Animal]**](Animal.md) |  | [optional]
+**map** | [**array<string,\OpenAPI\Client\Model\Animal>**](Animal.md) |  | [optional]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -6,6 +6,6 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **uuid** | **string** |  | [optional]
 **date_time** | [**\DateTime**](\DateTime.md) |  | [optional]
-**map** | [**map[string,\OpenAPI\Client\Model\Animal]**](Animal.md) |  | [optional]
+**map** | [**array[string,\OpenAPI\Client\Model\Animal]**](Animal.md) |  | [optional]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/NullableClass.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/NullableClass.md
@@ -13,8 +13,8 @@ Name | Type | Description | Notes
 **array_nullable_prop** | **object[]** |  | [optional]
 **array_and_items_nullable_prop** | **object[]** |  | [optional]
 **array_items_nullable** | **object[]** |  | [optional]
-**object_nullable_prop** | **map[string,object]** |  | [optional]
-**object_and_items_nullable_prop** | **map[string,object]** |  | [optional]
-**object_items_nullable** | **map[string,object]** |  | [optional]
+**object_nullable_prop** | **array[string,object]** |  | [optional]
+**object_and_items_nullable_prop** | **array[string,object]** |  | [optional]
+**object_items_nullable** | **array[string,object]** |  | [optional]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/NullableClass.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/NullableClass.md
@@ -13,8 +13,8 @@ Name | Type | Description | Notes
 **array_nullable_prop** | **object[]** |  | [optional]
 **array_and_items_nullable_prop** | **object[]** |  | [optional]
 **array_items_nullable** | **object[]** |  | [optional]
-**object_nullable_prop** | **array[string,object]** |  | [optional]
-**object_and_items_nullable_prop** | **array[string,object]** |  | [optional]
-**object_items_nullable** | **array[string,object]** |  | [optional]
+**object_nullable_prop** | **array<string,object>** |  | [optional]
+**object_and_items_nullable_prop** | **array<string,object>** |  | [optional]
+**object_items_nullable** | **array<string,object>** |  | [optional]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -3377,7 +3377,7 @@ class FakeApi
      *
      * test inline additionalProperties
      *
-     * @param  map[string,string] $request_body request body (required)
+     * @param  array[string,string] $request_body request body (required)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -3393,7 +3393,7 @@ class FakeApi
      *
      * test inline additionalProperties
      *
-     * @param  map[string,string] $request_body request body (required)
+     * @param  array[string,string] $request_body request body (required)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -3445,7 +3445,7 @@ class FakeApi
      *
      * test inline additionalProperties
      *
-     * @param  map[string,string] $request_body request body (required)
+     * @param  array[string,string] $request_body request body (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -3465,7 +3465,7 @@ class FakeApi
      *
      * test inline additionalProperties
      *
-     * @param  map[string,string] $request_body request body (required)
+     * @param  array[string,string] $request_body request body (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -3501,7 +3501,7 @@ class FakeApi
     /**
      * Create request for operation 'testInlineAdditionalProperties'
      *
-     * @param  map[string,string] $request_body request body (required)
+     * @param  array[string,string] $request_body request body (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -3377,7 +3377,7 @@ class FakeApi
      *
      * test inline additionalProperties
      *
-     * @param  array[string,string] $request_body request body (required)
+     * @param  array<string,string> $request_body request body (required)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -3393,7 +3393,7 @@ class FakeApi
      *
      * test inline additionalProperties
      *
-     * @param  array[string,string] $request_body request body (required)
+     * @param  array<string,string> $request_body request body (required)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -3445,7 +3445,7 @@ class FakeApi
      *
      * test inline additionalProperties
      *
-     * @param  array[string,string] $request_body request body (required)
+     * @param  array<string,string> $request_body request body (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -3465,7 +3465,7 @@ class FakeApi
      *
      * test inline additionalProperties
      *
-     * @param  array[string,string] $request_body request body (required)
+     * @param  array<string,string> $request_body request body (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -3501,7 +3501,7 @@ class FakeApi
     /**
      * Create request for operation 'testInlineAdditionalProperties'
      *
-     * @param  array[string,string] $request_body request body (required)
+     * @param  array<string,string> $request_body request body (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -342,7 +342,7 @@ class StoreApi
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
-     * @return array[string,int]
+     * @return array<string,int>
      */
     public function getInventory()
     {
@@ -358,7 +358,7 @@ class StoreApi
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
-     * @return array of array[string,int], HTTP status code, HTTP response headers (array of strings)
+     * @return array of array<string,int>, HTTP status code, HTTP response headers (array of strings)
      */
     public function getInventoryWithHttpInfo()
     {
@@ -395,20 +395,20 @@ class StoreApi
             $responseBody = $response->getBody();
             switch($statusCode) {
                 case 200:
-                    if ('array[string,int]' === '\SplFileObject') {
+                    if ('array<string,int>' === '\SplFileObject') {
                         $content = $responseBody; //stream goes to serializer
                     } else {
                         $content = (string) $responseBody;
                     }
 
                     return [
-                        ObjectSerializer::deserialize($content, 'array[string,int]', []),
+                        ObjectSerializer::deserialize($content, 'array<string,int>', []),
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
             }
 
-            $returnType = 'array[string,int]';
+            $returnType = 'array<string,int>';
             $responseBody = $response->getBody();
             if ($returnType === '\SplFileObject') {
                 $content = $responseBody; //stream goes to serializer
@@ -427,7 +427,7 @@ class StoreApi
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
-                        'array[string,int]',
+                        'array<string,int>',
                         $e->getResponseHeaders()
                     );
                     $e->setResponseObject($data);
@@ -467,7 +467,7 @@ class StoreApi
      */
     public function getInventoryAsyncWithHttpInfo()
     {
-        $returnType = 'array[string,int]';
+        $returnType = 'array<string,int>';
         $request = $this->getInventoryRequest();
 
         return $this->client

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -342,7 +342,7 @@ class StoreApi
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
-     * @return map[string,int]
+     * @return array[string,int]
      */
     public function getInventory()
     {
@@ -358,7 +358,7 @@ class StoreApi
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
-     * @return array of map[string,int], HTTP status code, HTTP response headers (array of strings)
+     * @return array of array[string,int], HTTP status code, HTTP response headers (array of strings)
      */
     public function getInventoryWithHttpInfo()
     {
@@ -395,20 +395,20 @@ class StoreApi
             $responseBody = $response->getBody();
             switch($statusCode) {
                 case 200:
-                    if ('map[string,int]' === '\SplFileObject') {
+                    if ('array[string,int]' === '\SplFileObject') {
                         $content = $responseBody; //stream goes to serializer
                     } else {
                         $content = (string) $responseBody;
                     }
 
                     return [
-                        ObjectSerializer::deserialize($content, 'map[string,int]', []),
+                        ObjectSerializer::deserialize($content, 'array[string,int]', []),
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
             }
 
-            $returnType = 'map[string,int]';
+            $returnType = 'array[string,int]';
             $responseBody = $response->getBody();
             if ($returnType === '\SplFileObject') {
                 $content = $responseBody; //stream goes to serializer
@@ -427,7 +427,7 @@ class StoreApi
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
-                        'map[string,int]',
+                        'array[string,int]',
                         $e->getResponseHeaders()
                     );
                     $e->setResponseObject($data);
@@ -467,7 +467,7 @@ class StoreApi
      */
     public function getInventoryAsyncWithHttpInfo()
     {
-        $returnType = 'map[string,int]';
+        $returnType = 'array[string,int]';
         $request = $this->getInventoryRequest();
 
         return $this->client

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -60,8 +60,8 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
       * @var string[]
       */
     protected static $openAPITypes = [
-        'map_property' => 'map[string,string]',
-        'map_of_map_property' => 'map[string,map[string,string]]'
+        'map_property' => 'array[string,string]',
+        'map_of_map_property' => 'array[string,array[string,string]]'
     ];
 
     /**
@@ -218,7 +218,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Gets map_property
      *
-     * @return map[string,string]|null
+     * @return array[string,string]|null
      */
     public function getMapProperty()
     {
@@ -228,7 +228,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Sets map_property
      *
-     * @param map[string,string]|null $map_property map_property
+     * @param array[string,string]|null $map_property map_property
      *
      * @return self
      */
@@ -242,7 +242,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Gets map_of_map_property
      *
-     * @return map[string,map[string,string]]|null
+     * @return array[string,array[string,string]]|null
      */
     public function getMapOfMapProperty()
     {
@@ -252,7 +252,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Sets map_of_map_property
      *
-     * @param map[string,map[string,string]]|null $map_of_map_property map_of_map_property
+     * @param array[string,array[string,string]]|null $map_of_map_property map_of_map_property
      *
      * @return self
      */

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -60,8 +60,8 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
       * @var string[]
       */
     protected static $openAPITypes = [
-        'map_property' => 'array[string,string]',
-        'map_of_map_property' => 'array[string,array[string,string]]'
+        'map_property' => 'array<string,string>',
+        'map_of_map_property' => 'array<string,array<string,string>>'
     ];
 
     /**
@@ -218,7 +218,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Gets map_property
      *
-     * @return array[string,string]|null
+     * @return array<string,string>|null
      */
     public function getMapProperty()
     {
@@ -228,7 +228,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Sets map_property
      *
-     * @param array[string,string]|null $map_property map_property
+     * @param array<string,string>|null $map_property map_property
      *
      * @return self
      */
@@ -242,7 +242,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Gets map_of_map_property
      *
-     * @return array[string,array[string,string]]|null
+     * @return array<string,array<string,string>>|null
      */
     public function getMapOfMapProperty()
     {
@@ -252,7 +252,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Sets map_of_map_property
      *
-     * @param array[string,array[string,string]]|null $map_of_map_property map_of_map_property
+     * @param array<string,array<string,string>>|null $map_of_map_property map_of_map_property
      *
      * @return self
      */

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -60,10 +60,10 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
       * @var string[]
       */
     protected static $openAPITypes = [
-        'map_map_of_string' => 'map[string,map[string,string]]',
-        'map_of_enum_string' => 'map[string,string]',
-        'direct_map' => 'map[string,bool]',
-        'indirect_map' => 'map[string,bool]'
+        'map_map_of_string' => 'array[string,array[string,string]]',
+        'map_of_enum_string' => 'array[string,string]',
+        'direct_map' => 'array[string,bool]',
+        'indirect_map' => 'array[string,bool]'
     ];
 
     /**
@@ -245,7 +245,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets map_map_of_string
      *
-     * @return map[string,map[string,string]]|null
+     * @return array[string,array[string,string]]|null
      */
     public function getMapMapOfString()
     {
@@ -255,7 +255,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets map_map_of_string
      *
-     * @param map[string,map[string,string]]|null $map_map_of_string map_map_of_string
+     * @param array[string,array[string,string]]|null $map_map_of_string map_map_of_string
      *
      * @return self
      */
@@ -269,7 +269,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets map_of_enum_string
      *
-     * @return map[string,string]|null
+     * @return array[string,string]|null
      */
     public function getMapOfEnumString()
     {
@@ -279,7 +279,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets map_of_enum_string
      *
-     * @param map[string,string]|null $map_of_enum_string map_of_enum_string
+     * @param array[string,string]|null $map_of_enum_string map_of_enum_string
      *
      * @return self
      */
@@ -302,7 +302,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets direct_map
      *
-     * @return map[string,bool]|null
+     * @return array[string,bool]|null
      */
     public function getDirectMap()
     {
@@ -312,7 +312,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets direct_map
      *
-     * @param map[string,bool]|null $direct_map direct_map
+     * @param array[string,bool]|null $direct_map direct_map
      *
      * @return self
      */
@@ -326,7 +326,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets indirect_map
      *
-     * @return map[string,bool]|null
+     * @return array[string,bool]|null
      */
     public function getIndirectMap()
     {
@@ -336,7 +336,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets indirect_map
      *
-     * @param map[string,bool]|null $indirect_map indirect_map
+     * @param array[string,bool]|null $indirect_map indirect_map
      *
      * @return self
      */

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -60,10 +60,10 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
       * @var string[]
       */
     protected static $openAPITypes = [
-        'map_map_of_string' => 'array[string,array[string,string]]',
-        'map_of_enum_string' => 'array[string,string]',
-        'direct_map' => 'array[string,bool]',
-        'indirect_map' => 'array[string,bool]'
+        'map_map_of_string' => 'array<string,array<string,string>>',
+        'map_of_enum_string' => 'array<string,string>',
+        'direct_map' => 'array<string,bool>',
+        'indirect_map' => 'array<string,bool>'
     ];
 
     /**
@@ -245,7 +245,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets map_map_of_string
      *
-     * @return array[string,array[string,string]]|null
+     * @return array<string,array<string,string>>|null
      */
     public function getMapMapOfString()
     {
@@ -255,7 +255,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets map_map_of_string
      *
-     * @param array[string,array[string,string]]|null $map_map_of_string map_map_of_string
+     * @param array<string,array<string,string>>|null $map_map_of_string map_map_of_string
      *
      * @return self
      */
@@ -269,7 +269,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets map_of_enum_string
      *
-     * @return array[string,string]|null
+     * @return array<string,string>|null
      */
     public function getMapOfEnumString()
     {
@@ -279,7 +279,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets map_of_enum_string
      *
-     * @param array[string,string]|null $map_of_enum_string map_of_enum_string
+     * @param array<string,string>|null $map_of_enum_string map_of_enum_string
      *
      * @return self
      */
@@ -302,7 +302,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets direct_map
      *
-     * @return array[string,bool]|null
+     * @return array<string,bool>|null
      */
     public function getDirectMap()
     {
@@ -312,7 +312,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets direct_map
      *
-     * @param array[string,bool]|null $direct_map direct_map
+     * @param array<string,bool>|null $direct_map direct_map
      *
      * @return self
      */
@@ -326,7 +326,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets indirect_map
      *
-     * @return array[string,bool]|null
+     * @return array<string,bool>|null
      */
     public function getIndirectMap()
     {
@@ -336,7 +336,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets indirect_map
      *
-     * @param array[string,bool]|null $indirect_map indirect_map
+     * @param array<string,bool>|null $indirect_map indirect_map
      *
      * @return self
      */

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -62,7 +62,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     protected static $openAPITypes = [
         'uuid' => 'string',
         'date_time' => '\DateTime',
-        'map' => 'map[string,\OpenAPI\Client\Model\Animal]'
+        'map' => 'array[string,\OpenAPI\Client\Model\Animal]'
     ];
 
     /**
@@ -272,7 +272,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Gets map
      *
-     * @return map[string,\OpenAPI\Client\Model\Animal]|null
+     * @return array[string,\OpenAPI\Client\Model\Animal]|null
      */
     public function getMap()
     {
@@ -282,7 +282,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Sets map
      *
-     * @param map[string,\OpenAPI\Client\Model\Animal]|null $map map
+     * @param array[string,\OpenAPI\Client\Model\Animal]|null $map map
      *
      * @return self
      */

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -62,7 +62,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     protected static $openAPITypes = [
         'uuid' => 'string',
         'date_time' => '\DateTime',
-        'map' => 'array[string,\OpenAPI\Client\Model\Animal]'
+        'map' => 'array<string,\OpenAPI\Client\Model\Animal>'
     ];
 
     /**
@@ -272,7 +272,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Gets map
      *
-     * @return array[string,\OpenAPI\Client\Model\Animal]|null
+     * @return array<string,\OpenAPI\Client\Model\Animal>|null
      */
     public function getMap()
     {
@@ -282,7 +282,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Sets map
      *
-     * @param array[string,\OpenAPI\Client\Model\Animal]|null $map map
+     * @param array<string,\OpenAPI\Client\Model\Animal>|null $map map
      *
      * @return self
      */

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
@@ -69,9 +69,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
         'array_nullable_prop' => 'object[]',
         'array_and_items_nullable_prop' => 'object[]',
         'array_items_nullable' => 'object[]',
-        'object_nullable_prop' => 'array[string,object]',
-        'object_and_items_nullable_prop' => 'array[string,object]',
-        'object_items_nullable' => 'array[string,object]'
+        'object_nullable_prop' => 'array<string,object>',
+        'object_and_items_nullable_prop' => 'array<string,object>',
+        'object_items_nullable' => 'array<string,object>'
     ];
 
     /**
@@ -494,7 +494,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets object_nullable_prop
      *
-     * @return array[string,object]|null
+     * @return array<string,object>|null
      */
     public function getObjectNullableProp()
     {
@@ -504,7 +504,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets object_nullable_prop
      *
-     * @param array[string,object]|null $object_nullable_prop object_nullable_prop
+     * @param array<string,object>|null $object_nullable_prop object_nullable_prop
      *
      * @return self
      */
@@ -518,7 +518,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets object_and_items_nullable_prop
      *
-     * @return array[string,object]|null
+     * @return array<string,object>|null
      */
     public function getObjectAndItemsNullableProp()
     {
@@ -528,7 +528,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets object_and_items_nullable_prop
      *
-     * @param array[string,object]|null $object_and_items_nullable_prop object_and_items_nullable_prop
+     * @param array<string,object>|null $object_and_items_nullable_prop object_and_items_nullable_prop
      *
      * @return self
      */
@@ -542,7 +542,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets object_items_nullable
      *
-     * @return array[string,object]|null
+     * @return array<string,object>|null
      */
     public function getObjectItemsNullable()
     {
@@ -552,7 +552,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets object_items_nullable
      *
-     * @param array[string,object]|null $object_items_nullable object_items_nullable
+     * @param array<string,object>|null $object_items_nullable object_items_nullable
      *
      * @return self
      */

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
@@ -69,9 +69,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
         'array_nullable_prop' => 'object[]',
         'array_and_items_nullable_prop' => 'object[]',
         'array_items_nullable' => 'object[]',
-        'object_nullable_prop' => 'map[string,object]',
-        'object_and_items_nullable_prop' => 'map[string,object]',
-        'object_items_nullable' => 'map[string,object]'
+        'object_nullable_prop' => 'array[string,object]',
+        'object_and_items_nullable_prop' => 'array[string,object]',
+        'object_items_nullable' => 'array[string,object]'
     ];
 
     /**
@@ -494,7 +494,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets object_nullable_prop
      *
-     * @return map[string,object]|null
+     * @return array[string,object]|null
      */
     public function getObjectNullableProp()
     {
@@ -504,7 +504,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets object_nullable_prop
      *
-     * @param map[string,object]|null $object_nullable_prop object_nullable_prop
+     * @param array[string,object]|null $object_nullable_prop object_nullable_prop
      *
      * @return self
      */
@@ -518,7 +518,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets object_and_items_nullable_prop
      *
-     * @return map[string,object]|null
+     * @return array[string,object]|null
      */
     public function getObjectAndItemsNullableProp()
     {
@@ -528,7 +528,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets object_and_items_nullable_prop
      *
-     * @param map[string,object]|null $object_and_items_nullable_prop object_and_items_nullable_prop
+     * @param array[string,object]|null $object_and_items_nullable_prop object_and_items_nullable_prop
      *
      * @return self
      */
@@ -542,7 +542,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets object_items_nullable
      *
-     * @return map[string,object]|null
+     * @return array[string,object]|null
      */
     public function getObjectItemsNullable()
     {
@@ -552,7 +552,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets object_items_nullable
      *
-     * @param map[string,object]|null $object_items_nullable object_items_nullable
+     * @param array[string,object]|null $object_items_nullable object_items_nullable
      *
      * @return self
      */

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -288,7 +288,7 @@ class ObjectSerializer
             return $values;
         }
 
-        if (substr($class, 0, 4) === 'map[') { // for associative array e.g. map[string,int]
+        if (preg_match('/^(array<|map\[)/', $class)) { // for associative array e.g. array<string,int>
             $data = is_string($data) ? json_decode($data) : $data;
             settype($data, 'array');
             $inner = substr($class, 4, -1);

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/OrderApiTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/OrderApiTest.php
@@ -114,9 +114,26 @@ ORDER;
   }
 }
 ORDER;
+        // Legacy.
         $order = ObjectSerializer::deserialize(
             json_decode($order_json),
             'map[string,map[string,\OpenAPI\Client\Model\Order]]'
+        );
+
+        $this->assertArrayHasKey('test', $order);
+        $this->assertArrayHasKey('test2', $order['test']);
+        $_order = $order['test']['test2'];
+        $this->assertInstanceOf('OpenAPI\Client\Model\Order', $_order);
+        $this->assertSame(10, $_order->getId());
+        $this->assertSame(20, $_order->getPetId());
+        $this->assertSame(30, $_order->getQuantity());
+        $this->assertTrue(new \DateTime("2015-08-22T07:13:36.613Z") == $_order->getShipDate());
+        $this->assertSame("placed", $_order->getStatus());
+        $this->assertSame(false, $_order->getComplete());
+
+        $order = ObjectSerializer::deserialize(
+            json_decode($order_json),
+            'array<string,array<string,\OpenAPI\Client\Model\Order>>'
         );
 
         $this->assertArrayHasKey('test', $order);

--- a/samples/client/petstore/typescript-axios/tests/default/package-lock.json
+++ b/samples/client/petstore/typescript-axios/tests/default/package-lock.json
@@ -8,6 +8,31 @@
       "version": "file:../../builds/with-npm-version",
       "requires": {
         "axios": "^0.21.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.1.tgz",
+          "integrity": "sha512-tCkE96/ZTO+cWbln2xfyvd6ngHLanvVlJ3e5BeirJ3BYI5GbAyubIrmV4JjjugDly5D9fHjOL5MNsqsCnqwW6g=="
+        },
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+          "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
+        },
+        "typescript": {
+          "version": "3.9.9",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+          "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
+        }
       }
     },
     "@types/chai": {

--- a/samples/server/petstore/php-laravel/lib/app/Models/AdditionalPropertiesClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/AdditionalPropertiesClass.php
@@ -9,10 +9,10 @@ namespace app\Models;
  */
 class AdditionalPropertiesClass {
 
-    /** @var array[string,string] $mapProperty */
+    /** @var array<string,string> $mapProperty */
     private $mapProperty;
 
-    /** @var array[string,array[string,string]] $mapOfMapProperty */
+    /** @var array<string,array<string,string>> $mapOfMapProperty */
     private $mapOfMapProperty;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/AdditionalPropertiesClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/AdditionalPropertiesClass.php
@@ -9,10 +9,10 @@ namespace app\Models;
  */
 class AdditionalPropertiesClass {
 
-    /** @var map[string,string] $mapProperty */
+    /** @var array[string,string] $mapProperty */
     private $mapProperty;
 
-    /** @var map[string,map[string,string]] $mapOfMapProperty */
+    /** @var array[string,array[string,string]] $mapOfMapProperty */
     private $mapOfMapProperty;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/MapTest.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/MapTest.php
@@ -9,16 +9,16 @@ namespace app\Models;
  */
 class MapTest {
 
-    /** @var map[string,map[string,string]] $mapMapOfString */
+    /** @var array[string,array[string,string]] $mapMapOfString */
     private $mapMapOfString;
 
-    /** @var map[string,string] $mapOfEnumString */
+    /** @var array[string,string] $mapOfEnumString */
     private $mapOfEnumString;
 
-    /** @var map[string,bool] $directMap */
+    /** @var array[string,bool] $directMap */
     private $directMap;
 
-    /** @var map[string,bool] $indirectMap */
+    /** @var array[string,bool] $indirectMap */
     private $indirectMap;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/MapTest.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/MapTest.php
@@ -9,16 +9,16 @@ namespace app\Models;
  */
 class MapTest {
 
-    /** @var array[string,array[string,string]] $mapMapOfString */
+    /** @var array<string,array<string,string>> $mapMapOfString */
     private $mapMapOfString;
 
-    /** @var array[string,string] $mapOfEnumString */
+    /** @var array<string,string> $mapOfEnumString */
     private $mapOfEnumString;
 
-    /** @var array[string,bool] $directMap */
+    /** @var array<string,bool> $directMap */
     private $directMap;
 
-    /** @var array[string,bool] $indirectMap */
+    /** @var array<string,bool> $indirectMap */
     private $indirectMap;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -15,7 +15,7 @@ class MixedPropertiesAndAdditionalPropertiesClass {
     /** @var \DateTime $dateTime */
     private $dateTime;
 
-    /** @var array[string,\app\Models\Animal] $map */
+    /** @var array<string,\app\Models\Animal> $map */
     private $map;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -15,7 +15,7 @@ class MixedPropertiesAndAdditionalPropertiesClass {
     /** @var \DateTime $dateTime */
     private $dateTime;
 
-    /** @var map[string,\app\Models\Animal] $map */
+    /** @var array[string,\app\Models\Animal] $map */
     private $map;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/NullableClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/NullableClass.php
@@ -36,13 +36,13 @@ class NullableClass {
     /** @var object[] $arrayItemsNullable */
     private $arrayItemsNullable;
 
-    /** @var map[string,object] $objectNullableProp */
+    /** @var array[string,object] $objectNullableProp */
     private $objectNullableProp;
 
-    /** @var map[string,object] $objectAndItemsNullableProp */
+    /** @var array[string,object] $objectAndItemsNullableProp */
     private $objectAndItemsNullableProp;
 
-    /** @var map[string,object] $objectItemsNullable */
+    /** @var array[string,object] $objectItemsNullable */
     private $objectItemsNullable;
 
 }

--- a/samples/server/petstore/php-laravel/lib/app/Models/NullableClass.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/NullableClass.php
@@ -36,13 +36,13 @@ class NullableClass {
     /** @var object[] $arrayItemsNullable */
     private $arrayItemsNullable;
 
-    /** @var array[string,object] $objectNullableProp */
+    /** @var array<string,object> $objectNullableProp */
     private $objectNullableProp;
 
-    /** @var array[string,object] $objectAndItemsNullableProp */
+    /** @var array<string,object> $objectAndItemsNullableProp */
     private $objectAndItemsNullableProp;
 
-    /** @var array[string,object] $objectItemsNullable */
+    /** @var array<string,object> $objectItemsNullable */
     private $objectItemsNullable;
 
 }

--- a/samples/server/petstore/php-mezzio-ph/src/App/Handler/StoreInventory.php
+++ b/samples/server/petstore/php-mezzio-ph/src/App/Handler/StoreInventory.php
@@ -25,7 +25,7 @@ class StoreInventory
      * @throws PHException\HttpCode 501 if the method is not implemented
      *
      * TODO check if generated return container type is valid
-     * @return array[string,int]
+     * @return array<string,int>
      */
     public function getInventory(ServerRequestInterface $request): array
     {

--- a/samples/server/petstore/php-mezzio-ph/src/App/Handler/StoreInventory.php
+++ b/samples/server/petstore/php-mezzio-ph/src/App/Handler/StoreInventory.php
@@ -25,7 +25,7 @@ class StoreInventory
      * @throws PHException\HttpCode 501 if the method is not implemented
      *
      * TODO check if generated return container type is valid
-     * @return map[string,int]
+     * @return array[string,int]
      */
     public function getInventory(ServerRequestInterface $request): array
     {


### PR DESCRIPTION
This pull request aligns the map types to native array types. 

It does this in two steps to show the impact of the change. 
1. It maps `map` to the native array type. 
2. It adjusts the syntax to match that expected by psalm, phpdoc, and IDE's that parse phpdoc.
 
@jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko @renepardon 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
