### PR TITLE
[dart][dart-dio] Remove manual json encode/decode calls in API classes

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -1,6 +1,5 @@
 {{>header}}
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -72,24 +71,22 @@ class {{classname}} {
         {{#isContainer}}
         {{#isArray}}
         const type = FullType(Built{{#uniqueItems}}Built{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}, [FullType({{baseType}})]);
-        final serializedBody = _serializers.serialize({{paramName}}, specifiedType: type);
+        bodyData = _serializers.serialize({{paramName}}, specifiedType: type);
         {{/isArray}}
         {{#isMap}}
         const type = FullType(BuiltMap, [FullType(String), FullType({{baseType}})]);
-        final serializedBody = _serializers.serialize({{paramName}}, specifiedType: type);
+        bodyData = _serializers.serialize({{paramName}}, specifiedType: type);
         {{/isMap}}
         {{/isContainer}}
         {{^isContainer}}
         {{#isPrimitiveType}}
-        final serializedBody = {{paramName}};
+        bodyData = {{paramName}};
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         final bodySerializer = _serializers.serializerForType({{{baseType}}}) as Serializer<{{{baseType}}}>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, {{paramName}});
+        bodyData = _serializers.serializeWith(bodySerializer, {{paramName}});
         {{/isPrimitiveType}}
         {{/isContainer}}
-        final json{{paramName}} = json.encode(serializedBody);
-        bodyData = json{{paramName}};
         {{/bodyParam}}
 
         return _dio.request<dynamic>(
@@ -130,20 +127,12 @@ class {{classname}} {
         {{/returnTypeIsPrimitive}}
         {{^returnTypeIsPrimitive}}
             final serializer = _serializers.serializerForType({{{returnType}}}) as Serializer<{{{returnType}}}>;
-            final data = _serializers.deserializeWith<{{{returnType}}}>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<{{{returnType}}}>(serializer, response.data);
         {{/returnTypeIsPrimitive}}
         {{/returnSimpleType}}
         {{^returnSimpleType}}
             const type = FullType(Built{{#isMap}}Map{{/isMap}}{{#isArray}}{{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}{{/isArray}}, [{{#isMap}}FullType(String), {{/isMap}}FullType({{{returnBaseType}}})]);
-            final data = _serializers.deserialize(
-                response.data is String
-                ? jsonDecode(response.data as String)
-                : response.data,
-                specifiedType: type,
-            ) as {{{returnType}}};
+            final data = _serializers.deserialize(response.data, specifiedType: type) as {{{returnType}}};
         {{/returnSimpleType}}
         {{/isResponseFile}}
 

--- a/modules/openapi-generator/src/main/resources/dart-dio/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/pubspec.mustache
@@ -13,5 +13,5 @@ dependencies:
 dev_dependencies:
     built_value_generator: ">=7.1.0 <9.0.0"
     build_runner: ^1.7.1
-    test: ^1.3.0
+    test: ">=1.3.0 <1.16.0"
 

--- a/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
@@ -15,4 +15,4 @@ dependencies:
   intl: '^0.16.1'
   meta: '^1.1.8'
 dev_dependencies:
-  test: '^1.3.0'
+  test: '>=1.3.0 <1.16.0'

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -53,9 +52,7 @@ class PetApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, body);
-        final jsonbody = json.encode(serializedBody);
-        bodyData = jsonbody;
+        bodyData = _serializers.serializeWith(bodySerializer, body);
 
         return _dio.request<dynamic>(
             _path,
@@ -184,12 +181,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             const type = FullType(BuiltList, [FullType(Pet)]);
-            final data = _serializers.deserialize(
-                response.data is String
-                ? jsonDecode(response.data as String)
-                : response.data,
-                specifiedType: type,
-            ) as BuiltList<Pet>;
+            final data = _serializers.deserialize(response.data, specifiedType: type) as BuiltList<Pet>;
 
             return Response<BuiltList<Pet>>(
                 data: data,
@@ -254,12 +246,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             const type = FullType(BuiltList, [FullType(Pet)]);
-            final data = _serializers.deserialize(
-                response.data is String
-                ? jsonDecode(response.data as String)
-                : response.data,
-                specifiedType: type,
-            ) as BuiltList<Pet>;
+            final data = _serializers.deserialize(response.data, specifiedType: type) as BuiltList<Pet>;
 
             return Response<BuiltList<Pet>>(
                 data: data,
@@ -325,10 +312,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
-            final data = _serializers.deserializeWith<Pet>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<Pet>(serializer, response.data);
 
             return Response<Pet>(
                 data: data,
@@ -372,9 +356,7 @@ class PetApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, body);
-        final jsonbody = json.encode(serializedBody);
-        bodyData = jsonbody;
+        bodyData = _serializers.serializeWith(bodySerializer, body);
 
         return _dio.request<dynamic>(
             _path,
@@ -520,10 +502,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(ApiResponse) as Serializer<ApiResponse>;
-            final data = _serializers.deserializeWith<ApiResponse>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<ApiResponse>(serializer, response.data);
 
             return Response<ApiResponse>(
                 data: data,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -116,12 +115,7 @@ class StoreApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             const type = FullType(BuiltMap, [FullType(String), FullType(int)]);
-            final data = _serializers.deserialize(
-                response.data is String
-                ? jsonDecode(response.data as String)
-                : response.data,
-                specifiedType: type,
-            ) as BuiltMap<String, int>;
+            final data = _serializers.deserialize(response.data, specifiedType: type) as BuiltMap<String, int>;
 
             return Response<BuiltMap<String, int>>(
                 data: data,
@@ -180,10 +174,7 @@ class StoreApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(Order) as Serializer<Order>;
-            final data = _serializers.deserializeWith<Order>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<Order>(serializer, response.data);
 
             return Response<Order>(
                 data: data,
@@ -224,9 +215,7 @@ class StoreApi {
         final contentTypes = <String>[];
 
         final bodySerializer = _serializers.serializerForType(Order) as Serializer<Order>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, body);
-        final jsonbody = json.encode(serializedBody);
-        bodyData = jsonbody;
+        bodyData = _serializers.serializeWith(bodySerializer, body);
 
         return _dio.request<dynamic>(
             _path,
@@ -247,10 +236,7 @@ class StoreApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(Order) as Serializer<Order>;
-            final data = _serializers.deserializeWith<Order>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<Order>(serializer, response.data);
 
             return Response<Order>(
                 data: data,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -47,9 +46,7 @@ class UserApi {
         final contentTypes = <String>[];
 
         final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, body);
-        final jsonbody = json.encode(serializedBody);
-        bodyData = jsonbody;
+        bodyData = _serializers.serializeWith(bodySerializer, body);
 
         return _dio.request<dynamic>(
             _path,
@@ -97,9 +94,7 @@ class UserApi {
         final contentTypes = <String>[];
 
         const type = FullType(BuiltList, [FullType(User)]);
-        final serializedBody = _serializers.serialize(body, specifiedType: type);
-        final jsonbody = json.encode(serializedBody);
-        bodyData = jsonbody;
+        bodyData = _serializers.serialize(body, specifiedType: type);
 
         return _dio.request<dynamic>(
             _path,
@@ -147,9 +142,7 @@ class UserApi {
         final contentTypes = <String>[];
 
         const type = FullType(BuiltList, [FullType(User)]);
-        final serializedBody = _serializers.serialize(body, specifiedType: type);
-        final jsonbody = json.encode(serializedBody);
-        bodyData = jsonbody;
+        bodyData = _serializers.serialize(body, specifiedType: type);
 
         return _dio.request<dynamic>(
             _path,
@@ -260,10 +253,7 @@ class UserApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(User) as Serializer<User>;
-            final data = _serializers.deserializeWith<User>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<User>(serializer, response.data);
 
             return Response<User>(
                 data: data,
@@ -410,9 +400,7 @@ class UserApi {
         final contentTypes = <String>[];
 
         final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, body);
-        final jsonbody = json.encode(serializedBody);
-        bodyData = jsonbody;
+        bodyData = _serializers.serializeWith(bodySerializer, body);
 
         return _dio.request<dynamic>(
             _path,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/pubspec.yaml
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
 dev_dependencies:
     built_value_generator: ">=7.1.0 <9.0.0"
     build_runner: ^1.7.1
-    test: ^1.3.0
+    test: ">=1.3.0 <1.16.0"
 

--- a/samples/client/petstore/dart2/petstore_client_lib/pubspec.yaml
+++ b/samples/client/petstore/dart2/petstore_client_lib/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
   intl: '^0.16.1'
   meta: '^1.1.8'
 dev_dependencies:
-  test: '^1.3.0'
+  test: '>=1.3.0 <1.16.0'

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -53,9 +52,7 @@ class PetApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, pet);
-        final jsonpet = json.encode(serializedBody);
-        bodyData = jsonpet;
+        bodyData = _serializers.serializeWith(bodySerializer, pet);
 
         return _dio.request<dynamic>(
             _path,
@@ -81,10 +78,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
-            final data = _serializers.deserializeWith<Pet>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<Pet>(serializer, response.data);
 
             return Response<Pet>(
                 data: data,
@@ -201,12 +195,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             const type = FullType(BuiltList, [FullType(Pet)]);
-            final data = _serializers.deserialize(
-                response.data is String
-                ? jsonDecode(response.data as String)
-                : response.data,
-                specifiedType: type,
-            ) as BuiltList<Pet>;
+            final data = _serializers.deserialize(response.data, specifiedType: type) as BuiltList<Pet>;
 
             return Response<BuiltList<Pet>>(
                 data: data,
@@ -271,12 +260,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             const type = FullType(BuiltList, [FullType(Pet)]);
-            final data = _serializers.deserialize(
-                response.data is String
-                ? jsonDecode(response.data as String)
-                : response.data,
-                specifiedType: type,
-            ) as BuiltList<Pet>;
+            final data = _serializers.deserialize(response.data, specifiedType: type) as BuiltList<Pet>;
 
             return Response<BuiltList<Pet>>(
                 data: data,
@@ -342,10 +326,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
-            final data = _serializers.deserializeWith<Pet>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<Pet>(serializer, response.data);
 
             return Response<Pet>(
                 data: data,
@@ -389,9 +370,7 @@ class PetApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, pet);
-        final jsonpet = json.encode(serializedBody);
-        bodyData = jsonpet;
+        bodyData = _serializers.serializeWith(bodySerializer, pet);
 
         return _dio.request<dynamic>(
             _path,
@@ -417,10 +396,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
-            final data = _serializers.deserializeWith<Pet>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<Pet>(serializer, response.data);
 
             return Response<Pet>(
                 data: data,
@@ -554,10 +530,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(ApiResponse) as Serializer<ApiResponse>;
-            final data = _serializers.deserializeWith<ApiResponse>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<ApiResponse>(serializer, response.data);
 
             return Response<ApiResponse>(
                 data: data,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -116,12 +115,7 @@ class StoreApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             const type = FullType(BuiltMap, [FullType(String), FullType(int)]);
-            final data = _serializers.deserialize(
-                response.data is String
-                ? jsonDecode(response.data as String)
-                : response.data,
-                specifiedType: type,
-            ) as BuiltMap<String, int>;
+            final data = _serializers.deserialize(response.data, specifiedType: type) as BuiltMap<String, int>;
 
             return Response<BuiltMap<String, int>>(
                 data: data,
@@ -180,10 +174,7 @@ class StoreApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(Order) as Serializer<Order>;
-            final data = _serializers.deserializeWith<Order>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<Order>(serializer, response.data);
 
             return Response<Order>(
                 data: data,
@@ -226,9 +217,7 @@ class StoreApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(Order) as Serializer<Order>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, order);
-        final jsonorder = json.encode(serializedBody);
-        bodyData = jsonorder;
+        bodyData = _serializers.serializeWith(bodySerializer, order);
 
         return _dio.request<dynamic>(
             _path,
@@ -249,10 +238,7 @@ class StoreApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(Order) as Serializer<Order>;
-            final data = _serializers.deserializeWith<Order>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<Order>(serializer, response.data);
 
             return Response<Order>(
                 data: data,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -49,9 +48,7 @@ class UserApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, user);
-        final jsonuser = json.encode(serializedBody);
-        bodyData = jsonuser;
+        bodyData = _serializers.serializeWith(bodySerializer, user);
 
         return _dio.request<dynamic>(
             _path,
@@ -108,9 +105,7 @@ class UserApi {
         ];
 
         const type = FullType(BuiltList, [FullType(User)]);
-        final serializedBody = _serializers.serialize(user, specifiedType: type);
-        final jsonuser = json.encode(serializedBody);
-        bodyData = jsonuser;
+        bodyData = _serializers.serialize(user, specifiedType: type);
 
         return _dio.request<dynamic>(
             _path,
@@ -167,9 +162,7 @@ class UserApi {
         ];
 
         const type = FullType(BuiltList, [FullType(User)]);
-        final serializedBody = _serializers.serialize(user, specifiedType: type);
-        final jsonuser = json.encode(serializedBody);
-        bodyData = jsonuser;
+        bodyData = _serializers.serialize(user, specifiedType: type);
 
         return _dio.request<dynamic>(
             _path,
@@ -294,10 +287,7 @@ class UserApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(User) as Serializer<User>;
-            final data = _serializers.deserializeWith<User>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<User>(serializer, response.data);
 
             return Response<User>(
                 data: data,
@@ -453,9 +443,7 @@ class UserApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, user);
-        final jsonuser = json.encode(serializedBody);
-        bodyData = jsonuser;
+        bodyData = _serializers.serializeWith(bodySerializer, user);
 
         return _dio.request<dynamic>(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
 dev_dependencies:
     built_value_generator: ">=7.1.0 <9.0.0"
     build_runner: ^1.7.1
-    test: ^1.3.0
+    test: ">=1.3.0 <1.16.0"
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -48,9 +47,7 @@ class AnotherFakeApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(ModelClient) as Serializer<ModelClient>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, modelClient);
-        final jsonmodelClient = json.encode(serializedBody);
-        bodyData = jsonmodelClient;
+        bodyData = _serializers.serializeWith(bodySerializer, modelClient);
 
         return _dio.request<dynamic>(
             _path,
@@ -71,10 +68,7 @@ class AnotherFakeApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(ModelClient) as Serializer<ModelClient>;
-            final data = _serializers.deserializeWith<ModelClient>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<ModelClient>(serializer, response.data);
 
             return Response<ModelClient>(
                 data: data,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/default_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -63,10 +62,7 @@ class DefaultApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(InlineResponseDefault) as Serializer<InlineResponseDefault>;
-            final data = _serializers.deserializeWith<InlineResponseDefault>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<InlineResponseDefault>(serializer, response.data);
 
             return Response<InlineResponseDefault>(
                 data: data,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -71,10 +70,7 @@ class FakeApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(HealthCheckResult) as Serializer<HealthCheckResult>;
-            final data = _serializers.deserializeWith<HealthCheckResult>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<HealthCheckResult>(serializer, response.data);
 
             return Response<HealthCheckResult>(
                 data: data,
@@ -122,9 +118,7 @@ class FakeApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, pet);
-        final jsonpet = json.encode(serializedBody);
-        bodyData = jsonpet;
+        bodyData = _serializers.serializeWith(bodySerializer, pet);
 
         return _dio.request<dynamic>(
             _path,
@@ -178,9 +172,7 @@ class FakeApi {
             'application/json',
         ];
 
-        final serializedBody = body;
-        final jsonbody = json.encode(serializedBody);
-        bodyData = jsonbody;
+        bodyData = body;
 
         return _dio.request<dynamic>(
             _path,
@@ -243,9 +235,7 @@ class FakeApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(OuterComposite) as Serializer<OuterComposite>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, outerComposite);
-        final jsonouterComposite = json.encode(serializedBody);
-        bodyData = jsonouterComposite;
+        bodyData = _serializers.serializeWith(bodySerializer, outerComposite);
 
         return _dio.request<dynamic>(
             _path,
@@ -266,10 +256,7 @@ class FakeApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(OuterComposite) as Serializer<OuterComposite>;
-            final data = _serializers.deserializeWith<OuterComposite>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<OuterComposite>(serializer, response.data);
 
             return Response<OuterComposite>(
                 data: data,
@@ -311,9 +298,7 @@ class FakeApi {
             'application/json',
         ];
 
-        final serializedBody = body;
-        final jsonbody = json.encode(serializedBody);
-        bodyData = jsonbody;
+        bodyData = body;
 
         return _dio.request<dynamic>(
             _path,
@@ -375,9 +360,7 @@ class FakeApi {
             'application/json',
         ];
 
-        final serializedBody = body;
-        final jsonbody = json.encode(serializedBody);
-        bodyData = jsonbody;
+        bodyData = body;
 
         return _dio.request<dynamic>(
             _path,
@@ -440,9 +423,7 @@ class FakeApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(FileSchemaTestClass) as Serializer<FileSchemaTestClass>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, fileSchemaTestClass);
-        final jsonfileSchemaTestClass = json.encode(serializedBody);
-        bodyData = jsonfileSchemaTestClass;
+        bodyData = _serializers.serializeWith(bodySerializer, fileSchemaTestClass);
 
         return _dio.request<dynamic>(
             _path,
@@ -494,9 +475,7 @@ class FakeApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, user);
-        final jsonuser = json.encode(serializedBody);
-        bodyData = jsonuser;
+        bodyData = _serializers.serializeWith(bodySerializer, user);
 
         return _dio.request<dynamic>(
             _path,
@@ -546,9 +525,7 @@ class FakeApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(ModelClient) as Serializer<ModelClient>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, modelClient);
-        final jsonmodelClient = json.encode(serializedBody);
-        bodyData = jsonmodelClient;
+        bodyData = _serializers.serializeWith(bodySerializer, modelClient);
 
         return _dio.request<dynamic>(
             _path,
@@ -569,10 +546,7 @@ class FakeApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(ModelClient) as Serializer<ModelClient>;
-            final data = _serializers.deserializeWith<ModelClient>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<ModelClient>(serializer, response.data);
 
             return Response<ModelClient>(
                 data: data,
@@ -825,9 +799,7 @@ class FakeApi {
         ];
 
         const type = FullType(BuiltMap, [FullType(String), FullType(String)]);
-        final serializedBody = _serializers.serialize(requestBody, specifiedType: type);
-        final jsonrequestBody = json.encode(serializedBody);
-        bodyData = jsonrequestBody;
+        bodyData = _serializers.serialize(requestBody, specifiedType: type);
 
         return _dio.request<dynamic>(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -48,9 +47,7 @@ class FakeClassnameTags123Api {
         ];
 
         final bodySerializer = _serializers.serializerForType(ModelClient) as Serializer<ModelClient>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, modelClient);
-        final jsonmodelClient = json.encode(serializedBody);
-        bodyData = jsonmodelClient;
+        bodyData = _serializers.serializeWith(bodySerializer, modelClient);
 
         return _dio.request<dynamic>(
             _path,
@@ -78,10 +75,7 @@ class FakeClassnameTags123Api {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(ModelClient) as Serializer<ModelClient>;
-            final data = _serializers.deserializeWith<ModelClient>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<ModelClient>(serializer, response.data);
 
             return Response<ModelClient>(
                 data: data,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -53,9 +52,7 @@ class PetApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, pet);
-        final jsonpet = json.encode(serializedBody);
-        bodyData = jsonpet;
+        bodyData = _serializers.serializeWith(bodySerializer, pet);
 
         return _dio.request<dynamic>(
             _path,
@@ -184,12 +181,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             const type = FullType(BuiltList, [FullType(Pet)]);
-            final data = _serializers.deserialize(
-                response.data is String
-                ? jsonDecode(response.data as String)
-                : response.data,
-                specifiedType: type,
-            ) as BuiltList<Pet>;
+            final data = _serializers.deserialize(response.data, specifiedType: type) as BuiltList<Pet>;
 
             return Response<BuiltList<Pet>>(
                 data: data,
@@ -254,12 +246,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             const type = FullType(BuiltSet, [FullType(Pet)]);
-            final data = _serializers.deserialize(
-                response.data is String
-                ? jsonDecode(response.data as String)
-                : response.data,
-                specifiedType: type,
-            ) as BuiltSet<Pet>;
+            final data = _serializers.deserialize(response.data, specifiedType: type) as BuiltSet<Pet>;
 
             return Response<BuiltSet<Pet>>(
                 data: data,
@@ -325,10 +312,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
-            final data = _serializers.deserializeWith<Pet>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<Pet>(serializer, response.data);
 
             return Response<Pet>(
                 data: data,
@@ -372,9 +356,7 @@ class PetApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(Pet) as Serializer<Pet>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, pet);
-        final jsonpet = json.encode(serializedBody);
-        bodyData = jsonpet;
+        bodyData = _serializers.serializeWith(bodySerializer, pet);
 
         return _dio.request<dynamic>(
             _path,
@@ -520,10 +502,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(ApiResponse) as Serializer<ApiResponse>;
-            final data = _serializers.deserializeWith<ApiResponse>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<ApiResponse>(serializer, response.data);
 
             return Response<ApiResponse>(
                 data: data,
@@ -597,10 +576,7 @@ class PetApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(ApiResponse) as Serializer<ApiResponse>;
-            final data = _serializers.deserializeWith<ApiResponse>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<ApiResponse>(serializer, response.data);
 
             return Response<ApiResponse>(
                 data: data,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -116,12 +115,7 @@ class StoreApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             const type = FullType(BuiltMap, [FullType(String), FullType(int)]);
-            final data = _serializers.deserialize(
-                response.data is String
-                ? jsonDecode(response.data as String)
-                : response.data,
-                specifiedType: type,
-            ) as BuiltMap<String, int>;
+            final data = _serializers.deserialize(response.data, specifiedType: type) as BuiltMap<String, int>;
 
             return Response<BuiltMap<String, int>>(
                 data: data,
@@ -180,10 +174,7 @@ class StoreApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(Order) as Serializer<Order>;
-            final data = _serializers.deserializeWith<Order>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<Order>(serializer, response.data);
 
             return Response<Order>(
                 data: data,
@@ -226,9 +217,7 @@ class StoreApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(Order) as Serializer<Order>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, order);
-        final jsonorder = json.encode(serializedBody);
-        bodyData = jsonorder;
+        bodyData = _serializers.serializeWith(bodySerializer, order);
 
         return _dio.request<dynamic>(
             _path,
@@ -249,10 +238,7 @@ class StoreApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(Order) as Serializer<Order>;
-            final data = _serializers.deserializeWith<Order>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<Order>(serializer, response.data);
 
             return Response<Order>(
                 data: data,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
@@ -6,7 +6,6 @@
 // ignore_for_file: unused_import
 
 import 'dart:async';
-import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:built_value/serializer.dart';
 
@@ -49,9 +48,7 @@ class UserApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, user);
-        final jsonuser = json.encode(serializedBody);
-        bodyData = jsonuser;
+        bodyData = _serializers.serializeWith(bodySerializer, user);
 
         return _dio.request<dynamic>(
             _path,
@@ -101,9 +98,7 @@ class UserApi {
         ];
 
         const type = FullType(BuiltList, [FullType(User)]);
-        final serializedBody = _serializers.serialize(user, specifiedType: type);
-        final jsonuser = json.encode(serializedBody);
-        bodyData = jsonuser;
+        bodyData = _serializers.serialize(user, specifiedType: type);
 
         return _dio.request<dynamic>(
             _path,
@@ -153,9 +148,7 @@ class UserApi {
         ];
 
         const type = FullType(BuiltList, [FullType(User)]);
-        final serializedBody = _serializers.serialize(user, specifiedType: type);
-        final jsonuser = json.encode(serializedBody);
-        bodyData = jsonuser;
+        bodyData = _serializers.serialize(user, specifiedType: type);
 
         return _dio.request<dynamic>(
             _path,
@@ -266,10 +259,7 @@ class UserApi {
             onReceiveProgress: onReceiveProgress,
         ).then((response) {
             final serializer = _serializers.serializerForType(User) as Serializer<User>;
-            final data = _serializers.deserializeWith<User>(
-                serializer,
-                response.data is String ? jsonDecode(response.data as String) : response.data,
-            );
+            final data = _serializers.deserializeWith<User>(serializer, response.data);
 
             return Response<User>(
                 data: data,
@@ -418,9 +408,7 @@ class UserApi {
         ];
 
         final bodySerializer = _serializers.serializerForType(User) as Serializer<User>;
-        final serializedBody = _serializers.serializeWith(bodySerializer, user);
-        final jsonuser = json.encode(serializedBody);
-        bodyData = jsonuser;
+        bodyData = _serializers.serializeWith(bodySerializer, user);
 
         return _dio.request<dynamic>(
             _path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/pom.xml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/pom.xml
@@ -97,6 +97,52 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>tests-pub-get</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>../petstore_client_lib_fake_tests</workingDirectory>
+                            <executable>pub</executable>
+                            <arguments>
+                                <argument>get</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-dartanalyzer</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>../petstore_client_lib_fake_tests</workingDirectory>
+                            <executable>dartanalyzer</executable>
+                            <arguments>
+                                <argument>--fatal-infos</argument>
+                                <argument>--options</argument>
+                                <argument>analysis_options.yaml</argument>
+                                <argument>.</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-pub-test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>../petstore_client_lib_fake_tests</workingDirectory>
+                            <executable>pub</executable>
+                            <arguments>
+                                <argument>run</argument>
+                                <argument>test</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
 dev_dependencies:
     built_value_generator: ">=7.1.0 <9.0.0"
     build_runner: ^1.7.1
-    test: ^1.3.0
+    test: ">=1.3.0 <1.16.0"
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/README.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/README.md
@@ -1,0 +1,6 @@
+# Manual tests for Dart-DIO (DO NOT DELETE)
+
+These tests depend on the `build_runner` having already been run in the
+parent package.
+
+The test are part of the integration tests for the parent package

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/analysis_options.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/analysis_options.yaml
@@ -1,0 +1,9 @@
+analyzer:
+  language:
+    strict-inference: true
+    strict-raw-types: true
+  strong-mode:
+    implicit-dynamic: false
+    implicit-casts: false
+  exclude:
+    - test/*.dart

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/pubspec.yaml
@@ -8,13 +8,16 @@ environment:
 dev_dependencies:
   built_collection: ">=4.3.2 <6.0.0"
   built_value: ">=7.1.0 <9.0.0"
-  dio: ^3.0.10
-#  http_mock_adapter: ^0.1.5
+  dio: 3.0.10
+#  http_mock_adapter: 0.1.5
   http_mock_adapter:
     git:
       url: https://github.com/kuhnroyal/http-mock-adapter.git
       ref: feature/response-building
   openapi:
     path: ../petstore_client_lib_fake
-  test: ">=1.15.0 <1.16.0"
+  test: 1.15.5
 
+dependency_overrides:
+  # This is required to prevent nullsafe versions from being pulled in
+  mockito: 4.1.1

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/pubspec.yaml
@@ -16,5 +16,5 @@ dev_dependencies:
       ref: feature/response-building
   openapi:
     path: ../petstore_client_lib_fake
-  test: ^1.16.2
+  test: ">=1.15.0 <1.16.0"
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/pubspec.yaml
@@ -1,0 +1,20 @@
+name: petstore_client_lib_fake_tests
+version: 1.0.0
+description: OpenAPI API Dart DIO client tests for petstore_client_lib_fake
+
+environment:
+  sdk: ">=2.10.0 <3.0.0"
+
+dev_dependencies:
+  built_collection: ">=4.3.2 <6.0.0"
+  built_value: ">=7.1.0 <9.0.0"
+  dio: ^3.0.10
+#  http_mock_adapter: ^0.1.5
+  http_mock_adapter:
+    git:
+      url: https://github.com/kuhnroyal/http-mock-adapter.git
+      ref: feature/response-building
+  openapi:
+    path: ../petstore_client_lib_fake
+  test: ^1.16.2
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/test/api/pet_api_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake_tests/test/api/pet_api_test.dart
@@ -1,0 +1,170 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:dio/dio.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+import 'package:openapi/api.dart';
+import 'package:openapi/api/pet_api.dart';
+import 'package:openapi/model/category.dart';
+import 'package:openapi/model/pet.dart';
+import 'package:openapi/model/tag.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const photo1 = "https://localhost/photo1.jpg";
+  const photo2 = "https://localhost/photo2.jpg";
+
+  Openapi client;
+  DioAdapter server;
+
+  setUp(() {
+    server = DioAdapter();
+    client = Openapi(dio: Dio()..httpClientAdapter = server);
+  });
+
+  tearDown(() {
+    server.close();
+  });
+
+  group(PetApi, () {
+    group('getPetById', () {
+      test('complete', () async {
+        server.onGet(
+          '/pet/5',
+          handler: (response) => response.reply(200, {
+            "id": 5,
+            "name": "Paula",
+            "status": "sold",
+            "category": {
+              "id": 1,
+              "name": "dog",
+            },
+            "photoUrls": [
+              "$photo1",
+              "$photo2",
+            ],
+            "tags": [
+              {
+                "id": 3,
+                "name": "smart",
+              },
+              {
+                "id": 4,
+                "name": "cute",
+              },
+            ]
+          }),
+        );
+
+        final response = await client.getPetApi().getPetById(5);
+
+        expect(response.statusCode, 200);
+        expect(response.data, isNotNull);
+        expect(response.data.id, 5);
+        expect(response.data.name, "Paula");
+        expect(response.data.status, PetStatusEnum.sold);
+        expect(response.data.category.id, 1);
+        expect(response.data.category.name, "dog");
+        expect(response.data.photoUrls.length, 2);
+        expect(response.data.tags.length, 2);
+      });
+
+      test('minimal', () async {
+        server.onGet(
+          '/pet/5',
+          handler: (response) => response.reply(200, {
+            "id": 5,
+            "name": "Paula",
+            "photoUrls": <String>[],
+          }),
+        );
+
+        final response = await client.getPetApi().getPetById(5);
+
+        expect(response.statusCode, 200);
+        expect(response.data, isNotNull);
+        expect(response.data.id, 5);
+        expect(response.data.name, "Paula");
+        expect(response.data.status, isNull);
+        expect(response.data.category, isNull);
+        expect(response.data.photoUrls, isNotNull);
+        expect(response.data.photoUrls, isEmpty);
+      });
+    });
+
+    group('addPet', () {
+      test('complete', () async {
+        server.onPost(
+          '/pet',
+          data: {
+            "id": 5,
+            "name": "Paula",
+            "status": "sold",
+            "category": {
+              "id": 1,
+              "name": "dog",
+            },
+            "photoUrls": [
+              "$photo1",
+              "$photo2",
+            ],
+            "tags": [
+              {
+                "id": 3,
+                "name": "smart",
+              },
+              {
+                "id": 4,
+                "name": "cute",
+              },
+            ]
+          },
+          headers: {
+            'content-type': 'application/json',
+            'content-length': 204,
+          },
+          handler: (response) => response.reply(200, ''),
+        );
+
+        final response = await client.getPetApi().addPet(Pet((p) => p
+          ..id = 5
+          ..name = "Paula"
+          ..status = PetStatusEnum.sold
+          ..category = (CategoryBuilder()
+            ..id = 1
+            ..name = "dog")
+          ..photoUrls = SetBuilder<String>(<String>[photo1, photo2])
+          ..tags = ListBuilder<Tag>(<Tag>[
+            Tag((t) => t
+              ..id = 3
+              ..name = "smart"),
+            Tag((t) => t
+              ..id = 4
+              ..name = "cute"),
+          ])));
+
+        expect(response.statusCode, 200);
+      });
+
+      test('minimal', () async {
+        server.onPost(
+          '/pet',
+          data: {
+            "id": 5,
+            "name": "Paula",
+            "photoUrls": <String>[],
+          },
+          headers: {
+            'content-type': 'application/json',
+            'content-length': 38,
+          },
+          handler: (response) => response.reply(200, ''),
+        );
+
+        final response = await client.getPetApi().addPet(Pet((p) => p
+          ..id = 5
+          ..name = "Paula"));
+
+        expect(response.statusCode, 200);
+      });
+    });
+  });
+}

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
   intl: '^0.16.1'
   meta: '^1.1.8'
 dev_dependencies:
-  test: '^1.3.0'
+  test: '>=1.3.0 <1.16.0'

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
   intl: '^0.16.1'
   meta: '^1.1.8'
 dev_dependencies:
-  test: '^1.3.0'
+  test: '>=1.3.0 <1.16.0'


### PR DESCRIPTION
Dio automatically adds a default transformer which does call `json.encode` and `json.decode` when the content-type is `application/json`. When the content-type is different, then it  is up to the consumer to configure the Dio instance correctly to support custom content-types.

Also tests!!!

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)