### PR TITLE
Revert "[Ruby] force users to specify the temp folder path to address security concerns (#8730)"

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
@@ -71,13 +71,6 @@ module {{moduleName}}
       {{/isFaraday}}
       {{#isFaraday}}
       if return_type == 'File'
-        # throw an exception if the temp folder path is not defined
-        # to avoid using the default temp directory which can be read by anyone
-        if @config.temp_folder_path.nil?
-          raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"]) " +
-                "to avoid dowloading the file to a location readable by everyone."
-        end
-
         content_disposition = response.headers['Content-Disposition']
         if content_disposition && content_disposition =~ /filename=/i
           filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_typhoeus_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_typhoeus_partial.mustache
@@ -52,8 +52,8 @@
 
       {{#hasAuthMethods}}
       update_params_for_auth! header_params, query_params, opts[:auth_names]
-
       {{/hasAuthMethods}}
+
       # set ssl_verifyhosts option based on @config.verify_ssl_host (true/false)
       _verify_ssl_host = @config.verify_ssl_host ? 2 : 0
 
@@ -122,13 +122,6 @@
     #
     # @see Configuration#temp_folder_path
     def download_file(request)
-      # throw an exception if the temp folder path is not defined
-      # to avoid using the default temp directory which can be read by anyone
-      if @config.temp_folder_path.nil?
-        raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"])" +
-              "to avoid dowloading the file to a location readable by everyone."
-      end
-
       tempfile = nil
       encoding = nil
       request.on_headers do |response|
@@ -144,12 +137,10 @@
         tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
         @tempfile = tempfile
       end
-
       request.on_body do |chunk|
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
-
       request.on_complete do |response|
         if tempfile
           tempfile.close

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -203,13 +203,6 @@ module Petstore
       # handle file downloading - return the File instance processed in request callbacks
       # note that response body is empty when the file is written in chunks in request on_body callback
       if return_type == 'File'
-        # throw an exception if the temp folder path is not defined
-        # to avoid using the default temp directory which can be read by anyone
-        if @config.temp_folder_path.nil?
-          raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"]) " +
-                "to avoid dowloading the file to a location readable by everyone."
-        end
-
         content_disposition = response.headers['Content-Disposition']
         if content_disposition && content_disposition =~ /filename=/i
           filename = content_disposition[/filename=['"]?([^'"\s]+)['"]?/, 1]

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -164,13 +164,6 @@ module Petstore
     #
     # @see Configuration#temp_folder_path
     def download_file(request)
-      # throw an exception if the temp folder path is not defined
-      # to avoid using the default temp directory which can be read by anyone
-      if @config.temp_folder_path.nil?
-        raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"])" +
-              "to avoid dowloading the file to a location readable by everyone."
-      end
-
       tempfile = nil
       encoding = nil
       request.on_headers do |response|
@@ -186,12 +179,10 @@ module Petstore
         tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
         @tempfile = tempfile
       end
-
       request.on_body do |chunk|
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
-
       request.on_complete do |response|
         if tempfile
           tempfile.close

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api_client.rb
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/api_client.rb
@@ -164,13 +164,6 @@ module XAuthIDAlias
     #
     # @see Configuration#temp_folder_path
     def download_file(request)
-      # throw an exception if the temp folder path is not defined
-      # to avoid using the default temp directory which can be read by anyone
-      if @config.temp_folder_path.nil?
-        raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"])" +
-              "to avoid dowloading the file to a location readable by everyone."
-      end
-
       tempfile = nil
       encoding = nil
       request.on_headers do |response|
@@ -186,12 +179,10 @@ module XAuthIDAlias
         tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
         @tempfile = tempfile
       end
-
       request.on_body do |chunk|
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
-
       request.on_complete do |response|
         if tempfile
           tempfile.close

--- a/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_client.rb
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/api_client.rb
@@ -94,6 +94,7 @@ module DynamicServers
       query_params = opts[:query_params] || {}
       form_params = opts[:form_params] || {}
 
+
       # set ssl_verifyhosts option based on @config.verify_ssl_host (true/false)
       _verify_ssl_host = @config.verify_ssl_host ? 2 : 0
 
@@ -162,13 +163,6 @@ module DynamicServers
     #
     # @see Configuration#temp_folder_path
     def download_file(request)
-      # throw an exception if the temp folder path is not defined
-      # to avoid using the default temp directory which can be read by anyone
-      if @config.temp_folder_path.nil?
-        raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"])" +
-              "to avoid dowloading the file to a location readable by everyone."
-      end
-
       tempfile = nil
       encoding = nil
       request.on_headers do |response|
@@ -184,12 +178,10 @@ module DynamicServers
         tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
         @tempfile = tempfile
       end
-
       request.on_body do |chunk|
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
-
       request.on_complete do |response|
         if tempfile
           tempfile.close

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_client.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/api_client.rb
@@ -94,6 +94,7 @@ module Petstore
       query_params = opts[:query_params] || {}
       form_params = opts[:form_params] || {}
 
+
       # set ssl_verifyhosts option based on @config.verify_ssl_host (true/false)
       _verify_ssl_host = @config.verify_ssl_host ? 2 : 0
 
@@ -162,13 +163,6 @@ module Petstore
     #
     # @see Configuration#temp_folder_path
     def download_file(request)
-      # throw an exception if the temp folder path is not defined
-      # to avoid using the default temp directory which can be read by anyone
-      if @config.temp_folder_path.nil?
-        raise "@config.temp_folder_path must be setup first (e.g. ENV[\"HOME\"], ENV[\"HOMEPATH\"])" +
-              "to avoid dowloading the file to a location readable by everyone."
-      end
-
       tempfile = nil
       encoding = nil
       request.on_headers do |response|
@@ -184,12 +178,10 @@ module Petstore
         tempfile = Tempfile.open(prefix, @config.temp_folder_path, encoding: encoding)
         @tempfile = tempfile
       end
-
       request.on_body do |chunk|
         chunk.force_encoding(encoding)
         tempfile.write(chunk)
       end
-
       request.on_complete do |response|
         if tempfile
           tempfile.close


### PR DESCRIPTION
… security concerns (#8730)"

This reverts commit 18a6f5a941f3b5777977693f3b59ac5d200928a8.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

 cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)

