### PR TITLE
[csharp-netcore] Fix handling of Dictionary query parameters and fix deepObject style parameter handling

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4190,7 +4190,8 @@ public class DefaultCodegen implements CodegenConfig {
             // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#user-content-parameterexplode
             codegenParameter.isExplode = parameter.getExplode() == null ? false : parameter.getExplode();
 
-            // TODO revise collectionFormat
+            // TODO revise collectionFormat, default collection format in OAS 3 appears to multi at least for query parameters
+            // https://swagger.io/docs/specification/serialization/
             String collectionFormat = null;
             if (ModelUtils.isArraySchema(parameterSchema)) { // for array parameter
                 final ArraySchema arraySchema = (ArraySchema) parameterSchema;
@@ -4347,6 +4348,7 @@ public class DefaultCodegen implements CodegenConfig {
             Schema schema = ModelUtils.getSchema(openAPI, codegenParameter.dataType);
             codegenParameter.items = fromProperty(codegenParameter.paramName, schema);
             // TODO Check why schema is actually null for a schema of type object defined inline
+            // https://swagger.io/docs/specification/serialization/
             if(schema != null) {
                 Map<String, Schema<?>> properties = schema.getProperties();
                 codegenParameter.items.vars =

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4346,14 +4346,20 @@ public class DefaultCodegen implements CodegenConfig {
         if (codegenParameter.isQueryParam && codegenParameter.isDeepObject) {
             Schema schema = ModelUtils.getSchema(openAPI, codegenParameter.dataType);
             codegenParameter.items = fromProperty(codegenParameter.paramName, schema);
-            Map<String, Schema<?>> properties = schema.getProperties();
-            codegenParameter.items.vars =
-                    properties.entrySet().stream()
-                            .map(entry -> {
-                                CodegenProperty property = fromProperty(entry.getKey(), entry.getValue());
-                                property.baseName = codegenParameter.baseName + "[" + entry.getKey() + "]";
-                                return property;
-                            }).collect(Collectors.toList());
+            // TODO Check why schema is actually null for a schema of type object defined inline
+            if(schema != null) {
+                Map<String, Schema<?>> properties = schema.getProperties();
+                codegenParameter.items.vars =
+                        properties.entrySet().stream()
+                                .map(entry -> {
+                                    CodegenProperty property = fromProperty(entry.getKey(), entry.getValue());
+                                    property.baseName = codegenParameter.baseName + "[" + entry.getKey() + "]";
+                                    return property;
+                                }).collect(Collectors.toList());
+            }
+            else {
+                LOGGER.warn("No object schema found for deepObject parameter" + codegenParameter + " deepObject won't have specific properties");
+            }
         }
 
         // set the parameter example value

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ClientUtils.mustache
@@ -63,6 +63,21 @@ namespace {{packageName}}.Client
                     parameters.Add(name, ParameterToString(item));
                 }
             }
+            else if (value is IDictionary dictionary)
+            {
+                if(collectionFormat == "deepObject") {
+                    foreach (DictionaryEntry entry in dictionary)
+                    {
+                        parameters.Add(name + "[" + entry.Key + "]", ParameterToString(entry.Value));
+                    }
+                }
+                else {
+                    foreach (DictionaryEntry entry in dictionary)
+                    {
+                        parameters.Add(entry.Key.ToString(), ParameterToString(entry.Value));
+                    }
+                }
+            }
             else
             {
                 parameters.Add(name, ParameterToString(value));

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
@@ -285,6 +285,9 @@ namespace {{packageName}}.{{apiPackage}}
             {{#items.vars}}
             localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}.{{name}}));
             {{/items.vars}}
+            {{^items}}
+            localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("deepObject", "{{baseName}}", {{paramName}}));
+            {{/items}}
             {{/isDeepObject}}
             {{^isDeepObject}}
             localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}));
@@ -301,6 +304,10 @@ namespace {{packageName}}.{{apiPackage}}
                     localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}.{{name}}));
                 }
                     {{/items.vars}}
