### PR TITLE
[Ruby] force users to specify the temp folder path to address security concerns

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
@@ -71,6 +71,13 @@ module {{moduleName}}
       {{/isFaraday}}
       {{#isFaraday}}
       if return_type == 'File'
+        # throw an exception if the temp folder path is not defined
+        # to avoid using the default temp directory which can be read by anyone
+        if @config.temp_folder_path.nil?
+          raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"]) " +
+                "to avoid dowloading the file to a location readable by everyone."
+        end
+
         content_disposition = response.headers['Content-Disposition']
         if content_disposition && content_disposition =~ /filename=/i
           filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
@@ -74,7 +74,7 @@ module {{moduleName}}
         # throw an exception if the temp folder path is not defined
         # to avoid using the default temp directory which can be read by anyone
         if @config.temp_folder_path.nil?
-          raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"]) " +
+          raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"]) " +
                 "to avoid dowloading the file to a location readable by everyone."
         end
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_typhoeus_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_typhoeus_partial.mustache
@@ -52,8 +52,8 @@
 
       {{#hasAuthMethods}}
       update_params_for_auth! header_params, query_params, opts[:auth_names]
-      {{/hasAuthMethods}}
 
+      {{/hasAuthMethods}}
       # set ssl_verifyhosts option based on @config.verify_ssl_host (true/false)
       _verify_ssl_host = @config.verify_ssl_host ? 2 : 0
 
@@ -122,6 +122,13 @@
     #
     # @see Configuration#temp_folder_path
     def download_file(request)
+      # throw an exception if the temp folder path is not defined
+      # to avoid using the default temp directory which can be read by anyone
+      if @config.temp_folder_path.nil?
+        raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"])" +
+              "to avoid dowloading the file to a location readable by everyone."
+      end
+
       tempfile = nil
       encoding = nil
       request.on_headers do |response|
@@ -137,10 +144,12 @@
         tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
         @tempfile = tempfile
       end
+
       request.on_body do |chunk|
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
+
       request.on_complete do |response|
         if tempfile
           tempfile.close

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_typhoeus_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_typhoeus_partial.mustache
@@ -125,7 +125,7 @@
       # throw an exception if the temp folder path is not defined
       # to avoid using the default temp directory which can be read by anyone
       if @config.temp_folder_path.nil?
-        raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"])" +
+        raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"])" +
               "to avoid dowloading the file to a location readable by everyone."
       end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -203,6 +203,13 @@ module Petstore
       # handle file downloading - return the File instance processed in request callbacks
       # note that response body is empty when the file is written in chunks in request on_body callback
       if return_type == 'File'
+        # throw an exception if the temp folder path is not defined
+        # to avoid using the default temp directory which can be read by anyone
+        if @config.temp_folder_path.nil?
+          raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"]) " +
+                "to avoid dowloading the file to a location readable by everyone."
+        end
+
         content_disposition = response.headers['Content-Disposition']
         if content_disposition && content_disposition =~ /filename=/i
           filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -206,7 +206,7 @@ module Petstore
         # throw an exception if the temp folder path is not defined
         # to avoid using the default temp directory which can be read by anyone
         if @config.temp_folder_path.nil?
-          raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"]) " +
+          raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"]) " +
                 "to avoid dowloading the file to a location readable by everyone."
         end
 

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -167,7 +167,7 @@ module Petstore
       # throw an exception if the temp folder path is not defined
       # to avoid using the default temp directory which can be read by anyone
       if @config.temp_folder_path.nil?
-        raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"])" +
+        raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"])" +
               "to avoid dowloading the file to a location readable by everyone."
       end
 

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -164,6 +164,13 @@ module Petstore
     #
     # @see Configuration#temp_folder_path
     def download_file(request)
+      # throw an exception if the temp folder path is not defined
+      # to avoid using the default temp directory which can be read by anyone
+      if @config.temp_folder_path.nil?
+        raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"])" +
+              "to avoid dowloading the file to a location readable by everyone."
+      end
+
       tempfile = nil
       encoding = nil
       request.on_headers do |response|
@@ -179,10 +186,12 @@ module Petstore
         tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
         @tempfile = tempfile
       end
+
       request.on_body do |chunk|
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
+
       request.on_complete do |response|
         if tempfile
           tempfile.close

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api_client.rb
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api_client.rb
@@ -164,6 +164,13 @@ module XAuthIDAlias
     #
     # @see Configuration#temp_folder_path
     def download_file(request)
+      # throw an exception if the temp folder path is not defined
+      # to avoid using the default temp directory which can be read by anyone
+      if @config.temp_folder_path.nil?
+        raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"])" +
+              "to avoid dowloading the file to a location readable by everyone."
+      end
+
       tempfile = nil
       encoding = nil
       request.on_headers do |response|
@@ -179,10 +186,12 @@ module XAuthIDAlias
         tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
         @tempfile = tempfile
       end
+
       request.on_body do |chunk|
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
+
       request.on_complete do |response|
         if tempfile
           tempfile.close

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api_client.rb
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api_client.rb
@@ -167,7 +167,7 @@ module XAuthIDAlias
       # throw an exception if the temp folder path is not defined
       # to avoid using the default temp directory which can be read by anyone
       if @config.temp_folder_path.nil?
-        raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"])" +
+        raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"])" +
               "to avoid dowloading the file to a location readable by everyone."
       end
 

--- a/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_client.rb
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_client.rb
@@ -165,7 +165,7 @@ module DynamicServers
       # throw an exception if the temp folder path is not defined
       # to avoid using the default temp directory which can be read by anyone
       if @config.temp_folder_path.nil?
-        raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"])" +
+        raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"])" +
               "to avoid dowloading the file to a location readable by everyone."
       end
 

--- a/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_client.rb
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_client.rb
@@ -94,7 +94,6 @@ module DynamicServers
       query_params = opts[:query_params] || {}
       form_params = opts[:form_params] || {}
 
-
       # set ssl_verifyhosts option based on @config.verify_ssl_host (true/false)
       _verify_ssl_host = @config.verify_ssl_host ? 2 : 0
 
@@ -163,6 +162,13 @@ module DynamicServers
     #
     # @see Configuration#temp_folder_path
     def download_file(request)
+      # throw an exception if the temp folder path is not defined
+      # to avoid using the default temp directory which can be read by anyone
+      if @config.temp_folder_path.nil?
+        raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"])" +
+              "to avoid dowloading the file to a location readable by everyone."
+      end
+
       tempfile = nil
       encoding = nil
       request.on_headers do |response|
@@ -178,10 +184,12 @@ module DynamicServers
         tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
         @tempfile = tempfile
       end
+
       request.on_body do |chunk|
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
+
       request.on_complete do |response|
         if tempfile
           tempfile.close

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_client.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_client.rb
@@ -165,7 +165,7 @@ module Petstore
       # throw an exception if the temp folder path is not defined
       # to avoid using the default temp directory which can be read by anyone
       if @config.temp_folder_path.nil?
-        raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"])" +
+        raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"])" +
               "to avoid dowloading the file to a location readable by everyone."
       end
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_client.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_client.rb
@@ -94,7 +94,6 @@ module Petstore
       query_params = opts[:query_params] || {}
       form_params = opts[:form_params] || {}
 
-
       # set ssl_verifyhosts option based on @config.verify_ssl_host (true/false)
       _verify_ssl_host = @config.verify_ssl_host ? 2 : 0
 
@@ -163,6 +162,13 @@ module Petstore
     #
     # @see Configuration#temp_folder_path
     def download_file(request)
+      # throw an exception if the temp folder path is not defined
+      # to avoid using the default temp directory which can be read by anyone
+      if @config.temp_folder_path.nil?
+        raise "@config.temp_folder_path must be setup first (e.g. ENV["HOME"], ENV["HOMEPATH"])" +
+              "to avoid dowloading the file to a location readable by everyone."
+      end
+
       tempfile = nil
       encoding = nil
       request.on_headers do |response|
@@ -178,10 +184,12 @@ module Petstore
         tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
         @tempfile = tempfile
       end
+
       request.on_body do |chunk|
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
+
       request.on_complete do |response|
         if tempfile
           tempfile.close


### PR DESCRIPTION
- force users to specify the temp folder path to address security concerns as the default location of the temp folder can be read by any users.
- if the temp folder path is not set, an exception will be thrown

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)
