### PR TITLE
[follow-up] patched to_dict method to use prop_name from attribute_map (python-flask, python-blueplanet)

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/models/base_model_.mustache
+++ b/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/models/base_model_.mustache
@@ -36,19 +36,19 @@ class Model(object):
         result = {}
 
         for attr, _ in six.iteritems(self.swagger_types):
-            attr = self.attribute_map[attr] if attr_map else attr
-
             value = getattr(self, attr)
+
+            attr = self.attribute_map[attr] if attr_map else attr
             if isinstance(value, list):
                 result[attr] = list(map(
-                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    lambda x: x.to_dict(attr_map=attr_map) if hasattr(x, "to_dict") else x,
                     value
                 ))
             elif hasattr(value, "to_dict"):
-                result[attr] = value.to_dict()
+                result[attr] = value.to_dict(attr_map=attr_map)
             elif isinstance(value, dict):
                 result[attr] = dict(map(
-                    lambda item: (item[0], item[1].to_dict())
+                    lambda item: (item[0], item[1].to_dict(attr_map=attr_map))
                     if hasattr(item[1], "to_dict") else item,
                     value.items()
                 ))

--- a/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/models/base_model_.mustache
+++ b/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/models/base_model_.mustache
@@ -22,18 +22,22 @@ class Model(object):
     attribute_map = {}
 
     @classmethod
-    def from_dict(cls{{^supportPython2}}: typing.Type[T]{{/supportPython2}}, dikt){{^supportPython2}} -> T{{/supportPython2}}:
+    def from_dict(cls{{^supportPython2}}: typing.Type[T]{{/supportPython2}}, dikt, attr_map=True){{^supportPython2}} -> T{{/supportPython2}}:
         """Returns the dict as a model"""
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
-    def to_dict(self):
+    def to_dict(self, attr_map=True):
         """Returns the model properties as a dict
 
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :rtype: dict
         """
         result = {}
 
         for attr, _ in six.iteritems(self.swagger_types):
