### PR TITLE
[go] Fix *Api*Request to use pointer receiver (OpenAPITools#8745)

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -56,13 +56,13 @@ type {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request s
 {{/allParams}}
 }
 {{#allParams}}{{^isPathParam}}
-func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) {{vendorExtensions.x-export-param-name}}({{paramName}} {{{dataType}}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request {
+func (r *{{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) {{vendorExtensions.x-export-param-name}}({{paramName}} {{{dataType}}}) *{{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request {
 	r.{{paramName}} = &{{paramName}}
 	return r
 }{{/isPathParam}}{{/allParams}}
 
-func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
-	return r.ApiService.{{nickname}}Execute(r)
+func (r *{{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
+	return r.ApiService.{{nickname}}Execute(*r)
 }
 
 /*

--- a/samples/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_another_fake.go
@@ -49,13 +49,13 @@ type ApiCall123TestSpecialTagsRequest struct {
 	body *Client
 }
 
-func (r ApiCall123TestSpecialTagsRequest) Body(body Client) ApiCall123TestSpecialTagsRequest {
+func (r *ApiCall123TestSpecialTagsRequest) Body(body Client) *ApiCall123TestSpecialTagsRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, error) {
-	return r.ApiService.Call123TestSpecialTagsExecute(r)
+func (r *ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, error) {
+	return r.ApiService.Call123TestSpecialTagsExecute(*r)
 }
 
 /*

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -225,13 +225,13 @@ type ApiCreateXmlItemRequest struct {
 	xmlItem *XmlItem
 }
 
-func (r ApiCreateXmlItemRequest) XmlItem(xmlItem XmlItem) ApiCreateXmlItemRequest {
+func (r *ApiCreateXmlItemRequest) XmlItem(xmlItem XmlItem) *ApiCreateXmlItemRequest {
 	r.xmlItem = &xmlItem
 	return r
 }
 
-func (r ApiCreateXmlItemRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.CreateXmlItemExecute(r)
+func (r *ApiCreateXmlItemRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.CreateXmlItemExecute(*r)
 }
 
 /*
@@ -326,13 +326,13 @@ type ApiFakeOuterBooleanSerializeRequest struct {
 	body *bool
 }
 
-func (r ApiFakeOuterBooleanSerializeRequest) Body(body bool) ApiFakeOuterBooleanSerializeRequest {
+func (r *ApiFakeOuterBooleanSerializeRequest) Body(body bool) *ApiFakeOuterBooleanSerializeRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, error) {
-	return r.ApiService.FakeOuterBooleanSerializeExecute(r)
+func (r *ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, error) {
+	return r.ApiService.FakeOuterBooleanSerializeExecute(*r)
 }
 
 /*
@@ -435,13 +435,13 @@ type ApiFakeOuterCompositeSerializeRequest struct {
 	body *OuterComposite
 }
 
-func (r ApiFakeOuterCompositeSerializeRequest) Body(body OuterComposite) ApiFakeOuterCompositeSerializeRequest {
+func (r *ApiFakeOuterCompositeSerializeRequest) Body(body OuterComposite) *ApiFakeOuterCompositeSerializeRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, error) {
-	return r.ApiService.FakeOuterCompositeSerializeExecute(r)
+func (r *ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, error) {
+	return r.ApiService.FakeOuterCompositeSerializeExecute(*r)
 }
 
 /*
@@ -544,13 +544,13 @@ type ApiFakeOuterNumberSerializeRequest struct {
 	body *float32
 }
 
-func (r ApiFakeOuterNumberSerializeRequest) Body(body float32) ApiFakeOuterNumberSerializeRequest {
+func (r *ApiFakeOuterNumberSerializeRequest) Body(body float32) *ApiFakeOuterNumberSerializeRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, error) {
-	return r.ApiService.FakeOuterNumberSerializeExecute(r)
+func (r *ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, error) {
+	return r.ApiService.FakeOuterNumberSerializeExecute(*r)
 }
 
 /*
@@ -653,13 +653,13 @@ type ApiFakeOuterStringSerializeRequest struct {
 	body *string
 }
 
-func (r ApiFakeOuterStringSerializeRequest) Body(body string) ApiFakeOuterStringSerializeRequest {
+func (r *ApiFakeOuterStringSerializeRequest) Body(body string) *ApiFakeOuterStringSerializeRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, error) {
-	return r.ApiService.FakeOuterStringSerializeExecute(r)
+func (r *ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, error) {
+	return r.ApiService.FakeOuterStringSerializeExecute(*r)
 }
 
 /*
@@ -762,13 +762,13 @@ type ApiTestBodyWithFileSchemaRequest struct {
 	body *FileSchemaTestClass
 }
 
-func (r ApiTestBodyWithFileSchemaRequest) Body(body FileSchemaTestClass) ApiTestBodyWithFileSchemaRequest {
+func (r *ApiTestBodyWithFileSchemaRequest) Body(body FileSchemaTestClass) *ApiTestBodyWithFileSchemaRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestBodyWithFileSchemaExecute(r)
+func (r *ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestBodyWithFileSchemaExecute(*r)
 }
 
 /*
@@ -864,17 +864,17 @@ type ApiTestBodyWithQueryParamsRequest struct {
 	body *User
 }
 
-func (r ApiTestBodyWithQueryParamsRequest) Query(query string) ApiTestBodyWithQueryParamsRequest {
+func (r *ApiTestBodyWithQueryParamsRequest) Query(query string) *ApiTestBodyWithQueryParamsRequest {
 	r.query = &query
 	return r
 }
-func (r ApiTestBodyWithQueryParamsRequest) Body(body User) ApiTestBodyWithQueryParamsRequest {
+func (r *ApiTestBodyWithQueryParamsRequest) Body(body User) *ApiTestBodyWithQueryParamsRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestBodyWithQueryParamsExecute(r)
+func (r *ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestBodyWithQueryParamsExecute(*r)
 }
 
 /*
@@ -972,13 +972,13 @@ type ApiTestClientModelRequest struct {
 	body *Client
 }
 
-func (r ApiTestClientModelRequest) Body(body Client) ApiTestClientModelRequest {
+func (r *ApiTestClientModelRequest) Body(body Client) *ApiTestClientModelRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error) {
-	return r.ApiService.TestClientModelExecute(r)
+func (r *ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error) {
+	return r.ApiService.TestClientModelExecute(*r)
 }
 
 /*
@@ -1097,65 +1097,65 @@ type ApiTestEndpointParametersRequest struct {
 	callback *string
 }
 
-func (r ApiTestEndpointParametersRequest) Number(number float32) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Number(number float32) *ApiTestEndpointParametersRequest {
 	r.number = &number
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Double(double float64) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Double(double float64) *ApiTestEndpointParametersRequest {
 	r.double = &double
 	return r
 }
-func (r ApiTestEndpointParametersRequest) PatternWithoutDelimiter(patternWithoutDelimiter string) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) PatternWithoutDelimiter(patternWithoutDelimiter string) *ApiTestEndpointParametersRequest {
 	r.patternWithoutDelimiter = &patternWithoutDelimiter
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Byte_(byte_ string) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Byte_(byte_ string) *ApiTestEndpointParametersRequest {
 	r.byte_ = &byte_
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Integer(integer int32) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Integer(integer int32) *ApiTestEndpointParametersRequest {
 	r.integer = &integer
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Int32_(int32_ int32) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Int32_(int32_ int32) *ApiTestEndpointParametersRequest {
 	r.int32_ = &int32_
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Int64_(int64_ int64) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Int64_(int64_ int64) *ApiTestEndpointParametersRequest {
 	r.int64_ = &int64_
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Float(float float32) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Float(float float32) *ApiTestEndpointParametersRequest {
 	r.float = &float
 	return r
 }
-func (r ApiTestEndpointParametersRequest) String_(string_ string) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) String_(string_ string) *ApiTestEndpointParametersRequest {
 	r.string_ = &string_
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Binary(binary *os.File) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Binary(binary *os.File) *ApiTestEndpointParametersRequest {
 	r.binary = &binary
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Date(date string) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Date(date string) *ApiTestEndpointParametersRequest {
 	r.date = &date
 	return r
 }
-func (r ApiTestEndpointParametersRequest) DateTime(dateTime time.Time) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) DateTime(dateTime time.Time) *ApiTestEndpointParametersRequest {
 	r.dateTime = &dateTime
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Password(password string) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Password(password string) *ApiTestEndpointParametersRequest {
 	r.password = &password
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Callback(callback string) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Callback(callback string) *ApiTestEndpointParametersRequest {
 	r.callback = &callback
 	return r
 }
 
-func (r ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestEndpointParametersExecute(r)
+func (r *ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestEndpointParametersExecute(*r)
 }
 
 /*
@@ -1321,41 +1321,41 @@ type ApiTestEnumParametersRequest struct {
 	enumFormString *string
 }
 
-func (r ApiTestEnumParametersRequest) EnumHeaderStringArray(enumHeaderStringArray []string) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumHeaderStringArray(enumHeaderStringArray []string) *ApiTestEnumParametersRequest {
 	r.enumHeaderStringArray = &enumHeaderStringArray
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumHeaderString(enumHeaderString string) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumHeaderString(enumHeaderString string) *ApiTestEnumParametersRequest {
 	r.enumHeaderString = &enumHeaderString
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryStringArray(enumQueryStringArray []string) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumQueryStringArray(enumQueryStringArray []string) *ApiTestEnumParametersRequest {
 	r.enumQueryStringArray = &enumQueryStringArray
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryString(enumQueryString string) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumQueryString(enumQueryString string) *ApiTestEnumParametersRequest {
 	r.enumQueryString = &enumQueryString
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryInteger(enumQueryInteger int32) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumQueryInteger(enumQueryInteger int32) *ApiTestEnumParametersRequest {
 	r.enumQueryInteger = &enumQueryInteger
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryDouble(enumQueryDouble float64) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumQueryDouble(enumQueryDouble float64) *ApiTestEnumParametersRequest {
 	r.enumQueryDouble = &enumQueryDouble
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumFormStringArray(enumFormStringArray []string) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumFormStringArray(enumFormStringArray []string) *ApiTestEnumParametersRequest {
 	r.enumFormStringArray = &enumFormStringArray
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumFormString(enumFormString string) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumFormString(enumFormString string) *ApiTestEnumParametersRequest {
 	r.enumFormString = &enumFormString
 	return r
 }
 
-func (r ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestEnumParametersExecute(r)
+func (r *ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestEnumParametersExecute(*r)
 }
 
 /*
@@ -1474,33 +1474,33 @@ type ApiTestGroupParametersRequest struct {
 	int64Group *int64
 }
 
-func (r ApiTestGroupParametersRequest) RequiredStringGroup(requiredStringGroup int32) ApiTestGroupParametersRequest {
+func (r *ApiTestGroupParametersRequest) RequiredStringGroup(requiredStringGroup int32) *ApiTestGroupParametersRequest {
 	r.requiredStringGroup = &requiredStringGroup
 	return r
 }
-func (r ApiTestGroupParametersRequest) RequiredBooleanGroup(requiredBooleanGroup bool) ApiTestGroupParametersRequest {
+func (r *ApiTestGroupParametersRequest) RequiredBooleanGroup(requiredBooleanGroup bool) *ApiTestGroupParametersRequest {
 	r.requiredBooleanGroup = &requiredBooleanGroup
 	return r
 }
-func (r ApiTestGroupParametersRequest) RequiredInt64Group(requiredInt64Group int64) ApiTestGroupParametersRequest {
+func (r *ApiTestGroupParametersRequest) RequiredInt64Group(requiredInt64Group int64) *ApiTestGroupParametersRequest {
 	r.requiredInt64Group = &requiredInt64Group
 	return r
 }
-func (r ApiTestGroupParametersRequest) StringGroup(stringGroup int32) ApiTestGroupParametersRequest {
+func (r *ApiTestGroupParametersRequest) StringGroup(stringGroup int32) *ApiTestGroupParametersRequest {
 	r.stringGroup = &stringGroup
 	return r
 }
-func (r ApiTestGroupParametersRequest) BooleanGroup(booleanGroup bool) ApiTestGroupParametersRequest {
+func (r *ApiTestGroupParametersRequest) BooleanGroup(booleanGroup bool) *ApiTestGroupParametersRequest {
 	r.booleanGroup = &booleanGroup
 	return r
 }
-func (r ApiTestGroupParametersRequest) Int64Group(int64Group int64) ApiTestGroupParametersRequest {
+func (r *ApiTestGroupParametersRequest) Int64Group(int64Group int64) *ApiTestGroupParametersRequest {
 	r.int64Group = &int64Group
 	return r
 }
 
-func (r ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestGroupParametersExecute(r)
+func (r *ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestGroupParametersExecute(*r)
 }
 
 /*
@@ -1611,13 +1611,13 @@ type ApiTestInlineAdditionalPropertiesRequest struct {
 	param *map[string]string
 }
 
-func (r ApiTestInlineAdditionalPropertiesRequest) Param(param map[string]string) ApiTestInlineAdditionalPropertiesRequest {
+func (r *ApiTestInlineAdditionalPropertiesRequest) Param(param map[string]string) *ApiTestInlineAdditionalPropertiesRequest {
 	r.param = &param
 	return r
 }
 
-func (r ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestInlineAdditionalPropertiesExecute(r)
+func (r *ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestInlineAdditionalPropertiesExecute(*r)
 }
 
 /*
@@ -1712,17 +1712,17 @@ type ApiTestJsonFormDataRequest struct {
 	param2 *string
 }
 
-func (r ApiTestJsonFormDataRequest) Param(param string) ApiTestJsonFormDataRequest {
+func (r *ApiTestJsonFormDataRequest) Param(param string) *ApiTestJsonFormDataRequest {
 	r.param = &param
 	return r
 }
-func (r ApiTestJsonFormDataRequest) Param2(param2 string) ApiTestJsonFormDataRequest {
+func (r *ApiTestJsonFormDataRequest) Param2(param2 string) *ApiTestJsonFormDataRequest {
 	r.param2 = &param2
 	return r
 }
 
-func (r ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestJsonFormDataExecute(r)
+func (r *ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestJsonFormDataExecute(*r)
 }
 
 /*
@@ -1823,29 +1823,29 @@ type ApiTestQueryParameterCollectionFormatRequest struct {
 	context *[]string
 }
 
-func (r ApiTestQueryParameterCollectionFormatRequest) Pipe(pipe []string) ApiTestQueryParameterCollectionFormatRequest {
+func (r *ApiTestQueryParameterCollectionFormatRequest) Pipe(pipe []string) *ApiTestQueryParameterCollectionFormatRequest {
 	r.pipe = &pipe
 	return r
 }
-func (r ApiTestQueryParameterCollectionFormatRequest) Ioutil(ioutil []string) ApiTestQueryParameterCollectionFormatRequest {
+func (r *ApiTestQueryParameterCollectionFormatRequest) Ioutil(ioutil []string) *ApiTestQueryParameterCollectionFormatRequest {
 	r.ioutil = &ioutil
 	return r
 }
-func (r ApiTestQueryParameterCollectionFormatRequest) Http(http []string) ApiTestQueryParameterCollectionFormatRequest {
+func (r *ApiTestQueryParameterCollectionFormatRequest) Http(http []string) *ApiTestQueryParameterCollectionFormatRequest {
 	r.http = &http
 	return r
 }
-func (r ApiTestQueryParameterCollectionFormatRequest) Url(url []string) ApiTestQueryParameterCollectionFormatRequest {
+func (r *ApiTestQueryParameterCollectionFormatRequest) Url(url []string) *ApiTestQueryParameterCollectionFormatRequest {
 	r.url = &url
 	return r
 }
-func (r ApiTestQueryParameterCollectionFormatRequest) Context(context []string) ApiTestQueryParameterCollectionFormatRequest {
+func (r *ApiTestQueryParameterCollectionFormatRequest) Context(context []string) *ApiTestQueryParameterCollectionFormatRequest {
 	r.context = &context
 	return r
 }
 
-func (r ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestQueryParameterCollectionFormatExecute(r)
+func (r *ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestQueryParameterCollectionFormatExecute(*r)
 }
 
 /*

--- a/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -49,13 +49,13 @@ type ApiTestClassnameRequest struct {
 	body *Client
 }
 
-func (r ApiTestClassnameRequest) Body(body Client) ApiTestClassnameRequest {
+func (r *ApiTestClassnameRequest) Body(body Client) *ApiTestClassnameRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
-	return r.ApiService.TestClassnameExecute(r)
+func (r *ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
+	return r.ApiService.TestClassnameExecute(*r)
 }
 
 /*

--- a/samples/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/client/petstore/go/go-petstore/api_pet.go
@@ -158,13 +158,13 @@ type ApiAddPetRequest struct {
 	body *Pet
 }
 
-func (r ApiAddPetRequest) Body(body Pet) ApiAddPetRequest {
+func (r *ApiAddPetRequest) Body(body Pet) *ApiAddPetRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiAddPetRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.AddPetExecute(r)
+func (r *ApiAddPetRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.AddPetExecute(*r)
 }
 
 /*
@@ -259,13 +259,13 @@ type ApiDeletePetRequest struct {
 	apiKey *string
 }
 
-func (r ApiDeletePetRequest) ApiKey(apiKey string) ApiDeletePetRequest {
+func (r *ApiDeletePetRequest) ApiKey(apiKey string) *ApiDeletePetRequest {
 	r.apiKey = &apiKey
 	return r
 }
 
-func (r ApiDeletePetRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.DeletePetExecute(r)
+func (r *ApiDeletePetRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.DeletePetExecute(*r)
 }
 
 /*
@@ -360,13 +360,13 @@ type ApiFindPetsByStatusRequest struct {
 	status *[]string
 }
 
-func (r ApiFindPetsByStatusRequest) Status(status []string) ApiFindPetsByStatusRequest {
+func (r *ApiFindPetsByStatusRequest) Status(status []string) *ApiFindPetsByStatusRequest {
 	r.status = &status
 	return r
 }
 
-func (r ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error) {
-	return r.ApiService.FindPetsByStatusExecute(r)
+func (r *ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error) {
+	return r.ApiService.FindPetsByStatusExecute(*r)
 }
 
 /*
@@ -471,13 +471,13 @@ type ApiFindPetsByTagsRequest struct {
 	tags *[]string
 }
 
-func (r ApiFindPetsByTagsRequest) Tags(tags []string) ApiFindPetsByTagsRequest {
+func (r *ApiFindPetsByTagsRequest) Tags(tags []string) *ApiFindPetsByTagsRequest {
 	r.tags = &tags
 	return r
 }
 
-func (r ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
-	return r.ApiService.FindPetsByTagsExecute(r)
+func (r *ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
+	return r.ApiService.FindPetsByTagsExecute(*r)
 }
 
 /*
@@ -583,8 +583,8 @@ type ApiGetPetByIdRequest struct {
 }
 
 
-func (r ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
-	return r.ApiService.GetPetByIdExecute(r)
+func (r *ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
+	return r.ApiService.GetPetByIdExecute(*r)
 }
 
 /*
@@ -702,13 +702,13 @@ type ApiUpdatePetRequest struct {
 	body *Pet
 }
 
-func (r ApiUpdatePetRequest) Body(body Pet) ApiUpdatePetRequest {
+func (r *ApiUpdatePetRequest) Body(body Pet) *ApiUpdatePetRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.UpdatePetExecute(r)
+func (r *ApiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.UpdatePetExecute(*r)
 }
 
 /*
@@ -804,17 +804,17 @@ type ApiUpdatePetWithFormRequest struct {
 	status *string
 }
 
-func (r ApiUpdatePetWithFormRequest) Name(name string) ApiUpdatePetWithFormRequest {
+func (r *ApiUpdatePetWithFormRequest) Name(name string) *ApiUpdatePetWithFormRequest {
 	r.name = &name
 	return r
 }
-func (r ApiUpdatePetWithFormRequest) Status(status string) ApiUpdatePetWithFormRequest {
+func (r *ApiUpdatePetWithFormRequest) Status(status string) *ApiUpdatePetWithFormRequest {
 	r.status = &status
 	return r
 }
 
-func (r ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.UpdatePetWithFormExecute(r)
+func (r *ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.UpdatePetWithFormExecute(*r)
 }
 
 /*
@@ -914,17 +914,17 @@ type ApiUploadFileRequest struct {
 	file **os.File
 }
 
-func (r ApiUploadFileRequest) AdditionalMetadata(additionalMetadata string) ApiUploadFileRequest {
+func (r *ApiUploadFileRequest) AdditionalMetadata(additionalMetadata string) *ApiUploadFileRequest {
 	r.additionalMetadata = &additionalMetadata
 	return r
 }
-func (r ApiUploadFileRequest) File(file *os.File) ApiUploadFileRequest {
+func (r *ApiUploadFileRequest) File(file *os.File) *ApiUploadFileRequest {
 	r.file = &file
 	return r
 }
 
-func (r ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
-	return r.ApiService.UploadFileExecute(r)
+func (r *ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
+	return r.ApiService.UploadFileExecute(*r)
 }
 
 /*
@@ -1043,17 +1043,17 @@ type ApiUploadFileWithRequiredFileRequest struct {
 	additionalMetadata *string
 }
 
-func (r ApiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile *os.File) ApiUploadFileWithRequiredFileRequest {
+func (r *ApiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile *os.File) *ApiUploadFileWithRequiredFileRequest {
 	r.requiredFile = &requiredFile
 	return r
 }
-func (r ApiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetadata string) ApiUploadFileWithRequiredFileRequest {
+func (r *ApiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetadata string) *ApiUploadFileWithRequiredFileRequest {
 	r.additionalMetadata = &additionalMetadata
 	return r
 }
 
-func (r ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
-	return r.ApiService.UploadFileWithRequiredFileExecute(r)
+func (r *ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
+	return r.ApiService.UploadFileWithRequiredFileExecute(*r)
 }
 
 /*

--- a/samples/client/petstore/go/go-petstore/api_store.go
+++ b/samples/client/petstore/go/go-petstore/api_store.go
@@ -93,8 +93,8 @@ type ApiDeleteOrderRequest struct {
 }
 
 
-func (r ApiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.DeleteOrderExecute(r)
+func (r *ApiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteOrderExecute(*r)
 }
 
 /*
@@ -187,8 +187,8 @@ type ApiGetInventoryRequest struct {
 }
 
 
-func (r ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, error) {
-	return r.ApiService.GetInventoryExecute(r)
+func (r *ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, error) {
+	return r.ApiService.GetInventoryExecute(*r)
 }
 
 /*
@@ -304,8 +304,8 @@ type ApiGetOrderByIdRequest struct {
 }
 
 
-func (r ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
-	return r.ApiService.GetOrderByIdExecute(r)
+func (r *ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
+	return r.ApiService.GetOrderByIdExecute(*r)
 }
 
 /*
@@ -415,13 +415,13 @@ type ApiPlaceOrderRequest struct {
 	body *Order
 }
 
-func (r ApiPlaceOrderRequest) Body(body Order) ApiPlaceOrderRequest {
+func (r *ApiPlaceOrderRequest) Body(body Order) *ApiPlaceOrderRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
-	return r.ApiService.PlaceOrderExecute(r)
+func (r *ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
+	return r.ApiService.PlaceOrderExecute(*r)
 }
 
 /*

--- a/samples/client/petstore/go/go-petstore/api_user.go
+++ b/samples/client/petstore/go/go-petstore/api_user.go
@@ -140,13 +140,13 @@ type ApiCreateUserRequest struct {
 	body *User
 }
 
-func (r ApiCreateUserRequest) Body(body User) ApiCreateUserRequest {
+func (r *ApiCreateUserRequest) Body(body User) *ApiCreateUserRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiCreateUserRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.CreateUserExecute(r)
+func (r *ApiCreateUserRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.CreateUserExecute(*r)
 }
 
 /*
@@ -241,13 +241,13 @@ type ApiCreateUsersWithArrayInputRequest struct {
 	body *[]User
 }
 
-func (r ApiCreateUsersWithArrayInputRequest) Body(body []User) ApiCreateUsersWithArrayInputRequest {
+func (r *ApiCreateUsersWithArrayInputRequest) Body(body []User) *ApiCreateUsersWithArrayInputRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.CreateUsersWithArrayInputExecute(r)
+func (r *ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.CreateUsersWithArrayInputExecute(*r)
 }
 
 /*
@@ -341,13 +341,13 @@ type ApiCreateUsersWithListInputRequest struct {
 	body *[]User
 }
 
-func (r ApiCreateUsersWithListInputRequest) Body(body []User) ApiCreateUsersWithListInputRequest {
+func (r *ApiCreateUsersWithListInputRequest) Body(body []User) *ApiCreateUsersWithListInputRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.CreateUsersWithListInputExecute(r)
+func (r *ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.CreateUsersWithListInputExecute(*r)
 }
 
 /*
@@ -442,8 +442,8 @@ type ApiDeleteUserRequest struct {
 }
 
 
-func (r ApiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.DeleteUserExecute(r)
+func (r *ApiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteUserExecute(*r)
 }
 
 /*
@@ -537,8 +537,8 @@ type ApiGetUserByNameRequest struct {
 }
 
 
-func (r ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
-	return r.ApiService.GetUserByNameExecute(r)
+func (r *ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
+	return r.ApiService.GetUserByNameExecute(*r)
 }
 
 /*
@@ -642,17 +642,17 @@ type ApiLoginUserRequest struct {
 	password *string
 }
 
-func (r ApiLoginUserRequest) Username(username string) ApiLoginUserRequest {
+func (r *ApiLoginUserRequest) Username(username string) *ApiLoginUserRequest {
 	r.username = &username
 	return r
 }
-func (r ApiLoginUserRequest) Password(password string) ApiLoginUserRequest {
+func (r *ApiLoginUserRequest) Password(password string) *ApiLoginUserRequest {
 	r.password = &password
 	return r
 }
 
-func (r ApiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
-	return r.ApiService.LoginUserExecute(r)
+func (r *ApiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
+	return r.ApiService.LoginUserExecute(*r)
 }
 
 /*
@@ -760,8 +760,8 @@ type ApiLogoutUserRequest struct {
 }
 
 
-func (r ApiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.LogoutUserExecute(r)
+func (r *ApiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.LogoutUserExecute(*r)
 }
 
 /*
@@ -851,13 +851,13 @@ type ApiUpdateUserRequest struct {
 	body *User
 }
 
-func (r ApiUpdateUserRequest) Body(body User) ApiUpdateUserRequest {
+func (r *ApiUpdateUserRequest) Body(body User) *ApiUpdateUserRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.UpdateUserExecute(r)
+func (r *ApiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.UpdateUserExecute(*r)
 }
 
 /*

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/api_usage.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/api_usage.go
@@ -32,8 +32,8 @@ type ApiAnyKeyRequest struct {
 }
 
 
-func (r ApiAnyKeyRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
-	return r.ApiService.AnyKeyExecute(r)
+func (r *ApiAnyKeyRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
+	return r.ApiService.AnyKeyExecute(*r)
 }
 
 /*
@@ -162,8 +162,8 @@ type ApiBothKeysRequest struct {
 }
 
 
-func (r ApiBothKeysRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
-	return r.ApiService.BothKeysExecute(r)
+func (r *ApiBothKeysRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
+	return r.ApiService.BothKeysExecute(*r)
 }
 
 /*
@@ -292,8 +292,8 @@ type ApiKeyInHeaderRequest struct {
 }
 
 
-func (r ApiKeyInHeaderRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
-	return r.ApiService.KeyInHeaderExecute(r)
+func (r *ApiKeyInHeaderRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
+	return r.ApiService.KeyInHeaderExecute(*r)
 }
 
 /*
@@ -408,8 +408,8 @@ type ApiKeyInQueryRequest struct {
 }
 
 
-func (r ApiKeyInQueryRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
-	return r.ApiService.KeyInQueryExecute(r)
+func (r *ApiKeyInQueryRequest) Execute() (map[string]interface{}, *_nethttp.Response, error) {
+	return r.ApiService.KeyInQueryExecute(*r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_another_fake.go
@@ -49,13 +49,13 @@ type ApiCall123TestSpecialTagsRequest struct {
 	client *Client
 }
 
-func (r ApiCall123TestSpecialTagsRequest) Client(client Client) ApiCall123TestSpecialTagsRequest {
+func (r *ApiCall123TestSpecialTagsRequest) Client(client Client) *ApiCall123TestSpecialTagsRequest {
 	r.client = &client
 	return r
 }
 
-func (r ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, error) {
-	return r.ApiService.Call123TestSpecialTagsExecute(r)
+func (r *ApiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, error) {
+	return r.ApiService.Call123TestSpecialTagsExecute(*r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go/go-petstore/api_default.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_default.go
@@ -48,8 +48,8 @@ type ApiFooGetRequest struct {
 }
 
 
-func (r ApiFooGetRequest) Execute() (InlineResponseDefault, *_nethttp.Response, error) {
-	return r.ApiService.FooGetExecute(r)
+func (r *ApiFooGetRequest) Execute() (InlineResponseDefault, *_nethttp.Response, error) {
+	return r.ApiService.FooGetExecute(*r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
@@ -226,8 +226,8 @@ type ApiFakeHealthGetRequest struct {
 }
 
 
-func (r ApiFakeHealthGetRequest) Execute() (HealthCheckResult, *_nethttp.Response, error) {
-	return r.ApiService.FakeHealthGetExecute(r)
+func (r *ApiFakeHealthGetRequest) Execute() (HealthCheckResult, *_nethttp.Response, error) {
+	return r.ApiService.FakeHealthGetExecute(*r)
 }
 
 /*
@@ -327,13 +327,13 @@ type ApiFakeOuterBooleanSerializeRequest struct {
 	body *bool
 }
 
-func (r ApiFakeOuterBooleanSerializeRequest) Body(body bool) ApiFakeOuterBooleanSerializeRequest {
+func (r *ApiFakeOuterBooleanSerializeRequest) Body(body bool) *ApiFakeOuterBooleanSerializeRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, error) {
-	return r.ApiService.FakeOuterBooleanSerializeExecute(r)
+func (r *ApiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, error) {
+	return r.ApiService.FakeOuterBooleanSerializeExecute(*r)
 }
 
 /*
@@ -436,13 +436,13 @@ type ApiFakeOuterCompositeSerializeRequest struct {
 	outerComposite *OuterComposite
 }
 
-func (r ApiFakeOuterCompositeSerializeRequest) OuterComposite(outerComposite OuterComposite) ApiFakeOuterCompositeSerializeRequest {
+func (r *ApiFakeOuterCompositeSerializeRequest) OuterComposite(outerComposite OuterComposite) *ApiFakeOuterCompositeSerializeRequest {
 	r.outerComposite = &outerComposite
 	return r
 }
 
-func (r ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, error) {
-	return r.ApiService.FakeOuterCompositeSerializeExecute(r)
+func (r *ApiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, error) {
+	return r.ApiService.FakeOuterCompositeSerializeExecute(*r)
 }
 
 /*
@@ -545,13 +545,13 @@ type ApiFakeOuterNumberSerializeRequest struct {
 	body *float32
 }
 
-func (r ApiFakeOuterNumberSerializeRequest) Body(body float32) ApiFakeOuterNumberSerializeRequest {
+func (r *ApiFakeOuterNumberSerializeRequest) Body(body float32) *ApiFakeOuterNumberSerializeRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, error) {
-	return r.ApiService.FakeOuterNumberSerializeExecute(r)
+func (r *ApiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, error) {
+	return r.ApiService.FakeOuterNumberSerializeExecute(*r)
 }
 
 /*
@@ -654,13 +654,13 @@ type ApiFakeOuterStringSerializeRequest struct {
 	body *string
 }
 
-func (r ApiFakeOuterStringSerializeRequest) Body(body string) ApiFakeOuterStringSerializeRequest {
+func (r *ApiFakeOuterStringSerializeRequest) Body(body string) *ApiFakeOuterStringSerializeRequest {
 	r.body = &body
 	return r
 }
 
-func (r ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, error) {
-	return r.ApiService.FakeOuterStringSerializeExecute(r)
+func (r *ApiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, error) {
+	return r.ApiService.FakeOuterStringSerializeExecute(*r)
 }
 
 /*
@@ -763,13 +763,13 @@ type ApiTestBodyWithFileSchemaRequest struct {
 	fileSchemaTestClass *FileSchemaTestClass
 }
 
-func (r ApiTestBodyWithFileSchemaRequest) FileSchemaTestClass(fileSchemaTestClass FileSchemaTestClass) ApiTestBodyWithFileSchemaRequest {
+func (r *ApiTestBodyWithFileSchemaRequest) FileSchemaTestClass(fileSchemaTestClass FileSchemaTestClass) *ApiTestBodyWithFileSchemaRequest {
 	r.fileSchemaTestClass = &fileSchemaTestClass
 	return r
 }
 
-func (r ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestBodyWithFileSchemaExecute(r)
+func (r *ApiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestBodyWithFileSchemaExecute(*r)
 }
 
 /*
@@ -865,17 +865,17 @@ type ApiTestBodyWithQueryParamsRequest struct {
 	user *User
 }
 
-func (r ApiTestBodyWithQueryParamsRequest) Query(query string) ApiTestBodyWithQueryParamsRequest {
+func (r *ApiTestBodyWithQueryParamsRequest) Query(query string) *ApiTestBodyWithQueryParamsRequest {
 	r.query = &query
 	return r
 }
-func (r ApiTestBodyWithQueryParamsRequest) User(user User) ApiTestBodyWithQueryParamsRequest {
+func (r *ApiTestBodyWithQueryParamsRequest) User(user User) *ApiTestBodyWithQueryParamsRequest {
 	r.user = &user
 	return r
 }
 
-func (r ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestBodyWithQueryParamsExecute(r)
+func (r *ApiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestBodyWithQueryParamsExecute(*r)
 }
 
 /*
@@ -973,13 +973,13 @@ type ApiTestClientModelRequest struct {
 	client *Client
 }
 
-func (r ApiTestClientModelRequest) Client(client Client) ApiTestClientModelRequest {
+func (r *ApiTestClientModelRequest) Client(client Client) *ApiTestClientModelRequest {
 	r.client = &client
 	return r
 }
 
-func (r ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error) {
-	return r.ApiService.TestClientModelExecute(r)
+func (r *ApiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error) {
+	return r.ApiService.TestClientModelExecute(*r)
 }
 
 /*
@@ -1098,65 +1098,65 @@ type ApiTestEndpointParametersRequest struct {
 	callback *string
 }
 
-func (r ApiTestEndpointParametersRequest) Number(number float32) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Number(number float32) *ApiTestEndpointParametersRequest {
 	r.number = &number
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Double(double float64) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Double(double float64) *ApiTestEndpointParametersRequest {
 	r.double = &double
 	return r
 }
-func (r ApiTestEndpointParametersRequest) PatternWithoutDelimiter(patternWithoutDelimiter string) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) PatternWithoutDelimiter(patternWithoutDelimiter string) *ApiTestEndpointParametersRequest {
 	r.patternWithoutDelimiter = &patternWithoutDelimiter
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Byte_(byte_ string) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Byte_(byte_ string) *ApiTestEndpointParametersRequest {
 	r.byte_ = &byte_
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Integer(integer int32) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Integer(integer int32) *ApiTestEndpointParametersRequest {
 	r.integer = &integer
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Int32_(int32_ int32) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Int32_(int32_ int32) *ApiTestEndpointParametersRequest {
 	r.int32_ = &int32_
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Int64_(int64_ int64) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Int64_(int64_ int64) *ApiTestEndpointParametersRequest {
 	r.int64_ = &int64_
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Float(float float32) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Float(float float32) *ApiTestEndpointParametersRequest {
 	r.float = &float
 	return r
 }
-func (r ApiTestEndpointParametersRequest) String_(string_ string) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) String_(string_ string) *ApiTestEndpointParametersRequest {
 	r.string_ = &string_
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Binary(binary *os.File) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Binary(binary *os.File) *ApiTestEndpointParametersRequest {
 	r.binary = &binary
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Date(date string) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Date(date string) *ApiTestEndpointParametersRequest {
 	r.date = &date
 	return r
 }
-func (r ApiTestEndpointParametersRequest) DateTime(dateTime time.Time) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) DateTime(dateTime time.Time) *ApiTestEndpointParametersRequest {
 	r.dateTime = &dateTime
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Password(password string) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Password(password string) *ApiTestEndpointParametersRequest {
 	r.password = &password
 	return r
 }
-func (r ApiTestEndpointParametersRequest) Callback(callback string) ApiTestEndpointParametersRequest {
+func (r *ApiTestEndpointParametersRequest) Callback(callback string) *ApiTestEndpointParametersRequest {
 	r.callback = &callback
 	return r
 }
 
-func (r ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestEndpointParametersExecute(r)
+func (r *ApiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestEndpointParametersExecute(*r)
 }
 
 /*
@@ -1323,41 +1323,41 @@ type ApiTestEnumParametersRequest struct {
 	enumFormString *string
 }
 
-func (r ApiTestEnumParametersRequest) EnumHeaderStringArray(enumHeaderStringArray []string) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumHeaderStringArray(enumHeaderStringArray []string) *ApiTestEnumParametersRequest {
 	r.enumHeaderStringArray = &enumHeaderStringArray
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumHeaderString(enumHeaderString string) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumHeaderString(enumHeaderString string) *ApiTestEnumParametersRequest {
 	r.enumHeaderString = &enumHeaderString
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryStringArray(enumQueryStringArray []string) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumQueryStringArray(enumQueryStringArray []string) *ApiTestEnumParametersRequest {
 	r.enumQueryStringArray = &enumQueryStringArray
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryString(enumQueryString string) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumQueryString(enumQueryString string) *ApiTestEnumParametersRequest {
 	r.enumQueryString = &enumQueryString
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryInteger(enumQueryInteger int32) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumQueryInteger(enumQueryInteger int32) *ApiTestEnumParametersRequest {
 	r.enumQueryInteger = &enumQueryInteger
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumQueryDouble(enumQueryDouble float64) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumQueryDouble(enumQueryDouble float64) *ApiTestEnumParametersRequest {
 	r.enumQueryDouble = &enumQueryDouble
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumFormStringArray(enumFormStringArray []string) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumFormStringArray(enumFormStringArray []string) *ApiTestEnumParametersRequest {
 	r.enumFormStringArray = &enumFormStringArray
 	return r
 }
-func (r ApiTestEnumParametersRequest) EnumFormString(enumFormString string) ApiTestEnumParametersRequest {
+func (r *ApiTestEnumParametersRequest) EnumFormString(enumFormString string) *ApiTestEnumParametersRequest {
 	r.enumFormString = &enumFormString
 	return r
 }
 
-func (r ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestEnumParametersExecute(r)
+func (r *ApiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestEnumParametersExecute(*r)
 }
 
 /*
@@ -1484,33 +1484,33 @@ type ApiTestGroupParametersRequest struct {
 	int64Group *int64
 }
 
-func (r ApiTestGroupParametersRequest) RequiredStringGroup(requiredStringGroup int32) ApiTestGroupParametersRequest {
+func (r *ApiTestGroupParametersRequest) RequiredStringGroup(requiredStringGroup int32) *ApiTestGroupParametersRequest {
 	r.requiredStringGroup = &requiredStringGroup
 	return r
 }
-func (r ApiTestGroupParametersRequest) RequiredBooleanGroup(requiredBooleanGroup bool) ApiTestGroupParametersRequest {
+func (r *ApiTestGroupParametersRequest) RequiredBooleanGroup(requiredBooleanGroup bool) *ApiTestGroupParametersRequest {
 	r.requiredBooleanGroup = &requiredBooleanGroup
 	return r
 }
-func (r ApiTestGroupParametersRequest) RequiredInt64Group(requiredInt64Group int64) ApiTestGroupParametersRequest {
+func (r *ApiTestGroupParametersRequest) RequiredInt64Group(requiredInt64Group int64) *ApiTestGroupParametersRequest {
 	r.requiredInt64Group = &requiredInt64Group
 	return r
 }
-func (r ApiTestGroupParametersRequest) StringGroup(stringGroup int32) ApiTestGroupParametersRequest {
+func (r *ApiTestGroupParametersRequest) StringGroup(stringGroup int32) *ApiTestGroupParametersRequest {
 	r.stringGroup = &stringGroup
 	return r
 }
-func (r ApiTestGroupParametersRequest) BooleanGroup(booleanGroup bool) ApiTestGroupParametersRequest {
+func (r *ApiTestGroupParametersRequest) BooleanGroup(booleanGroup bool) *ApiTestGroupParametersRequest {
 	r.booleanGroup = &booleanGroup
 	return r
 }
-func (r ApiTestGroupParametersRequest) Int64Group(int64Group int64) ApiTestGroupParametersRequest {
+func (r *ApiTestGroupParametersRequest) Int64Group(int64Group int64) *ApiTestGroupParametersRequest {
 	r.int64Group = &int64Group
 	return r
 }
 
-func (r ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestGroupParametersExecute(r)
+func (r *ApiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestGroupParametersExecute(*r)
 }
 
 /*
@@ -1621,13 +1621,13 @@ type ApiTestInlineAdditionalPropertiesRequest struct {
 	requestBody *map[string]string
 }
 
-func (r ApiTestInlineAdditionalPropertiesRequest) RequestBody(requestBody map[string]string) ApiTestInlineAdditionalPropertiesRequest {
+func (r *ApiTestInlineAdditionalPropertiesRequest) RequestBody(requestBody map[string]string) *ApiTestInlineAdditionalPropertiesRequest {
 	r.requestBody = &requestBody
 	return r
 }
 
-func (r ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestInlineAdditionalPropertiesExecute(r)
+func (r *ApiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestInlineAdditionalPropertiesExecute(*r)
 }
 
 /*
@@ -1722,17 +1722,17 @@ type ApiTestJsonFormDataRequest struct {
 	param2 *string
 }
 
-func (r ApiTestJsonFormDataRequest) Param(param string) ApiTestJsonFormDataRequest {
+func (r *ApiTestJsonFormDataRequest) Param(param string) *ApiTestJsonFormDataRequest {
 	r.param = &param
 	return r
 }
-func (r ApiTestJsonFormDataRequest) Param2(param2 string) ApiTestJsonFormDataRequest {
+func (r *ApiTestJsonFormDataRequest) Param2(param2 string) *ApiTestJsonFormDataRequest {
 	r.param2 = &param2
 	return r
 }
 
-func (r ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestJsonFormDataExecute(r)
+func (r *ApiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestJsonFormDataExecute(*r)
 }
 
 /*
@@ -1833,29 +1833,29 @@ type ApiTestQueryParameterCollectionFormatRequest struct {
 	context *[]string
 }
 
-func (r ApiTestQueryParameterCollectionFormatRequest) Pipe(pipe []string) ApiTestQueryParameterCollectionFormatRequest {
+func (r *ApiTestQueryParameterCollectionFormatRequest) Pipe(pipe []string) *ApiTestQueryParameterCollectionFormatRequest {
 	r.pipe = &pipe
 	return r
 }
-func (r ApiTestQueryParameterCollectionFormatRequest) Ioutil(ioutil []string) ApiTestQueryParameterCollectionFormatRequest {
+func (r *ApiTestQueryParameterCollectionFormatRequest) Ioutil(ioutil []string) *ApiTestQueryParameterCollectionFormatRequest {
 	r.ioutil = &ioutil
 	return r
 }
-func (r ApiTestQueryParameterCollectionFormatRequest) Http(http []string) ApiTestQueryParameterCollectionFormatRequest {
+func (r *ApiTestQueryParameterCollectionFormatRequest) Http(http []string) *ApiTestQueryParameterCollectionFormatRequest {
 	r.http = &http
 	return r
 }
-func (r ApiTestQueryParameterCollectionFormatRequest) Url(url []string) ApiTestQueryParameterCollectionFormatRequest {
+func (r *ApiTestQueryParameterCollectionFormatRequest) Url(url []string) *ApiTestQueryParameterCollectionFormatRequest {
 	r.url = &url
 	return r
 }
-func (r ApiTestQueryParameterCollectionFormatRequest) Context(context []string) ApiTestQueryParameterCollectionFormatRequest {
+func (r *ApiTestQueryParameterCollectionFormatRequest) Context(context []string) *ApiTestQueryParameterCollectionFormatRequest {
 	r.context = &context
 	return r
 }
 
-func (r ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.TestQueryParameterCollectionFormatExecute(r)
+func (r *ApiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.TestQueryParameterCollectionFormatExecute(*r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -49,13 +49,13 @@ type ApiTestClassnameRequest struct {
 	client *Client
 }
 
-func (r ApiTestClassnameRequest) Client(client Client) ApiTestClassnameRequest {
+func (r *ApiTestClassnameRequest) Client(client Client) *ApiTestClassnameRequest {
 	r.client = &client
 	return r
 }
 
-func (r ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
-	return r.ApiService.TestClassnameExecute(r)
+func (r *ApiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
+	return r.ApiService.TestClassnameExecute(*r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
@@ -158,13 +158,13 @@ type ApiAddPetRequest struct {
 	pet *Pet
 }
 
-func (r ApiAddPetRequest) Pet(pet Pet) ApiAddPetRequest {
+func (r *ApiAddPetRequest) Pet(pet Pet) *ApiAddPetRequest {
 	r.pet = &pet
 	return r
 }
 
-func (r ApiAddPetRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.AddPetExecute(r)
+func (r *ApiAddPetRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.AddPetExecute(*r)
 }
 
 /*
@@ -259,13 +259,13 @@ type ApiDeletePetRequest struct {
 	apiKey *string
 }
 
-func (r ApiDeletePetRequest) ApiKey(apiKey string) ApiDeletePetRequest {
+func (r *ApiDeletePetRequest) ApiKey(apiKey string) *ApiDeletePetRequest {
 	r.apiKey = &apiKey
 	return r
 }
 
-func (r ApiDeletePetRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.DeletePetExecute(r)
+func (r *ApiDeletePetRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.DeletePetExecute(*r)
 }
 
 /*
@@ -360,13 +360,13 @@ type ApiFindPetsByStatusRequest struct {
 	status *[]string
 }
 
-func (r ApiFindPetsByStatusRequest) Status(status []string) ApiFindPetsByStatusRequest {
+func (r *ApiFindPetsByStatusRequest) Status(status []string) *ApiFindPetsByStatusRequest {
 	r.status = &status
 	return r
 }
 
-func (r ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error) {
-	return r.ApiService.FindPetsByStatusExecute(r)
+func (r *ApiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error) {
+	return r.ApiService.FindPetsByStatusExecute(*r)
 }
 
 /*
@@ -471,13 +471,13 @@ type ApiFindPetsByTagsRequest struct {
 	tags *[]string
 }
 
-func (r ApiFindPetsByTagsRequest) Tags(tags []string) ApiFindPetsByTagsRequest {
+func (r *ApiFindPetsByTagsRequest) Tags(tags []string) *ApiFindPetsByTagsRequest {
 	r.tags = &tags
 	return r
 }
 
-func (r ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
-	return r.ApiService.FindPetsByTagsExecute(r)
+func (r *ApiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
+	return r.ApiService.FindPetsByTagsExecute(*r)
 }
 
 /*
@@ -583,8 +583,8 @@ type ApiGetPetByIdRequest struct {
 }
 
 
-func (r ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
-	return r.ApiService.GetPetByIdExecute(r)
+func (r *ApiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
+	return r.ApiService.GetPetByIdExecute(*r)
 }
 
 /*
@@ -702,13 +702,13 @@ type ApiUpdatePetRequest struct {
 	pet *Pet
 }
 
-func (r ApiUpdatePetRequest) Pet(pet Pet) ApiUpdatePetRequest {
+func (r *ApiUpdatePetRequest) Pet(pet Pet) *ApiUpdatePetRequest {
 	r.pet = &pet
 	return r
 }
 
-func (r ApiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.UpdatePetExecute(r)
+func (r *ApiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.UpdatePetExecute(*r)
 }
 
 /*
@@ -804,17 +804,17 @@ type ApiUpdatePetWithFormRequest struct {
 	status *string
 }
 
-func (r ApiUpdatePetWithFormRequest) Name(name string) ApiUpdatePetWithFormRequest {
+func (r *ApiUpdatePetWithFormRequest) Name(name string) *ApiUpdatePetWithFormRequest {
 	r.name = &name
 	return r
 }
-func (r ApiUpdatePetWithFormRequest) Status(status string) ApiUpdatePetWithFormRequest {
+func (r *ApiUpdatePetWithFormRequest) Status(status string) *ApiUpdatePetWithFormRequest {
 	r.status = &status
 	return r
 }
 
-func (r ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.UpdatePetWithFormExecute(r)
+func (r *ApiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.UpdatePetWithFormExecute(*r)
 }
 
 /*
@@ -914,17 +914,17 @@ type ApiUploadFileRequest struct {
 	file **os.File
 }
 
-func (r ApiUploadFileRequest) AdditionalMetadata(additionalMetadata string) ApiUploadFileRequest {
+func (r *ApiUploadFileRequest) AdditionalMetadata(additionalMetadata string) *ApiUploadFileRequest {
 	r.additionalMetadata = &additionalMetadata
 	return r
 }
-func (r ApiUploadFileRequest) File(file *os.File) ApiUploadFileRequest {
+func (r *ApiUploadFileRequest) File(file *os.File) *ApiUploadFileRequest {
 	r.file = &file
 	return r
 }
 
-func (r ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
-	return r.ApiService.UploadFileExecute(r)
+func (r *ApiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
+	return r.ApiService.UploadFileExecute(*r)
 }
 
 /*
@@ -1043,17 +1043,17 @@ type ApiUploadFileWithRequiredFileRequest struct {
 	additionalMetadata *string
 }
 
-func (r ApiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile *os.File) ApiUploadFileWithRequiredFileRequest {
+func (r *ApiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile *os.File) *ApiUploadFileWithRequiredFileRequest {
 	r.requiredFile = &requiredFile
 	return r
 }
-func (r ApiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetadata string) ApiUploadFileWithRequiredFileRequest {
+func (r *ApiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetadata string) *ApiUploadFileWithRequiredFileRequest {
 	r.additionalMetadata = &additionalMetadata
 	return r
 }
 
-func (r ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
-	return r.ApiService.UploadFileWithRequiredFileExecute(r)
+func (r *ApiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
+	return r.ApiService.UploadFileWithRequiredFileExecute(*r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go/go-petstore/api_store.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_store.go
@@ -93,8 +93,8 @@ type ApiDeleteOrderRequest struct {
 }
 
 
-func (r ApiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.DeleteOrderExecute(r)
+func (r *ApiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteOrderExecute(*r)
 }
 
 /*
@@ -187,8 +187,8 @@ type ApiGetInventoryRequest struct {
 }
 
 
-func (r ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, error) {
-	return r.ApiService.GetInventoryExecute(r)
+func (r *ApiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, error) {
+	return r.ApiService.GetInventoryExecute(*r)
 }
 
 /*
@@ -304,8 +304,8 @@ type ApiGetOrderByIdRequest struct {
 }
 
 
-func (r ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
-	return r.ApiService.GetOrderByIdExecute(r)
+func (r *ApiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
+	return r.ApiService.GetOrderByIdExecute(*r)
 }
 
 /*
@@ -415,13 +415,13 @@ type ApiPlaceOrderRequest struct {
 	order *Order
 }
 
-func (r ApiPlaceOrderRequest) Order(order Order) ApiPlaceOrderRequest {
+func (r *ApiPlaceOrderRequest) Order(order Order) *ApiPlaceOrderRequest {
 	r.order = &order
 	return r
 }
 
-func (r ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
-	return r.ApiService.PlaceOrderExecute(r)
+func (r *ApiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
+	return r.ApiService.PlaceOrderExecute(*r)
 }
 
 /*

--- a/samples/openapi3/client/petstore/go/go-petstore/api_user.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_user.go
@@ -140,13 +140,13 @@ type ApiCreateUserRequest struct {
 	user *User
 }
 
-func (r ApiCreateUserRequest) User(user User) ApiCreateUserRequest {
+func (r *ApiCreateUserRequest) User(user User) *ApiCreateUserRequest {
 	r.user = &user
 	return r
 }
 
-func (r ApiCreateUserRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.CreateUserExecute(r)
+func (r *ApiCreateUserRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.CreateUserExecute(*r)
 }
 
 /*
@@ -241,13 +241,13 @@ type ApiCreateUsersWithArrayInputRequest struct {
 	user *[]User
 }
 
-func (r ApiCreateUsersWithArrayInputRequest) User(user []User) ApiCreateUsersWithArrayInputRequest {
+func (r *ApiCreateUsersWithArrayInputRequest) User(user []User) *ApiCreateUsersWithArrayInputRequest {
 	r.user = &user
 	return r
 }
 
-func (r ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.CreateUsersWithArrayInputExecute(r)
+func (r *ApiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.CreateUsersWithArrayInputExecute(*r)
 }
 
 /*
@@ -341,13 +341,13 @@ type ApiCreateUsersWithListInputRequest struct {
 	user *[]User
 }
 
-func (r ApiCreateUsersWithListInputRequest) User(user []User) ApiCreateUsersWithListInputRequest {
+func (r *ApiCreateUsersWithListInputRequest) User(user []User) *ApiCreateUsersWithListInputRequest {
 	r.user = &user
 	return r
 }
 
-func (r ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.CreateUsersWithListInputExecute(r)
+func (r *ApiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.CreateUsersWithListInputExecute(*r)
 }
 
 /*
@@ -442,8 +442,8 @@ type ApiDeleteUserRequest struct {
 }
 
 
-func (r ApiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.DeleteUserExecute(r)
+func (r *ApiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteUserExecute(*r)
 }
 
 /*
@@ -537,8 +537,8 @@ type ApiGetUserByNameRequest struct {
 }
 
 
-func (r ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
-	return r.ApiService.GetUserByNameExecute(r)
+func (r *ApiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
+	return r.ApiService.GetUserByNameExecute(*r)
 }
 
 /*
@@ -642,17 +642,17 @@ type ApiLoginUserRequest struct {
 	password *string
 }
 
-func (r ApiLoginUserRequest) Username(username string) ApiLoginUserRequest {
+func (r *ApiLoginUserRequest) Username(username string) *ApiLoginUserRequest {
 	r.username = &username
 	return r
 }
-func (r ApiLoginUserRequest) Password(password string) ApiLoginUserRequest {
+func (r *ApiLoginUserRequest) Password(password string) *ApiLoginUserRequest {
 	r.password = &password
 	return r
 }
 
-func (r ApiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
-	return r.ApiService.LoginUserExecute(r)
+func (r *ApiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
+	return r.ApiService.LoginUserExecute(*r)
 }
 
 /*
@@ -760,8 +760,8 @@ type ApiLogoutUserRequest struct {
 }
 
 
-func (r ApiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.LogoutUserExecute(r)
+func (r *ApiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.LogoutUserExecute(*r)
 }
 
 /*
@@ -851,13 +851,13 @@ type ApiUpdateUserRequest struct {
 	user *User
 }
 
-func (r ApiUpdateUserRequest) User(user User) ApiUpdateUserRequest {
+func (r *ApiUpdateUserRequest) User(user User) *ApiUpdateUserRequest {
 	r.user = &user
 	return r
 }
 
-func (r ApiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
-	return r.ApiService.UpdateUserExecute(r)
+func (r *ApiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.UpdateUserExecute(*r)
 }
 
 /*


### PR DESCRIPTION
Change `*Api*Request` methods to use pointer receiver.

Tested by generating the definiton from the bug and verifying the code
compiles and produces desired working output.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax  @grokify @kemokemo @jirikuncar
