### PR TITLE
Adds fix for composed schema model vars

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2619,7 +2619,7 @@ public class DefaultCodegen implements CodegenConfig {
         return m;
     }
 
-    private void setAddProps(Schema schema, IJsonSchemaValidationProperties property){
+    protected void setAddProps(Schema schema, IJsonSchemaValidationProperties property){
         if (schema.equals(new Schema())) {
             // if we are trying to set additionalProperties on an empty schema stop recursing
             return;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -6174,7 +6174,7 @@ public class DefaultCodegen implements CodegenConfig {
         return codegenParameter;
     }
 
-    protected void addVarsRequiredVarsAdditionaProps(Schema schema, IJsonSchemaValidationProperties property){
+    protected void addVarsRequiredVarsAdditionalProps(Schema schema, IJsonSchemaValidationProperties property){
         setAddProps(schema, property);
         if (!"object".equals(schema.getType())) {
             return;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2495,7 +2495,6 @@ public class DefaultCodegen implements CodegenConfig {
             }
 
             addVars(m, unaliasPropertySchema(properties), required, unaliasPropertySchema(allProperties), allRequired);
-
             // Per OAS specification, composed schemas may use the 'additionalProperties' keyword.
             if (supportsAdditionalPropertiesWithComposedSchema) {
                 // Process the schema specified with the 'additionalProperties' keyword.
@@ -4856,7 +4855,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param properties a map of properties (schema)
      * @param mandatory  a set of required properties' name
      */
-    private void addVars(IJsonSchemaValidationProperties m, List<CodegenProperty> vars, Map<String, Schema> properties, Set<String> mandatory) {
+    protected void addVars(IJsonSchemaValidationProperties m, List<CodegenProperty> vars, Map<String, Schema> properties, Set<String> mandatory) {
         if (properties == null) {
             return;
         }
@@ -6175,7 +6174,7 @@ public class DefaultCodegen implements CodegenConfig {
         return codegenParameter;
     }
 
-    private void addVarsRequiredVarsAdditionalProps(Schema schema, IJsonSchemaValidationProperties property){
+    protected void addVarsRequiredVarsAdditionaProps(Schema schema, IJsonSchemaValidationProperties property){
         setAddProps(schema, property);
         if (!"object".equals(schema.getType())) {
             return;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2264,6 +2264,11 @@ public class DefaultCodegen implements CodegenConfig {
 
     Map<NamedSchema, CodegenProperty> schemaCodegenPropertyCache = new HashMap<NamedSchema, CodegenProperty>();
 
+    protected void accumulatePropertiesAndRequiredPropertiesFromComposedSchema(Map<String, Schema> properties, List<String> required, Schema refSchema, Map<String, Schema> allProperties, List<String> allRequired) {
+        addProperties(properties, required, refSchema);
+        addProperties(allProperties, allRequired, refSchema);
+    }
+
     /**
      * Convert OAS Model object to Codegen Model object.
      *
@@ -2442,8 +2447,7 @@ public class DefaultCodegen implements CodegenConfig {
                             addProperties(allProperties, allRequired, refSchema);
                         } else {
                             // composition
-                            addProperties(properties, required, refSchema);
-                            addProperties(allProperties, allRequired, refSchema);
+                            accumulatePropertiesAndRequiredPropertiesFromComposedSchema(properties, required, refSchema, allProperties, allRequired);
                         }
                     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -183,6 +183,16 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
         }
         this.setDisallowAdditionalPropertiesIfNotPresent(disallowAddProps);
 
+        /*
+        in this generator we turn these off because
+        each schema should be validated independently across schemas per OpenApi
+        also schemas can have variable name collisions across schemas
+        so property a can have type int in one schema and string in another
+        Turning these off allows each of the a definitions to remain separate and to not be stuffed into and collide in
+        a composed schema
+         */
+        this.supportsInheritance = false;
+        this.supportsMultipleInheritance = false;
 
         // check library option to ensure only urllib3 is supported
         if (!DEFAULT_LIBRARY.equals(getLibrary())) {
@@ -667,6 +677,18 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
 
         List<String> referencedModelNames = new ArrayList<String>();
         model.dataType = getTypeString(schema, "", "", referencedModelNames);
+    }
+
+    @Override
+    protected void accumulatePropertiesAndRequiredPropertiesFromComposedSchema(Map<String, Schema> properties, List<String> required, Schema refSchema, Map<String, Schema> allProperties, List<String> allRequired) {
+        /*
+        in this generator we turn these off because
+        each schema should be validated independently across schemas per OpenApi
+        also schemas can have variable name collisions across schemas
+        so property a can have type int in one schema and string in another
+        Turning these off allows each of the a definitions to remain separate and to not be stuffed into and collide in
+        a composed schema
+         */
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -1497,6 +1497,7 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
 
     @Override
     protected void addVarsRequiredVarsAdditionaProps(Schema schema, IJsonSchemaValidationProperties property){
+        setAddProps(schema, property);
         if (schema instanceof ComposedSchema && supportsAdditionalPropertiesWithComposedSchema) {
             // if schema has properties outside of allOf/oneOf/anyOf also add them
             ComposedSchema cs = (ComposedSchema) schema;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -1496,7 +1496,7 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
     }
 
     @Override
-    protected void addVarsRequiredVarsAdditionaProps(Schema schema, IJsonSchemaValidationProperties property){
+    protected void addVarsRequiredVarsAdditionalProps(Schema schema, IJsonSchemaValidationProperties property){
         setAddProps(schema, property);
         if (schema instanceof ComposedSchema && supportsAdditionalPropertiesWithComposedSchema) {
             // if schema has properties outside of allOf/oneOf/anyOf also add them

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
@@ -40,6 +40,8 @@ import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
+
 @SuppressWarnings("static-method")
 public class PythonClientTest {
 
@@ -464,4 +466,148 @@ public class PythonClientTest {
 
     }
 
+    @Test
+    public void testModelVarsCorrect() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_8813.yaml");
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        String modelName;
+        Schema sc;
+        CodegenModel cm;
+
+        modelName = "ObjectNoProps";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.vars.size(), 0);
+
+        modelName = "ObjectWithABProps";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.vars.size(), 2);
+
+        modelName = "ObjectWithCDProps";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.vars.size(), 2);
+
+        modelName = "ComposedOneOfNoProps";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.vars.size(), 0);
+
+        modelName = "ComposedAnyOfNoProps";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.vars.size(), 0);
+
+        modelName = "ComposedAllOfNoProps";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.vars.size(), 0);
+
+        modelName = "ComposedOneOfWithProps";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.vars.size(), 2);
+
+        modelName = "ComposedAnyOfWithProps";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.vars.size(), 2);
+
+        modelName = "ComposedAllOfWithProps";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.vars.size(), 2);
+    }
+
+    @Test
+    public void testPropertyVarsCorrect() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_8813.yaml");
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        String modelName;
+        Schema sc;
+        CodegenModel cm;
+
+        modelName = "OpjectWithPropsInObjectProps";
+        sc = openAPI.getComponents().getSchemas().get(modelName);
+        cm = codegen.fromModel(modelName, sc);
+        assertEquals(cm.vars.get(0).vars.size(), 0); // ObjectNoProps
+        // these are complexTypes so vars will not be accurate
+        // assertEquals(cm.vars.get(1).vars.size(), 2); // ObjectWithABProps
+        // assertEquals(cm.vars.get(2).vars.size(), 2); // ObjectWithCDProps
+        assertEquals(cm.vars.get(3).vars.size(), 0); // ComposedOneOfNoProps
+        assertEquals(cm.vars.get(4).vars.size(), 0); // ComposedAnyOfNoProps
+        assertEquals(cm.vars.get(5).vars.size(), 0); // ComposedAllOfNoProps
+        assertEquals(cm.vars.get(6).vars.size(), 2); // ComposedOneOfWithProps
+        assertEquals(cm.vars.get(7).vars.size(), 2); // ComposedAnyOfWithProps
+        assertEquals(cm.vars.get(8).vars.size(), 2); // ComposedAllOfWithProps
+    }
+
+    @Test
+    public void testQueryParameterVarsCorrect() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_8813.yaml");
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+
+        final String path = "/queryParamVars";
+        final Operation operation = openAPI.getPaths().get(path).getGet();
+        final CodegenOperation co = codegen.fromOperation(path, "get", operation, null);
+
+        assertEquals(co.queryParams.get(0).vars.size(), 0); // ObjectNoProps
+        // these are complexTypes so vars will not be accurate
+        // assertEquals(co.queryParams.get(1).vars.size(), 2); // ObjectWithABProps
+        // assertEquals(co.queryParams.get(2).vars.size(), 2); // ObjectWithCDProps
+        assertEquals(co.queryParams.get(3).vars.size(), 0); // ComposedOneOfNoProps
+        assertEquals(co.queryParams.get(4).vars.size(), 0); // ComposedAnyOfNoProps
+        assertEquals(co.queryParams.get(5).vars.size(), 0); // ComposedAllOfNoProps
+        assertEquals(co.queryParams.get(6).vars.size(), 2); // ComposedOneOfWithProps
+        assertEquals(co.queryParams.get(7).vars.size(), 2); // ComposedAnyOfWithProps
+        assertEquals(co.queryParams.get(8).vars.size(), 2); // ComposedAllOfWithProps
+    }
+
+    @Test
+    public void testBodyParamAndResponseVarsCorrect() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_8813.yaml");
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        String path;
+        Operation op;
+        CodegenOperation co;
+
+        path = "/ComposedOneOfNoProps";
+        op = openAPI.getPaths().get(path).getPost();
+        co = codegen.fromOperation(path, "post", op, null);
+        assertEquals(co.bodyParam.vars.size(), 0);
+        assertEquals(co.responses.get(0).vars.size(), 0);
+
+        path = "/ComposedAnyOfNoProps";
+        op = openAPI.getPaths().get(path).getPost();
+        co = codegen.fromOperation(path, "post", op, null);
+        assertEquals(co.bodyParam.vars.size(), 0);
+        assertEquals(co.responses.get(0).vars.size(), 0);
+
+        path = "/ComposedAllOfNoProps";
+        op = openAPI.getPaths().get(path).getPost();
+        co = codegen.fromOperation(path, "post", op, null);
+        assertEquals(co.bodyParam.vars.size(), 0);
+        assertEquals(co.responses.get(0).vars.size(), 0);
+
+        path = "/ComposedOneOfWithProps";
+        op = openAPI.getPaths().get(path).getPost();
+        co = codegen.fromOperation(path, "post", op, null);
+        assertEquals(co.bodyParam.vars.size(), 2);
+        assertEquals(co.responses.get(0).vars.size(), 2);
+
+        path = "/ComposedAllOfWithProps";
+        op = openAPI.getPaths().get(path).getPost();
+        co = codegen.fromOperation(path, "post", op, null);
+        assertEquals(co.bodyParam.vars.size(), 2);
+        assertEquals(co.responses.get(0).vars.size(), 2);
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_8813.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_8813.yaml
@@ -1,0 +1,343 @@
+openapi: 3.0.0
+info:
+  title: foo
+  version: 1.0.0
+paths:
+  /queryParamVars:
+    get:
+      responses:
+        '200':
+          description: Successful response
+      parameters:
+        - in: query
+          name: ObjectNoProps
+          schema:
+            type: object
+        - in: query
+          name: ObjectWithABProps
+          schema:
+            type: object
+            properties:
+              a:
+                type: integer
+              b:
+                type: string
+        - in: query
+          name: ObjectWithCDProps
+          schema:
+            type: object
+            properties:
+              c:
+                type: integer
+              d:
+                type: string
+        - in: query
+          name: ComposedOneOfNoProps
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/ObjectWithABProps'
+              - $ref: '#/components/schemas/ObjectWithCDProps'
+        - in: query
+          name: ComposedAnyOfNoProps
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/ObjectWithABProps'
+              - $ref: '#/components/schemas/ObjectWithCDProps'
+        - in: query
+          name: ComposedAllOfNoProps
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/ObjectWithABProps'
+              - $ref: '#/components/schemas/ObjectWithCDProps'
+        - in: query
+          name: ComposedOneOfWithProps
+          schema:
+            properties:
+              e:
+                type: integer
+              f:
+                type: string
+            oneOf:
+              - $ref: '#/components/schemas/ObjectWithABProps'
+              - $ref: '#/components/schemas/ObjectWithCDProps'
+
+        - in: query
+          name: ComposedAnyOfWithProps
+          schema:
+            properties:
+              e:
+                type: integer
+              f:
+                type: string
+            anyOf:
+              - $ref: '#/components/schemas/ObjectWithABProps'
+              - $ref: '#/components/schemas/ObjectWithCDProps'
+        - in: query
+          name: ComposedAllOfWithProps
+          schema:
+            properties:
+              e:
+                type: integer
+              f:
+                type: string
+            allOf:
+              - $ref: '#/components/schemas/ObjectWithABProps'
+              - $ref: '#/components/schemas/ObjectWithCDProps'
+  /ComposedOneOfNoProps:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/ObjectWithABProps'
+                - $ref: '#/components/schemas/ObjectWithCDProps'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ObjectWithABProps'
+                  - $ref: '#/components/schemas/ObjectWithCDProps'
+  /ComposedAnyOfNoProps:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/ObjectWithABProps'
+                - $ref: '#/components/schemas/ObjectWithCDProps'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/ObjectWithABProps'
+                  - $ref: '#/components/schemas/ObjectWithCDProps'
+  /ComposedAllOfNoProps:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/ObjectWithABProps'
+                - $ref: '#/components/schemas/ObjectWithCDProps'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ObjectWithABProps'
+                  - $ref: '#/components/schemas/ObjectWithCDProps'
+  /ComposedOneOfWithProps:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                e:
+                  type: integer
+                f:
+                  type: string
+              oneOf:
+                - $ref: '#/components/schemas/ObjectWithABProps'
+                - $ref: '#/components/schemas/ObjectWithCDProps'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                properties:
+                  e:
+                    type: integer
+                  f:
+                    type: string
+                oneOf:
+                  - $ref: '#/components/schemas/ObjectWithABProps'
+                  - $ref: '#/components/schemas/ObjectWithCDProps'
+  /ComposedAnyOfWithProps:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                e:
+                  type: integer
+                f:
+                  type: string
+              anyOf:
+                - $ref: '#/components/schemas/ObjectWithABProps'
+                - $ref: '#/components/schemas/ObjectWithCDProps'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                properties:
+                  e:
+                    type: integer
+                  f:
+                    type: string
+                anyOf:
+                  - $ref: '#/components/schemas/ObjectWithABProps'
+                  - $ref: '#/components/schemas/ObjectWithCDProps'
+  /ComposedAllOfWithProps:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                e:
+                  type: integer
+                f:
+                  type: string
+              allOf:
+                - $ref: '#/components/schemas/ObjectWithABProps'
+                - $ref: '#/components/schemas/ObjectWithCDProps'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                properties:
+                  e:
+                    type: integer
+                  f:
+                    type: string
+                allOf:
+                  - $ref: '#/components/schemas/ObjectWithABProps'
+                  - $ref: '#/components/schemas/ObjectWithCDProps'
+components:
+  schemas:
+    ObjectNoProps:
+      type: object
+    ObjectWithABProps:
+      type: object
+      properties:
+        a:
+          type: integer
+        b:
+          type: string
+    ObjectWithCDProps:
+      type: object
+      properties:
+        c:
+          type: integer
+        d:
+          type: string
+    ComposedOneOfNoProps:
+      oneOf:
+        - $ref: '#/components/schemas/ObjectWithABProps'
+        - $ref: '#/components/schemas/ObjectWithCDProps'
+    ComposedAnyOfNoProps:
+      anyOf:
+        - $ref: '#/components/schemas/ObjectWithABProps'
+        - $ref: '#/components/schemas/ObjectWithCDProps'
+    ComposedAllOfNoProps:
+      allOf:
+        - $ref: '#/components/schemas/ObjectWithABProps'
+        - $ref: '#/components/schemas/ObjectWithCDProps'
+    ComposedOneOfWithProps:
+      properties:
+        e:
+          type: integer
+        f:
+          type: string
+      oneOf:
+        - $ref: '#/components/schemas/ObjectWithABProps'
+        - $ref: '#/components/schemas/ObjectWithCDProps'
+    ComposedAnyOfWithProps:
+      properties:
+        e:
+          type: integer
+        f:
+          type: string
+      anyOf:
+        - $ref: '#/components/schemas/ObjectWithABProps'
+        - $ref: '#/components/schemas/ObjectWithCDProps'
+    ComposedAllOfWithProps:
+      properties:
+        e:
+          type: integer
+        f:
+          type: string
+      allOf:
+        - $ref: '#/components/schemas/ObjectWithABProps'
+        - $ref: '#/components/schemas/ObjectWithCDProps'
+    OpjectWithPropsInObjectProps:
+      properties:
+        ObjectNoProps:
+          type: object
+        ObjectWithABProps:
+          type: object
+          properties:
+            a:
+              type: integer
+            b:
+              type: string
+        ObjectWithCDProps:
+          type: object
+          properties:
+            c:
+              type: integer
+            d:
+              type: string
+        ComposedOneOfNoProps:
+          oneOf:
+            - $ref: '#/components/schemas/ObjectWithABProps'
+            - $ref: '#/components/schemas/ObjectWithCDProps'
+        ComposedAnyOfNoProps:
+          anyOf:
+            - $ref: '#/components/schemas/ObjectWithABProps'
+            - $ref: '#/components/schemas/ObjectWithCDProps'
+        ComposedAllOfNoProps:
+          allOf:
+            - $ref: '#/components/schemas/ObjectWithABProps'
+            - $ref: '#/components/schemas/ObjectWithCDProps'
+        ComposedOneOfWithProps:
+          properties:
+            e:
+              type: integer
+            f:
+              type: string
+          oneOf:
+            - $ref: '#/components/schemas/ObjectWithABProps'
+            - $ref: '#/components/schemas/ObjectWithCDProps'
+        ComposedAnyOfWithProps:
+          properties:
+            e:
+              type: integer
+            f:
+              type: string
+          anyOf:
+            - $ref: '#/components/schemas/ObjectWithABProps'
+            - $ref: '#/components/schemas/ObjectWithCDProps'
+        ComposedAllOfWithProps:
+          properties:
+            e:
+              type: integer
+            f:
+              type: string
+          allOf:
+            - $ref: '#/components/schemas/ObjectWithABProps'
+            - $ref: '#/components/schemas/ObjectWithCDProps'

--- a/samples/openapi3/client/petstore/python/.openapi-generator/VERSION
+++ b/samples/openapi3/client/petstore/python/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-5.2.0-SNAPSHOT
+unset

--- a/samples/openapi3/client/petstore/python/docs/Cat.md
+++ b/samples/openapi3/client/petstore/python/docs/Cat.md
@@ -4,9 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**class_name** | **str** |  | 
-**declawed** | **bool** |  | [optional] 
-**color** | **str** |  | [optional]  if omitted the server will use the default value of "red"
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/ChildCat.md
+++ b/samples/openapi3/client/petstore/python/docs/ChildCat.md
@@ -4,8 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**pet_type** | **str** |  | 
-**name** | **str** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/ComplexQuadrilateral.md
+++ b/samples/openapi3/client/petstore/python/docs/ComplexQuadrilateral.md
@@ -4,8 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**shape_type** | **str** |  | 
-**quadrilateral_type** | **str** |  | 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/ComposedOneOfNumberWithValidations.md
+++ b/samples/openapi3/client/petstore/python/docs/ComposedOneOfNumberWithValidations.md
@@ -5,8 +5,6 @@ this is a model that allows payloads of type object or number
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**color** | **str** |  | [optional]  if omitted the server will use the default value of "red"
-**class_name** | **str** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/ComposedSchemaWithPropsAndNoAddProps.md
+++ b/samples/openapi3/client/petstore/python/docs/ComposedSchemaWithPropsAndNoAddProps.md
@@ -5,8 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **color** | **str** |  | [optional] 
-**id** | **int** |  | [optional] 
-**name** | **str** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/Dog.md
+++ b/samples/openapi3/client/petstore/python/docs/Dog.md
@@ -4,9 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**class_name** | **str** |  | 
-**breed** | **str** |  | [optional] 
-**color** | **str** |  | [optional]  if omitted the server will use the default value of "red"
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/EquilateralTriangle.md
+++ b/samples/openapi3/client/petstore/python/docs/EquilateralTriangle.md
@@ -4,8 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**shape_type** | **str** |  | 
-**triangle_type** | **str** |  | 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/Fruit.md
+++ b/samples/openapi3/client/petstore/python/docs/Fruit.md
@@ -5,10 +5,7 @@ a schema that tests oneOf and includes a schema level property
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**cultivar** | **str** |  | 
-**length_cm** | **float** |  | 
 **color** | **str** |  | [optional] 
-**origin** | **str** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/FruitReq.md
+++ b/samples/openapi3/client/petstore/python/docs/FruitReq.md
@@ -5,10 +5,6 @@ a schema where additionalProperties is on in the composed schema and off in the 
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**mealy** | **bool** |  | [optional] 
-**sweet** | **bool** |  | [optional] 
-**cultivar** | **str** |  | [optional] 
-**length_cm** | **float** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/GmFruit.md
+++ b/samples/openapi3/client/petstore/python/docs/GmFruit.md
@@ -4,10 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**cultivar** | **str** |  | 
-**length_cm** | **float** |  | 
 **color** | **str** |  | [optional] 
-**origin** | **str** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/IsoscelesTriangle.md
+++ b/samples/openapi3/client/petstore/python/docs/IsoscelesTriangle.md
@@ -4,8 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**shape_type** | **str** |  | 
-**triangle_type** | **str** |  | 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/Mammal.md
+++ b/samples/openapi3/client/petstore/python/docs/Mammal.md
@@ -4,10 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**class_name** | **str** |  | 
-**has_baleen** | **bool** |  | [optional] 
-**has_teeth** | **bool** |  | [optional] 
-**type** | **str** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/NullableShape.md
+++ b/samples/openapi3/client/petstore/python/docs/NullableShape.md
@@ -5,9 +5,6 @@ The value may be a shape or the 'null' value. The 'nullable' attribute was intro
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**shape_type** | **str** |  | 
-**quadrilateral_type** | **str** |  | [optional] 
-**triangle_type** | **str** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/ParentPet.md
+++ b/samples/openapi3/client/petstore/python/docs/ParentPet.md
@@ -4,7 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**pet_type** | **str** |  | 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/Pig.md
+++ b/samples/openapi3/client/petstore/python/docs/Pig.md
@@ -4,7 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**class_name** | **str** |  | 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/Quadrilateral.md
+++ b/samples/openapi3/client/petstore/python/docs/Quadrilateral.md
@@ -4,8 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**quadrilateral_type** | **str** |  | 
-**shape_type** | **str** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/ScaleneTriangle.md
+++ b/samples/openapi3/client/petstore/python/docs/ScaleneTriangle.md
@@ -4,8 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**shape_type** | **str** |  | 
-**triangle_type** | **str** |  | 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/Shape.md
+++ b/samples/openapi3/client/petstore/python/docs/Shape.md
@@ -4,9 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**shape_type** | **str** |  | 
-**quadrilateral_type** | **str** |  | [optional] 
-**triangle_type** | **str** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/ShapeOrNull.md
+++ b/samples/openapi3/client/petstore/python/docs/ShapeOrNull.md
@@ -5,9 +5,6 @@ The value may be a shape or the 'null' value. This is introduced in OAS schema >
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**shape_type** | **str** |  | 
-**quadrilateral_type** | **str** |  | [optional] 
-**triangle_type** | **str** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/SimpleQuadrilateral.md
+++ b/samples/openapi3/client/petstore/python/docs/SimpleQuadrilateral.md
@@ -4,8 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**shape_type** | **str** |  | 
-**quadrilateral_type** | **str** |  | 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/docs/Triangle.md
+++ b/samples/openapi3/client/petstore/python/docs/Triangle.md
@@ -4,8 +4,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**triangle_type** | **str** |  | 
-**shape_type** | **str** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/cat.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/cat.py
@@ -89,9 +89,6 @@ class Cat(ModelComposed):
         """
         lazy_import()
         return {
-            'class_name': (str,),  # noqa: E501
-            'declawed': (bool,),  # noqa: E501
-            'color': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -103,9 +100,6 @@ class Cat(ModelComposed):
         return {'class_name': val}
 
     attribute_map = {
-        'class_name': 'className',  # noqa: E501
-        'declawed': 'declawed',  # noqa: E501
-        'color': 'color',  # noqa: E501
     }
 
     read_only_vars = {
@@ -117,7 +111,6 @@ class Cat(ModelComposed):
         """Cat - a model defined in OpenAPI
 
         Keyword Args:
-            class_name (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -148,8 +141,6 @@ class Cat(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            declawed (bool): [optional]  # noqa: E501
-            color (str): [optional] if omitted the server will use the default value of "red"  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -219,7 +210,6 @@ class Cat(ModelComposed):
         """Cat - a model defined in OpenAPI
 
         Keyword Args:
-            class_name (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -250,8 +240,6 @@ class Cat(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            declawed (bool): [optional]  # noqa: E501
-            color (str): [optional] if omitted the server will use the default value of "red"  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/child_cat.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/child_cat.py
@@ -89,8 +89,6 @@ class ChildCat(ModelComposed):
         """
         lazy_import()
         return {
-            'pet_type': (str,),  # noqa: E501
-            'name': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -102,8 +100,6 @@ class ChildCat(ModelComposed):
         return {'pet_type': val}
 
     attribute_map = {
-        'pet_type': 'pet_type',  # noqa: E501
-        'name': 'name',  # noqa: E501
     }
 
     read_only_vars = {
@@ -115,7 +111,6 @@ class ChildCat(ModelComposed):
         """ChildCat - a model defined in OpenAPI
 
         Keyword Args:
-            pet_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -146,7 +141,6 @@ class ChildCat(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            name (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -216,7 +210,6 @@ class ChildCat(ModelComposed):
         """ChildCat - a model defined in OpenAPI
 
         Keyword Args:
-            pet_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -247,7 +240,6 @@ class ChildCat(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            name (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/complex_quadrilateral.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/complex_quadrilateral.py
@@ -89,8 +89,6 @@ class ComplexQuadrilateral(ModelComposed):
         """
         lazy_import()
         return {
-            'shape_type': (str,),  # noqa: E501
-            'quadrilateral_type': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -99,8 +97,6 @@ class ComplexQuadrilateral(ModelComposed):
 
 
     attribute_map = {
-        'shape_type': 'shapeType',  # noqa: E501
-        'quadrilateral_type': 'quadrilateralType',  # noqa: E501
     }
 
     read_only_vars = {
@@ -112,8 +108,6 @@ class ComplexQuadrilateral(ModelComposed):
         """ComplexQuadrilateral - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
-            quadrilateral_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -213,8 +207,6 @@ class ComplexQuadrilateral(ModelComposed):
         """ComplexQuadrilateral - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
-            quadrilateral_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.

--- a/samples/openapi3/client/petstore/python/petstore_api/model/composed_one_of_number_with_validations.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/composed_one_of_number_with_validations.py
@@ -89,8 +89,6 @@ class ComposedOneOfNumberWithValidations(ModelComposed):
         """
         lazy_import()
         return {
-            'color': (str,),  # noqa: E501
-            'class_name': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -99,8 +97,6 @@ class ComposedOneOfNumberWithValidations(ModelComposed):
 
 
     attribute_map = {
-        'color': 'color',  # noqa: E501
-        'class_name': 'className',  # noqa: E501
     }
 
     read_only_vars = {
@@ -142,8 +138,6 @@ class ComposedOneOfNumberWithValidations(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            color (str): [optional] if omitted the server will use the default value of "red"  # noqa: E501
-            class_name (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -243,8 +237,6 @@ class ComposedOneOfNumberWithValidations(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            color (str): [optional] if omitted the server will use the default value of "red"  # noqa: E501
-            class_name (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/composed_schema_with_props_and_no_add_props.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/composed_schema_with_props_and_no_add_props.py
@@ -81,8 +81,6 @@ class ComposedSchemaWithPropsAndNoAddProps(ModelComposed):
         lazy_import()
         return {
             'color': (str,),  # noqa: E501
-            'id': (int,),  # noqa: E501
-            'name': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -92,8 +90,6 @@ class ComposedSchemaWithPropsAndNoAddProps(ModelComposed):
 
     attribute_map = {
         'color': 'color',  # noqa: E501
-        'id': 'id',  # noqa: E501
-        'name': 'name',  # noqa: E501
     }
 
     read_only_vars = {
@@ -136,8 +132,6 @@ class ComposedSchemaWithPropsAndNoAddProps(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
             color (str): [optional]  # noqa: E501
-            id (int): [optional]  # noqa: E501
-            name (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -238,8 +232,6 @@ class ComposedSchemaWithPropsAndNoAddProps(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
             color (str): [optional]  # noqa: E501
-            id (int): [optional]  # noqa: E501
-            name (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/dog.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/dog.py
@@ -89,9 +89,6 @@ class Dog(ModelComposed):
         """
         lazy_import()
         return {
-            'class_name': (str,),  # noqa: E501
-            'breed': (str,),  # noqa: E501
-            'color': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -103,9 +100,6 @@ class Dog(ModelComposed):
         return {'class_name': val}
 
     attribute_map = {
-        'class_name': 'className',  # noqa: E501
-        'breed': 'breed',  # noqa: E501
-        'color': 'color',  # noqa: E501
     }
 
     read_only_vars = {
@@ -117,7 +111,6 @@ class Dog(ModelComposed):
         """Dog - a model defined in OpenAPI
 
         Keyword Args:
-            class_name (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -148,8 +141,6 @@ class Dog(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            breed (str): [optional]  # noqa: E501
-            color (str): [optional] if omitted the server will use the default value of "red"  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -219,7 +210,6 @@ class Dog(ModelComposed):
         """Dog - a model defined in OpenAPI
 
         Keyword Args:
-            class_name (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -250,8 +240,6 @@ class Dog(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            breed (str): [optional]  # noqa: E501
-            color (str): [optional] if omitted the server will use the default value of "red"  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/equilateral_triangle.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/equilateral_triangle.py
@@ -89,8 +89,6 @@ class EquilateralTriangle(ModelComposed):
         """
         lazy_import()
         return {
-            'shape_type': (str,),  # noqa: E501
-            'triangle_type': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -99,8 +97,6 @@ class EquilateralTriangle(ModelComposed):
 
 
     attribute_map = {
-        'shape_type': 'shapeType',  # noqa: E501
-        'triangle_type': 'triangleType',  # noqa: E501
     }
 
     read_only_vars = {
@@ -112,8 +108,6 @@ class EquilateralTriangle(ModelComposed):
         """EquilateralTriangle - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
-            triangle_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -213,8 +207,6 @@ class EquilateralTriangle(ModelComposed):
         """EquilateralTriangle - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
-            triangle_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.

--- a/samples/openapi3/client/petstore/python/petstore_api/model/fruit.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/fruit.py
@@ -64,17 +64,6 @@ class Fruit(ModelComposed):
     }
 
     validations = {
-        ('cultivar',): {
-            'regex': {
-                'pattern': r'^[a-zA-Z\s]*$',  # noqa: E501
-            },
-        },
-        ('origin',): {
-            'regex': {
-                'pattern': r'^[A-Z\s]*$',  # noqa: E501
-                'flags': (re.IGNORECASE)
-            },
-        },
     }
 
     @cached_property
@@ -100,10 +89,7 @@ class Fruit(ModelComposed):
         """
         lazy_import()
         return {
-            'cultivar': (str,),  # noqa: E501
-            'length_cm': (float,),  # noqa: E501
             'color': (str,),  # noqa: E501
-            'origin': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -112,10 +98,7 @@ class Fruit(ModelComposed):
 
 
     attribute_map = {
-        'cultivar': 'cultivar',  # noqa: E501
-        'length_cm': 'lengthCm',  # noqa: E501
         'color': 'color',  # noqa: E501
-        'origin': 'origin',  # noqa: E501
     }
 
     read_only_vars = {
@@ -127,8 +110,6 @@ class Fruit(ModelComposed):
         """Fruit - a model defined in OpenAPI
 
         Keyword Args:
-            cultivar (str):
-            length_cm (float):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -160,7 +141,6 @@ class Fruit(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
             color (str): [optional]  # noqa: E501
-            origin (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -230,8 +210,6 @@ class Fruit(ModelComposed):
         """Fruit - a model defined in OpenAPI
 
         Keyword Args:
-            cultivar (str):
-            length_cm (float):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -263,7 +241,6 @@ class Fruit(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
             color (str): [optional]  # noqa: E501
-            origin (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/fruit_req.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/fruit_req.py
@@ -89,10 +89,6 @@ class FruitReq(ModelComposed):
         """
         lazy_import()
         return {
-            'mealy': (bool,),  # noqa: E501
-            'sweet': (bool,),  # noqa: E501
-            'cultivar': (str,),  # noqa: E501
-            'length_cm': (float,),  # noqa: E501
         }
 
     @cached_property
@@ -101,10 +97,6 @@ class FruitReq(ModelComposed):
 
 
     attribute_map = {
-        'mealy': 'mealy',  # noqa: E501
-        'sweet': 'sweet',  # noqa: E501
-        'cultivar': 'cultivar',  # noqa: E501
-        'length_cm': 'lengthCm',  # noqa: E501
     }
 
     read_only_vars = {
@@ -146,10 +138,6 @@ class FruitReq(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            mealy (bool): [optional]  # noqa: E501
-            sweet (bool): [optional]  # noqa: E501
-            cultivar (str): [optional]  # noqa: E501
-            length_cm (float): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -249,10 +237,6 @@ class FruitReq(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            mealy (bool): [optional]  # noqa: E501
-            sweet (bool): [optional]  # noqa: E501
-            cultivar (str): [optional]  # noqa: E501
-            length_cm (float): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/gm_fruit.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/gm_fruit.py
@@ -64,17 +64,6 @@ class GmFruit(ModelComposed):
     }
 
     validations = {
-        ('cultivar',): {
-            'regex': {
-                'pattern': r'^[a-zA-Z\s]*$',  # noqa: E501
-            },
-        },
-        ('origin',): {
-            'regex': {
-                'pattern': r'^[A-Z\s]*$',  # noqa: E501
-                'flags': (re.IGNORECASE)
-            },
-        },
     }
 
     @cached_property
@@ -100,10 +89,7 @@ class GmFruit(ModelComposed):
         """
         lazy_import()
         return {
-            'cultivar': (str,),  # noqa: E501
-            'length_cm': (float,),  # noqa: E501
             'color': (str,),  # noqa: E501
-            'origin': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -112,10 +98,7 @@ class GmFruit(ModelComposed):
 
 
     attribute_map = {
-        'cultivar': 'cultivar',  # noqa: E501
-        'length_cm': 'lengthCm',  # noqa: E501
         'color': 'color',  # noqa: E501
-        'origin': 'origin',  # noqa: E501
     }
 
     read_only_vars = {
@@ -127,8 +110,6 @@ class GmFruit(ModelComposed):
         """GmFruit - a model defined in OpenAPI
 
         Keyword Args:
-            cultivar (str):
-            length_cm (float):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -160,7 +141,6 @@ class GmFruit(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
             color (str): [optional]  # noqa: E501
-            origin (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -230,8 +210,6 @@ class GmFruit(ModelComposed):
         """GmFruit - a model defined in OpenAPI
 
         Keyword Args:
-            cultivar (str):
-            length_cm (float):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -263,7 +241,6 @@ class GmFruit(ModelComposed):
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
             color (str): [optional]  # noqa: E501
-            origin (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/isosceles_triangle.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/isosceles_triangle.py
@@ -89,8 +89,6 @@ class IsoscelesTriangle(ModelComposed):
         """
         lazy_import()
         return {
-            'shape_type': (str,),  # noqa: E501
-            'triangle_type': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -99,8 +97,6 @@ class IsoscelesTriangle(ModelComposed):
 
 
     attribute_map = {
-        'shape_type': 'shapeType',  # noqa: E501
-        'triangle_type': 'triangleType',  # noqa: E501
     }
 
     read_only_vars = {
@@ -112,8 +108,6 @@ class IsoscelesTriangle(ModelComposed):
         """IsoscelesTriangle - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
-            triangle_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -213,8 +207,6 @@ class IsoscelesTriangle(ModelComposed):
         """IsoscelesTriangle - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
-            triangle_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.

--- a/samples/openapi3/client/petstore/python/petstore_api/model/mammal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/mammal.py
@@ -63,11 +63,6 @@ class Mammal(ModelComposed):
     """
 
     allowed_values = {
-        ('type',): {
-            'PLAINS': "plains",
-            'MOUNTAIN': "mountain",
-            'GREVYS': "grevys",
-        },
     }
 
     validations = {
@@ -96,10 +91,6 @@ class Mammal(ModelComposed):
         """
         lazy_import()
         return {
-            'class_name': (str,),  # noqa: E501
-            'has_baleen': (bool,),  # noqa: E501
-            'has_teeth': (bool,),  # noqa: E501
-            'type': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -115,10 +106,6 @@ class Mammal(ModelComposed):
         return {'class_name': val}
 
     attribute_map = {
-        'class_name': 'className',  # noqa: E501
-        'has_baleen': 'hasBaleen',  # noqa: E501
-        'has_teeth': 'hasTeeth',  # noqa: E501
-        'type': 'type',  # noqa: E501
     }
 
     read_only_vars = {
@@ -130,7 +117,6 @@ class Mammal(ModelComposed):
         """Mammal - a model defined in OpenAPI
 
         Keyword Args:
-            class_name (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -161,9 +147,6 @@ class Mammal(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            has_baleen (bool): [optional]  # noqa: E501
-            has_teeth (bool): [optional]  # noqa: E501
-            type (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -233,7 +216,6 @@ class Mammal(ModelComposed):
         """Mammal - a model defined in OpenAPI
 
         Keyword Args:
-            class_name (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -264,9 +246,6 @@ class Mammal(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            has_baleen (bool): [optional]  # noqa: E501
-            has_teeth (bool): [optional]  # noqa: E501
-            type (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/nullable_shape.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/nullable_shape.py
@@ -89,9 +89,6 @@ class NullableShape(ModelComposed):
         """
         lazy_import()
         return {
-            'shape_type': (str,),  # noqa: E501
-            'quadrilateral_type': (str,),  # noqa: E501
-            'triangle_type': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -106,9 +103,6 @@ class NullableShape(ModelComposed):
         return {'shape_type': val}
 
     attribute_map = {
-        'shape_type': 'shapeType',  # noqa: E501
-        'quadrilateral_type': 'quadrilateralType',  # noqa: E501
-        'triangle_type': 'triangleType',  # noqa: E501
     }
 
     read_only_vars = {
@@ -120,7 +114,6 @@ class NullableShape(ModelComposed):
         """NullableShape - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -151,8 +144,6 @@ class NullableShape(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            quadrilateral_type (str): [optional]  # noqa: E501
-            triangle_type (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -222,7 +213,6 @@ class NullableShape(ModelComposed):
         """NullableShape - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -253,8 +243,6 @@ class NullableShape(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            quadrilateral_type (str): [optional]  # noqa: E501
-            triangle_type (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/parent_pet.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/parent_pet.py
@@ -89,7 +89,6 @@ class ParentPet(ModelComposed):
         """
         lazy_import()
         return {
-            'pet_type': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -103,7 +102,6 @@ class ParentPet(ModelComposed):
         return {'pet_type': val}
 
     attribute_map = {
-        'pet_type': 'pet_type',  # noqa: E501
     }
 
     read_only_vars = {
@@ -115,7 +113,6 @@ class ParentPet(ModelComposed):
         """ParentPet - a model defined in OpenAPI
 
         Keyword Args:
-            pet_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -215,7 +212,6 @@ class ParentPet(ModelComposed):
         """ParentPet - a model defined in OpenAPI
 
         Keyword Args:
-            pet_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.

--- a/samples/openapi3/client/petstore/python/petstore_api/model/pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/pig.py
@@ -89,7 +89,6 @@ class Pig(ModelComposed):
         """
         lazy_import()
         return {
-            'class_name': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -104,7 +103,6 @@ class Pig(ModelComposed):
         return {'class_name': val}
 
     attribute_map = {
-        'class_name': 'className',  # noqa: E501
     }
 
     read_only_vars = {
@@ -116,7 +114,6 @@ class Pig(ModelComposed):
         """Pig - a model defined in OpenAPI
 
         Keyword Args:
-            class_name (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -216,7 +213,6 @@ class Pig(ModelComposed):
         """Pig - a model defined in OpenAPI
 
         Keyword Args:
-            class_name (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.

--- a/samples/openapi3/client/petstore/python/petstore_api/model/quadrilateral.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/quadrilateral.py
@@ -89,8 +89,6 @@ class Quadrilateral(ModelComposed):
         """
         lazy_import()
         return {
-            'quadrilateral_type': (str,),  # noqa: E501
-            'shape_type': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -105,8 +103,6 @@ class Quadrilateral(ModelComposed):
         return {'quadrilateral_type': val}
 
     attribute_map = {
-        'quadrilateral_type': 'quadrilateralType',  # noqa: E501
-        'shape_type': 'shapeType',  # noqa: E501
     }
 
     read_only_vars = {
@@ -118,7 +114,6 @@ class Quadrilateral(ModelComposed):
         """Quadrilateral - a model defined in OpenAPI
 
         Keyword Args:
-            quadrilateral_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -149,7 +144,6 @@ class Quadrilateral(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            shape_type (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -219,7 +213,6 @@ class Quadrilateral(ModelComposed):
         """Quadrilateral - a model defined in OpenAPI
 
         Keyword Args:
-            quadrilateral_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -250,7 +243,6 @@ class Quadrilateral(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            shape_type (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/scalene_triangle.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/scalene_triangle.py
@@ -89,8 +89,6 @@ class ScaleneTriangle(ModelComposed):
         """
         lazy_import()
         return {
-            'shape_type': (str,),  # noqa: E501
-            'triangle_type': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -99,8 +97,6 @@ class ScaleneTriangle(ModelComposed):
 
 
     attribute_map = {
-        'shape_type': 'shapeType',  # noqa: E501
-        'triangle_type': 'triangleType',  # noqa: E501
     }
 
     read_only_vars = {
@@ -112,8 +108,6 @@ class ScaleneTriangle(ModelComposed):
         """ScaleneTriangle - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
-            triangle_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -213,8 +207,6 @@ class ScaleneTriangle(ModelComposed):
         """ScaleneTriangle - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
-            triangle_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.

--- a/samples/openapi3/client/petstore/python/petstore_api/model/shape.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/shape.py
@@ -89,9 +89,6 @@ class Shape(ModelComposed):
         """
         lazy_import()
         return {
-            'shape_type': (str,),  # noqa: E501
-            'quadrilateral_type': (str,),  # noqa: E501
-            'triangle_type': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -106,9 +103,6 @@ class Shape(ModelComposed):
         return {'shape_type': val}
 
     attribute_map = {
-        'shape_type': 'shapeType',  # noqa: E501
-        'quadrilateral_type': 'quadrilateralType',  # noqa: E501
-        'triangle_type': 'triangleType',  # noqa: E501
     }
 
     read_only_vars = {
@@ -120,7 +114,6 @@ class Shape(ModelComposed):
         """Shape - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -151,8 +144,6 @@ class Shape(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            quadrilateral_type (str): [optional]  # noqa: E501
-            triangle_type (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -222,7 +213,6 @@ class Shape(ModelComposed):
         """Shape - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -253,8 +243,6 @@ class Shape(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            quadrilateral_type (str): [optional]  # noqa: E501
-            triangle_type (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/shape_or_null.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/shape_or_null.py
@@ -89,9 +89,6 @@ class ShapeOrNull(ModelComposed):
         """
         lazy_import()
         return {
-            'shape_type': (str,),  # noqa: E501
-            'quadrilateral_type': (str,),  # noqa: E501
-            'triangle_type': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -106,9 +103,6 @@ class ShapeOrNull(ModelComposed):
         return {'shape_type': val}
 
     attribute_map = {
-        'shape_type': 'shapeType',  # noqa: E501
-        'quadrilateral_type': 'quadrilateralType',  # noqa: E501
-        'triangle_type': 'triangleType',  # noqa: E501
     }
 
     read_only_vars = {
@@ -120,7 +114,6 @@ class ShapeOrNull(ModelComposed):
         """ShapeOrNull - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -151,8 +144,6 @@ class ShapeOrNull(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            quadrilateral_type (str): [optional]  # noqa: E501
-            triangle_type (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -222,7 +213,6 @@ class ShapeOrNull(ModelComposed):
         """ShapeOrNull - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -253,8 +243,6 @@ class ShapeOrNull(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            quadrilateral_type (str): [optional]  # noqa: E501
-            triangle_type (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/samples/openapi3/client/petstore/python/petstore_api/model/simple_quadrilateral.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/simple_quadrilateral.py
@@ -89,8 +89,6 @@ class SimpleQuadrilateral(ModelComposed):
         """
         lazy_import()
         return {
-            'shape_type': (str,),  # noqa: E501
-            'quadrilateral_type': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -99,8 +97,6 @@ class SimpleQuadrilateral(ModelComposed):
 
 
     attribute_map = {
-        'shape_type': 'shapeType',  # noqa: E501
-        'quadrilateral_type': 'quadrilateralType',  # noqa: E501
     }
 
     read_only_vars = {
@@ -112,8 +108,6 @@ class SimpleQuadrilateral(ModelComposed):
         """SimpleQuadrilateral - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
-            quadrilateral_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -213,8 +207,6 @@ class SimpleQuadrilateral(ModelComposed):
         """SimpleQuadrilateral - a model defined in OpenAPI
 
         Keyword Args:
-            shape_type (str):
-            quadrilateral_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.

--- a/samples/openapi3/client/petstore/python/petstore_api/model/triangle.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/triangle.py
@@ -91,8 +91,6 @@ class Triangle(ModelComposed):
         """
         lazy_import()
         return {
-            'triangle_type': (str,),  # noqa: E501
-            'shape_type': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -108,8 +106,6 @@ class Triangle(ModelComposed):
         return {'triangle_type': val}
 
     attribute_map = {
-        'triangle_type': 'triangleType',  # noqa: E501
-        'shape_type': 'shapeType',  # noqa: E501
     }
 
     read_only_vars = {
@@ -121,7 +117,6 @@ class Triangle(ModelComposed):
         """Triangle - a model defined in OpenAPI
 
         Keyword Args:
-            triangle_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -152,7 +147,6 @@ class Triangle(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            shape_type (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -222,7 +216,6 @@ class Triangle(ModelComposed):
         """Triangle - a model defined in OpenAPI
 
         Keyword Args:
-            triangle_type (str):
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -253,7 +246,6 @@ class Triangle(ModelComposed):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            shape_type (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)


### PR DESCRIPTION
Adds fix for composed schema model vars
Per [guidance from json schema and openapi people](https://github.com/OAI/OpenAPI-Specification/issues/2478), when a composed schema has properties or additionalProperties
object payloads are validated to the properties or additionalProerties definition at the composed schema level, independent of properties in composed oneOf/anyOf/allOf definition

So that means that CodegenModel.vars must store only the properties present in the composed schema, if they are present.
This has implications to how we validate composed schemas across generators, and that all generators should eventually support supportsAdditionalPropertiesWithComposedSchema = True.
For now only python and java support it.

This is a fix for: https://github.com/OpenAPITools/openapi-generator/issues/8813

### Blocker
Landing this PR is blocked by: https://github.com/OpenAPITools/openapi-generator/pull/8802
because we need additionalProperties to be set at the model level before we can use it to allow any value in in all key value pairs.

@sebastien-rosset should the go generator set supportsAdditionalPropertiesWithComposedSchema to True?

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
