### PR TITLE
[C++][Qt5] added QSet as datatype for unique items

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
@@ -105,6 +105,7 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
         typeMapping.put("number", "double");
         typeMapping.put("array", "QList");
         typeMapping.put("map", "QMap");
+        typeMapping.put("set", "QSet");
         typeMapping.put("object", PREFIX + "Object");
         // mapped as "file" type for OAS 3.0
         typeMapping.put("ByteArray", "QByteArray");
@@ -122,6 +123,7 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
         systemIncludes.add("QString");
         systemIncludes.add("QList");
         systemIncludes.add("QMap");
+        systemIncludes.add("QSet");
         systemIncludes.add("QDate");
         systemIncludes.add("QDateTime");
         systemIncludes.add("QByteArray");

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-header.mustache
@@ -26,7 +26,13 @@ template <typename T>
 QString toStringValue(const QList<T> &val);
 
 template <typename T>
+QString toStringValue(const QSet<T> &val);
+
+template <typename T>
 bool fromStringValue(const QList<QString> &inStr, QList<T> &val);
+
+template <typename T>
+bool fromStringValue(const QSet<QString> &inStr, QList<T> &val);
 
 template <typename T>
 bool fromStringValue(const QMap<QString, QString> &inStr, QMap<QString, T> &val);
@@ -35,10 +41,16 @@ template <typename T>
 QJsonValue toJsonValue(const QList<T> &val);
 
 template <typename T>
+QJsonValue toJsonValue(const QSet<T> &val);
+
+template <typename T>
 QJsonValue toJsonValue(const QMap<QString, T> &val);
 
 template <typename T>
 bool fromJsonValue(QList<T> &val, const QJsonValue &jval);
+
+template <typename T>
+bool fromJsonValue(QSet<T> &val, const QJsonValue &jval);
 
 template <typename T>
 bool fromJsonValue(QMap<QString, T> &val, const QJsonValue &jval);
@@ -68,6 +80,18 @@ QString toStringValue(const QList<T> &val) {
     return strArray;
 }
 
+template <typename T>
+QString toStringValue(const QSet<T> &val) {
+    QString strArray;
+    for (const auto &item : val) {
+        strArray.append(toStringValue(item) + ",");
+    }
+    if (val.count() > 0) {
+        strArray.chop(1);
+    }
+    return strArray;
+}
+
 QJsonValue toJsonValue(const QString &value);
 QJsonValue toJsonValue(const QDateTime &value);
 QJsonValue toJsonValue(const QByteArray &value);
