### PR TITLE
[C++][Qt5] Added function to add a new Server. Removed unused variables

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/ServerConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/ServerConfiguration.mustache
@@ -17,14 +17,14 @@ namespace {{this}} {
 class {{prefix}}ServerConfiguration {
 public:
     /**
-     * @param URL A URL to the target host.
+     * @param url A URL to the target host.
      * @param description A description of the host designated by the URL.
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      */
-    {{prefix}}ServerConfiguration(const QString& URL, const QString& description, const QMap<QString, {{prefix}}ServerVariable>& variables)
+    {{prefix}}ServerConfiguration(const QUrl &url, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables)
     : _description(description),
       _variables(variables),
-      _URL(URL){}
+      _url(url){}
     {{prefix}}ServerConfiguration(){}
     ~{{prefix}}ServerConfiguration(){}
 
@@ -35,7 +35,7 @@ public:
      * @return Formatted URL.
      */
     QString URL() {
-        QString url = _URL;
+        QString url = _url.toString();
         if(!_variables.empty()){
             // go through variables and replace placeholders
             for (auto const& v : _variables.keys()) {
@@ -55,7 +55,7 @@ public:
         return url;
     }
 
-    int setDefaultValue(const QString& variable,const QString& value){
+    int setDefaultValue(const QString &variable,const QString &value){
       if(_variables.contains(variable))
         return _variables[variable].setDefaultValue(value);
       return -1;
@@ -63,7 +63,7 @@ public:
 
     QString _description;
     QMap<QString, {{prefix}}ServerVariable> _variables;
-    QString _URL;
+    QUrl _url;
 
 };
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -9,12 +9,8 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
-{{classname}}::{{classname}}(const QString &scheme, const QString &host, int port, const QString &basePath, const int timeOut)
-    : _scheme(scheme),
-      _host(host),
-      _port(port),
-      _basePath(basePath),
-      _timeOut(timeOut),
+{{classname}}::{{classname}}(const int timeOut)
+    : _timeOut(timeOut),
       _manager(nullptr),
       isResponseCompressionEnabled(false),
       isRequestCompressionEnabled(false) {
@@ -79,18 +75,6 @@ void {{classname}}::setServerIndex(const QString &operation, int serverIndex){
         _serverIndices[operation] = serverIndex;
 }
 
-void {{classname}}::setScheme(const QString &scheme) {
-    _scheme = scheme;
-}
-
-void {{classname}}::setHost(const QString &host) {
-    _host = host;
-}
-
-void {{classname}}::setPort(int port) {
-    _port = port;
-}
-
 void {{classname}}::setApiKey(const QString &apiKeyName, const QString &apiKey){
     _apiKeys.insert(apiKeyName,apiKey);
 }
@@ -107,9 +91,6 @@ void {{classname}}::setPassword(const QString &password) {
     _password = password;
 }
 
-void {{classname}}::setBasePath(const QString &basePath) {
-    _basePath = basePath;
-}
 
 void {{classname}}::setTimeOut(const int timeOut) {
     _timeOut = timeOut;
@@ -121,6 +102,26 @@ void {{classname}}::setWorkingDirectory(const QString &path) {
 
 void {{classname}}::setNetworkAccessManager(QNetworkAccessManager* manager) {
     _manager = manager;  
+}
+
+    /**
+     * Appends a new ServerConfiguration to the config mal for a specific operation.
+     * @param operation The id to the target operation.
+     * @param URL 
+     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
+     * returns the index of the new server config on success and -1 if the operation is not found
+     */
+int {{classname}}::addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, {{prefix}}ServerVariable>& variables){
+    if(_serverConfigs.contains(operation)){
+        _serverConfigs[operation].append({{prefix}}ServerConfiguration(
+                    URL,
+                    description,
+                     variables));
+        return _serverConfigs[operation].size()-1;
+    }else{
+        return -1;
+    }
+
 }
 
 void {{classname}}::addHeaders(const QString &key, const QString &value) {

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -28,7 +28,7 @@ QList<{{prefix}}ServerConfiguration> defaultConf = QList<{{prefix}}ServerConfigu
 QList<{{prefix}}ServerConfiguration> serverConf = QList<{{prefix}}ServerConfiguration>();
 {{#vendorExtensions.x-cpp-global-server-list}}
 defaultConf.append({{prefix}}ServerConfiguration(
-    "{{{url}}}",
+    QUrl("{{{url}}}"),
     "{{{description}}}{{^description}}No description provided{{/description}}",
     {{#variables}}{{#-first}}QMap<QString, {{prefix}}ServerVariable>{ {{/-first}}
     {"{{{name}}}", {{prefix}}ServerVariable("{{{description}}}{{^description}}No description provided{{/description}}","{{{defaultValue}}}",
@@ -44,7 +44,7 @@ _serverIndices.insert("{{nickname}}",0);
 {{/servers}}
 {{#servers}}
 serverConf.append({{prefix}}ServerConfiguration(
-    "{{{url}}}",
+    QUrl("{{{url}}}"),
     "{{{description}}}{{^description}}No description provided{{/description}}",
     {{#variables}}{{#-first}}QMap<QString, {{prefix}}ServerVariable>{ {{/-first}}
     {"{{{name}}}", {{prefix}}ServerVariable("{{{description}}}{{^description}}No description provided{{/description}}","{{{defaultValue}}}",
@@ -107,15 +107,15 @@ void {{classname}}::setNetworkAccessManager(QNetworkAccessManager* manager) {
     /**
      * Appends a new ServerConfiguration to the config map for a specific operation.
      * @param operation The id to the target operation.
-     * @param URL A string that contains the URL of the server
+     * @param url A string that contains the URL of the server
      * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      * returns the index of the new server config on success and -1 if the operation is not found
      */
-int {{classname}}::addServerConfiguration(const QString &operation, const QString &URL, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables){
+int {{classname}}::addServerConfiguration(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables){
     if(_serverConfigs.contains(operation)){
         _serverConfigs[operation].append({{prefix}}ServerConfiguration(
-                    URL,
+                    url,
                     description,
                     variables));
         return _serverConfigs[operation].size()-1;
@@ -126,13 +126,13 @@ int {{classname}}::addServerConfiguration(const QString &operation, const QStrin
 
     /**
      * Appends a new ServerConfiguration to the config map for a all operations and sets the index to that server.
-     * @param URL A string that contains the URL of the server
+     * @param url A string that contains the URL of the server
      * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      */
-void {{classname}}::setNewServerForAllOperations(const QString &URL, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables){
+void {{classname}}::setNewServerForAllOperations(const QUrl &url, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables){
         for(auto e : _serverIndices.keys()){
-            setServerIndex(e, addServerConfiguration(e, URL, description, variables));
+            setServerIndex(e, addServerConfiguration(e, url, description, variables));
         }
 } 
     /**
@@ -141,9 +141,9 @@ void {{classname}}::setNewServerForAllOperations(const QString &URL, const QStri
      * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      */
-void {{classname}}::setNewServer(const QString &operation, const QString &URL, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables){
+void {{classname}}::setNewServer(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables){
 
-    setServerIndex(operation, addServerConfiguration(operation, URL, description, variables));
+    setServerIndex(operation, addServerConfiguration(operation, url, description, variables));
 
 }
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -105,22 +105,45 @@ void {{classname}}::setNetworkAccessManager(QNetworkAccessManager* manager) {
 }
 
     /**
-     * Appends a new ServerConfiguration to the config mal for a specific operation.
+     * Appends a new ServerConfiguration to the config map for a specific operation.
      * @param operation The id to the target operation.
-     * @param URL 
+     * @param URL A string that contains the URL of the server
+     * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      * returns the index of the new server config on success and -1 if the operation is not found
      */
-int {{classname}}::addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, {{prefix}}ServerVariable>& variables){
+int {{classname}}::addServerConfiguration(const QString &operation, const QString &URL, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables){
     if(_serverConfigs.contains(operation)){
         _serverConfigs[operation].append({{prefix}}ServerConfiguration(
                     URL,
                     description,
-                     variables));
+                    variables));
         return _serverConfigs[operation].size()-1;
     }else{
         return -1;
     }
+}
+
+    /**
+     * Appends a new ServerConfiguration to the config map for a all operations and sets the index to that server.
+     * @param URL A string that contains the URL of the server
+     * @param description A String that describes the server
+     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
+     */
+void {{classname}}::setNewServerForAllOperations(const QString &URL, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables){
+        for(auto e : _serverIndices.keys()){
+            setServerIndex(e, addServerConfiguration(e, URL, description, variables));
+        }
+} 
+    /**
+     * Appends a new ServerConfiguration to the config map for an operations and sets the index to that server.
+     * @param URL A string that contains the URL of the server
+     * @param description A String that describes the server
+     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
+     */
+void {{classname}}::setNewServer(const QString &operation, const QString &URL, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables){
+
+    setServerIndex(operation, addServerConfiguration(operation, URL, description, variables));
 
 }
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
@@ -35,7 +35,9 @@ public:
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
-    int addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, {{prefix}}ServerVariable>& variables);
+    int addServerConfiguration(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, {{prefix}}ServerVariable> &variables = QMap<QString, {{prefix}}ServerVariable>());
+    void setNewServerForAllOperations(const QString &URL, const QString &description = "", const QMap<QString, {{prefix}}ServerVariable> &variables =  QMap<QString, {{prefix}}ServerVariable>());
+    void setNewServer(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, {{prefix}}ServerVariable> &variables =  QMap<QString, {{prefix}}ServerVariable>());
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
@@ -35,9 +35,9 @@ public:
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
-    int addServerConfiguration(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, {{prefix}}ServerVariable> &variables = QMap<QString, {{prefix}}ServerVariable>());
-    void setNewServerForAllOperations(const QString &URL, const QString &description = "", const QMap<QString, {{prefix}}ServerVariable> &variables =  QMap<QString, {{prefix}}ServerVariable>());
-    void setNewServer(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, {{prefix}}ServerVariable> &variables =  QMap<QString, {{prefix}}ServerVariable>());
+    int addServerConfiguration(const QString &operation, const QUrl &url, const QString &description = "", const QMap<QString, {{prefix}}ServerVariable> &variables = QMap<QString, {{prefix}}ServerVariable>());
+    void setNewServerForAllOperations(const QUrl &url, const QString &description = "", const QMap<QString, {{prefix}}ServerVariable> &variables =  QMap<QString, {{prefix}}ServerVariable>());
+    void setNewServer(const QString &operation, const QUrl &url, const QString &description = "", const QMap<QString, {{prefix}}ServerVariable> &variables =  QMap<QString, {{prefix}}ServerVariable>());
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
@@ -22,23 +22,20 @@ class {{classname}} : public QObject {
     Q_OBJECT
 
 public:
-    {{classname}}(const QString &scheme = "{{scheme}}", const QString &host = "{{serverHost}}", int port = {{#serverPort}}{{serverPort}}{{/serverPort}}{{^serverPort}}0{{/serverPort}}, const QString &basePath = "{{basePathWithoutHost}}", const int timeOut = 0);
+    {{classname}}(const int timeOut = 0);
     ~{{classname}}();
 
     void initializeServerConfigs();
     int setDefaultServerValue(int serverIndex,const QString &operation, const QString &variable,const QString &val);
     void setServerIndex(const QString &operation, int serverIndex);
-    void setScheme(const QString &scheme);
-    void setHost(const QString &host);
-    void setPort(int port);
     void setApiKey(const QString &apiKeyName, const QString &apiKey);
     void setBearerToken(const QString &token);
     void setUsername(const QString &username);
     void setPassword(const QString &password);
-    void setBasePath(const QString &basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
+    int addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, {{prefix}}ServerVariable>& variables);
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();
@@ -50,9 +47,6 @@ public:
     void {{nickname}}({{#allParams}}const {{{dataType}}} &{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});{{/operation}}{{/operations}}
 
 private:
-    QString _scheme, _host;
-    int _port;
-    QString _basePath;
     QMap<QString,int> _serverIndices;
     QMap<QString,QList<{{prefix}}ServerConfiguration>> _serverConfigs;
     QMap<QString, QString> _apiKeys;

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
@@ -17,12 +17,8 @@
 
 namespace test_namespace {
 
-PFXPetApi::PFXPetApi(const QString &scheme, const QString &host, int port, const QString &basePath, const int timeOut)
-    : _scheme(scheme),
-      _host(host),
-      _port(port),
-      _basePath(basePath),
-      _timeOut(timeOut),
+PFXPetApi::PFXPetApi(const int timeOut)
+    : _timeOut(timeOut),
       _manager(nullptr),
       isResponseCompressionEnabled(false),
       isRequestCompressionEnabled(false) {
@@ -85,18 +81,6 @@ void PFXPetApi::setServerIndex(const QString &operation, int serverIndex){
         _serverIndices[operation] = serverIndex;
 }
 
-void PFXPetApi::setScheme(const QString &scheme) {
-    _scheme = scheme;
-}
-
-void PFXPetApi::setHost(const QString &host) {
-    _host = host;
-}
-
-void PFXPetApi::setPort(int port) {
-    _port = port;
-}
-
 void PFXPetApi::setApiKey(const QString &apiKeyName, const QString &apiKey){
     _apiKeys.insert(apiKeyName,apiKey);
 }
@@ -113,9 +97,6 @@ void PFXPetApi::setPassword(const QString &password) {
     _password = password;
 }
 
-void PFXPetApi::setBasePath(const QString &basePath) {
-    _basePath = basePath;
-}
 
 void PFXPetApi::setTimeOut(const int timeOut) {
     _timeOut = timeOut;
@@ -127,6 +108,26 @@ void PFXPetApi::setWorkingDirectory(const QString &path) {
 
 void PFXPetApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
     _manager = manager;  
+}
+
+    /**
+     * Appends a new ServerConfiguration to the config mal for a specific operation.
+     * @param operation The id to the target operation.
+     * @param URL 
+     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
+     * returns the index of the new server config on success and -1 if the operation is not found
+     */
+int PFXPetApi::addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables){
+    if(_serverConfigs.contains(operation)){
+        _serverConfigs[operation].append(PFXServerConfiguration(
+                    URL,
+                    description,
+                     variables));
+        return _serverConfigs[operation].size()-1;
+    }else{
+        return -1;
+    }
+
 }
 
 void PFXPetApi::addHeaders(const QString &key, const QString &value) {

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
@@ -111,22 +111,45 @@ void PFXPetApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
 }
 
     /**
-     * Appends a new ServerConfiguration to the config mal for a specific operation.
+     * Appends a new ServerConfiguration to the config map for a specific operation.
      * @param operation The id to the target operation.
-     * @param URL 
+     * @param URL A string that contains the URL of the server
+     * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      * returns the index of the new server config on success and -1 if the operation is not found
      */
-int PFXPetApi::addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables){
+int PFXPetApi::addServerConfiguration(const QString &operation, const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
     if(_serverConfigs.contains(operation)){
         _serverConfigs[operation].append(PFXServerConfiguration(
                     URL,
                     description,
-                     variables));
+                    variables));
         return _serverConfigs[operation].size()-1;
     }else{
         return -1;
     }
+}
+
+    /**
+     * Appends a new ServerConfiguration to the config map for a all operations and sets the index to that server.
+     * @param URL A string that contains the URL of the server
+     * @param description A String that describes the server
+     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
+     */
+void PFXPetApi::setNewServerForAllOperations(const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+        for(auto e : _serverIndices.keys()){
+            setServerIndex(e, addServerConfiguration(e, URL, description, variables));
+        }
+} 
+    /**
+     * Appends a new ServerConfiguration to the config map for an operations and sets the index to that server.
+     * @param URL A string that contains the URL of the server
+     * @param description A String that describes the server
+     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
+     */
+void PFXPetApi::setNewServer(const QString &operation, const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+
+    setServerIndex(operation, addServerConfiguration(operation, URL, description, variables));
 
 }
 

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
@@ -35,7 +35,7 @@ QList<PFXServerConfiguration> defaultConf = QList<PFXServerConfiguration>();
 //varying endpoint server 
 QList<PFXServerConfiguration> serverConf = QList<PFXServerConfiguration>();
 defaultConf.append(PFXServerConfiguration(
-    "http://petstore.swagger.io/v2",
+    QUrl("http://petstore.swagger.io/v2"),
     "No description provided",
     QMap<QString, PFXServerVariable>()));
 _serverConfigs.insert("addPet",defaultConf);
@@ -113,15 +113,15 @@ void PFXPetApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
     /**
      * Appends a new ServerConfiguration to the config map for a specific operation.
      * @param operation The id to the target operation.
-     * @param URL A string that contains the URL of the server
+     * @param url A string that contains the URL of the server
      * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      * returns the index of the new server config on success and -1 if the operation is not found
      */
-int PFXPetApi::addServerConfiguration(const QString &operation, const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+int PFXPetApi::addServerConfiguration(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
     if(_serverConfigs.contains(operation)){
         _serverConfigs[operation].append(PFXServerConfiguration(
-                    URL,
+                    url,
                     description,
                     variables));
         return _serverConfigs[operation].size()-1;
@@ -132,13 +132,13 @@ int PFXPetApi::addServerConfiguration(const QString &operation, const QString &U
 
     /**
      * Appends a new ServerConfiguration to the config map for a all operations and sets the index to that server.
-     * @param URL A string that contains the URL of the server
+     * @param url A string that contains the URL of the server
      * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      */
-void PFXPetApi::setNewServerForAllOperations(const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+void PFXPetApi::setNewServerForAllOperations(const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
         for(auto e : _serverIndices.keys()){
-            setServerIndex(e, addServerConfiguration(e, URL, description, variables));
+            setServerIndex(e, addServerConfiguration(e, url, description, variables));
         }
 } 
     /**
@@ -147,9 +147,9 @@ void PFXPetApi::setNewServerForAllOperations(const QString &URL, const QString &
      * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      */
-void PFXPetApi::setNewServer(const QString &operation, const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+void PFXPetApi::setNewServer(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
 
-    setServerIndex(operation, addServerConfiguration(operation, URL, description, variables));
+    setServerIndex(operation, addServerConfiguration(operation, url, description, variables));
 
 }
 

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
@@ -45,9 +45,9 @@ public:
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
-    int addServerConfiguration(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables = QMap<QString, PFXServerVariable>());
-    void setNewServerForAllOperations(const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
-    void setNewServer(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
+    int addServerConfiguration(const QString &operation, const QUrl &url, const QString &description = "", const QMap<QString, PFXServerVariable> &variables = QMap<QString, PFXServerVariable>());
+    void setNewServerForAllOperations(const QUrl &url, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
+    void setNewServer(const QString &operation, const QUrl &url, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
@@ -32,23 +32,20 @@ class PFXPetApi : public QObject {
     Q_OBJECT
 
 public:
-    PFXPetApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 0, const QString &basePath = "/v2", const int timeOut = 0);
+    PFXPetApi(const int timeOut = 0);
     ~PFXPetApi();
 
     void initializeServerConfigs();
     int setDefaultServerValue(int serverIndex,const QString &operation, const QString &variable,const QString &val);
     void setServerIndex(const QString &operation, int serverIndex);
-    void setScheme(const QString &scheme);
-    void setHost(const QString &host);
-    void setPort(int port);
     void setApiKey(const QString &apiKeyName, const QString &apiKey);
     void setBearerToken(const QString &token);
     void setUsername(const QString &username);
     void setPassword(const QString &password);
-    void setBasePath(const QString &basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
+    int addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables);
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();
@@ -67,9 +64,6 @@ public:
     void uploadFile(const qint64 &pet_id, const QString &additional_metadata, const PFXHttpFileElement &file);
 
 private:
-    QString _scheme, _host;
-    int _port;
-    QString _basePath;
     QMap<QString,int> _serverIndices;
     QMap<QString,QList<PFXServerConfiguration>> _serverConfigs;
     QMap<QString, QString> _apiKeys;

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
@@ -45,7 +45,9 @@ public:
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
-    int addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables);
+    int addServerConfiguration(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables = QMap<QString, PFXServerVariable>());
+    void setNewServerForAllOperations(const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
+    void setNewServer(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();

--- a/samples/client/petstore/cpp-qt5/client/PFXServerConfiguration.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXServerConfiguration.h
@@ -25,14 +25,14 @@ namespace test_namespace {
 class PFXServerConfiguration {
 public:
     /**
-     * @param URL A URL to the target host.
+     * @param url A URL to the target host.
      * @param description A description of the host designated by the URL.
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      */
-    PFXServerConfiguration(const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables)
+    PFXServerConfiguration(const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables)
     : _description(description),
       _variables(variables),
-      _URL(URL){}
+      _url(url){}
     PFXServerConfiguration(){}
     ~PFXServerConfiguration(){}
 
@@ -43,7 +43,7 @@ public:
      * @return Formatted URL.
      */
     QString URL() {
-        QString url = _URL;
+        QString url = _url.toString();
         if(!_variables.empty()){
             // go through variables and replace placeholders
             for (auto const& v : _variables.keys()) {
@@ -63,7 +63,7 @@ public:
         return url;
     }
 
-    int setDefaultValue(const QString& variable,const QString& value){
+    int setDefaultValue(const QString &variable,const QString &value){
       if(_variables.contains(variable))
         return _variables[variable].setDefaultValue(value);
       return -1;
@@ -71,7 +71,7 @@ public:
 
     QString _description;
     QMap<QString, PFXServerVariable> _variables;
-    QString _URL;
+    QUrl _url;
 
 };
 

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
@@ -35,7 +35,7 @@ QList<PFXServerConfiguration> defaultConf = QList<PFXServerConfiguration>();
 //varying endpoint server 
 QList<PFXServerConfiguration> serverConf = QList<PFXServerConfiguration>();
 defaultConf.append(PFXServerConfiguration(
-    "http://petstore.swagger.io/v2",
+    QUrl("http://petstore.swagger.io/v2"),
     "No description provided",
     QMap<QString, PFXServerVariable>()));
 _serverConfigs.insert("deleteOrder",defaultConf);
@@ -101,15 +101,15 @@ void PFXStoreApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
     /**
      * Appends a new ServerConfiguration to the config map for a specific operation.
      * @param operation The id to the target operation.
-     * @param URL A string that contains the URL of the server
+     * @param url A string that contains the URL of the server
      * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      * returns the index of the new server config on success and -1 if the operation is not found
      */
-int PFXStoreApi::addServerConfiguration(const QString &operation, const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+int PFXStoreApi::addServerConfiguration(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
     if(_serverConfigs.contains(operation)){
         _serverConfigs[operation].append(PFXServerConfiguration(
-                    URL,
+                    url,
                     description,
                     variables));
         return _serverConfigs[operation].size()-1;
@@ -120,13 +120,13 @@ int PFXStoreApi::addServerConfiguration(const QString &operation, const QString 
 
     /**
      * Appends a new ServerConfiguration to the config map for a all operations and sets the index to that server.
-     * @param URL A string that contains the URL of the server
+     * @param url A string that contains the URL of the server
      * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      */
-void PFXStoreApi::setNewServerForAllOperations(const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+void PFXStoreApi::setNewServerForAllOperations(const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
         for(auto e : _serverIndices.keys()){
-            setServerIndex(e, addServerConfiguration(e, URL, description, variables));
+            setServerIndex(e, addServerConfiguration(e, url, description, variables));
         }
 } 
     /**
@@ -135,9 +135,9 @@ void PFXStoreApi::setNewServerForAllOperations(const QString &URL, const QString
      * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      */
-void PFXStoreApi::setNewServer(const QString &operation, const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+void PFXStoreApi::setNewServer(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
 
-    setServerIndex(operation, addServerConfiguration(operation, URL, description, variables));
+    setServerIndex(operation, addServerConfiguration(operation, url, description, variables));
 
 }
 

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
@@ -17,12 +17,8 @@
 
 namespace test_namespace {
 
-PFXStoreApi::PFXStoreApi(const QString &scheme, const QString &host, int port, const QString &basePath, const int timeOut)
-    : _scheme(scheme),
-      _host(host),
-      _port(port),
-      _basePath(basePath),
-      _timeOut(timeOut),
+PFXStoreApi::PFXStoreApi(const int timeOut)
+    : _timeOut(timeOut),
       _manager(nullptr),
       isResponseCompressionEnabled(false),
       isRequestCompressionEnabled(false) {
@@ -73,18 +69,6 @@ void PFXStoreApi::setServerIndex(const QString &operation, int serverIndex){
         _serverIndices[operation] = serverIndex;
 }
 
-void PFXStoreApi::setScheme(const QString &scheme) {
-    _scheme = scheme;
-}
-
-void PFXStoreApi::setHost(const QString &host) {
-    _host = host;
-}
-
-void PFXStoreApi::setPort(int port) {
-    _port = port;
-}
-
 void PFXStoreApi::setApiKey(const QString &apiKeyName, const QString &apiKey){
     _apiKeys.insert(apiKeyName,apiKey);
 }
@@ -101,9 +85,6 @@ void PFXStoreApi::setPassword(const QString &password) {
     _password = password;
 }
 
-void PFXStoreApi::setBasePath(const QString &basePath) {
-    _basePath = basePath;
-}
 
 void PFXStoreApi::setTimeOut(const int timeOut) {
     _timeOut = timeOut;
@@ -115,6 +96,26 @@ void PFXStoreApi::setWorkingDirectory(const QString &path) {
 
 void PFXStoreApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
     _manager = manager;  
+}
+
+    /**
+     * Appends a new ServerConfiguration to the config mal for a specific operation.
+     * @param operation The id to the target operation.
+     * @param URL 
+     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
+     * returns the index of the new server config on success and -1 if the operation is not found
+     */
+int PFXStoreApi::addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables){
+    if(_serverConfigs.contains(operation)){
+        _serverConfigs[operation].append(PFXServerConfiguration(
+                    URL,
+                    description,
+                     variables));
+        return _serverConfigs[operation].size()-1;
+    }else{
+        return -1;
+    }
+
 }
 
 void PFXStoreApi::addHeaders(const QString &key, const QString &value) {

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
@@ -99,22 +99,45 @@ void PFXStoreApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
 }
 
     /**
-     * Appends a new ServerConfiguration to the config mal for a specific operation.
+     * Appends a new ServerConfiguration to the config map for a specific operation.
      * @param operation The id to the target operation.
-     * @param URL 
+     * @param URL A string that contains the URL of the server
+     * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      * returns the index of the new server config on success and -1 if the operation is not found
      */
-int PFXStoreApi::addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables){
+int PFXStoreApi::addServerConfiguration(const QString &operation, const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
     if(_serverConfigs.contains(operation)){
         _serverConfigs[operation].append(PFXServerConfiguration(
                     URL,
                     description,
-                     variables));
+                    variables));
         return _serverConfigs[operation].size()-1;
     }else{
         return -1;
     }
+}
+
+    /**
+     * Appends a new ServerConfiguration to the config map for a all operations and sets the index to that server.
+     * @param URL A string that contains the URL of the server
+     * @param description A String that describes the server
+     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
+     */
+void PFXStoreApi::setNewServerForAllOperations(const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+        for(auto e : _serverIndices.keys()){
+            setServerIndex(e, addServerConfiguration(e, URL, description, variables));
+        }
+} 
+    /**
+     * Appends a new ServerConfiguration to the config map for an operations and sets the index to that server.
+     * @param URL A string that contains the URL of the server
+     * @param description A String that describes the server
+     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
+     */
+void PFXStoreApi::setNewServer(const QString &operation, const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+
+    setServerIndex(operation, addServerConfiguration(operation, URL, description, variables));
 
 }
 

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
@@ -31,23 +31,20 @@ class PFXStoreApi : public QObject {
     Q_OBJECT
 
 public:
-    PFXStoreApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 0, const QString &basePath = "/v2", const int timeOut = 0);
+    PFXStoreApi(const int timeOut = 0);
     ~PFXStoreApi();
 
     void initializeServerConfigs();
     int setDefaultServerValue(int serverIndex,const QString &operation, const QString &variable,const QString &val);
     void setServerIndex(const QString &operation, int serverIndex);
-    void setScheme(const QString &scheme);
-    void setHost(const QString &host);
-    void setPort(int port);
     void setApiKey(const QString &apiKeyName, const QString &apiKey);
     void setBearerToken(const QString &token);
     void setUsername(const QString &username);
     void setPassword(const QString &password);
-    void setBasePath(const QString &basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
+    int addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables);
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();
@@ -62,9 +59,6 @@ public:
     void placeOrder(const PFXOrder &body);
 
 private:
-    QString _scheme, _host;
-    int _port;
-    QString _basePath;
     QMap<QString,int> _serverIndices;
     QMap<QString,QList<PFXServerConfiguration>> _serverConfigs;
     QMap<QString, QString> _apiKeys;

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
@@ -44,7 +44,9 @@ public:
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
-    int addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables);
+    int addServerConfiguration(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables = QMap<QString, PFXServerVariable>());
+    void setNewServerForAllOperations(const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
+    void setNewServer(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
@@ -44,9 +44,9 @@ public:
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
-    int addServerConfiguration(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables = QMap<QString, PFXServerVariable>());
-    void setNewServerForAllOperations(const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
-    void setNewServer(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
+    int addServerConfiguration(const QString &operation, const QUrl &url, const QString &description = "", const QMap<QString, PFXServerVariable> &variables = QMap<QString, PFXServerVariable>());
+    void setNewServerForAllOperations(const QUrl &url, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
+    void setNewServer(const QString &operation, const QUrl &url, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
@@ -17,12 +17,8 @@
 
 namespace test_namespace {
 
-PFXUserApi::PFXUserApi(const QString &scheme, const QString &host, int port, const QString &basePath, const int timeOut)
-    : _scheme(scheme),
-      _host(host),
-      _port(port),
-      _basePath(basePath),
-      _timeOut(timeOut),
+PFXUserApi::PFXUserApi(const int timeOut)
+    : _timeOut(timeOut),
       _manager(nullptr),
       isResponseCompressionEnabled(false),
       isRequestCompressionEnabled(false) {
@@ -85,18 +81,6 @@ void PFXUserApi::setServerIndex(const QString &operation, int serverIndex){
         _serverIndices[operation] = serverIndex;
 }
 
-void PFXUserApi::setScheme(const QString &scheme) {
-    _scheme = scheme;
-}
-
-void PFXUserApi::setHost(const QString &host) {
-    _host = host;
-}
-
-void PFXUserApi::setPort(int port) {
-    _port = port;
-}
-
 void PFXUserApi::setApiKey(const QString &apiKeyName, const QString &apiKey){
     _apiKeys.insert(apiKeyName,apiKey);
 }
@@ -113,9 +97,6 @@ void PFXUserApi::setPassword(const QString &password) {
     _password = password;
 }
 
-void PFXUserApi::setBasePath(const QString &basePath) {
-    _basePath = basePath;
-}
 
 void PFXUserApi::setTimeOut(const int timeOut) {
     _timeOut = timeOut;
@@ -127,6 +108,26 @@ void PFXUserApi::setWorkingDirectory(const QString &path) {
 
 void PFXUserApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
     _manager = manager;  
+}
+
+    /**
+     * Appends a new ServerConfiguration to the config mal for a specific operation.
+     * @param operation The id to the target operation.
+     * @param URL 
+     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
+     * returns the index of the new server config on success and -1 if the operation is not found
+     */
+int PFXUserApi::addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables){
+    if(_serverConfigs.contains(operation)){
+        _serverConfigs[operation].append(PFXServerConfiguration(
+                    URL,
+                    description,
+                     variables));
+        return _serverConfigs[operation].size()-1;
+    }else{
+        return -1;
+    }
+
 }
 
 void PFXUserApi::addHeaders(const QString &key, const QString &value) {

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
@@ -111,22 +111,45 @@ void PFXUserApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
 }
 
     /**
-     * Appends a new ServerConfiguration to the config mal for a specific operation.
+     * Appends a new ServerConfiguration to the config map for a specific operation.
      * @param operation The id to the target operation.
-     * @param URL 
+     * @param URL A string that contains the URL of the server
+     * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      * returns the index of the new server config on success and -1 if the operation is not found
      */
-int PFXUserApi::addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables){
+int PFXUserApi::addServerConfiguration(const QString &operation, const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
     if(_serverConfigs.contains(operation)){
         _serverConfigs[operation].append(PFXServerConfiguration(
                     URL,
                     description,
-                     variables));
+                    variables));
         return _serverConfigs[operation].size()-1;
     }else{
         return -1;
     }
+}
+
+    /**
+     * Appends a new ServerConfiguration to the config map for a all operations and sets the index to that server.
+     * @param URL A string that contains the URL of the server
+     * @param description A String that describes the server
+     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
+     */
+void PFXUserApi::setNewServerForAllOperations(const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+        for(auto e : _serverIndices.keys()){
+            setServerIndex(e, addServerConfiguration(e, URL, description, variables));
+        }
+} 
+    /**
+     * Appends a new ServerConfiguration to the config map for an operations and sets the index to that server.
+     * @param URL A string that contains the URL of the server
+     * @param description A String that describes the server
+     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
+     */
+void PFXUserApi::setNewServer(const QString &operation, const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+
+    setServerIndex(operation, addServerConfiguration(operation, URL, description, variables));
 
 }
 

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
@@ -35,7 +35,7 @@ QList<PFXServerConfiguration> defaultConf = QList<PFXServerConfiguration>();
 //varying endpoint server 
 QList<PFXServerConfiguration> serverConf = QList<PFXServerConfiguration>();
 defaultConf.append(PFXServerConfiguration(
-    "http://petstore.swagger.io/v2",
+    QUrl("http://petstore.swagger.io/v2"),
     "No description provided",
     QMap<QString, PFXServerVariable>()));
 _serverConfigs.insert("createUser",defaultConf);
@@ -113,15 +113,15 @@ void PFXUserApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
     /**
      * Appends a new ServerConfiguration to the config map for a specific operation.
      * @param operation The id to the target operation.
-     * @param URL A string that contains the URL of the server
+     * @param url A string that contains the URL of the server
      * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      * returns the index of the new server config on success and -1 if the operation is not found
      */
-int PFXUserApi::addServerConfiguration(const QString &operation, const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+int PFXUserApi::addServerConfiguration(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
     if(_serverConfigs.contains(operation)){
         _serverConfigs[operation].append(PFXServerConfiguration(
-                    URL,
+                    url,
                     description,
                     variables));
         return _serverConfigs[operation].size()-1;
@@ -132,13 +132,13 @@ int PFXUserApi::addServerConfiguration(const QString &operation, const QString &
 
     /**
      * Appends a new ServerConfiguration to the config map for a all operations and sets the index to that server.
-     * @param URL A string that contains the URL of the server
+     * @param url A string that contains the URL of the server
      * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      */
-void PFXUserApi::setNewServerForAllOperations(const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+void PFXUserApi::setNewServerForAllOperations(const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
         for(auto e : _serverIndices.keys()){
-            setServerIndex(e, addServerConfiguration(e, URL, description, variables));
+            setServerIndex(e, addServerConfiguration(e, url, description, variables));
         }
 } 
     /**
@@ -147,9 +147,9 @@ void PFXUserApi::setNewServerForAllOperations(const QString &URL, const QString 
      * @param description A String that describes the server
      * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
      */
-void PFXUserApi::setNewServer(const QString &operation, const QString &URL, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+void PFXUserApi::setNewServer(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
 
-    setServerIndex(operation, addServerConfiguration(operation, URL, description, variables));
+    setServerIndex(operation, addServerConfiguration(operation, url, description, variables));
 
 }
 

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
@@ -31,23 +31,20 @@ class PFXUserApi : public QObject {
     Q_OBJECT
 
 public:
-    PFXUserApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 0, const QString &basePath = "/v2", const int timeOut = 0);
+    PFXUserApi(const int timeOut = 0);
     ~PFXUserApi();
 
     void initializeServerConfigs();
     int setDefaultServerValue(int serverIndex,const QString &operation, const QString &variable,const QString &val);
     void setServerIndex(const QString &operation, int serverIndex);
-    void setScheme(const QString &scheme);
-    void setHost(const QString &host);
-    void setPort(int port);
     void setApiKey(const QString &apiKeyName, const QString &apiKey);
     void setBearerToken(const QString &token);
     void setUsername(const QString &username);
     void setPassword(const QString &password);
-    void setBasePath(const QString &basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
+    int addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables);
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();
@@ -66,9 +63,6 @@ public:
     void updateUser(const QString &username, const PFXUser &body);
 
 private:
-    QString _scheme, _host;
-    int _port;
-    QString _basePath;
     QMap<QString,int> _serverIndices;
     QMap<QString,QList<PFXServerConfiguration>> _serverConfigs;
     QMap<QString, QString> _apiKeys;

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
@@ -44,7 +44,9 @@ public:
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
-    int addServerConfiguration(const QString& operation, const QString& URL, const QString& description, const QMap<QString, PFXServerVariable>& variables);
+    int addServerConfiguration(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables = QMap<QString, PFXServerVariable>());
+    void setNewServerForAllOperations(const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
+    void setNewServer(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
@@ -44,9 +44,9 @@ public:
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString &path);
     void setNetworkAccessManager(QNetworkAccessManager* manager);
-    int addServerConfiguration(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables = QMap<QString, PFXServerVariable>());
-    void setNewServerForAllOperations(const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
-    void setNewServer(const QString &operation, const QString &URL, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
+    int addServerConfiguration(const QString &operation, const QUrl &url, const QString &description = "", const QMap<QString, PFXServerVariable> &variables = QMap<QString, PFXServerVariable>());
+    void setNewServerForAllOperations(const QUrl &url, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
+    void setNewServer(const QString &operation, const QUrl &url, const QString &description = "", const QMap<QString, PFXServerVariable> &variables =  QMap<QString, PFXServerVariable>());
     void addHeaders(const QString &key, const QString &value);
     void enableRequestCompression();
     void enableResponseCompression();


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The issue #8694 pointed out that there are some unused variables and that it would be handy to be able to add new servers that are not provided in the OpenAPI file. The variables `host`, `port`, `scheme` and `basePath` have been removed since the servers are handled by the `ServerConfiguration` class.  Furthermore one can add a new `ServerConfiguration` for an Operation: 

```
[...]
    API api;
    //add a new server with port and server variables
    int newDefaultServerIndex =  api.addServerConfiguration("defaultServer","{server}:{port}","newly added default server", 
        QMap<QString, PFXServerVariable>{ 
        {"server", PFXServerVariable("No description provided","custom-petstore",
        QSet<QString>{ {"custom-petstore"},{"custom-qa-petstore"},{"custom-dev-petstore"} })}, 

        {"port", PFXServerVariable("No description provided","8080",
        QSet<QString>{ {"80"},{"8080"} })},  });

    //using the new servers
    api.setServerIndex("defaultServer",newDefaultServerIndex);
[...]
```

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

PING @wing328 @ravinikam (2017/07) @stkrwork (2017/07) @etherealjoy (2018/02) @MartinDelille (2018/03) @muttleyxd (2019/08)