+
+                {{^items}}
+                localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("deepObject", "{{baseName}}", {{paramName}}));
+                {{/items}}
                 {{/isDeepObject}}
                 {{^isDeepObject}}
                 localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}));

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
@@ -279,9 +279,18 @@ namespace {{packageName}}.{{apiPackage}}
             {{/required}}
             {{/pathParams}}
             {{#queryParams}}
+
             {{#required}}
+            {{#isDeepObject}}
+            {{#items.vars}}
+            localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}.{{name}}));
+            {{/items.vars}}
+            {{/isDeepObject}}
+            {{^isDeepObject}}
             localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}));
+            {{/isDeepObject}}
             {{/required}}
+
             {{^required}}
             if ({{paramName}} != null)
             {
@@ -298,6 +307,7 @@ namespace {{packageName}}.{{apiPackage}}
                 {{/isDeepObject}}
             }
             {{/required}}
+
             {{/queryParams}}
             {{#headerParams}}
             {{#required}}

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
@@ -279,7 +279,6 @@ namespace {{packageName}}.{{apiPackage}}
             {{/required}}
             {{/pathParams}}
             {{#queryParams}}
-
             {{#required}}
             {{#isDeepObject}}
             {{#items.vars}}
@@ -293,7 +292,6 @@ namespace {{packageName}}.{{apiPackage}}
             localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}));
             {{/isDeepObject}}
             {{/required}}
-
             {{^required}}
             if ({{paramName}} != null)
             {
@@ -304,7 +302,6 @@ namespace {{packageName}}.{{apiPackage}}
                     localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}.{{name}}));
                 }
                     {{/items.vars}}
-
                 {{^items}}
                 localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("deepObject", "{{baseName}}", {{paramName}}));
                 {{/items}}
@@ -314,7 +311,6 @@ namespace {{packageName}}.{{apiPackage}}
                 {{/isDeepObject}}
             }
             {{/required}}
-
             {{/queryParams}}
             {{#headerParams}}
             {{#required}}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -67,6 +67,21 @@ namespace Org.OpenAPITools.Client
                     parameters.Add(name, ParameterToString(item));
                 }
             }
+            else if (value is IDictionary dictionary)
+            {
+                if(collectionFormat == "deepObject") {
+                    foreach (DictionaryEntry entry in dictionary)
+                    {
+                        parameters.Add(name + "[" + entry.Key + "]", ParameterToString(entry.Value));
+                    }
+                }
+                else {
+                    foreach (DictionaryEntry entry in dictionary)
+                    {
+                        parameters.Add(entry.Key.ToString(), ParameterToString(entry.Value));
+                    }
+                }
+            }
             else
             {
                 parameters.Add(name, ParameterToString(value));

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -67,6 +67,21 @@ namespace Org.OpenAPITools.Client
                     parameters.Add(name, ParameterToString(item));
                 }
             }
+            else if (value is IDictionary dictionary)
+            {
+                if(collectionFormat == "deepObject") {
+                    foreach (DictionaryEntry entry in dictionary)
+                    {
+                        parameters.Add(name + "[" + entry.Key + "]", ParameterToString(entry.Value));
+                    }
+                }
+                else {
+                    foreach (DictionaryEntry entry in dictionary)
+                    {
+                        parameters.Add(entry.Key.ToString(), ParameterToString(entry.Value));
+                    }
+                }
+            }
             else
             {
                 parameters.Add(name, ParameterToString(value));

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -67,6 +67,21 @@ namespace Org.OpenAPITools.Client
                     parameters.Add(name, ParameterToString(item));
                 }
             }
+            else if (value is IDictionary dictionary)
+            {
+                if(collectionFormat == "deepObject") {
+                    foreach (DictionaryEntry entry in dictionary)
+                    {
+                        parameters.Add(name + "[" + entry.Key + "]", ParameterToString(entry.Value));
+                    }
+                }
+                else {
+                    foreach (DictionaryEntry entry in dictionary)
+                    {
+                        parameters.Add(entry.Key.ToString(), ParameterToString(entry.Value));
+                    }
+                }
+            }
             else
             {
                 parameters.Add(name, ParameterToString(value));

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ClientUtils.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ClientUtils.cs
@@ -67,6 +67,21 @@ namespace Org.OpenAPITools.Client
                     parameters.Add(name, ParameterToString(item));
                 }
             }
+            else if (value is IDictionary dictionary)
+            {
+                if(collectionFormat == "deepObject") {
+                    foreach (DictionaryEntry entry in dictionary)
+                    {
+                        parameters.Add(name + "[" + entry.Key + "]", ParameterToString(entry.Value));
+                    }
+                }
+                else {
+                    foreach (DictionaryEntry entry in dictionary)
+                    {
+                        parameters.Add(entry.Key.ToString(), ParameterToString(entry.Value));
+                    }
+                }
+            }
             else
             {
                 parameters.Add(name, ParameterToString(value));


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This was triggered by this issue which it should close https://github.com/OpenAPITools/openapi-generator/issues/8798

Looking into the issue I found that indeed SwaggerUI and the csharp-netcore client libraries were generating different queries. Neither of which was getting read by the newly updated aspnetcore generator (https://github.com/OpenAPITools/openapi-generator/pull/8826). It appears that neither format was acceptable there and this is also something Swashbuckle needs to fix (https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2034) as their generated spec does not actually work with the controller its supposed to query.

This pull request does two things:

- Fix default handling so that it corresponds to what SwaggerUI is doing for Dictionaries
- Fix deepObject handling so that it works for required parameters as well
- Fix deepObject handling for Dictionary style inline objects with no properties defined (this might not be completely to spec, but it makes sense to do so, see also: https://swagger.io/docs/specification/serialization/, 
- Fix NullPointerException caused by the DefaultCodegen not finding a Schema

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Closes https://github.com/OpenAPITools/openapi-generator/issues/8798