### PR TITLE
Fix base type naming in Go

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -393,7 +393,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         String type = null;
 
         if (ref != null && !ref.isEmpty()) {
-            type = openAPIType;
+            type = toModelName(openAPIType);
         } else if ("object".equals(openAPIType) && isAnyTypeSchema(p)) {
             // Arbitrary type. Note this is not the same thing as free-form object.
             type = "interface{}";

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/DefaultApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/DefaultApi.md
@@ -51,7 +51,7 @@ Other parameters are passed through a pointer to a apiFooGetRequest struct via t
 
 ### Return type
 
-[**InlineResponseDefault**](inline_response_default.md)
+[**InlineResponseDefault**](InlineResponseDefault.md)
 
 ### Authorization
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Go generation didn't properly named base type in `getSchemaType`, which ends up
breaking some doc generation.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.