### PR TITLE
[Java][Vert.x] Make ApiHandler reusable

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaVertXWebServer/apiHandler.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXWebServer/apiHandler.mustache
@@ -21,10 +21,10 @@ public class {{classname}}Handler {
 
     private static final Logger logger = LoggerFactory.getLogger({{classname}}Handler.class);
 
-    private final {{classname}} apiImpl;
+    private final {{classname}} api;
 
-    public {{classname}}Handler() {
-        this.apiImpl = new {{classname}}Impl();
+    public {{classname}}Handler({{classname}} api) {
+        this.api = api;
     }
 
     public void mount(RouterBuilder builder) {
@@ -48,7 +48,7 @@ public class {{classname}}Handler {
         logger.debug("Parameter {{paramName}} is {}", {{paramName}});
 {{/allParams}}
 
-        apiImpl.{{operationId}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
+        api.{{operationId}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {

--- a/modules/openapi-generator/src/main/resources/JavaVertXWebServer/apiHandler.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXWebServer/apiHandler.mustache
@@ -27,6 +27,10 @@ public class {{classname}}Handler {
         this.api = api;
     }
 
+    public {{classname}}Handler() {
+        this(new {{classname}}Impl());
+    }
+
     public void mount(RouterBuilder builder) {
 {{#operations}}
 {{#operation}}

--- a/modules/openapi-generator/src/main/resources/JavaVertXWebServer/apiHandler.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXWebServer/apiHandler.mustache
@@ -27,6 +27,7 @@ public class {{classname}}Handler {
         this.api = api;
     }
 
+    @Deprecated
     public {{classname}}Handler() {
         this(new {{classname}}Impl());
     }

--- a/modules/openapi-generator/src/main/resources/JavaVertXWebServer/supportFiles/HttpServerVerticle.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXWebServer/supportFiles/HttpServerVerticle.mustache
@@ -10,7 +10,8 @@ import io.vertx.ext.web.openapi.RouterBuilderOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 {{#apiInfo}}{{#apis}}
-import {{apiPackage}}.{{classname}}Handler;{{/apis}}{{/apiInfo}}
+import {{apiPackage}}.{{classname}}Handler;
+import {{apiPackage}}.{{classname}}Impl;{{/apis}}{{/apiInfo}}
 
 public class HttpServerVerticle extends AbstractVerticle {
 
@@ -18,7 +19,7 @@ public class HttpServerVerticle extends AbstractVerticle {
     private static final String specFile = "src/main/resources/openapi.yaml";
 
     {{#apiInfo}}{{#apis}}
-    private final {{classname}}Handler {{classVarName}}Handler = new {{classname}}Handler();{{/apis}}{{/apiInfo}}
+    private final {{classname}}Handler {{classVarName}}Handler = new {{classname}}Handler(new {{classname}}Impl());{{/apis}}{{/apiInfo}}
 
     @Override
     public void start(Promise<Void> startPromise) {

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/HttpServerVerticle.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/HttpServerVerticle.java
@@ -11,8 +11,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.openapitools.vertxweb.server.api.PetApiHandler;
+import org.openapitools.vertxweb.server.api.PetApiImpl;
 import org.openapitools.vertxweb.server.api.StoreApiHandler;
+import org.openapitools.vertxweb.server.api.StoreApiImpl;
 import org.openapitools.vertxweb.server.api.UserApiHandler;
+import org.openapitools.vertxweb.server.api.UserApiImpl;
 
 public class HttpServerVerticle extends AbstractVerticle {
 
@@ -20,9 +23,9 @@ public class HttpServerVerticle extends AbstractVerticle {
     private static final String specFile = "src/main/resources/openapi.yaml";
 
     
-    private final PetApiHandler petHandler = new PetApiHandler();
-    private final StoreApiHandler storeHandler = new StoreApiHandler();
-    private final UserApiHandler userHandler = new UserApiHandler();
+    private final PetApiHandler petHandler = new PetApiHandler(new PetApiImpl());
+    private final StoreApiHandler storeHandler = new StoreApiHandler(new StoreApiImpl());
+    private final UserApiHandler userHandler = new UserApiHandler(new UserApiImpl());
 
     @Override
     public void start(Promise<Void> startPromise) {

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApiHandler.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApiHandler.java
@@ -28,6 +28,7 @@ public class PetApiHandler {
         this.api = api;
     }
 
+    @Deprecated
     public PetApiHandler() {
         this(new PetApiImpl());
     }

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApiHandler.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApiHandler.java
@@ -28,6 +28,10 @@ public class PetApiHandler {
         this.api = api;
     }
 
+    public PetApiHandler() {
+        this(new PetApiImpl());
+    }
+
     public void mount(RouterBuilder builder) {
         builder.operation("addPet").handler(this::addPet);
         builder.operation("deletePet").handler(this::deletePet);

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApiHandler.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/PetApiHandler.java
@@ -22,10 +22,10 @@ public class PetApiHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(PetApiHandler.class);
 
-    private final PetApi apiImpl;
+    private final PetApi api;
 
-    public PetApiHandler() {
-        this.apiImpl = new PetApiImpl();
+    public PetApiHandler(PetApi api) {
+        this.api = api;
     }
 
     public void mount(RouterBuilder builder) {
@@ -50,7 +50,7 @@ public class PetApiHandler {
 
         logger.debug("Parameter pet is {}", pet);
 
-        apiImpl.addPet(pet)
+        api.addPet(pet)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -74,7 +74,7 @@ public class PetApiHandler {
         logger.debug("Parameter petId is {}", petId);
         logger.debug("Parameter apiKey is {}", apiKey);
 
-        apiImpl.deletePet(petId, apiKey)
+        api.deletePet(petId, apiKey)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -96,7 +96,7 @@ public class PetApiHandler {
 
         logger.debug("Parameter status is {}", status);
 
-        apiImpl.findPetsByStatus(status)
+        api.findPetsByStatus(status)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -118,7 +118,7 @@ public class PetApiHandler {
 
         logger.debug("Parameter tags is {}", tags);
 
-        apiImpl.findPetsByTags(tags)
+        api.findPetsByTags(tags)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -140,7 +140,7 @@ public class PetApiHandler {
 
         logger.debug("Parameter petId is {}", petId);
 
-        apiImpl.getPetById(petId)
+        api.getPetById(petId)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -163,7 +163,7 @@ public class PetApiHandler {
 
         logger.debug("Parameter pet is {}", pet);
 
-        apiImpl.updatePet(pet)
+        api.updatePet(pet)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -188,7 +188,7 @@ public class PetApiHandler {
         logger.debug("Parameter petId is {}", petId);
         logger.debug("Parameter formBody is {}", formBody);
 
-        apiImpl.updatePetWithForm(petId, formBody)
+        api.updatePetWithForm(petId, formBody)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -212,7 +212,7 @@ public class PetApiHandler {
         logger.debug("Parameter petId is {}", petId);
         logger.debug("Parameter file is {}", file);
 
-        apiImpl.uploadFile(petId, file)
+        api.uploadFile(petId, file)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/StoreApiHandler.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/StoreApiHandler.java
@@ -20,10 +20,10 @@ public class StoreApiHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(StoreApiHandler.class);
 
-    private final StoreApi apiImpl;
+    private final StoreApi api;
 
-    public StoreApiHandler() {
-        this.apiImpl = new StoreApiImpl();
+    public StoreApiHandler(StoreApi api) {
+        this.api = api;
     }
 
     public void mount(RouterBuilder builder) {
@@ -43,7 +43,7 @@ public class StoreApiHandler {
 
         logger.debug("Parameter orderId is {}", orderId);
 
-        apiImpl.deleteOrder(orderId)
+        api.deleteOrder(orderId)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -63,7 +63,7 @@ public class StoreApiHandler {
 
 
 
-        apiImpl.getInventory()
+        api.getInventory()
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -85,7 +85,7 @@ public class StoreApiHandler {
 
         logger.debug("Parameter orderId is {}", orderId);
 
-        apiImpl.getOrderById(orderId)
+        api.getOrderById(orderId)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -108,7 +108,7 @@ public class StoreApiHandler {
 
         logger.debug("Parameter order is {}", order);
 
-        apiImpl.placeOrder(order)
+        api.placeOrder(order)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/StoreApiHandler.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/StoreApiHandler.java
@@ -26,6 +26,7 @@ public class StoreApiHandler {
         this.api = api;
     }
 
+    @Deprecated
     public StoreApiHandler() {
         this(new StoreApiImpl());
     }

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/StoreApiHandler.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/StoreApiHandler.java
@@ -26,6 +26,10 @@ public class StoreApiHandler {
         this.api = api;
     }
 
+    public StoreApiHandler() {
+        this(new StoreApiImpl());
+    }
+
     public void mount(RouterBuilder builder) {
         builder.operation("deleteOrder").handler(this::deleteOrder);
         builder.operation("getInventory").handler(this::getInventory);

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/UserApiHandler.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/UserApiHandler.java
@@ -26,6 +26,10 @@ public class UserApiHandler {
         this.api = api;
     }
 
+    public UserApiHandler() {
+        this(new UserApiImpl());
+    }
+
     public void mount(RouterBuilder builder) {
         builder.operation("createUser").handler(this::createUser);
         builder.operation("createUsersWithArrayInput").handler(this::createUsersWithArrayInput);

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/UserApiHandler.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/UserApiHandler.java
@@ -26,6 +26,7 @@ public class UserApiHandler {
         this.api = api;
     }
 
+    @Deprecated
     public UserApiHandler() {
         this(new UserApiImpl());
     }

--- a/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/UserApiHandler.java
+++ b/samples/server/petstore/java-vertx-web/src/main/java/org/openapitools/vertxweb/server/api/UserApiHandler.java
@@ -20,10 +20,10 @@ public class UserApiHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(UserApiHandler.class);
 
-    private final UserApi apiImpl;
+    private final UserApi api;
 
-    public UserApiHandler() {
-        this.apiImpl = new UserApiImpl();
+    public UserApiHandler(UserApi api) {
+        this.api = api;
     }
 
     public void mount(RouterBuilder builder) {
@@ -48,7 +48,7 @@ public class UserApiHandler {
 
         logger.debug("Parameter user is {}", user);
 
-        apiImpl.createUser(user)
+        api.createUser(user)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -71,7 +71,7 @@ public class UserApiHandler {
 
         logger.debug("Parameter user is {}", user);
 
-        apiImpl.createUsersWithArrayInput(user)
+        api.createUsersWithArrayInput(user)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -94,7 +94,7 @@ public class UserApiHandler {
 
         logger.debug("Parameter user is {}", user);
 
-        apiImpl.createUsersWithListInput(user)
+        api.createUsersWithListInput(user)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -116,7 +116,7 @@ public class UserApiHandler {
 
         logger.debug("Parameter username is {}", username);
 
-        apiImpl.deleteUser(username)
+        api.deleteUser(username)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -138,7 +138,7 @@ public class UserApiHandler {
 
         logger.debug("Parameter username is {}", username);
 
-        apiImpl.getUserByName(username)
+        api.getUserByName(username)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -162,7 +162,7 @@ public class UserApiHandler {
         logger.debug("Parameter username is {}", username);
         logger.debug("Parameter password is {}", password);
 
-        apiImpl.loginUser(username, password)
+        api.loginUser(username, password)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -182,7 +182,7 @@ public class UserApiHandler {
 
 
 
-        apiImpl.logoutUser()
+        api.logoutUser()
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {
@@ -207,7 +207,7 @@ public class UserApiHandler {
         logger.debug("Parameter username is {}", username);
         logger.debug("Parameter user is {}", user);
 
-        apiImpl.updateUser(username, user)
+        api.updateUser(username, user)
             .onSuccess(apiResponse -> {
                 routingContext.response().setStatusCode(apiResponse.getStatusCode());
                 if (apiResponse.hasData()) {


### PR DESCRIPTION
Fix #8710

This PR deprecates the default no-args constructor for `ApiHandler` and replaces it with a constructor requiring to provide the implementation, in order to make easier to use the generated code without modifying it

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
