### PR TITLE
[Fix GO Server] Add mime/multipart missing import in go server

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -4,6 +4,7 @@ package {{packageName}}
 import (
 	"encoding/json"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"strconv"

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -12,6 +12,7 @@ package petstoreserver
 import (
 	"encoding/json"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"strconv"


### PR DESCRIPTION
Fork of https://github.com/OpenAPITools/openapi-generator/pull/8683 with the samples regenerated

This is a similar fix to the other PR but I was able to regenerate the samples.

This adds a missing import into the routers from go server