### PR TITLE
Use Files.createTempFile in asciidoc generator tests if possible

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/IncludeMarkupFilterTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/IncludeMarkupFilterTest.java
@@ -34,7 +34,7 @@ public class IncludeMarkupFilterTest extends LambdaTest {
     @Test
     public void testIncludeMarkupFilterFoundFileOk() throws IOException {
 
-        File tempFile = File.createTempFile("IncludeMarkupFilterTestDummyfile", "-adoc");
+        File tempFile = Files.createTempFile("IncludeMarkupFilterTestDummyfile", "-adoc").toFile();
         tempFile.deleteOnExit();
 
         final AsciidocDocumentationCodegen generator = new AsciidocDocumentationCodegen();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/LinkMarkupFilterTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/LinkMarkupFilterTest.java
@@ -2,6 +2,7 @@ package org.openapitools.codegen.asciidoc;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Map;
 
 import org.mockito.MockitoAnnotations;
@@ -32,7 +33,7 @@ public class LinkMarkupFilterTest extends LambdaTest {
     @Test
     public void testLinkMarkupFilterLinksFoundFileOk() throws IOException {
 
-        File tempFile = File.createTempFile("LinkMarkupFilterTestDummyfile", ".adoc");
+        File tempFile = Files.createTempFile("LinkMarkupFilterTestDummyfile", ".adoc").toFile();
         tempFile.deleteOnExit();
 
         final AsciidocDocumentationCodegen generator = new AsciidocDocumentationCodegen();


### PR DESCRIPTION
Use Files.createTempFile in asciidoc generator tests if possible to avoid potential security issues.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
