### PR TITLE
[typescript-axios] Support array query arguments

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -83,7 +83,7 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
             if (Array.isArray(object[key])) {
                 searchParams.delete(key);
                 for (const item of object[key]) {
-                    searchParams.set(key, item);
+                    searchParams.append(key, item);
                 }
             } else {
                 searchParams.set(key, object[key]);

--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -80,7 +80,14 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
     for (const object of objects) {
         for (const key in object) {
-            searchParams.set(key, object[key]);
+            if (Array.isArray(object[key])) {
+                searchParams.delete(key);
+                for (const item of object[key]) {
+                    searchParams.set(key, item);
+                }
+            } else {
+                searchParams.set(key, object[key]);
+            }
         }
     }
     url.search = searchParams.toString();

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
@@ -94,7 +94,7 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
             if (Array.isArray(object[key])) {
                 searchParams.delete(key);
                 for (const item of object[key]) {
-                    searchParams.set(key, item);
+                    searchParams.append(key, item);
                 }
             } else {
                 searchParams.set(key, object[key]);

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
@@ -91,7 +91,14 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
     for (const object of objects) {
         for (const key in object) {
-            searchParams.set(key, object[key]);
+            if (Array.isArray(object[key])) {
+                searchParams.delete(key);
+                for (const item of object[key]) {
+                    searchParams.set(key, item);
+                }
+            } else {
+                searchParams.set(key, object[key]);
+            }
         }
     }
     url.search = searchParams.toString();

--- a/samples/client/petstore/typescript-axios/builds/default/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/common.ts
@@ -94,7 +94,7 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
             if (Array.isArray(object[key])) {
                 searchParams.delete(key);
                 for (const item of object[key]) {
-                    searchParams.set(key, item);
+                    searchParams.append(key, item);
                 }
             } else {
                 searchParams.set(key, object[key]);

--- a/samples/client/petstore/typescript-axios/builds/default/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/common.ts
@@ -91,7 +91,14 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
     for (const object of objects) {
         for (const key in object) {
-            searchParams.set(key, object[key]);
+            if (Array.isArray(object[key])) {
+                searchParams.delete(key);
+                for (const item of object[key]) {
+                    searchParams.set(key, item);
+                }
+            } else {
+                searchParams.set(key, object[key]);
+            }
         }
     }
     url.search = searchParams.toString();

--- a/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
@@ -94,7 +94,7 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
             if (Array.isArray(object[key])) {
                 searchParams.delete(key);
                 for (const item of object[key]) {
-                    searchParams.set(key, item);
+                    searchParams.append(key, item);
                 }
             } else {
                 searchParams.set(key, object[key]);

--- a/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
@@ -91,7 +91,14 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
     for (const object of objects) {
         for (const key in object) {
-            searchParams.set(key, object[key]);
+            if (Array.isArray(object[key])) {
+                searchParams.delete(key);
+                for (const item of object[key]) {
+                    searchParams.set(key, item);
+                }
+            } else {
+                searchParams.set(key, object[key]);
+            }
         }
     }
     url.search = searchParams.toString();

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
@@ -94,7 +94,7 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
             if (Array.isArray(object[key])) {
                 searchParams.delete(key);
                 for (const item of object[key]) {
-                    searchParams.set(key, item);
+                    searchParams.append(key, item);
                 }
             } else {
                 searchParams.set(key, object[key]);

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
@@ -91,7 +91,14 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
     for (const object of objects) {
         for (const key in object) {
-            searchParams.set(key, object[key]);
+            if (Array.isArray(object[key])) {
+                searchParams.delete(key);
+                for (const item of object[key]) {
+                    searchParams.set(key, item);
+                }
+            } else {
+                searchParams.set(key, object[key]);
+            }
         }
     }
     url.search = searchParams.toString();

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
@@ -94,7 +94,7 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
             if (Array.isArray(object[key])) {
                 searchParams.delete(key);
                 for (const item of object[key]) {
-                    searchParams.set(key, item);
+                    searchParams.append(key, item);
                 }
             } else {
                 searchParams.set(key, object[key]);

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
@@ -91,7 +91,14 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
     for (const object of objects) {
         for (const key in object) {
-            searchParams.set(key, object[key]);
+            if (Array.isArray(object[key])) {
+                searchParams.delete(key);
+                for (const item of object[key]) {
+                    searchParams.set(key, item);
+                }
+            } else {
+                searchParams.set(key, object[key]);
+            }
         }
     }
     url.search = searchParams.toString();

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
@@ -94,7 +94,7 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
             if (Array.isArray(object[key])) {
                 searchParams.delete(key);
                 for (const item of object[key]) {
-                    searchParams.set(key, item);
+                    searchParams.append(key, item);
                 }
             } else {
                 searchParams.set(key, object[key]);

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
@@ -91,7 +91,14 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
     for (const object of objects) {
         for (const key in object) {
-            searchParams.set(key, object[key]);
+            if (Array.isArray(object[key])) {
+                searchParams.delete(key);
+                for (const item of object[key]) {
+                    searchParams.set(key, item);
+                }
+            } else {
+                searchParams.set(key, object[key]);
+            }
         }
     }
     url.search = searchParams.toString();

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
@@ -94,7 +94,7 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
             if (Array.isArray(object[key])) {
                 searchParams.delete(key);
                 for (const item of object[key]) {
-                    searchParams.set(key, item);
+                    searchParams.append(key, item);
                 }
             } else {
                 searchParams.set(key, object[key]);

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
@@ -91,7 +91,14 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
     for (const object of objects) {
         for (const key in object) {
-            searchParams.set(key, object[key]);
+            if (Array.isArray(object[key])) {
+                searchParams.delete(key);
+                for (const item of object[key]) {
+                    searchParams.set(key, item);
+                }
+            } else {
+                searchParams.set(key, object[key]);
+            }
         }
     }
     url.search = searchParams.toString();

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
@@ -94,7 +94,7 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
             if (Array.isArray(object[key])) {
                 searchParams.delete(key);
                 for (const item of object[key]) {
-                    searchParams.set(key, item);
+                    searchParams.append(key, item);
                 }
             } else {
                 searchParams.set(key, object[key]);

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
@@ -91,7 +91,14 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
     const searchParams = new URLSearchParams(url.search);
     for (const object of objects) {
         for (const key in object) {
-            searchParams.set(key, object[key]);
+            if (Array.isArray(object[key])) {
+                searchParams.delete(key);
+                for (const item of object[key]) {
+                    searchParams.set(key, item);
+                }
+            } else {
+                searchParams.set(key, object[key]);
+            }
         }
     }
     url.search = searchParams.toString();


### PR DESCRIPTION
typescript-axios does not correctly output query arguments when you use `explode: true` for a parameter.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
  - CC: @TiFu @taxpon  @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov 

fixes #7966
fixes #7973