### PR TITLE
Add an option to skip operation examples

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -217,6 +217,10 @@ public class Generate extends OpenApiGeneratorCommand {
             description = CodegenConstants.REMOVE_OPERATION_ID_PREFIX_DESC)
     private Boolean removeOperationIdPrefix;
 
+    @Option(name = {"--skip-operation-example"}, title = "skip examples defined in the operation",
+            description = CodegenConstants.SKIP_OPERATION_EXAMPLE_DESC)
+    private Boolean skipOperationExample;
+
     @Option(name = {"--skip-validate-spec"},
             title = "skip spec validation",
             description = "Skips the default behavior of validating an input specification.")
@@ -391,6 +395,10 @@ public class Generate extends OpenApiGeneratorCommand {
 
         if (removeOperationIdPrefix != null) {
             configurator.setRemoveOperationIdPrefix(removeOperationIdPrefix);
+        }
+
+        if (skipOperationExample != null) {
+            configurator.setSkipOperationExample(skipOperationExample);
         }
 
         if (enablePostProcessFile != null) {

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
@@ -42,6 +42,7 @@ public class WorkflowSettings {
     public static final boolean DEFAULT_VERBOSE = false;
     public static final boolean DEFAULT_SKIP_OVERWRITE = false;
     public static final boolean DEFAULT_REMOVE_OPERATION_ID_PREFIX = false;
+    public static final boolean DEFAULT_SKIP_OPERATION_EXAMPLE = true;
     public static final boolean DEFAULT_LOG_TO_STDERR = false;
     public static final boolean DEFAULT_VALIDATE_SPEC = true;
     public static final boolean DEFAULT_ENABLE_POST_PROCESS_FILE = false;
@@ -56,6 +57,7 @@ public class WorkflowSettings {
     private boolean verbose = DEFAULT_VERBOSE;
     private boolean skipOverwrite = DEFAULT_SKIP_OVERWRITE;
     private boolean removeOperationIdPrefix = DEFAULT_REMOVE_OPERATION_ID_PREFIX;
+    private boolean skipOperationExample = DEFAULT_SKIP_OPERATION_EXAMPLE;
     private boolean logToStderr = DEFAULT_LOG_TO_STDERR;
     private boolean validateSpec = DEFAULT_VALIDATE_SPEC;
     private boolean enablePostProcessFile = DEFAULT_ENABLE_POST_PROCESS_FILE;
@@ -104,6 +106,7 @@ public class WorkflowSettings {
         builder.verbose = copy.isVerbose();
         builder.skipOverwrite = copy.isSkipOverwrite();
         builder.removeOperationIdPrefix = copy.isRemoveOperationIdPrefix();
+        builder.skipOperationExample = copy.isSkipOperationExample();
         builder.logToStderr = copy.isLogToStderr();
         builder.validateSpec = copy.isValidateSpec();
         builder.enablePostProcessFile = copy.isEnablePostProcessFile();
@@ -167,6 +170,15 @@ public class WorkflowSettings {
      */
     public boolean isRemoveOperationIdPrefix() {
         return removeOperationIdPrefix;
+    }
+
+    /**
+     * Indicates whether or not to skip examples defined in the operation.
+     *
+     * @return <code>true</code> if the examples defined in the operation should be skipped.
+     */
+    public boolean isSkipOperationExample() {
+        return skipOperationExample;
     }
 
     /**
@@ -284,6 +296,7 @@ public class WorkflowSettings {
         private Boolean verbose = DEFAULT_VERBOSE;
         private Boolean skipOverwrite = DEFAULT_SKIP_OVERWRITE;
         private Boolean removeOperationIdPrefix = DEFAULT_REMOVE_OPERATION_ID_PREFIX;
+        private Boolean skipOperationExample = DEFAULT_SKIP_OPERATION_EXAMPLE;
         private Boolean logToStderr = DEFAULT_LOG_TO_STDERR;
         private Boolean validateSpec = DEFAULT_VALIDATE_SPEC;
         private Boolean enablePostProcessFile = DEFAULT_ENABLE_POST_PROCESS_FILE;
@@ -359,6 +372,17 @@ public class WorkflowSettings {
          */
         public Builder withRemoveOperationIdPrefix(Boolean removeOperationIdPrefix) {
             this.removeOperationIdPrefix = removeOperationIdPrefix != null ? removeOperationIdPrefix : Boolean.valueOf(DEFAULT_REMOVE_OPERATION_ID_PREFIX);
+            return this;
+        }
+
+        /**
+         * Sets the {@code skipOperationExample} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param skipOperationExample the {@code skipOperationExample} to set
+         * @return a reference to this Builder
+         */
+        public Builder withSkipOperationExample(Boolean skipOperationExample) {
+            this.skipOperationExample = skipOperationExample != null ? skipOperationExample : Boolean.valueOf(DEFAULT_REMOVE_OPERATION_ID_PREFIX);
             return this;
         }
 
@@ -568,6 +592,7 @@ public class WorkflowSettings {
         return isVerbose() == that.isVerbose() &&
                 isSkipOverwrite() == that.isSkipOverwrite() &&
                 isRemoveOperationIdPrefix() == that.isRemoveOperationIdPrefix() &&
+                isSkipOperationExample() == that.isSkipOperationExample() &&
                 isLogToStderr() == that.isLogToStderr() &&
                 isValidateSpec() == that.isValidateSpec() &&
                 isEnablePostProcessFile() == that.isEnablePostProcessFile() &&
@@ -590,6 +615,7 @@ public class WorkflowSettings {
                 isVerbose(),
                 isSkipOverwrite(),
                 isRemoveOperationIdPrefix(),
+                isSkipOperationExample(),
                 isLogToStderr(),
                 isValidateSpec(),
                 isGenerateAliasAsModel(),

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
@@ -42,7 +42,7 @@ public class WorkflowSettings {
     public static final boolean DEFAULT_VERBOSE = false;
     public static final boolean DEFAULT_SKIP_OVERWRITE = false;
     public static final boolean DEFAULT_REMOVE_OPERATION_ID_PREFIX = false;
-    public static final boolean DEFAULT_SKIP_OPERATION_EXAMPLE = true;
+    public static final boolean DEFAULT_SKIP_OPERATION_EXAMPLE = false;
     public static final boolean DEFAULT_LOG_TO_STDERR = false;
     public static final boolean DEFAULT_VALIDATE_SPEC = true;
     public static final boolean DEFAULT_ENABLE_POST_PROCESS_FILE = false;

--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -294,6 +294,11 @@ apply plugin: 'org.openapi.generator'
 |false
 |Remove prefix of operationId, e.g. config_getId => getId.
 
+|skipOperationExample
+|Boolean
+|false
+|Skip examples defined in the operation
+
 |apiFilesConstrainedTo
 |List(String)
 |None

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -125,6 +125,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     reservedWordsMappings.set(generate.reservedWordsMappings)
                     ignoreFileOverride.set(generate.ignoreFileOverride)
                     removeOperationIdPrefix.set(generate.removeOperationIdPrefix)
+                    skipOperationExample.set(generate.skipOperationExample)
                     apiFilesConstrainedTo.set(generate.apiFilesConstrainedTo)
                     modelFilesConstrainedTo.set(generate.modelFilesConstrainedTo)
                     supportingFilesConstrainedTo.set(generate.supportingFilesConstrainedTo)

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -202,6 +202,11 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val removeOperationIdPrefix = project.objects.property<Boolean?>()
 
     /**
+     * Skip examples defined in the operation
+     */
+    val skipOperationExample = project.objects.property<Boolean?>()
+
+    /**
      * Defines which API-related files should be generated. This allows you to create a subset of generated files (or none at all).
      *
      * NOTE: Configuring any one of [apiFilesConstrainedTo], [modelFilesConstrainedTo], or [supportingFilesConstrainedTo] results

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -305,6 +305,13 @@ open class GenerateTask : DefaultTask() {
     val removeOperationIdPrefix = project.objects.property<Boolean?>()
 
     /**
+     * Remove examples defined in the operation
+     */
+    @Optional
+    @Input
+    val skipOperationExample = project.objects.property<Boolean?>()
+
+    /**
      * Defines which API-related files should be generated. This allows you to create a subset of generated files (or none at all).
      *
      * This option enables/disables generation of ALL api-related files.
@@ -613,6 +620,10 @@ open class GenerateTask : DefaultTask() {
 
             removeOperationIdPrefix.ifNotEmpty { value ->
                 configurator.setRemoveOperationIdPrefix(value!!)
+            }
+
+            skipOperationExample.ifNotEmpty { value ->
+                configurator.setSkipOperationExample(value!!)
             }
 
             logToStderr.ifNotEmpty { value ->

--- a/modules/openapi-generator-maven-plugin/README.md
+++ b/modules/openapi-generator-maven-plugin/README.md
@@ -70,6 +70,7 @@ mvn clean compile
 | `ignoreFileOverride` |  `openapi.generator.maven.plugin.ignoreFileOverride` | specifies the full path to a `.openapi-generator-ignore` used for pattern based overrides of generated outputs
 | `httpUserAgent` | `openapi.generator.maven.plugin.httpUserAgent` | Sets custom User-Agent header value
 | `removeOperationIdPrefix` |  `openapi.generator.maven.plugin.removeOperationIdPrefix` | remove operationId prefix (e.g. user_getName => getName)
+| `skipOperationExample` |  `openapi.generator.maven.plugin.skipOperationExample` | skip examples defined in the operation
 | `logToStderr` |  `openapi.generator.maven.plugin.logToStderr` | write all log messages (not just errors) to STDOUT
 | `enablePostProcessFile` |  `openapi.generator.maven.plugin.` | enable file post-processing hook
 | `skipValidateSpec` |  `openapi.generator.maven.plugin.skipValidateSpec` | Whether or not to skip validating the input spec prior to generation. By default, invalid specifications will result in an error.

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -238,6 +238,12 @@ public class CodeGenMojo extends AbstractMojo {
     private Boolean removeOperationIdPrefix;
 
     /**
+     * To skip examples defined in the operation
+     */
+    @Parameter(name = "skipOperationExample", property = "openapi.generator.maven.plugin.skipOperationExample")
+    private Boolean skipOperationExample;
+
+    /**
      * To write all log messages (not just errors) to STDOUT
      */
     @Parameter(name = "logToStderr", property = "openapi.generator.maven.plugin.logToStderr")
@@ -483,6 +489,10 @@ public class CodeGenMojo extends AbstractMojo {
 
             if (removeOperationIdPrefix != null) {
                 configurator.setRemoveOperationIdPrefix(removeOperationIdPrefix);
+            }
+
+            if (skipOperationExample != null) {
+                configurator.setSkipOperationExample(skipOperationExample);
             }
 
             if (isNotEmpty(inputSpec)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -214,6 +214,10 @@ public interface CodegenConfig {
 
     void setRemoveOperationIdPrefix(boolean removeOperationIdPrefix);
 
+    boolean isSkipOperationExample();
+
+    void setSkipOperationExample(boolean skipOperationExample);
+
     public boolean isHideGenerationTimestamp();
 
     public void setHideGenerationTimestamp(boolean hideGenerationTimestamp);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -309,6 +309,9 @@ public class CodegenConstants {
     public static final String REMOVE_OPERATION_ID_PREFIX = "removeOperationIdPrefix";
     public static final String REMOVE_OPERATION_ID_PREFIX_DESC = "Remove prefix of operationId, e.g. config_getId => getId";
 
+    public static final String SKIP_OPERATION_EXAMPLE = "skipOperationExample";
+    public static final String SKIP_OPERATION_EXAMPLE_DESC = "Skip examples defined in operations to avoid out of memory errors.";
+
     public static final String STRIP_PACKAGE_NAME = "stripPackageName";
     public static final String STRIP_PACKAGE_NAME_DESC = "Whether to strip leading dot-separated packages from generated model classes";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -177,6 +177,7 @@ public class DefaultCodegen implements CodegenConfig {
     protected List<CliOption> cliOptions = new ArrayList<CliOption>();
     protected boolean skipOverwrite;
     protected boolean removeOperationIdPrefix;
+    protected boolean skipOperationExample;
 
     /**
      * True if the code generator supports multiple class inheritance.
@@ -316,6 +317,11 @@ public class DefaultCodegen implements CodegenConfig {
         if (additionalProperties.containsKey(CodegenConstants.REMOVE_OPERATION_ID_PREFIX)) {
             this.setRemoveOperationIdPrefix(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.REMOVE_OPERATION_ID_PREFIX).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.SKIP_OPERATION_EXAMPLE)) {
+            this.setSkipOperationExample(Boolean.valueOf(additionalProperties
+                    .get(CodegenConstants.SKIP_OPERATION_EXAMPLE).toString()));
         }
 
         if (additionalProperties.containsKey(CodegenConstants.DOCEXTENSION)) {
@@ -3547,14 +3553,18 @@ public class DefaultCodegen implements CodegenConfig {
                 }
             }
 
-            // generate examples
-            String exampleStatusCode = "200";
-            for (String key : operation.getResponses().keySet()) {
-                if (operation.getResponses().get(key) == methodResponse && !key.equals("default")) {
-                    exampleStatusCode = key;
+            // check skipOperationExample, which can be set to true to avoid out of memory errors for large spec
+            if (!isSkipOperationExample()) {
+                // generate examples
+                String exampleStatusCode = "200";
+                for (String key : operation.getResponses().keySet()) {
+                    if (operation.getResponses().get(key) == methodResponse && !key.equals("default")) {
+                        exampleStatusCode = key;
+                    }
                 }
+                op.examples = new ExampleGenerator(schemas, this.openAPI).generateFromResponseSchema(exampleStatusCode, responseSchema, getProducesInfo(this.openAPI, operation));
             }
-            op.examples = new ExampleGenerator(schemas, this.openAPI).generateFromResponseSchema(exampleStatusCode, responseSchema, getProducesInfo(this.openAPI, operation));
+
             op.defaultResponse = toDefaultValue(responseSchema);
             op.returnType = cm.dataType;
             op.returnFormat = cm.dataFormat;
@@ -4954,8 +4964,16 @@ public class DefaultCodegen implements CodegenConfig {
         return removeOperationIdPrefix;
     }
 
+    public boolean isSkipOperationExample() {
+        return skipOperationExample;
+    }
+
     public void setRemoveOperationIdPrefix(boolean removeOperationIdPrefix) {
         this.removeOperationIdPrefix = removeOperationIdPrefix;
+    }
+
+    public void setSkipOperationExample(boolean skipOperationExample) {
+        this.skipOperationExample = skipOperationExample;
     }
 
     public boolean isHideGenerationTimestamp() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -429,6 +429,11 @@ public class CodegenConfigurator {
         return this;
     }
 
+    public CodegenConfigurator setSkipOperationExample(boolean skipOperationExample) {
+        workflowSettingsBuilder.withSkipOperationExample(skipOperationExample);
+        return this;
+    }
+
     public CodegenConfigurator setSkipOverwrite(boolean skipOverwrite) {
         workflowSettingsBuilder.withSkipOverwrite(skipOverwrite);
         return this;
@@ -583,6 +588,7 @@ public class CodegenConfigurator {
         config.setSkipOverwrite(workflowSettings.isSkipOverwrite());
         config.setIgnoreFilePathOverride(workflowSettings.getIgnoreFileOverride());
         config.setRemoveOperationIdPrefix(workflowSettings.isRemoveOperationIdPrefix());
+        config.setSkipOperationExample(workflowSettings.isSkipOperationExample());
         config.setEnablePostProcessFile(workflowSettings.isEnablePostProcessFile());
         config.setEnableMinimalUpdate(workflowSettings.isEnableMinimalUpdate());
         config.setStrictSpecBehavior(workflowSettings.isStrictSpecBehavior());


### PR DESCRIPTION
Add an option to skip operation examples to avoid potential JVM out of memory errors
 
Closes https://github.com/OpenAPITools/openapi-generator/issues/6597
Closes https://github.com/OpenAPITools/openapi-generator/issues/8682
Closes https://github.com/OpenAPITools/openapi-generator/issues/4398

cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
