### PR TITLE
[GO] use latest available oauth2 version

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/go.mod.mustache
+++ b/modules/openapi-generator/src/main/resources/go/go.mod.mustache
@@ -3,7 +3,7 @@ module {{gitHost}}/{{gitUserId}}/{{gitRepoId}}{{#isGoSubmodule}}/{{packageName}}
 go 1.13
 
 require (
-	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
 	{{#withAWSV4Signature}}
 	github.com/aws/aws-sdk-go v1.34.14
 	{{/withAWSV4Signature}}

--- a/samples/client/petstore/go/go-petstore/go.mod
+++ b/samples/client/petstore/go/go-petstore/go.mod
@@ -3,5 +3,5 @@ module github.com/GIT_USER_ID/GIT_REPO_ID
 go 1.13
 
 require (
-	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
 )

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/go.mod
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/go.mod
@@ -3,5 +3,5 @@ module github.com/GIT_USER_ID/GIT_REPO_ID
 go 1.13
 
 require (
-	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
 )

--- a/samples/openapi3/client/petstore/go/go-petstore/go.mod
+++ b/samples/openapi3/client/petstore/go/go-petstore/go.mod
@@ -3,5 +3,5 @@ module github.com/GIT_USER_ID/GIT_REPO_ID
 go 1.13
 
 require (
-	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99
 )


### PR DESCRIPTION
Temporary fix for #8763 till an official release of oauth2 package is actually made

Using the latest available version of this package at the time of writing https://pkg.go.dev/golang.org/x/oauth2?tab=versions