### PR TITLE
feat(adapter): add BigDecimal kotlin support

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -463,6 +463,8 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/LocalDateAdapter.kt.mustache", infrastructureFolder, "LocalDateAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/LocalDateTimeAdapter.kt.mustache", infrastructureFolder, "LocalDateTimeAdapter.kt"));
                 supportingFiles.add(new SupportingFile("jvm-common/infrastructure/OffsetDateTimeAdapter.kt.mustache", infrastructureFolder, "OffsetDateTimeAdapter.kt"));
+                supportingFiles.add(new SupportingFile("jvm-common/infrastructure/BigDecimalAdapter.kt.mustache", infrastructureFolder, "BigDecimalAdapter.kt"));
+                supportingFiles.add(new SupportingFile("jvm-common/infrastructure/BigIntegerAdapter.kt.mustache", infrastructureFolder, "BigIntegerAdapter.kt"));
                 break;
 
             case gson:

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/BigDecimalAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/BigDecimalAdapter.kt.mustache
@@ -1,5 +1,6 @@
 package {{packageName}}.infrastructure
 
+{{#kotlinx_serialization}}
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
@@ -7,13 +8,26 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
+{{/kotlinx_serialization}}
+{{#moshi}}
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+{{/moshi}}
 import java.math.BigDecimal
 
-@Serializer(forClass = BigDecimal::class)
+{{#kotlinx_serialization}}@Serializer(forClass = BigDecimal::class)
 object BigDecimalAdapter : KSerializer<BigDecimal> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigDecimal", PrimitiveKind.STRING)
-
     override fun deserialize(decoder: Decoder): BigDecimal = BigDecimal(decoder.decodeString())
-
     override fun serialize(encoder: Encoder, value: BigDecimal) = encoder.encodeString(value.toPlainString())
-}
+}{{/kotlinx_serialization}}{{#moshi}}{{#nonPublicApi}}internal {{/nonPublicApi}}class BigDecimalAdapter {
+    @ToJson
+    fun toJson(value: BigDecimal): String {
+        return value.toPlainString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigDecimal {
+        return BigDecimal(value)
+    }
+}{{/moshi}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/BigIntegerAdapter.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/BigIntegerAdapter.kt.mustache
@@ -1,5 +1,6 @@
 package {{packageName}}.infrastructure
 
+{{#kotlinx_serialization}}
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializer
 import kotlinx.serialization.encoding.Decoder
@@ -7,12 +8,16 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
+{{/kotlinx_serialization}}
+{{#moshi}}
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+{{/moshi}}
 import java.math.BigInteger
 
-@Serializer(forClass = BigInteger::class)
+{{#kotlinx_serialization}}@Serializer(forClass = BigInteger::class)
 object BigIntegerAdapter : KSerializer<BigInteger> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigInteger", PrimitiveKind.STRING)
-
     override fun deserialize(decoder: Decoder): BigInteger {
         return BigInteger(decoder.decodeString())
     }
@@ -20,4 +25,14 @@ object BigIntegerAdapter : KSerializer<BigInteger> {
     override fun serialize(encoder: Encoder, value: BigInteger) {
         encoder.encodeString(value.toString())
     }
-}
+}{{/kotlinx_serialization}}{{#moshi}}{{#nonPublicApi}}internal {{/nonPublicApi}}class BigIntegerAdapter {
+    @ToJson
+    fun toJson(value: BigInteger): String {
+        return value.toString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigInteger {
+        return BigInteger(value)
+    }
+}{{/moshi}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
@@ -63,6 +63,8 @@ import java.util.concurrent.atomic.AtomicLong
         {{^moshiCodeGen}}
         .add(KotlinJsonAdapterFactory())
         {{/moshiCodeGen}}
+        .add(BigDecimalAdapter())
+        .add(BigIntegerAdapter())
 
     @JvmStatic
     val moshi: Moshi by lazy {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -459,7 +459,7 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 24);
+            Assert.assertEquals(files.size(), 26);
 
             // Generator should report a library templated file as a generated file
             TestUtils.ensureContainsFile(files, output, "src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt");
@@ -501,7 +501,7 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 24);
+            Assert.assertEquals(files.size(), 26);
 
             // Generator should report README.md as a generated file
             TestUtils.ensureContainsFile(files, output, "README.md");
@@ -566,7 +566,7 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 24);
+            Assert.assertEquals(files.size(), 26);
 
             // Generator should report a library templated file as a generated file
             TestUtils.ensureContainsFile(files, output, "src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt");
@@ -620,7 +620,7 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 24);
+            Assert.assertEquals(files.size(), 26);
 
             // Generator should report README.md as a generated file
             TestUtils.ensureContainsFile(files, output, "README.md");

--- a/samples/client/petstore/kotlin-json-request-string/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-json-request-string/.openapi-generator/FILES
@@ -21,6 +21,8 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiInfrastructureResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApplicationDelegates.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+class BigDecimalAdapter {
+    @ToJson
+    fun toJson(value: BigDecimal): String {
+        return value.toPlainString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigDecimal {
+        return BigDecimal(value)
+    }
+}

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigInteger
+
+class BigIntegerAdapter {
+    @ToJson
+    fun toJson(value: BigInteger): String {
+        return value.toString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigInteger {
+        return BigInteger(value)
+    }
+}

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,8 @@ object Serializer {
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(KotlinJsonAdapterFactory())
+        .add(BigDecimalAdapter())
+        .add(BigIntegerAdapter())
 
     @JvmStatic
     val moshi: Moshi by lazy {

--- a/samples/client/petstore/kotlin-moshi-codegen/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-moshi-codegen/.openapi-generator/FILES
@@ -21,6 +21,8 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiInfrastructureResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApplicationDelegates.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+class BigDecimalAdapter {
+    @ToJson
+    fun toJson(value: BigDecimal): String {
+        return value.toPlainString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigDecimal {
+        return BigDecimal(value)
+    }
+}

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigInteger
+
+class BigIntegerAdapter {
+    @ToJson
+    fun toJson(value: BigInteger): String {
+        return value.toString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigInteger {
+        return BigInteger(value)
+    }
+}

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -11,6 +11,8 @@ object Serializer {
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
+        .add(BigDecimalAdapter())
+        .add(BigIntegerAdapter())
 
     @JvmStatic
     val moshi: Moshi by lazy {

--- a/samples/client/petstore/kotlin-nonpublic/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-nonpublic/.openapi-generator/FILES
@@ -21,6 +21,8 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiInfrastructureResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApplicationDelegates.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+internal class BigDecimalAdapter {
+    @ToJson
+    fun toJson(value: BigDecimal): String {
+        return value.toPlainString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigDecimal {
+        return BigDecimal(value)
+    }
+}

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigInteger
+
+internal class BigIntegerAdapter {
+    @ToJson
+    fun toJson(value: BigInteger): String {
+        return value.toString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigInteger {
+        return BigInteger(value)
+    }
+}

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,8 @@ internal object Serializer {
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(KotlinJsonAdapterFactory())
+        .add(BigDecimalAdapter())
+        .add(BigIntegerAdapter())
 
     @JvmStatic
     val moshi: Moshi by lazy {

--- a/samples/client/petstore/kotlin-nullable/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-nullable/.openapi-generator/FILES
@@ -21,6 +21,8 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiInfrastructureResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApplicationDelegates.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+class BigDecimalAdapter {
+    @ToJson
+    fun toJson(value: BigDecimal): String {
+        return value.toPlainString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigDecimal {
+        return BigDecimal(value)
+    }
+}

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigInteger
+
+class BigIntegerAdapter {
+    @ToJson
+    fun toJson(value: BigInteger): String {
+        return value.toString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigInteger {
+        return BigInteger(value)
+    }
+}

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,8 @@ object Serializer {
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(KotlinJsonAdapterFactory())
+        .add(BigDecimalAdapter())
+        .add(BigIntegerAdapter())
 
     @JvmStatic
     val moshi: Moshi by lazy {

--- a/samples/client/petstore/kotlin-okhttp3/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-okhttp3/.openapi-generator/FILES
@@ -21,6 +21,8 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiInfrastructureResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApplicationDelegates.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+class BigDecimalAdapter {
+    @ToJson
+    fun toJson(value: BigDecimal): String {
+        return value.toPlainString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigDecimal {
+        return BigDecimal(value)
+    }
+}

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigInteger
+
+class BigIntegerAdapter {
+    @ToJson
+    fun toJson(value: BigInteger): String {
+        return value.toString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigInteger {
+        return BigInteger(value)
+    }
+}

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,8 @@ object Serializer {
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(KotlinJsonAdapterFactory())
+        .add(BigDecimalAdapter())
+        .add(BigIntegerAdapter())
 
     @JvmStatic
     val moshi: Moshi by lazy {

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -12,8 +12,6 @@ import java.math.BigDecimal
 @Serializer(forClass = BigDecimal::class)
 object BigDecimalAdapter : KSerializer<BigDecimal> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigDecimal", PrimitiveKind.STRING)
-
     override fun deserialize(decoder: Decoder): BigDecimal = BigDecimal(decoder.decodeString())
-
     override fun serialize(encoder: Encoder, value: BigDecimal) = encoder.encodeString(value.toPlainString())
 }

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -12,7 +12,6 @@ import java.math.BigInteger
 @Serializer(forClass = BigInteger::class)
 object BigIntegerAdapter : KSerializer<BigInteger> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigInteger", PrimitiveKind.STRING)
-
     override fun deserialize(decoder: Decoder): BigInteger {
         return BigInteger(decoder.decodeString())
     }

--- a/samples/client/petstore/kotlin-retrofit2-rx3/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/.openapi-generator/FILES
@@ -22,6 +22,8 @@ src/main/kotlin/org/openapitools/client/auth/OAuth.kt
 src/main/kotlin/org/openapitools/client/auth/OAuthFlow.kt
 src/main/kotlin/org/openapitools/client/auth/OAuthOkHttpClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/CollectionFormats.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+class BigDecimalAdapter {
+    @ToJson
+    fun toJson(value: BigDecimal): String {
+        return value.toPlainString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigDecimal {
+        return BigDecimal(value)
+    }
+}

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigInteger
+
+class BigIntegerAdapter {
+    @ToJson
+    fun toJson(value: BigInteger): String {
+        return value.toString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigInteger {
+        return BigInteger(value)
+    }
+}

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,8 @@ object Serializer {
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(KotlinJsonAdapterFactory())
+        .add(BigDecimalAdapter())
+        .add(BigIntegerAdapter())
 
     @JvmStatic
     val moshi: Moshi by lazy {

--- a/samples/client/petstore/kotlin-retrofit2/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-retrofit2/.openapi-generator/FILES
@@ -22,6 +22,8 @@ src/main/kotlin/org/openapitools/client/auth/OAuth.kt
 src/main/kotlin/org/openapitools/client/auth/OAuthFlow.kt
 src/main/kotlin/org/openapitools/client/auth/OAuthOkHttpClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/CollectionFormats.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+class BigDecimalAdapter {
+    @ToJson
+    fun toJson(value: BigDecimal): String {
+        return value.toPlainString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigDecimal {
+        return BigDecimal(value)
+    }
+}

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigInteger
+
+class BigIntegerAdapter {
+    @ToJson
+    fun toJson(value: BigInteger): String {
+        return value.toString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigInteger {
+        return BigInteger(value)
+    }
+}

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,8 @@ object Serializer {
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(KotlinJsonAdapterFactory())
+        .add(BigDecimalAdapter())
+        .add(BigIntegerAdapter())
 
     @JvmStatic
     val moshi: Moshi by lazy {

--- a/samples/client/petstore/kotlin-string/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-string/.openapi-generator/FILES
@@ -21,6 +21,8 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiInfrastructureResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApplicationDelegates.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+class BigDecimalAdapter {
+    @ToJson
+    fun toJson(value: BigDecimal): String {
+        return value.toPlainString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigDecimal {
+        return BigDecimal(value)
+    }
+}

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigInteger
+
+class BigIntegerAdapter {
+    @ToJson
+    fun toJson(value: BigInteger): String {
+        return value.toString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigInteger {
+        return BigInteger(value)
+    }
+}

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,8 @@ object Serializer {
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(KotlinJsonAdapterFactory())
+        .add(BigDecimalAdapter())
+        .add(BigIntegerAdapter())
 
     @JvmStatic
     val moshi: Moshi by lazy {

--- a/samples/client/petstore/kotlin-threetenbp/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-threetenbp/.openapi-generator/FILES
@@ -21,6 +21,8 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiInfrastructureResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApplicationDelegates.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+class BigDecimalAdapter {
+    @ToJson
+    fun toJson(value: BigDecimal): String {
+        return value.toPlainString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigDecimal {
+        return BigDecimal(value)
+    }
+}

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigInteger
+
+class BigIntegerAdapter {
+    @ToJson
+    fun toJson(value: BigInteger): String {
+        return value.toString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigInteger {
+        return BigInteger(value)
+    }
+}

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,8 @@ object Serializer {
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(KotlinJsonAdapterFactory())
+        .add(BigDecimalAdapter())
+        .add(BigIntegerAdapter())
 
     @JvmStatic
     val moshi: Moshi by lazy {

--- a/samples/client/petstore/kotlin-uppercase-enum/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin-uppercase-enum/.openapi-generator/FILES
@@ -12,6 +12,8 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiInfrastructureResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApplicationDelegates.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+class BigDecimalAdapter {
+    @ToJson
+    fun toJson(value: BigDecimal): String {
+        return value.toPlainString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigDecimal {
+        return BigDecimal(value)
+    }
+}

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigInteger
+
+class BigIntegerAdapter {
+    @ToJson
+    fun toJson(value: BigInteger): String {
+        return value.toString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigInteger {
+        return BigInteger(value)
+    }
+}

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,8 @@ object Serializer {
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(KotlinJsonAdapterFactory())
+        .add(BigDecimalAdapter())
+        .add(BigIntegerAdapter())
 
     @JvmStatic
     val moshi: Moshi by lazy {

--- a/samples/client/petstore/kotlin/.openapi-generator/FILES
+++ b/samples/client/petstore/kotlin/.openapi-generator/FILES
@@ -21,6 +21,8 @@ src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApiInfrastructureResponse.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ApplicationDelegates.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/ByteArrayAdapter.kt
 src/main/kotlin/org/openapitools/client/infrastructure/Errors.kt
 src/main/kotlin/org/openapitools/client/infrastructure/LocalDateAdapter.kt

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/BigDecimalAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+class BigDecimalAdapter {
+    @ToJson
+    fun toJson(value: BigDecimal): String {
+        return value.toPlainString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigDecimal {
+        return BigDecimal(value)
+    }
+}

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/BigIntegerAdapter.kt
@@ -1,0 +1,17 @@
+package org.openapitools.client.infrastructure
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigInteger
+
+class BigIntegerAdapter {
+    @ToJson
+    fun toJson(value: BigInteger): String {
+        return value.toString()
+    }
+
+    @FromJson
+    fun fromJson(value: String): BigInteger {
+        return BigInteger(value)
+    }
+}

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -13,6 +13,8 @@ object Serializer {
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         .add(KotlinJsonAdapterFactory())
+        .add(BigDecimalAdapter())
+        .add(BigIntegerAdapter())
 
     @JvmStatic
     val moshi: Moshi by lazy {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

this allows the kotlin client generator to support
BigDecimal values

This was originally created by @kuFEAR in their own branch, but a PR wasn't made into this project. 
I hope you don't mind me making the PR for you, I happen to need this for my own project.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:

  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. - [x] 

Kotlin

@jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03)