+            attr = self.attribute_map[attr] if attr_map else attr
+
             value = getattr(self, attr)
             if isinstance(value, list):
                 result[attr] = list(map(

--- a/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/models/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/models/model.mustache
@@ -52,15 +52,17 @@ class {{classname}}(Model):
 {{/vars}}
 
     @classmethod
-    def from_dict(cls, dikt){{^supportPython2}} -> '{{classname}}'{{/supportPython2}}:
+    def from_dict(cls, dikt, attr_map=True){{^supportPython2}} -> '{{classname}}'{{/supportPython2}}:
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The {{name}} of this {{classname}}.  # noqa: E501
         :rtype: {{classname}}
         """
-        return util.deserialize_model(dikt, cls){{#vars}}{{#-first}}
+        return util.deserialize_model(dikt, cls, attr_map=attr_map){{#vars}}{{#-first}}
 
 {{/-first}}
     @property

--- a/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/util.mustache
+++ b/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/util.mustache
@@ -91,12 +91,14 @@ def deserialize_datetime(string):
         return string
 
 
-def deserialize_model(data, klass):
+def deserialize_model(data, klass, attr_map=True):
     """Deserializes list or dict to model.
 
     :param data: dict, list.
     :type data: dict | list
     :param klass: class literal.
+    :param attr_map: defines if attribute_map is used in dict.
+    :type attr_map: bool
     :return: model object.
     """
     instance = klass()
@@ -104,11 +106,13 @@ def deserialize_model(data, klass):
     if not instance.swagger_types:
         return data
 
-    for attr, attr_type in six.iteritems(instance.swagger_types):
+    for attr, attr_type in six.iteritems(instance.openapi_types):
+        attr = instance.attribute_map[attr] if attr_map else attr
+
         if data is not None \
-                and instance.attribute_map[attr] in data \
+                and attr in data \
                 and isinstance(data, (list, dict)):
-            value = data[instance.attribute_map[attr]]
+            value = data[attr]
             setattr(instance, attr, _deserialize(value, attr_type))
 
     return instance

--- a/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/util.mustache
+++ b/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/util.mustache
@@ -103,16 +103,21 @@ def deserialize_model(data, klass, attr_map=True):
     """
     instance = klass()
 
+    # should be included in return types
     if not instance.swagger_types:
         return data
 
-    for attr, attr_type in six.iteritems(instance.openapi_types):
-        attr = instance.attribute_map[attr] if attr_map else attr
+    if data is None:
+        return instance
 
-        if data is not None \
-                and attr in data \
-                and isinstance(data, (list, dict)):
-            value = data[attr]
+    if not isinstance(data, (list, dict)):
+        return instance
+
+    for attr, attr_type in six.iteritems(instance.openapi_types):
+        dict_attr = instance.attribute_map[attr] if attr_map else attr
+
+        if dict_attr in data:
+            value = data[dict_attr]
             setattr(instance, attr, _deserialize(value, attr_type))
 
     return instance

--- a/modules/openapi-generator/src/main/resources/python-flask/base_model_.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/base_model_.mustache
@@ -36,19 +36,19 @@ class Model(object):
         result = {}
 
         for attr, _ in six.iteritems(self.openapi_types):
-            attr = self.attribute_map[attr] if attr_map else attr
-
             value = getattr(self, attr)
+
+            attr = self.attribute_map[attr] if attr_map else attr
             if isinstance(value, list):
                 result[attr] = list(map(
-                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    lambda x: x.to_dict(attr_map=attr_map) if hasattr(x, "to_dict") else x,
                     value
                 ))
             elif hasattr(value, "to_dict"):
-                result[attr] = value.to_dict()
+                result[attr] = value.to_dict(attr_map=attr_map)
             elif isinstance(value, dict):
                 result[attr] = dict(map(
-                    lambda item: (item[0], item[1].to_dict())
+                    lambda item: (item[0], item[1].to_dict(attr_map=attr_map))
                     if hasattr(item[1], "to_dict") else item,
                     value.items()
                 ))

--- a/modules/openapi-generator/src/main/resources/python-flask/base_model_.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/base_model_.mustache
@@ -22,18 +22,22 @@ class Model(object):
     attribute_map = {}
 
     @classmethod
-    def from_dict(cls{{^supportPython2}}: typing.Type[T]{{/supportPython2}}, dikt){{^supportPython2}} -> T{{/supportPython2}}:
+    def from_dict(cls{{^supportPython2}}: typing.Type[T]{{/supportPython2}}, dikt, attr_map=True){{^supportPython2}} -> T{{/supportPython2}}:
         """Returns the dict as a model"""
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
-    def to_dict(self):
+    def to_dict(self, attr_map=True):
         """Returns the model properties as a dict
 
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :rtype: dict
         """
         result = {}
 
         for attr, _ in six.iteritems(self.openapi_types):
+            attr = self.attribute_map[attr] if attr_map else attr
+
             value = getattr(self, attr)
             if isinstance(value, list):
                 result[attr] = list(map(

--- a/modules/openapi-generator/src/main/resources/python-flask/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/model.mustache
@@ -62,15 +62,17 @@ class {{classname}}(Model):
 {{/vars}}
 
     @classmethod
-    def from_dict(cls, dikt){{^supportPython2}} -> '{{classname}}'{{/supportPython2}}:
+    def from_dict(cls, dikt, attr_map=True){{^supportPython2}} -> '{{classname}}'{{/supportPython2}}:
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The {{name}} of this {{classname}}.  # noqa: E501
         :rtype: {{classname}}
         """
-        return util.deserialize_model(dikt, cls){{#vars}}{{#-first}}
+        return util.deserialize_model(dikt, cls, attr_map=attr_map){{#vars}}{{#-first}}
 
 {{/-first}}
     @property

--- a/modules/openapi-generator/src/main/resources/python-flask/util.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/util.mustache
@@ -91,12 +91,14 @@ def deserialize_datetime(string):
         return string
 
 
-def deserialize_model(data, klass):
+def deserialize_model(data, klass, attr_map=True):
     """Deserializes list or dict to model.
 
     :param data: dict, list.
     :type data: dict | list
     :param klass: class literal.
+    :param attr_map: defines if attribute_map is used in dict.
+    :type attr_map: bool
     :return: model object.
     """
     instance = klass()
@@ -105,10 +107,12 @@ def deserialize_model(data, klass):
         return data
 
     for attr, attr_type in six.iteritems(instance.openapi_types):
+        attr = instance.attribute_map[attr] if attr_map else attr
+
         if data is not None \
-                and instance.attribute_map[attr] in data \
+                and attr in data \
                 and isinstance(data, (list, dict)):
-            value = data[instance.attribute_map[attr]]
+            value = data[attr]
             setattr(instance, attr, _deserialize(value, attr_type))
 
     return instance

--- a/modules/openapi-generator/src/main/resources/python-flask/util.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/util.mustache
@@ -103,16 +103,21 @@ def deserialize_model(data, klass, attr_map=True):
     """
     instance = klass()
 
+    # should be included in return types
     if not instance.openapi_types:
         return data
 
-    for attr, attr_type in six.iteritems(instance.openapi_types):
-        attr = instance.attribute_map[attr] if attr_map else attr
+    if data is None:
+        return instance
 
-        if data is not None \
-                and attr in data \
-                and isinstance(data, (list, dict)):
-            value = data[attr]
+    if not isinstance(data, (list, dict)):
+        return instance
+
+    for attr, attr_type in six.iteritems(instance.openapi_types):
+        dict_attr = instance.attribute_map[attr] if attr_map else attr
+
+        if dict_attr in data:
+            value = data[dict_attr]
             setattr(instance, attr, _deserialize(value, attr_type))
 
     return instance

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/models/api_response.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/models/api_response.py
@@ -42,15 +42,17 @@ class ApiResponse(Model):
         self._message = message
 
     @classmethod
-    def from_dict(cls, dikt) -> 'ApiResponse':
+    def from_dict(cls, dikt, attr_map=True) -> 'ApiResponse':
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The ApiResponse of this ApiResponse.  # noqa: E501
         :rtype: ApiResponse
         """
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
     @property
     def code(self) -> int:

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/models/base_model_.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/models/base_model_.py
@@ -32,19 +32,19 @@ class Model(object):
         result = {}
 
         for attr, _ in six.iteritems(self.swagger_types):
-            attr = self.attribute_map[attr] if attr_map else attr
-
             value = getattr(self, attr)
+
+            attr = self.attribute_map[attr] if attr_map else attr
             if isinstance(value, list):
                 result[attr] = list(map(
-                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    lambda x: x.to_dict(attr_map=attr_map) if hasattr(x, "to_dict") else x,
                     value
                 ))
             elif hasattr(value, "to_dict"):
-                result[attr] = value.to_dict()
+                result[attr] = value.to_dict(attr_map=attr_map)
             elif isinstance(value, dict):
                 result[attr] = dict(map(
-                    lambda item: (item[0], item[1].to_dict())
+                    lambda item: (item[0], item[1].to_dict(attr_map=attr_map))
                     if hasattr(item[1], "to_dict") else item,
                     value.items()
                 ))

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/models/base_model_.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/models/base_model_.py
@@ -18,18 +18,22 @@ class Model(object):
     attribute_map = {}
 
     @classmethod
-    def from_dict(cls: typing.Type[T], dikt) -> T:
+    def from_dict(cls: typing.Type[T], dikt, attr_map=True) -> T:
         """Returns the dict as a model"""
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
-    def to_dict(self):
+    def to_dict(self, attr_map=True):
         """Returns the model properties as a dict
 
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :rtype: dict
         """
         result = {}
 
         for attr, _ in six.iteritems(self.swagger_types):
+            attr = self.attribute_map[attr] if attr_map else attr
+
             value = getattr(self, attr)
             if isinstance(value, list):
                 result[attr] = list(map(

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/models/category.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/models/category.py
@@ -37,15 +37,17 @@ class Category(Model):
         self._name = name
 
     @classmethod
-    def from_dict(cls, dikt) -> 'Category':
+    def from_dict(cls, dikt, attr_map=True) -> 'Category':
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The Category of this Category.  # noqa: E501
         :rtype: Category
         """
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
     @property
     def id(self) -> int:

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/models/order.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/models/order.py
@@ -57,15 +57,17 @@ class Order(Model):
         self._complete = complete
 
     @classmethod
-    def from_dict(cls, dikt) -> 'Order':
+    def from_dict(cls, dikt, attr_map=True) -> 'Order':
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The Order of this Order.  # noqa: E501
         :rtype: Order
         """
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
     @property
     def id(self) -> int:

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/models/pet.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/models/pet.py
@@ -59,15 +59,17 @@ class Pet(Model):
         self._status = status
 
     @classmethod
-    def from_dict(cls, dikt) -> 'Pet':
+    def from_dict(cls, dikt, attr_map=True) -> 'Pet':
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The Pet of this Pet.  # noqa: E501
         :rtype: Pet
         """
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
     @property
     def id(self) -> int:

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/models/tag.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/models/tag.py
@@ -37,15 +37,17 @@ class Tag(Model):
         self._name = name
 
     @classmethod
-    def from_dict(cls, dikt) -> 'Tag':
+    def from_dict(cls, dikt, attr_map=True) -> 'Tag':
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The Tag of this Tag.  # noqa: E501
         :rtype: Tag
         """
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
     @property
     def id(self) -> int:

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/models/user.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/models/user.py
@@ -67,15 +67,17 @@ class User(Model):
         self._user_status = user_status
 
     @classmethod
-    def from_dict(cls, dikt) -> 'User':
+    def from_dict(cls, dikt, attr_map=True) -> 'User':
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The User of this User.  # noqa: E501
         :rtype: User
         """
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
     @property
     def id(self) -> int:

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/util.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/util.py
@@ -91,12 +91,14 @@ def deserialize_datetime(string):
         return string
 
 
-def deserialize_model(data, klass):
+def deserialize_model(data, klass, attr_map=True):
     """Deserializes list or dict to model.
 
     :param data: dict, list.
     :type data: dict | list
     :param klass: class literal.
+    :param attr_map: defines if attribute_map is used in dict.
+    :type attr_map: bool
     :return: model object.
     """
     instance = klass()
@@ -104,11 +106,13 @@ def deserialize_model(data, klass):
     if not instance.swagger_types:
         return data
 
-    for attr, attr_type in six.iteritems(instance.swagger_types):
+    for attr, attr_type in six.iteritems(instance.openapi_types):
+        attr = instance.attribute_map[attr] if attr_map else attr
+
         if data is not None \
-                and instance.attribute_map[attr] in data \
+                and attr in data \
                 and isinstance(data, (list, dict)):
-            value = data[instance.attribute_map[attr]]
+            value = data[attr]
             setattr(instance, attr, _deserialize(value, attr_type))
 
     return instance

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/util.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/util.py
@@ -103,16 +103,21 @@ def deserialize_model(data, klass, attr_map=True):
     """
     instance = klass()
 
+    # should be included in return types
     if not instance.swagger_types:
         return data
 
-    for attr, attr_type in six.iteritems(instance.openapi_types):
-        attr = instance.attribute_map[attr] if attr_map else attr
+    if data is None:
+        return instance
 
-        if data is not None \
-                and attr in data \
-                and isinstance(data, (list, dict)):
-            value = data[attr]
+    if not isinstance(data, (list, dict)):
+        return instance
+
+    for attr, attr_type in six.iteritems(instance.openapi_types):
+        dict_attr = instance.attribute_map[attr] if attr_map else attr
+
+        if dict_attr in data:
+            value = data[dict_attr]
             setattr(instance, attr, _deserialize(value, attr_type))
 
     return instance

--- a/samples/server/petstore/python-flask/openapi_server/models/api_response.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/api_response.py
@@ -42,15 +42,17 @@ class ApiResponse(Model):
         self._message = message
 
     @classmethod
-    def from_dict(cls, dikt) -> 'ApiResponse':
+    def from_dict(cls, dikt, attr_map=True) -> 'ApiResponse':
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The ApiResponse of this ApiResponse.  # noqa: E501
         :rtype: ApiResponse
         """
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
     @property
     def code(self):

--- a/samples/server/petstore/python-flask/openapi_server/models/base_model_.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/base_model_.py
@@ -18,18 +18,22 @@ class Model(object):
     attribute_map = {}
 
     @classmethod
-    def from_dict(cls: typing.Type[T], dikt) -> T:
+    def from_dict(cls: typing.Type[T], dikt, attr_map=True) -> T:
         """Returns the dict as a model"""
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
-    def to_dict(self):
+    def to_dict(self, attr_map=True):
         """Returns the model properties as a dict
 
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :rtype: dict
         """
         result = {}
 
         for attr, _ in six.iteritems(self.openapi_types):
+            attr = self.attribute_map[attr] if attr_map else attr
+
             value = getattr(self, attr)
             if isinstance(value, list):
                 result[attr] = list(map(

--- a/samples/server/petstore/python-flask/openapi_server/models/base_model_.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/base_model_.py
@@ -32,19 +32,19 @@ class Model(object):
         result = {}
 
         for attr, _ in six.iteritems(self.openapi_types):
-            attr = self.attribute_map[attr] if attr_map else attr
-
             value = getattr(self, attr)
+
+            attr = self.attribute_map[attr] if attr_map else attr
             if isinstance(value, list):
                 result[attr] = list(map(
-                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    lambda x: x.to_dict(attr_map=attr_map) if hasattr(x, "to_dict") else x,
                     value
                 ))
             elif hasattr(value, "to_dict"):
-                result[attr] = value.to_dict()
+                result[attr] = value.to_dict(attr_map=attr_map)
             elif isinstance(value, dict):
                 result[attr] = dict(map(
-                    lambda item: (item[0], item[1].to_dict())
+                    lambda item: (item[0], item[1].to_dict(attr_map=attr_map))
                     if hasattr(item[1], "to_dict") else item,
                     value.items()
                 ))

--- a/samples/server/petstore/python-flask/openapi_server/models/category.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/category.py
@@ -37,15 +37,17 @@ class Category(Model):
         self._name = name
 
     @classmethod
-    def from_dict(cls, dikt) -> 'Category':
+    def from_dict(cls, dikt, attr_map=True) -> 'Category':
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The Category of this Category.  # noqa: E501
         :rtype: Category
         """
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
     @property
     def id(self):

--- a/samples/server/petstore/python-flask/openapi_server/models/order.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/order.py
@@ -57,15 +57,17 @@ class Order(Model):
         self._complete = complete
 
     @classmethod
-    def from_dict(cls, dikt) -> 'Order':
+    def from_dict(cls, dikt, attr_map=True) -> 'Order':
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The Order of this Order.  # noqa: E501
         :rtype: Order
         """
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
     @property
     def id(self):

--- a/samples/server/petstore/python-flask/openapi_server/models/pet.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/pet.py
@@ -61,15 +61,17 @@ class Pet(Model):
         self._status = status
 
     @classmethod
-    def from_dict(cls, dikt) -> 'Pet':
+    def from_dict(cls, dikt, attr_map=True) -> 'Pet':
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The Pet of this Pet.  # noqa: E501
         :rtype: Pet
         """
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
     @property
     def id(self):

--- a/samples/server/petstore/python-flask/openapi_server/models/tag.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/tag.py
@@ -37,15 +37,17 @@ class Tag(Model):
         self._name = name
 
     @classmethod
-    def from_dict(cls, dikt) -> 'Tag':
+    def from_dict(cls, dikt, attr_map=True) -> 'Tag':
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The Tag of this Tag.  # noqa: E501
         :rtype: Tag
         """
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
     @property
     def id(self):

--- a/samples/server/petstore/python-flask/openapi_server/models/user.py
+++ b/samples/server/petstore/python-flask/openapi_server/models/user.py
@@ -67,15 +67,17 @@ class User(Model):
         self._user_status = user_status
 
     @classmethod
-    def from_dict(cls, dikt) -> 'User':
+    def from_dict(cls, dikt, attr_map=True) -> 'User':
         """Returns the dict as a model
 
         :param dikt: A dict.
         :type: dict
+        :param attr_map: Defines if attribute_map is used in dict.
+        :type: bool
         :return: The User of this User.  # noqa: E501
         :rtype: User
         """
-        return util.deserialize_model(dikt, cls)
+        return util.deserialize_model(dikt, cls, attr_map=attr_map)
 
     @property
     def id(self):

--- a/samples/server/petstore/python-flask/openapi_server/test/test_attribute_map_order.py
+++ b/samples/server/petstore/python-flask/openapi_server/test/test_attribute_map_order.py
@@ -1,0 +1,68 @@
+# coding: utf-8
+
+from __future__ import absolute_import
+import unittest
+from datetime import datetime
+
+from openapi_server.models.api_response import ApiResponse  # noqa: E501
+from openapi_server.models.order import Order
+from openapi_server.test import BaseTestCase
+
+
+class TestOrderAttributeMap(BaseTestCase):
+    """Model serialization has to respect attribute_map on the class"""
+
+    def setUp(self) -> None:
+        now = datetime.now()
+
+        self.data = {
+            "id": 0,
+            "pet_id": 1,
+            "quantity": 25,
+            "ship_date": now,
+            "status": "placed",
+            "complete": True
+        }
+
+        self.desired_data = {
+            "id": 0,
+            "petId": 1,
+            "quantity": 25,
+            "shipDate": now,
+            "status": "placed",
+            "complete": True
+        }
+
+    def test_order_to_dict_default(self):
+        """
+        By default `attribute_map` uses `True` value,
+        attribute_map of the class is respected.
+        """
+        order = Order(**self.data)
+        dikt = order.to_dict()
+        self.assertEqual(dikt, self.desired_data)
+
+    def test_order_to_dict_false(self):
+        """
+        Passing `False` into `to_dict` method does not use
+        `attribute_map` on the class.
+        """
+        order = Order(**self.data)
+        dikt = order.to_dict(attr_map=False)
+        self.assertEqual(dikt, self.data)
+
+    def test_order_from_dict_to_dict(self):
+        """
+        Creates new `Order` instance by using `from_dict` method,
+        passing in data from existing `Order` `to_dict` method.
+        Instances and their `dict` data are equal.
+        """
+        order = Order(**self.data)
+        order2 = Order.from_dict(order.to_dict())
+
+        self.assertEqual(order.to_dict(), order2.to_dict())
+        self.assertEqual(order, order2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/samples/server/petstore/python-flask/openapi_server/test/test_attribute_map_pet.py
+++ b/samples/server/petstore/python-flask/openapi_server/test/test_attribute_map_pet.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+
+from __future__ import absolute_import
+import unittest
+
+from openapi_server.models.api_response import ApiResponse  # noqa: E501
+from openapi_server.models.pet import Pet
+from openapi_server.test import BaseTestCase
+
+
+class TestPetAttributeMap(BaseTestCase):
+    """Model serialization has to respect attribute_map on the class"""
+
+    def setUp(self) -> None:
+
+        self.data = {
+            "photo_urls": ["photoUrls", "photoUrls"],
+            "name": "doggie",
+            "id": 0,
+            "category": {
+                "name": "name",
+                "id": 6
+            },
+            "tags": [{
+                "name": "name",
+                "id": 1
+            }, {
+                "name": "name",
+                "id": 1
+            }],
+            "status": "available"
+        }
+
+        self.desired_data = {
+            "photoUrls": ["photoUrls", "photoUrls"],
+            "name": "doggie",
+            "id": 0,
+            "category": {
+                "name": "name",
+                "id": 6
+            },
+            "tags": [{
+                "name": "name",
+                "id": 1
+            }, {
+                "name": "name",
+                "id": 1
+            }],
+            "status": "available"
+        }
+
+    def test_pet_to_dict_default(self):
+        """
+        By default `attribute_map` uses `True` value,
+        attribute_map of the class is respected.
+        """
+        pet = Pet(**self.data)
+        dikt = pet.to_dict()
+        self.assertEqual(dikt, self.desired_data)
+
+    def test_pet_to_dict_false(self):
+        """
+        Passing `False` into `to_dict` method does not use
+        `attribute_map` on the class.
+        """
+        pet = Pet(**self.data)
+        dikt = pet.to_dict(attr_map=False)
+        self.assertEqual(dikt, self.data)
+
+    def test_pet_from_dict_to_dict(self):
+        """
+        Creates new `Pet` instance by using `from_dict` method
+        passing in data from existing pet `to_dict` method.
+        Instances and their `dict` data are equal.
+        """
+        pet = Pet(**self.data)
+        pet2 = Pet.from_dict(pet.to_dict())
+
+        self.assertEqual(pet.to_dict(), pet2.to_dict())
+        self.assertEqual(pet, pet2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/samples/server/petstore/python-flask/openapi_server/test/test_attribute_map_user.py
+++ b/samples/server/petstore/python-flask/openapi_server/test/test_attribute_map_user.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+
+from __future__ import absolute_import
+import unittest
+
+from openapi_server.models.api_response import ApiResponse  # noqa: E501
+from openapi_server.models.user import User
+from openapi_server.test import BaseTestCase
+
+
+class TestUserAttributeMap(BaseTestCase):
+    """Model serialization has to respect attribute_map on the class"""
+
+    def setUp(self) -> None:
+
+        self.data = {
+            'id': 8,
+            'username': "john",
+            'first_name': "doe",
+            'last_name': "johm",
+            'email': "example@example.com",
+            'password': "123",
+            'phone': "123",
+            'user_status': 1
+        }
+
+        self.desired_data = {
+            'id': 8,
+            'username': "john",
+            'firstName': "doe",
+            'lastName': "johm",
+            'email': "example@example.com",
+            'password': "123",
+            'phone': "123",
+            'userStatus': 1
+        }
+
+    def test_user_to_dict_default(self):
+        """
+        By default `attribute_map` uses `True` value,
+        attribute_map of the class is respected.
+        """
+        user = User(**self.data)
+        dikt = user.to_dict()
+        self.assertEqual(dikt, self.desired_data)
+
+    def test_user_to_dict_false(self):
+        """
+        Passing `False` into `to_dict` method does not use
+        `attribute_map` on the class.
+        """
+        user = User(**self.data)
+        dikt = user.to_dict(attr_map=False)
+        self.assertEqual(dikt, self.data)
+
+    def test_user_from_dict_to_dict(self):
+        """
+        Creates new `User` instance by using `from_dict` method
+        passing in data from existing user `to_dict` method.
+        Instances are their `dict` data are equal.
+        """
+        user = User(**self.data)
+        user2 = User.from_dict(user.to_dict())
+
+        self.assertEqual(user.to_dict(), user2.to_dict())
+        self.assertEqual(user, user2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/samples/server/petstore/python-flask/openapi_server/util.py
+++ b/samples/server/petstore/python-flask/openapi_server/util.py
@@ -91,12 +91,14 @@ def deserialize_datetime(string):
         return string
 
 
-def deserialize_model(data, klass):
+def deserialize_model(data, klass, attr_map=True):
     """Deserializes list or dict to model.
 
     :param data: dict, list.
     :type data: dict | list
     :param klass: class literal.
+    :param attr_map: defines if attribute_map is used in dict.
+    :type attr_map: bool
     :return: model object.
     """
     instance = klass()
@@ -105,10 +107,12 @@ def deserialize_model(data, klass):
         return data
 
     for attr, attr_type in six.iteritems(instance.openapi_types):
+        attr = instance.attribute_map[attr] if attr_map else attr
+
         if data is not None \
-                and instance.attribute_map[attr] in data \
+                and attr in data \
                 and isinstance(data, (list, dict)):
-            value = data[instance.attribute_map[attr]]
+            value = data[attr]
             setattr(instance, attr, _deserialize(value, attr_type))
 
     return instance

--- a/samples/server/petstore/python-flask/openapi_server/util.py
+++ b/samples/server/petstore/python-flask/openapi_server/util.py
@@ -103,16 +103,21 @@ def deserialize_model(data, klass, attr_map=True):
     """
     instance = klass()
 
+    # should be included in return types
     if not instance.openapi_types:
         return data
 
-    for attr, attr_type in six.iteritems(instance.openapi_types):
-        attr = instance.attribute_map[attr] if attr_map else attr
+    if data is None:
+        return instance
 
-        if data is not None \
-                and attr in data \
-                and isinstance(data, (list, dict)):
-            value = data[attr]
+    if not isinstance(data, (list, dict)):
+        return instance
+
+    for attr, attr_type in six.iteritems(instance.openapi_types):
+        dict_attr = instance.attribute_map[attr] if attr_map else attr
+
+        if dict_attr in data:
+            value = data[dict_attr]
             setattr(instance, attr, _deserialize(value, attr_type))
 
     return instance


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This is based on pull request https://github.com/OpenAPITools/openapi-generator/pull/4587 made by @Shogoki as a fix to https://github.com/OpenAPITools/openapi-generator/issues/4586 also https://github.com/kubernetes-client/python/issues/1228 https://github.com/kubernetes-client/python/issues/1215

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
### note 
I ran only `generate-samples.sh` 

  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@spacether (2020/05)


1. I think that using `attr_map` is more obvious than using `json_keys` - please comment. 
2. Some tests are not passing with strange behaviour please take a look ( https://travis-ci.org/github/bukforks/openapi-generator/builds/760203683#L4574 )
3. I think tests regarding chained `attr_map` in `to_dict` method should be added?
3. Tests are included only in the `python-flask` samples for now.