### PR TITLE
[dart][dart-dio] Add DioError wrapping

### DIFF
--- a/docs/generators/dart-dio.md
+++ b/docs/generators/dart-dio.md
@@ -9,10 +9,11 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 | ------ | ----------- | ------ | ------- |
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |dateLibrary|Option. Date library to use|<dl><dt>**core**</dt><dd>Dart core library (DateTime)</dd><dt>**timemachine**</dt><dd>Time Machine is date and time library for Flutter, Web, and Server with support for timezones, calendars, cultures, formatting and parsing.</dd></dl>|core|
+|dioErrorWrapping|Wrap serialization errors in DioErrors| |true|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |legacyDiscriminatorBehavior|Set to true for generators with better support for discriminators. (Python, Java, Go, PowerShell, C#have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
-|nullableFields|Make all fields nullable in the JSON payload| |null|
+|nullableFields|Make all fields nullable in the JSON payload| |false|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |pubAuthor|Author name in generated pubspec| |null|
 |pubAuthorEmail|Email address of the author in generated pubspec| |null|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -79,6 +79,15 @@ public class CodegenOperation {
     }
 
     /**
+     * Check if there's at least one body parameter or at least one form parameter
+     *
+     * @return true if body or form parameter exists, false otherwise
+     */
+    public boolean getHasBodyOrFormParams() {
+        return getHasBodyParam() || getHasFormParams();
+    }
+
+    /**
      * Check if there's at least one query parameter
      *
      * @return true if query parameter exists, false otherwise

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
@@ -54,7 +54,7 @@ public class DartClientCodegen extends AbstractDartCodegen {
         super.processOpts();
 
         // handle library not being set
-        if(additionalProperties.get(CodegenConstants.SERIALIZATION_LIBRARY) == null) {
+        if (additionalProperties.get(CodegenConstants.SERIALIZATION_LIBRARY) == null) {
             this.library = SERIALIZATION_LIBRARY_NATIVE;
             LOGGER.debug("Serialization library not set, using default {}", SERIALIZATION_LIBRARY_NATIVE);
         } else {

--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -71,64 +71,93 @@ class {{classname}} {
       onSendProgress: onSendProgress,
       onReceiveProgress: onReceiveProgress,
     );
+    {{#hasBodyOrFormParams}}
 
     dynamic _bodyData;
-    {{#hasFormParams}}
 
-    _bodyData = {{#isMultipart}}FormData.fromMap({{/isMultipart}}<String, dynamic>{
-      {{#formParams}}
-      {{^required}}{{^nullable}}if ({{{paramName}}} != null) {{/nullable}}{{/required}}r'{{{baseName}}}': {{#isFile}}MultipartFile.fromBytes({{{paramName}}}, filename: r'{{{baseName}}}'){{/isFile}}{{^isFile}}parameterToString(_serializers, {{{paramName}}}){{/isFile}},
-      {{/formParams}}
-    }{{#isMultipart}}){{/isMultipart}};
-    {{/hasFormParams}}
-    {{#bodyParam}}
-
-    {{#isPrimitiveType}}
-    _bodyData = {{paramName}};
-    {{/isPrimitiveType}}
-    {{^isPrimitiveType}}
-    {{#isContainer}}
-    const _type = FullType(Built{{#isMap}}Map{{/isMap}}{{#isArray}}{{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}{{/isArray}}, [{{#isMap}}FullType(String), {{/isMap}}FullType({{{baseType}}})]);
-    _bodyData = _serializers.serialize({{paramName}}, specifiedType: _type);
-    {{/isContainer}}
-    {{^isContainer}}
-    const _type = FullType({{{baseType}}});
-    _bodyData = _serializers.serialize({{paramName}}, specifiedType: _type);
-    {{/isContainer}}
-    {{/isPrimitiveType}}
-    {{/bodyParam}}
+    try {
+      {{#hasFormParams}}
+      _bodyData = {{#isMultipart}}FormData.fromMap({{/isMultipart}}<String, dynamic>{
+        {{#formParams}}
+        {{^required}}{{^nullable}}if ({{{paramName}}} != null) {{/nullable}}{{/required}}r'{{{baseName}}}': {{#isFile}}MultipartFile.fromBytes({{{paramName}}}, filename: r'{{{baseName}}}'){{/isFile}}{{^isFile}}parameterToString(_serializers, {{{paramName}}}){{/isFile}},
+        {{/formParams}}
+      }{{#isMultipart}}){{/isMultipart}};
+      {{/hasFormParams}}
+      {{#bodyParam}}
+      {{#isPrimitiveType}}
+      _bodyData = {{paramName}};
+      {{/isPrimitiveType}}
+      {{^isPrimitiveType}}
+      {{#isContainer}}
+      const _type = FullType(Built{{#isMap}}Map{{/isMap}}{{#isArray}}{{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}{{/isArray}}, [{{#isMap}}FullType(String), {{/isMap}}FullType({{{baseType}}})]);
+      _bodyData = _serializers.serialize({{paramName}}, specifiedType: _type);
+      {{/isContainer}}
+      {{^isContainer}}
+      const _type = FullType({{{baseType}}});
+      _bodyData = _serializers.serialize({{paramName}}, specifiedType: _type);
+      {{/isContainer}}
+      {{/isPrimitiveType}}
+      {{/bodyParam}}
+    } catch(error) {
+      {{#dioErrorWrapping}}
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+      {{/dioErrorWrapping}}
+      {{^dioErrorWrapping}}
+      rethrow;
+      {{/dioErrorWrapping}}
+    }
+    {{/hasBodyOrFormParams}}
 
     final _response = await _dio.request<dynamic>(
-      _request.path,
-      data: _bodyData,
+      _request.path,{{#hasBodyOrFormParams}}
+      data: _bodyData,{{/hasBodyOrFormParams}}
       options: _request,
     );
     {{#returnType}}
 
-    {{#isResponseFile}}
-    final {{{returnType}}} _responseData = _response.data;
-    {{/isResponseFile}}
-    {{^isResponseFile}}
-    {{#returnSimpleType}}
-    {{#returnTypeIsPrimitive}}
-    final {{{returnType}}} _responseData = _response.data as {{{returnType}}};
-    {{/returnTypeIsPrimitive}}
-    {{^returnTypeIsPrimitive}}
-    const _responseType = FullType({{{returnType}}});
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as {{{returnType}}};
-    {{/returnTypeIsPrimitive}}
-    {{/returnSimpleType}}
-    {{^returnSimpleType}}
-    const _responseType = FullType(Built{{#isArray}}{{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}{{/isArray}}{{#isMap}}Map{{/isMap}}, [{{#isMap}}FullType(String), {{/isMap}}FullType({{{returnBaseType}}})]);
-    final {{{returnType}}} _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as {{{returnType}}};
-    {{/returnSimpleType}}
-    {{/isResponseFile}}
+    {{{returnType}}} _responseData;
+    try {
+      {{#isResponseFile}}
+      _responseData = _response.data;
+      {{/isResponseFile}}
+      {{^isResponseFile}}
+      {{#returnSimpleType}}
+      {{#returnTypeIsPrimitive}}
+      _responseData = _response.data as {{{returnType}}};
+      {{/returnTypeIsPrimitive}}
+      {{^returnTypeIsPrimitive}}
+      const _responseType = FullType({{{returnType}}});
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as {{{returnType}}};
+      {{/returnTypeIsPrimitive}}
+      {{/returnSimpleType}}
+      {{^returnSimpleType}}
+      const _responseType = FullType(Built{{#isArray}}{{#uniqueItems}}Set{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}{{/isArray}}{{#isMap}}Map{{/isMap}}, [{{#isMap}}FullType(String), {{/isMap}}FullType({{{returnBaseType}}})]);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as {{{returnType}}};
+      {{/returnSimpleType}}
+      {{/isResponseFile}}
+    } catch (error) {
+      {{#dioErrorWrapping}}
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+      {{/dioErrorWrapping}}
+      {{^dioErrorWrapping}}
+      rethrow;
+      {{/dioErrorWrapping}}
+    }
 
     return Response<{{{returnType}}}>(
       data: _responseData,

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dartdio/DartDioClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dartdio/DartDioClientOptionsTest.java
@@ -45,12 +45,14 @@ public class DartDioClientOptionsTest extends AbstractOptionsTest {
         verify(clientCodegen).setPubName(DartDioClientOptionsProvider.PUB_NAME_VALUE);
         verify(clientCodegen).setPubVersion(DartDioClientOptionsProvider.PUB_VERSION_VALUE);
         verify(clientCodegen).setPubDescription(DartDioClientOptionsProvider.PUB_DESCRIPTION_VALUE);
-        //verify(clientCodegen).setPubAuthor(DartDioClientOptionsProvider.PUB_AUTHOR_VALUE);
-        //verify(clientCodegen).setPubAuthorEmail(DartDioClientOptionsProvider.PUB_AUTHOR_EMAIL_VALUE);
-        //verify(clientCodegen).setPubHomepage(DartDioClientOptionsProvider.PUB_HOMEPAGE_VALUE);
+        verify(clientCodegen).setPubAuthor(DartDioClientOptionsProvider.PUB_AUTHOR_VALUE);
+        verify(clientCodegen).setPubAuthorEmail(DartDioClientOptionsProvider.PUB_AUTHOR_EMAIL_VALUE);
+        verify(clientCodegen).setPubHomepage(DartDioClientOptionsProvider.PUB_HOMEPAGE_VALUE);
         verify(clientCodegen).setSourceFolder(DartDioClientOptionsProvider.SOURCE_FOLDER_VALUE);
         verify(clientCodegen).setUseEnumExtension(Boolean.parseBoolean(DartDioClientOptionsProvider.USE_ENUM_EXTENSION));
-        verify(clientCodegen).setDateLibrary(DartDioClientOptionsProvider.DATE_LIBRARY);
-        verify(clientCodegen).setNullableFields(Boolean.parseBoolean(DartDioClientOptionsProvider.NULLABLE_FIELDS));
+        verify(clientCodegen).setClientName("Openapi");
+        verify(clientCodegen).setDateLibrary(DartDioClientCodegen.DATE_LIBRARY_DEFAULT);
+        verify(clientCodegen).setNullableFields(DartDioClientCodegen.NULLABLE_FIELDS_DEFAULT);
+        verify(clientCodegen).setDioErrorWrapping(DartDioClientCodegen.DIO_ERROR_WRAPPING_DEFAULT);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dartdio/DartDioModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dartdio/DartDioModelTest.java
@@ -18,7 +18,6 @@
 package org.openapitools.codegen.dartdio;
 
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.DateSchema;
 import io.swagger.v3.oas.models.media.DateTimeSchema;
@@ -26,17 +25,11 @@ import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.MapSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
-import org.openapitools.codegen.ClientOptInput;
-import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
-import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultCodegen;
-import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.TestUtils;
-import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.DartDioClientCodegen;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -108,8 +101,7 @@ public class DartDioModelTest {
             .addRequiredItem("name");
 
         final DartDioClientCodegen codegen = new DartDioClientCodegen();
-        codegen.additionalProperties().put(DartDioClientCodegen.DATE_LIBRARY, "timemachine");
-        codegen.setDateLibrary("timemachine");
+        codegen.additionalProperties().put(DartDioClientCodegen.DATE_LIBRARY, DartDioClientCodegen.DATE_LIBRARY_TIME_MACHINE);
         codegen.processOpts();
 
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
@@ -421,7 +413,7 @@ public class DartDioModelTest {
         OpenAPI openAPI = TestUtils.createOpenAPI();
         final Schema model = new Schema();
         final DartDioClientCodegen codegen = new DartDioClientCodegen();
-        codegen.setDateLibrary("timemachine");
+        codegen.additionalProperties().put(DartDioClientCodegen.DATE_LIBRARY, DartDioClientCodegen.DATE_LIBRARY_TIME_MACHINE);
         codegen.processOpts();
         codegen.setOpenAPI(openAPI);
         final CodegenModel cm = codegen.fromModel(name, model);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/DartDioClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/DartDioClientOptionsProvider.java
@@ -36,8 +36,6 @@ public class DartDioClientOptionsProvider implements OptionsProvider {
     public static final String USE_ENUM_EXTENSION = "true";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = "true";
-    public static final String DATE_LIBRARY = "core";
-    public static final String NULLABLE_FIELDS = "true";
     public static final String PUB_AUTHOR_VALUE = "Author";
     public static final String PUB_AUTHOR_EMAIL_VALUE = "author@homepage";
     public static final String PUB_HOMEPAGE_VALUE = "Homepage";
@@ -64,8 +62,9 @@ public class DartDioClientOptionsProvider implements OptionsProvider {
                 .put(DartDioClientCodegen.USE_ENUM_EXTENSION, USE_ENUM_EXTENSION)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
-                .put(DartDioClientCodegen.DATE_LIBRARY, DATE_LIBRARY)
-                .put(DartDioClientCodegen.NULLABLE_FIELDS, NULLABLE_FIELDS)
+                .put(DartDioClientCodegen.DATE_LIBRARY, DartDioClientCodegen.DATE_LIBRARY_DEFAULT)
+                .put(DartDioClientCodegen.DIO_ERROR_WRAPPING, DartDioClientCodegen.DIO_ERROR_WRAPPING_DEFAULT.toString())
+                .put(DartDioClientCodegen.NULLABLE_FIELDS, DartDioClientCodegen.NULLABLE_FIELDS_DEFAULT.toString())
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
                 .build();

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -64,8 +64,16 @@ class PetApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(Pet);
-    _bodyData = _serializers.serialize(body, specifiedType: _type);
+    try {
+      const _type = FullType(Pet);
+      _bodyData = _serializers.serialize(body, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -116,11 +124,8 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -166,19 +171,26 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(BuiltList, [FullType(Pet)]);
-    final BuiltList<Pet> _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as BuiltList<Pet>;
+    BuiltList<Pet> _responseData;
+    try {
+      const _responseType = FullType(BuiltList, [FullType(Pet)]);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as BuiltList<Pet>;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<BuiltList<Pet>>(
       data: _responseData,
@@ -231,19 +243,26 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(BuiltList, [FullType(Pet)]);
-    final BuiltList<Pet> _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as BuiltList<Pet>;
+    BuiltList<Pet> _responseData;
+    try {
+      const _responseType = FullType(BuiltList, [FullType(Pet)]);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as BuiltList<Pet>;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<BuiltList<Pet>>(
       data: _responseData,
@@ -297,19 +316,26 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(Pet);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as Pet;
+    Pet _responseData;
+    try {
+      const _responseType = FullType(Pet);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as Pet;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<Pet>(
       data: _responseData,
@@ -364,8 +390,16 @@ class PetApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(Pet);
-    _bodyData = _serializers.serialize(body, specifiedType: _type);
+    try {
+      const _type = FullType(Pet);
+      _bodyData = _serializers.serialize(body, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -418,10 +452,18 @@ class PetApi {
 
     dynamic _bodyData;
 
-    _bodyData = <String, dynamic>{
-      if (name != null) r'name': parameterToString(_serializers, name),
-      if (status != null) r'status': parameterToString(_serializers, status),
-    };
+    try {
+      _bodyData = <String, dynamic>{
+        if (name != null) r'name': parameterToString(_serializers, name),
+        if (status != null) r'status': parameterToString(_serializers, status),
+      };
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -474,10 +516,18 @@ class PetApi {
 
     dynamic _bodyData;
 
-    _bodyData = FormData.fromMap(<String, dynamic>{
-      if (additionalMetadata != null) r'additionalMetadata': parameterToString(_serializers, additionalMetadata),
-      if (file != null) r'file': MultipartFile.fromBytes(file, filename: r'file'),
-    });
+    try {
+      _bodyData = FormData.fromMap(<String, dynamic>{
+        if (additionalMetadata != null) r'additionalMetadata': parameterToString(_serializers, additionalMetadata),
+        if (file != null) r'file': MultipartFile.fromBytes(file, filename: r'file'),
+      });
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -485,11 +535,21 @@ class PetApi {
       options: _request,
     );
 
-    const _responseType = FullType(ApiResponse);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as ApiResponse;
+    ApiResponse _responseData;
+    try {
+      const _responseType = FullType(ApiResponse);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as ApiResponse;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<ApiResponse>(
       data: _responseData,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -53,11 +53,8 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -103,19 +100,26 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(BuiltMap, [FullType(String), FullType(int)]);
-    final BuiltMap<String, int> _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as BuiltMap<String, int>;
+    BuiltMap<String, int> _responseData;
+    try {
+      const _responseType = FullType(BuiltMap, [FullType(String), FullType(int)]);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as BuiltMap<String, int>;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<BuiltMap<String, int>>(
       data: _responseData,
@@ -162,19 +166,26 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(Order);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as Order;
+    Order _responseData;
+    try {
+      const _responseType = FullType(Order);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as Order;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<Order>(
       data: _responseData,
@@ -223,8 +234,16 @@ class StoreApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(Order);
-    _bodyData = _serializers.serialize(body, specifiedType: _type);
+    try {
+      const _type = FullType(Order);
+      _bodyData = _serializers.serialize(body, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -232,11 +251,21 @@ class StoreApi {
       options: _request,
     );
 
-    const _responseType = FullType(Order);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as Order;
+    Order _responseData;
+    try {
+      const _responseType = FullType(Order);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as Order;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<Order>(
       data: _responseData,

--- a/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -55,8 +55,16 @@ class UserApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(User);
-    _bodyData = _serializers.serialize(body, specifiedType: _type);
+    try {
+      const _type = FullType(User);
+      _bodyData = _serializers.serialize(body, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -102,8 +110,16 @@ class UserApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(BuiltList, [FullType(User)]);
-    _bodyData = _serializers.serialize(body, specifiedType: _type);
+    try {
+      const _type = FullType(BuiltList, [FullType(User)]);
+      _bodyData = _serializers.serialize(body, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -149,8 +165,16 @@ class UserApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(BuiltList, [FullType(User)]);
-    _bodyData = _serializers.serialize(body, specifiedType: _type);
+    try {
+      const _type = FullType(BuiltList, [FullType(User)]);
+      _bodyData = _serializers.serialize(body, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -194,11 +218,8 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -238,19 +259,26 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(User);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as User;
+    User _responseData;
+    try {
+      const _responseType = FullType(User);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as User;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<User>(
       data: _responseData,
@@ -300,15 +328,22 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    final String _responseData = _response.data as String;
+    String _responseData;
+    try {
+      _responseData = _response.data as String;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<String>(
       data: _responseData,
@@ -354,11 +389,8 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -401,8 +433,16 @@ class UserApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(User);
-    _bodyData = _serializers.serialize(body, specifiedType: _type);
+    try {
+      const _type = FullType(User);
+      _bodyData = _serializers.serialize(body, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/pet_api.dart
@@ -64,8 +64,16 @@ class PetApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(Pet);
-    _bodyData = _serializers.serialize(pet, specifiedType: _type);
+    try {
+      const _type = FullType(Pet);
+      _bodyData = _serializers.serialize(pet, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -73,11 +81,21 @@ class PetApi {
       options: _request,
     );
 
-    const _responseType = FullType(Pet);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as Pet;
+    Pet _responseData;
+    try {
+      const _responseType = FullType(Pet);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as Pet;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<Pet>(
       data: _responseData,
@@ -131,11 +149,8 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -181,19 +196,26 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(BuiltList, [FullType(Pet)]);
-    final BuiltList<Pet> _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as BuiltList<Pet>;
+    BuiltList<Pet> _responseData;
+    try {
+      const _responseType = FullType(BuiltList, [FullType(Pet)]);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as BuiltList<Pet>;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<BuiltList<Pet>>(
       data: _responseData,
@@ -246,19 +268,26 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(BuiltList, [FullType(Pet)]);
-    final BuiltList<Pet> _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as BuiltList<Pet>;
+    BuiltList<Pet> _responseData;
+    try {
+      const _responseType = FullType(BuiltList, [FullType(Pet)]);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as BuiltList<Pet>;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<BuiltList<Pet>>(
       data: _responseData,
@@ -312,19 +341,26 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(Pet);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as Pet;
+    Pet _responseData;
+    try {
+      const _responseType = FullType(Pet);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as Pet;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<Pet>(
       data: _responseData,
@@ -379,8 +415,16 @@ class PetApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(Pet);
-    _bodyData = _serializers.serialize(pet, specifiedType: _type);
+    try {
+      const _type = FullType(Pet);
+      _bodyData = _serializers.serialize(pet, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -388,11 +432,21 @@ class PetApi {
       options: _request,
     );
 
-    const _responseType = FullType(Pet);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as Pet;
+    Pet _responseData;
+    try {
+      const _responseType = FullType(Pet);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as Pet;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<Pet>(
       data: _responseData,
@@ -448,10 +502,18 @@ class PetApi {
 
     dynamic _bodyData;
 
-    _bodyData = <String, dynamic>{
-      if (name != null) r'name': parameterToString(_serializers, name),
-      if (status != null) r'status': parameterToString(_serializers, status),
-    };
+    try {
+      _bodyData = <String, dynamic>{
+        if (name != null) r'name': parameterToString(_serializers, name),
+        if (status != null) r'status': parameterToString(_serializers, status),
+      };
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -504,10 +566,18 @@ class PetApi {
 
     dynamic _bodyData;
 
-    _bodyData = FormData.fromMap(<String, dynamic>{
-      if (additionalMetadata != null) r'additionalMetadata': parameterToString(_serializers, additionalMetadata),
-      if (file != null) r'file': MultipartFile.fromBytes(file, filename: r'file'),
-    });
+    try {
+      _bodyData = FormData.fromMap(<String, dynamic>{
+        if (additionalMetadata != null) r'additionalMetadata': parameterToString(_serializers, additionalMetadata),
+        if (file != null) r'file': MultipartFile.fromBytes(file, filename: r'file'),
+      });
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -515,11 +585,21 @@ class PetApi {
       options: _request,
     );
 
-    const _responseType = FullType(ApiResponse);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as ApiResponse;
+    ApiResponse _responseData;
+    try {
+      const _responseType = FullType(ApiResponse);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as ApiResponse;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<ApiResponse>(
       data: _responseData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/store_api.dart
@@ -53,11 +53,8 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -103,19 +100,26 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(BuiltMap, [FullType(String), FullType(int)]);
-    final BuiltMap<String, int> _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as BuiltMap<String, int>;
+    BuiltMap<String, int> _responseData;
+    try {
+      const _responseType = FullType(BuiltMap, [FullType(String), FullType(int)]);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as BuiltMap<String, int>;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<BuiltMap<String, int>>(
       data: _responseData,
@@ -162,19 +166,26 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(Order);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as Order;
+    Order _responseData;
+    try {
+      const _responseType = FullType(Order);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as Order;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<Order>(
       data: _responseData,
@@ -223,8 +234,16 @@ class StoreApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(Order);
-    _bodyData = _serializers.serialize(order, specifiedType: _type);
+    try {
+      const _type = FullType(Order);
+      _bodyData = _serializers.serialize(order, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -232,11 +251,21 @@ class StoreApi {
       options: _request,
     );
 
-    const _responseType = FullType(Order);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as Order;
+    Order _responseData;
+    try {
+      const _responseType = FullType(Order);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as Order;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<Order>(
       data: _responseData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/lib/api/user_api.dart
@@ -62,8 +62,16 @@ class UserApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(User);
-    _bodyData = _serializers.serialize(user, specifiedType: _type);
+    try {
+      const _type = FullType(User);
+      _bodyData = _serializers.serialize(user, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -116,8 +124,16 @@ class UserApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(BuiltList, [FullType(User)]);
-    _bodyData = _serializers.serialize(user, specifiedType: _type);
+    try {
+      const _type = FullType(BuiltList, [FullType(User)]);
+      _bodyData = _serializers.serialize(user, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -170,8 +186,16 @@ class UserApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(BuiltList, [FullType(User)]);
-    _bodyData = _serializers.serialize(user, specifiedType: _type);
+    try {
+      const _type = FullType(BuiltList, [FullType(User)]);
+      _bodyData = _serializers.serialize(user, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -222,11 +246,8 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -266,19 +287,26 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(User);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as User;
+    User _responseData;
+    try {
+      const _responseType = FullType(User);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as User;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<User>(
       data: _responseData,
@@ -328,15 +356,22 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    final String _responseData = _response.data as String;
+    String _responseData;
+    try {
+      _responseData = _response.data as String;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<String>(
       data: _responseData,
@@ -389,11 +424,8 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -443,8 +475,16 @@ class UserApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(User);
-    _bodyData = _serializers.serialize(user, specifiedType: _type);
+    try {
+      const _type = FullType(User);
+      _bodyData = _serializers.serialize(user, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/another_fake_api.dart
@@ -54,8 +54,16 @@ class AnotherFakeApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(ModelClient);
-    _bodyData = _serializers.serialize(modelClient, specifiedType: _type);
+    try {
+      const _type = FullType(ModelClient);
+      _bodyData = _serializers.serialize(modelClient, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -63,11 +71,21 @@ class AnotherFakeApi {
       options: _request,
     );
 
-    const _responseType = FullType(ModelClient);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as ModelClient;
+    ModelClient _responseData;
+    try {
+      const _responseType = FullType(ModelClient);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as ModelClient;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<ModelClient>(
       data: _responseData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/default_api.dart
@@ -51,19 +51,26 @@ class DefaultApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(InlineResponseDefault);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as InlineResponseDefault;
+    InlineResponseDefault _responseData;
+    try {
+      const _responseType = FullType(InlineResponseDefault);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as InlineResponseDefault;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<InlineResponseDefault>(
       data: _responseData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -59,19 +59,26 @@ class FakeApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(HealthCheckResult);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as HealthCheckResult;
+    HealthCheckResult _responseData;
+    try {
+      const _responseType = FullType(HealthCheckResult);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as HealthCheckResult;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<HealthCheckResult>(
       data: _responseData,
@@ -130,8 +137,16 @@ class FakeApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(Pet);
-    _bodyData = _serializers.serialize(pet, specifiedType: _type);
+    try {
+      const _type = FullType(Pet);
+      _bodyData = _serializers.serialize(pet, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -177,7 +192,15 @@ class FakeApi {
 
     dynamic _bodyData;
 
-    _bodyData = body;
+    try {
+      _bodyData = body;
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -185,7 +208,17 @@ class FakeApi {
       options: _request,
     );
 
-    final bool _responseData = _response.data as bool;
+    bool _responseData;
+    try {
+      _responseData = _response.data as bool;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<bool>(
       data: _responseData,
@@ -234,8 +267,16 @@ class FakeApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(OuterComposite);
-    _bodyData = _serializers.serialize(outerComposite, specifiedType: _type);
+    try {
+      const _type = FullType(OuterComposite);
+      _bodyData = _serializers.serialize(outerComposite, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -243,11 +284,21 @@ class FakeApi {
       options: _request,
     );
 
-    const _responseType = FullType(OuterComposite);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as OuterComposite;
+    OuterComposite _responseData;
+    try {
+      const _responseType = FullType(OuterComposite);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as OuterComposite;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<OuterComposite>(
       data: _responseData,
@@ -296,7 +347,15 @@ class FakeApi {
 
     dynamic _bodyData;
 
-    _bodyData = body;
+    try {
+      _bodyData = body;
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -304,7 +363,17 @@ class FakeApi {
       options: _request,
     );
 
-    final num _responseData = _response.data as num;
+    num _responseData;
+    try {
+      _responseData = _response.data as num;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<num>(
       data: _responseData,
@@ -353,7 +422,15 @@ class FakeApi {
 
     dynamic _bodyData;
 
-    _bodyData = body;
+    try {
+      _bodyData = body;
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -361,7 +438,17 @@ class FakeApi {
       options: _request,
     );
 
-    final String _responseData = _response.data as String;
+    String _responseData;
+    try {
+      _responseData = _response.data as String;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<String>(
       data: _responseData,
@@ -410,8 +497,16 @@ class FakeApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(FileSchemaTestClass);
-    _bodyData = _serializers.serialize(fileSchemaTestClass, specifiedType: _type);
+    try {
+      const _type = FullType(FileSchemaTestClass);
+      _bodyData = _serializers.serialize(fileSchemaTestClass, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -459,8 +554,16 @@ class FakeApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(User);
-    _bodyData = _serializers.serialize(user, specifiedType: _type);
+    try {
+      const _type = FullType(User);
+      _bodyData = _serializers.serialize(user, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -506,8 +609,16 @@ class FakeApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(ModelClient);
-    _bodyData = _serializers.serialize(modelClient, specifiedType: _type);
+    try {
+      const _type = FullType(ModelClient);
+      _bodyData = _serializers.serialize(modelClient, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -515,11 +626,21 @@ class FakeApi {
       options: _request,
     );
 
-    const _responseType = FullType(ModelClient);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as ModelClient;
+    ModelClient _responseData;
+    try {
+      const _responseType = FullType(ModelClient);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as ModelClient;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<ModelClient>(
       data: _responseData,
@@ -586,22 +707,30 @@ class FakeApi {
 
     dynamic _bodyData;
 
-    _bodyData = <String, dynamic>{
-      if (integer != null) r'integer': parameterToString(_serializers, integer),
-      if (int32 != null) r'int32': parameterToString(_serializers, int32),
-      if (int64 != null) r'int64': parameterToString(_serializers, int64),
-      r'number': parameterToString(_serializers, number),
-      if (float != null) r'float': parameterToString(_serializers, float),
-      r'double': parameterToString(_serializers, double_),
-      if (string != null) r'string': parameterToString(_serializers, string),
-      r'pattern_without_delimiter': parameterToString(_serializers, patternWithoutDelimiter),
-      r'byte': parameterToString(_serializers, byte),
-      if (binary != null) r'binary': MultipartFile.fromBytes(binary, filename: r'binary'),
-      if (date != null) r'date': parameterToString(_serializers, date),
-      if (dateTime != null) r'dateTime': parameterToString(_serializers, dateTime),
-      if (password != null) r'password': parameterToString(_serializers, password),
-      if (callback != null) r'callback': parameterToString(_serializers, callback),
-    };
+    try {
+      _bodyData = <String, dynamic>{
+        if (integer != null) r'integer': parameterToString(_serializers, integer),
+        if (int32 != null) r'int32': parameterToString(_serializers, int32),
+        if (int64 != null) r'int64': parameterToString(_serializers, int64),
+        r'number': parameterToString(_serializers, number),
+        if (float != null) r'float': parameterToString(_serializers, float),
+        r'double': parameterToString(_serializers, double_),
+        if (string != null) r'string': parameterToString(_serializers, string),
+        r'pattern_without_delimiter': parameterToString(_serializers, patternWithoutDelimiter),
+        r'byte': parameterToString(_serializers, byte),
+        if (binary != null) r'binary': MultipartFile.fromBytes(binary, filename: r'binary'),
+        if (date != null) r'date': parameterToString(_serializers, date),
+        if (dateTime != null) r'dateTime': parameterToString(_serializers, dateTime),
+        if (password != null) r'password': parameterToString(_serializers, password),
+        if (callback != null) r'callback': parameterToString(_serializers, callback),
+      };
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -660,10 +789,18 @@ class FakeApi {
 
     dynamic _bodyData;
 
-    _bodyData = <String, dynamic>{
-      if (enumFormStringArray != null) r'enum_form_string_array': parameterToString(_serializers, enumFormStringArray),
-      if (enumFormString != null) r'enum_form_string': parameterToString(_serializers, enumFormString),
-    };
+    try {
+      _bodyData = <String, dynamic>{
+        if (enumFormStringArray != null) r'enum_form_string_array': parameterToString(_serializers, enumFormStringArray),
+        if (enumFormString != null) r'enum_form_string': parameterToString(_serializers, enumFormString),
+      };
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -723,11 +860,8 @@ class FakeApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -769,8 +903,16 @@ class FakeApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(BuiltMap, [FullType(String), FullType(String)]);
-    _bodyData = _serializers.serialize(requestBody, specifiedType: _type);
+    try {
+      const _type = FullType(BuiltMap, [FullType(String), FullType(String)]);
+      _bodyData = _serializers.serialize(requestBody, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -817,10 +959,18 @@ class FakeApi {
 
     dynamic _bodyData;
 
-    _bodyData = <String, dynamic>{
-      r'param': parameterToString(_serializers, param),
-      r'param2': parameterToString(_serializers, param2),
-    };
+    try {
+      _bodyData = <String, dynamic>{
+        r'param': parameterToString(_serializers, param),
+        r'param2': parameterToString(_serializers, param2),
+      };
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -873,11 +1023,8 @@ class FakeApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
@@ -61,8 +61,16 @@ class FakeClassnameTags123Api {
 
     dynamic _bodyData;
 
-    const _type = FullType(ModelClient);
-    _bodyData = _serializers.serialize(modelClient, specifiedType: _type);
+    try {
+      const _type = FullType(ModelClient);
+      _bodyData = _serializers.serialize(modelClient, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -70,11 +78,21 @@ class FakeClassnameTags123Api {
       options: _request,
     );
 
-    const _responseType = FullType(ModelClient);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as ModelClient;
+    ModelClient _responseData;
+    try {
+      const _responseType = FullType(ModelClient);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as ModelClient;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<ModelClient>(
       data: _responseData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -64,8 +64,16 @@ class PetApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(Pet);
-    _bodyData = _serializers.serialize(pet, specifiedType: _type);
+    try {
+      const _type = FullType(Pet);
+      _bodyData = _serializers.serialize(pet, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -116,11 +124,8 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -166,19 +171,26 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(BuiltList, [FullType(Pet)]);
-    final BuiltList<Pet> _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as BuiltList<Pet>;
+    BuiltList<Pet> _responseData;
+    try {
+      const _responseType = FullType(BuiltList, [FullType(Pet)]);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as BuiltList<Pet>;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<BuiltList<Pet>>(
       data: _responseData,
@@ -231,19 +243,26 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(BuiltSet, [FullType(Pet)]);
-    final BuiltSet<Pet> _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as BuiltSet<Pet>;
+    BuiltSet<Pet> _responseData;
+    try {
+      const _responseType = FullType(BuiltSet, [FullType(Pet)]);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as BuiltSet<Pet>;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<BuiltSet<Pet>>(
       data: _responseData,
@@ -297,19 +316,26 @@ class PetApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(Pet);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as Pet;
+    Pet _responseData;
+    try {
+      const _responseType = FullType(Pet);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as Pet;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<Pet>(
       data: _responseData,
@@ -364,8 +390,16 @@ class PetApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(Pet);
-    _bodyData = _serializers.serialize(pet, specifiedType: _type);
+    try {
+      const _type = FullType(Pet);
+      _bodyData = _serializers.serialize(pet, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -418,10 +452,18 @@ class PetApi {
 
     dynamic _bodyData;
 
-    _bodyData = <String, dynamic>{
-      if (name != null) r'name': parameterToString(_serializers, name),
-      if (status != null) r'status': parameterToString(_serializers, status),
-    };
+    try {
+      _bodyData = <String, dynamic>{
+        if (name != null) r'name': parameterToString(_serializers, name),
+        if (status != null) r'status': parameterToString(_serializers, status),
+      };
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -474,10 +516,18 @@ class PetApi {
 
     dynamic _bodyData;
 
-    _bodyData = FormData.fromMap(<String, dynamic>{
-      if (additionalMetadata != null) r'additionalMetadata': parameterToString(_serializers, additionalMetadata),
-      if (file != null) r'file': MultipartFile.fromBytes(file, filename: r'file'),
-    });
+    try {
+      _bodyData = FormData.fromMap(<String, dynamic>{
+        if (additionalMetadata != null) r'additionalMetadata': parameterToString(_serializers, additionalMetadata),
+        if (file != null) r'file': MultipartFile.fromBytes(file, filename: r'file'),
+      });
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -485,11 +535,21 @@ class PetApi {
       options: _request,
     );
 
-    const _responseType = FullType(ApiResponse);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as ApiResponse;
+    ApiResponse _responseData;
+    try {
+      const _responseType = FullType(ApiResponse);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as ApiResponse;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<ApiResponse>(
       data: _responseData,
@@ -545,10 +605,18 @@ class PetApi {
 
     dynamic _bodyData;
 
-    _bodyData = FormData.fromMap(<String, dynamic>{
-      if (additionalMetadata != null) r'additionalMetadata': parameterToString(_serializers, additionalMetadata),
-      r'requiredFile': MultipartFile.fromBytes(requiredFile, filename: r'requiredFile'),
-    });
+    try {
+      _bodyData = FormData.fromMap(<String, dynamic>{
+        if (additionalMetadata != null) r'additionalMetadata': parameterToString(_serializers, additionalMetadata),
+        r'requiredFile': MultipartFile.fromBytes(requiredFile, filename: r'requiredFile'),
+      });
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -556,11 +624,21 @@ class PetApi {
       options: _request,
     );
 
-    const _responseType = FullType(ApiResponse);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as ApiResponse;
+    ApiResponse _responseData;
+    try {
+      const _responseType = FullType(ApiResponse);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as ApiResponse;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<ApiResponse>(
       data: _responseData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/store_api.dart
@@ -53,11 +53,8 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -103,19 +100,26 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(BuiltMap, [FullType(String), FullType(int)]);
-    final BuiltMap<String, int> _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as BuiltMap<String, int>;
+    BuiltMap<String, int> _responseData;
+    try {
+      const _responseType = FullType(BuiltMap, [FullType(String), FullType(int)]);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as BuiltMap<String, int>;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<BuiltMap<String, int>>(
       data: _responseData,
@@ -162,19 +166,26 @@ class StoreApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(Order);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as Order;
+    Order _responseData;
+    try {
+      const _responseType = FullType(Order);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as Order;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<Order>(
       data: _responseData,
@@ -223,8 +234,16 @@ class StoreApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(Order);
-    _bodyData = _serializers.serialize(order, specifiedType: _type);
+    try {
+      const _type = FullType(Order);
+      _bodyData = _serializers.serialize(order, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -232,11 +251,21 @@ class StoreApi {
       options: _request,
     );
 
-    const _responseType = FullType(Order);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as Order;
+    Order _responseData;
+    try {
+      const _responseType = FullType(Order);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as Order;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<Order>(
       data: _responseData,

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/user_api.dart
@@ -55,8 +55,16 @@ class UserApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(User);
-    _bodyData = _serializers.serialize(user, specifiedType: _type);
+    try {
+      const _type = FullType(User);
+      _bodyData = _serializers.serialize(user, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -102,8 +110,16 @@ class UserApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(BuiltList, [FullType(User)]);
-    _bodyData = _serializers.serialize(user, specifiedType: _type);
+    try {
+      const _type = FullType(BuiltList, [FullType(User)]);
+      _bodyData = _serializers.serialize(user, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -149,8 +165,16 @@ class UserApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(BuiltList, [FullType(User)]);
-    _bodyData = _serializers.serialize(user, specifiedType: _type);
+    try {
+      const _type = FullType(BuiltList, [FullType(User)]);
+      _bodyData = _serializers.serialize(user, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,
@@ -194,11 +218,8 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -238,19 +259,26 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    const _responseType = FullType(User);
-    final _responseData = _serializers.deserialize(
-      _response.data,
-      specifiedType: _responseType,
-    ) as User;
+    User _responseData;
+    try {
+      const _responseType = FullType(User);
+      _responseData = _serializers.deserialize(
+        _response.data,
+        specifiedType: _responseType,
+      ) as User;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<User>(
       data: _responseData,
@@ -300,15 +328,22 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
-    final String _responseData = _response.data as String;
+    String _responseData;
+    try {
+      _responseData = _response.data as String;
+    } catch (error) {
+      throw DioError(
+        request: _request,
+        response: _response,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     return Response<String>(
       data: _responseData,
@@ -354,11 +389,8 @@ class UserApi {
       onReceiveProgress: onReceiveProgress,
     );
 
-    dynamic _bodyData;
-
     final _response = await _dio.request<dynamic>(
       _request.path,
-      data: _bodyData,
       options: _request,
     );
 
@@ -401,8 +433,16 @@ class UserApi {
 
     dynamic _bodyData;
 
-    const _type = FullType(User);
-    _bodyData = _serializers.serialize(user, specifiedType: _type);
+    try {
+      const _type = FullType(User);
+      _bodyData = _serializers.serialize(user, specifiedType: _type);
+    } catch(error) {
+      throw DioError(
+        request: _request,
+        type: DioErrorType.DEFAULT,
+        error: error,
+      );
+    }
 
     final _response = await _dio.request<dynamic>(
       _request.path,


### PR DESCRIPTION
* wrap (de)serialization in try/catch and throw a `DioError` (this uses the new `RequestOptions` instance) - generic `StateError` and `FormatException` are now wrapped in a `DioError` which makes it clear that they originated from an API call
* this is a new option in the generator wich defaults to true
* no longer generate code for null body data

This is a breaking change with fallback.
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)