### PR TITLE
[C#][netcore] Call static method without creating instance

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -484,7 +484,7 @@ namespace {{packageName}}.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                response.Data = method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -603,7 +603,7 @@ namespace {{packageName}}.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                response.Data = method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -482,9 +482,9 @@ namespace {{packageName}}.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                T instance = (T)Activator.CreateInstance(typeof(T));
-                MethodInfo method = typeof(T).GetMethod("FromJson");
-                method.Invoke(instance, new object[] { response.Content });
+                Type type = typeof(T);
+                MethodInfo method = type.GetMethod("FromJson");
+                method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response
@@ -602,9 +602,9 @@ namespace {{packageName}}.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                T instance = (T)Activator.CreateInstance(typeof(T));
-                MethodInfo method = typeof(T).GetMethod("FromJson");
-                method.Invoke(instance, new object[] { response.Content });
+                Type type = typeof(T);
+                MethodInfo method = type.GetMethod("FromJson");
+                method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -484,7 +484,7 @@ namespace {{packageName}}.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                method.Invoke(null, new object[] { response.Content });
+                T instance = method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response
@@ -604,7 +604,7 @@ namespace {{packageName}}.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                method.Invoke(null, new object[] { response.Content });
+                T instance method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -604,7 +604,7 @@ namespace {{packageName}}.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                T instance method.Invoke(null, new object[] { response.Content });
+                T instance = method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -484,8 +484,7 @@ namespace {{packageName}}.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                T instance = method.Invoke(null, new object[] { response.Content });
-                response.Data = instance;
+                response.Data = method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -604,8 +603,7 @@ namespace {{packageName}}.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                T instance = method.Invoke(null, new object[] { response.Content });
-                response.Data = instance;
+                response.Data = method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -482,9 +482,7 @@ namespace {{packageName}}.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                Type type = typeof(T);
-                MethodInfo method = type.GetMethod("FromJson");
-                response.Data = (T) method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -601,9 +599,7 @@ namespace {{packageName}}.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                Type type = typeof(T);
-                MethodInfo method = type.GetMethod("FromJson");
-                response.Data = (T) method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
@@ -450,10 +450,7 @@ namespace {{packageName}}.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                T instance = (T) Activator.CreateInstance(typeof(T));
-                MethodInfo method = typeof(T).GetMethod("FromJson");
-                method.Invoke(instance, new object[] {response.Content});
-                responseData = instance;
+                responseData = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -428,10 +428,7 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                T instance = (T) Activator.CreateInstance(typeof(T));
-                MethodInfo method = typeof(T).GetMethod("FromJson");
-                method.Invoke(instance, new object[] {response.Content});
-                responseData = instance;
+                responseData = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -484,7 +484,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                response.Data = method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -598,7 +598,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                response.Data = method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -484,7 +484,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                method.Invoke(null, new object[] { response.Content });
+                T instance = method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response
@@ -599,7 +599,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                method.Invoke(null, new object[] { response.Content });
+                T instance method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -482,9 +482,7 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                Type type = typeof(T);
-                MethodInfo method = type.GetMethod("FromJson");
-                response.Data = (T) method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -596,9 +594,7 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                Type type = typeof(T);
-                MethodInfo method = type.GetMethod("FromJson");
-                response.Data = (T) method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -484,8 +484,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                T instance = method.Invoke(null, new object[] { response.Content });
-                response.Data = instance;
+                response.Data = method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -599,8 +598,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                T instance method.Invoke(null, new object[] { response.Content });
-                response.Data = instance;
+                response.Data = method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -482,9 +482,9 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                T instance = (T)Activator.CreateInstance(typeof(T));
-                MethodInfo method = typeof(T).GetMethod("FromJson");
-                method.Invoke(instance, new object[] { response.Content });
+                Type type = typeof(T);
+                MethodInfo method = type.GetMethod("FromJson");
+                method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response
@@ -597,9 +597,9 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                T instance = (T)Activator.CreateInstance(typeof(T));
-                MethodInfo method = typeof(T).GetMethod("FromJson");
-                method.Invoke(instance, new object[] { response.Content });
+                Type type = typeof(T);
+                MethodInfo method = type.GetMethod("FromJson");
+                method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -484,7 +484,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                response.Data = method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -598,7 +598,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                response.Data = method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -484,7 +484,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                method.Invoke(null, new object[] { response.Content });
+                T instance = method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response
@@ -599,7 +599,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                method.Invoke(null, new object[] { response.Content });
+                T instance method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -482,9 +482,7 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                Type type = typeof(T);
-                MethodInfo method = type.GetMethod("FromJson");
-                response.Data = (T) method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -596,9 +594,7 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                Type type = typeof(T);
-                MethodInfo method = type.GetMethod("FromJson");
-                response.Data = (T) method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -484,8 +484,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                T instance = method.Invoke(null, new object[] { response.Content });
-                response.Data = instance;
+                response.Data = method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -599,8 +598,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                T instance method.Invoke(null, new object[] { response.Content });
-                response.Data = instance;
+                response.Data = method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -482,9 +482,9 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                T instance = (T)Activator.CreateInstance(typeof(T));
-                MethodInfo method = typeof(T).GetMethod("FromJson");
-                method.Invoke(instance, new object[] { response.Content });
+                Type type = typeof(T);
+                MethodInfo method = type.GetMethod("FromJson");
+                method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response
@@ -597,9 +597,9 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                T instance = (T)Activator.CreateInstance(typeof(T));
-                MethodInfo method = typeof(T).GetMethod("FromJson");
-                method.Invoke(instance, new object[] { response.Content });
+                Type type = typeof(T);
+                MethodInfo method = type.GetMethod("FromJson");
+                method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -481,9 +481,7 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                Type type = typeof(T);
-                MethodInfo method = type.GetMethod("FromJson");
-                response.Data = (T) method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -595,9 +593,7 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                Type type = typeof(T);
-                MethodInfo method = type.GetMethod("FromJson");
-                response.Data = (T) method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -481,9 +481,9 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                T instance = (T)Activator.CreateInstance(typeof(T));
-                MethodInfo method = typeof(T).GetMethod("FromJson");
-                method.Invoke(instance, new object[] { response.Content });
+                Type type = typeof(T);
+                MethodInfo method = type.GetMethod("FromJson");
+                method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response
@@ -596,9 +596,9 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                T instance = (T)Activator.CreateInstance(typeof(T));
-                MethodInfo method = typeof(T).GetMethod("FromJson");
-                method.Invoke(instance, new object[] { response.Content });
+                Type type = typeof(T);
+                MethodInfo method = type.GetMethod("FromJson");
+                method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -483,7 +483,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                response.Data = method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -597,7 +597,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                response.Data = method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -483,8 +483,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                T instance = method.Invoke(null, new object[] { response.Content });
-                response.Data = instance;
+                response.Data = method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -598,8 +597,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                T instance method.Invoke(null, new object[] { response.Content });
-                response.Data = instance;
+                response.Data = method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -483,7 +483,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                method.Invoke(null, new object[] { response.Content });
+                T instance = method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response
@@ -598,7 +598,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                method.Invoke(null, new object[] { response.Content });
+                T instance method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -484,7 +484,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                response.Data = method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -598,7 +598,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                response.Data = method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -484,7 +484,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                method.Invoke(null, new object[] { response.Content });
+                T instance = method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response
@@ -599,7 +599,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                method.Invoke(null, new object[] { response.Content });
+                T instance method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -482,9 +482,7 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                Type type = typeof(T);
-                MethodInfo method = type.GetMethod("FromJson");
-                response.Data = (T) method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -596,9 +594,7 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                Type type = typeof(T);
-                MethodInfo method = type.GetMethod("FromJson");
-                response.Data = (T) method.Invoke(null, new object[] { response.Content });
+                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -484,8 +484,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                T instance = method.Invoke(null, new object[] { response.Content });
-                response.Data = instance;
+                response.Data = method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {
@@ -599,8 +598,7 @@ namespace Org.OpenAPITools.Client
             {
                 Type type = typeof(T);
                 MethodInfo method = type.GetMethod("FromJson");
-                T instance method.Invoke(null, new object[] { response.Content });
-                response.Data = instance;
+                response.Data = method.Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -482,9 +482,9 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                T instance = (T)Activator.CreateInstance(typeof(T));
-                MethodInfo method = typeof(T).GetMethod("FromJson");
-                method.Invoke(instance, new object[] { response.Content });
+                Type type = typeof(T);
+                MethodInfo method = type.GetMethod("FromJson");
+                method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response
@@ -597,9 +597,9 @@ namespace Org.OpenAPITools.Client
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
             if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                T instance = (T)Activator.CreateInstance(typeof(T));
-                MethodInfo method = typeof(T).GetMethod("FromJson");
-                method.Invoke(instance, new object[] { response.Content });
+                Type type = typeof(T);
+                MethodInfo method = type.GetMethod("FromJson");
+                method.Invoke(null, new object[] { response.Content });
                 response.Data = instance;
             }
             else if (typeof(T).Name == "Stream") // for binary response


### PR DESCRIPTION
- Call static method without creating instance as the class may not have the default constructor.
 
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02) @Blackclaws (2021/03)