@@ -83,6 +107,15 @@ QJsonValue toJsonValue(const {{prefix}}HttpFileElement &value);
 
 template <typename T>
 QJsonValue toJsonValue(const QList<T> &val) {
+    QJsonArray jArray;
+    for (const auto &item : val) {
+        jArray.append(toJsonValue(item));
+    }
+    return jArray;
+}
+
+template <typename T>
+QJsonValue toJsonValue(const QSet<T> &val) {
     QJsonArray jArray;
     for (const auto &item : val) {
         jArray.append(toJsonValue(item));
@@ -124,6 +157,17 @@ bool fromStringValue(const QList<QString> &inStr, QList<T> &val) {
 }
 
 template <typename T>
+bool fromStringValue(const QSet<QString> &inStr, QList<T> &val) {
+    bool ok = (inStr.count() > 0);
+    for (const auto &item : inStr) {
+        T itemVal;
+        ok &= fromStringValue(item, itemVal);
+        val.push_back(itemVal);
+    }
+    return ok;
+}
+
+template <typename T>
 bool fromStringValue(const QMap<QString, QString> &inStr, QMap<QString, T> &val) {
     bool ok = (inStr.count() > 0);
     for (const auto &itemkey : inStr.keys()) {
@@ -155,6 +199,21 @@ bool fromJsonValue(QList<T> &val, const QJsonValue &jval) {
             T item;
             ok &= fromJsonValue(item, jitem);
             val.push_back(item);
+        }
+    } else {
+        ok = false;
+    }
+    return ok;
+}
+
+template <typename T>
+bool fromJsonValue(QSet<T> &val, const QJsonValue &jval) {
+    bool ok = true;
+    if (jval.isArray()) {
+        for (const auto jitem : jval.toArray()) {
+            T item;
+            ok &= fromJsonValue(item, jitem);
+            val.insert(item);
         }
     } else {
         ok = false;

--- a/samples/client/petstore/cpp-qt5/client/PFXHelpers.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXHelpers.h
@@ -34,7 +34,13 @@ template <typename T>
 QString toStringValue(const QList<T> &val);
 
 template <typename T>
+QString toStringValue(const QSet<T> &val);
+
+template <typename T>
 bool fromStringValue(const QList<QString> &inStr, QList<T> &val);
+
+template <typename T>
+bool fromStringValue(const QSet<QString> &inStr, QList<T> &val);
 
 template <typename T>
 bool fromStringValue(const QMap<QString, QString> &inStr, QMap<QString, T> &val);
@@ -43,10 +49,16 @@ template <typename T>
 QJsonValue toJsonValue(const QList<T> &val);
 
 template <typename T>
+QJsonValue toJsonValue(const QSet<T> &val);
+
+template <typename T>
 QJsonValue toJsonValue(const QMap<QString, T> &val);
 
 template <typename T>
 bool fromJsonValue(QList<T> &val, const QJsonValue &jval);
+
+template <typename T>
+bool fromJsonValue(QSet<T> &val, const QJsonValue &jval);
 
 template <typename T>
 bool fromJsonValue(QMap<QString, T> &val, const QJsonValue &jval);
@@ -76,6 +88,18 @@ QString toStringValue(const QList<T> &val) {
     return strArray;
 }
 
+template <typename T>
+QString toStringValue(const QSet<T> &val) {
+    QString strArray;
+    for (const auto &item : val) {
+        strArray.append(toStringValue(item) + ",");
+    }
+    if (val.count() > 0) {
+        strArray.chop(1);
+    }
+    return strArray;
+}
+
 QJsonValue toJsonValue(const QString &value);
 QJsonValue toJsonValue(const QDateTime &value);
 QJsonValue toJsonValue(const QByteArray &value);
@@ -91,6 +115,15 @@ QJsonValue toJsonValue(const PFXHttpFileElement &value);
 
 template <typename T>
 QJsonValue toJsonValue(const QList<T> &val) {
+    QJsonArray jArray;
+    for (const auto &item : val) {
+        jArray.append(toJsonValue(item));
+    }
+    return jArray;
+}
+
+template <typename T>
+QJsonValue toJsonValue(const QSet<T> &val) {
     QJsonArray jArray;
     for (const auto &item : val) {
         jArray.append(toJsonValue(item));
@@ -132,6 +165,17 @@ bool fromStringValue(const QList<QString> &inStr, QList<T> &val) {
 }
 
 template <typename T>
+bool fromStringValue(const QSet<QString> &inStr, QList<T> &val) {
+    bool ok = (inStr.count() > 0);
+    for (const auto &item : inStr) {
+        T itemVal;
+        ok &= fromStringValue(item, itemVal);
+        val.push_back(itemVal);
+    }
+    return ok;
+}
+
+template <typename T>
 bool fromStringValue(const QMap<QString, QString> &inStr, QMap<QString, T> &val) {
     bool ok = (inStr.count() > 0);
     for (const auto &itemkey : inStr.keys()) {
@@ -163,6 +207,21 @@ bool fromJsonValue(QList<T> &val, const QJsonValue &jval) {
             T item;
             ok &= fromJsonValue(item, jitem);
             val.push_back(item);
+        }
+    } else {
+        ok = false;
+    }
+    return ok;
+}
+
+template <typename T>
+bool fromJsonValue(QSet<T> &val, const QJsonValue &jval) {
+    bool ok = true;
+    if (jval.isArray()) {
+        for (const auto jitem : jval.toArray()) {
+            T item;
+            ok &= fromJsonValue(item, jitem);
+            val.insert(item);
         }
     } else {
         ok = false;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR will add support for QSet as a datatype when using unique items. QSet is added to the `typeMapping` in the `CppQt5AbstractCodegen` and the all helper functions are implemented in the `helpers-header.mustache` template.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

PING @wing328 @ravinikam (2017/07) @stkrwork (2017/07) @etherealjoy (2018/02) @MartinDelille (2018/03) @muttleyxd (2019/08)