### PR TITLE
Fix String cast error on default object

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -349,8 +349,12 @@ public class GoClientCodegen extends AbstractGoCodegen {
     public String toDefaultValue(Schema p) {
         p = ModelUtils.getReferencedSchema(this.openAPI, p);
         if (ModelUtils.isStringSchema(p)) {
-            if (p.getDefault() != null) {
-                return "\"" + escapeText((String) p.getDefault()) + "\"";
+            Object defaultObj = p.getDefault();
+            if (defaultObj != null) {
+                if (defaultObj instanceof java.lang.String) {
+                    return "\"" + escapeText((String) defaultObj) + "\"";
+                }
+                return "\"" + escapeText(defaultObj.toString()) + "\"";
             }
             return null;
         }


### PR DESCRIPTION
See #8896 . The Go client was failing when a schema looked like:
```json
"schema": {
          "type": "string",
          "format": "date-time",
          "default": "2000-01-01T00:00:00Z"
        }
```
This fixes that! Not sure who to tag in this... @wing328 ?
