### PR TITLE
typescript-nestjs: removed unused basePath from api.service template

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.module.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.module.mustache
@@ -7,7 +7,7 @@ import { {{classname}} } from './{{importPath}}';
 {{/apis}}
 {{/apiInfo}}
 
-@Global
+@Global()
 @Module({
   imports:      [ HttpModule ],
   exports:      [

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -32,7 +32,7 @@ export class {{classname}} {
     public configuration = new Configuration();
 
     constructor(protected httpClient: HttpService, @Optional() configuration: Configuration) {
-        this.configuration = configuration;
+        this.configuration = configuration || this.configuration;
         this.basePath = configuration?.basePath || this.basePath;
     }
 

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -1,16 +1,15 @@
 {{>licenseInfo}}
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { HttpService, Inject, Injectable }                      from '@nestjs/common';
+import { HttpService, Inject, Injectable, Optional } from '@nestjs/common';
 import { AxiosResponse } from 'axios';
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 {{#imports}}
 import { {{classname}} } from '../{{filename}}';
 {{/imports}}
-import { Configuration }                                     from '../configuration';
-import { COLLECTION_FORMATS }                     from '../variables';
+import { Configuration } from '../configuration';
 {{#withInterfaces}}
-import { {{classname}}Interface }                            from './{{classFilename}}Interface';
+import { {{classname}}Interface } from './{{classFilename}}Interface';
 {{/withInterfaces}}
 
 {{#operations}}
@@ -32,9 +31,9 @@ export class {{classname}} {
     public defaultHeaders = new Map()
     public configuration = new Configuration();
 
-    constructor(protected httpClient: HttpService, configuration: Configuration) {
+    constructor(protected httpClient: HttpService, @Optional() configuration: Configuration) {
         this.configuration = configuration;
-        this.basePath = basePath || configuration.basePath || this.basePath;
+        this.basePath = configuration?.basePath || this.basePath;
     }
 
     /**

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api.module.ts
@@ -5,7 +5,7 @@ import { PetService } from './api/pet.service';
 import { StoreService } from './api/store.service';
 import { UserService } from './api/user.service';
 
-@Global
+@Global()
 @Module({
   imports:      [ HttpModule ],
   exports:      [

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -27,7 +27,7 @@ export class PetService {
     public configuration = new Configuration();
 
     constructor(protected httpClient: HttpService, @Optional() configuration: Configuration) {
-        this.configuration = configuration;
+        this.configuration = configuration || this.configuration;
         this.basePath = configuration?.basePath || this.basePath;
     }
 

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -11,13 +11,12 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { HttpService, Inject, Injectable }                      from '@nestjs/common';
+import { HttpService, Inject, Injectable, Optional } from '@nestjs/common';
 import { AxiosResponse } from 'axios';
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
-import { Configuration }                                     from '../configuration';
-import { COLLECTION_FORMATS }                     from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -27,9 +26,9 @@ export class PetService {
     public defaultHeaders = new Map()
     public configuration = new Configuration();
 
-    constructor(protected httpClient: HttpService, configuration: Configuration) {
+    constructor(protected httpClient: HttpService, @Optional() configuration: Configuration) {
         this.configuration = configuration;
-        this.basePath = basePath || configuration.basePath || this.basePath;
+        this.basePath = configuration?.basePath || this.basePath;
     }
 
     /**

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/store.service.ts
@@ -11,12 +11,11 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { HttpService, Inject, Injectable }                      from '@nestjs/common';
+import { HttpService, Inject, Injectable, Optional } from '@nestjs/common';
 import { AxiosResponse } from 'axios';
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 import { Order } from '../model/order';
-import { Configuration }                                     from '../configuration';
-import { COLLECTION_FORMATS }                     from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -26,9 +25,9 @@ export class StoreService {
     public defaultHeaders = new Map()
     public configuration = new Configuration();
 
-    constructor(protected httpClient: HttpService, configuration: Configuration) {
+    constructor(protected httpClient: HttpService, @Optional() configuration: Configuration) {
         this.configuration = configuration;
-        this.basePath = basePath || configuration.basePath || this.basePath;
+        this.basePath = configuration?.basePath || this.basePath;
     }
 
     /**

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/store.service.ts
@@ -26,7 +26,7 @@ export class StoreService {
     public configuration = new Configuration();
 
     constructor(protected httpClient: HttpService, @Optional() configuration: Configuration) {
-        this.configuration = configuration;
+        this.configuration = configuration || this.configuration;
         this.basePath = configuration?.basePath || this.basePath;
     }
 

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
@@ -11,12 +11,11 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { HttpService, Inject, Injectable }                      from '@nestjs/common';
+import { HttpService, Inject, Injectable, Optional } from '@nestjs/common';
 import { AxiosResponse } from 'axios';
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 import { User } from '../model/user';
-import { Configuration }                                     from '../configuration';
-import { COLLECTION_FORMATS }                     from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -26,9 +25,9 @@ export class UserService {
     public defaultHeaders = new Map()
     public configuration = new Configuration();
 
-    constructor(protected httpClient: HttpService, configuration: Configuration) {
+    constructor(protected httpClient: HttpService, @Optional() configuration: Configuration) {
         this.configuration = configuration;
-        this.basePath = basePath || configuration.basePath || this.basePath;
+        this.basePath = configuration?.basePath || this.basePath;
     }
 
     /**

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
@@ -26,7 +26,7 @@ export class UserService {
     public configuration = new Configuration();
 
     constructor(protected httpClient: HttpService, @Optional() configuration: Configuration) {
-        this.configuration = configuration;
+        this.configuration = configuration || this.configuration;
         this.basePath = configuration?.basePath || this.basePath;
     }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes: https://github.com/OpenAPITools/openapi-generator/issues/8810

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
