### PR TITLE
Fix default value generation for composed schemas in AbstractJavaCodegen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -938,6 +938,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 return super.toDefaultValue(schema);
             }
             return null;
+        } else if (ModelUtils.isComposedSchema(schema)) {
+            if (schema.getDefault() != null) {
+                return super.toDefaultValue(schema);
+            }
+            return null;
         }
 
         return super.toDefaultValue(schema);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Drawing.java
@@ -53,13 +53,13 @@ import org.openapitools.client.JSON;
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class Drawing {
   public static final String JSON_PROPERTY_MAIN_SHAPE = "mainShape";
-  private Shape mainShape = null;
+  private Shape mainShape;
 
   public static final String JSON_PROPERTY_SHAPE_OR_NULL = "shapeOrNull";
-  private ShapeOrNull shapeOrNull = null;
+  private ShapeOrNull shapeOrNull;
 
   public static final String JSON_PROPERTY_NULLABLE_SHAPE = "nullableShape";
-  private JsonNullable<NullableShape> nullableShape = JsonNullable.<NullableShape>of(null);
+  private JsonNullable<NullableShape> nullableShape = JsonNullable.<NullableShape>undefined();
 
   public static final String JSON_PROPERTY_SHAPES = "shapes";
   private List<Shape> shapes = null;

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Drawing.java
@@ -54,13 +54,13 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class Drawing extends HashMap<String, Fruit> {
   public static final String JSON_PROPERTY_MAIN_SHAPE = "mainShape";
-  private Shape mainShape = null;
+  private Shape mainShape;
 
   public static final String JSON_PROPERTY_SHAPE_OR_NULL = "shapeOrNull";
-  private ShapeOrNull shapeOrNull = null;
+  private ShapeOrNull shapeOrNull;
 
   public static final String JSON_PROPERTY_NULLABLE_SHAPE = "nullableShape";
-  private JsonNullable<NullableShape> nullableShape = JsonNullable.<NullableShape>of(null);
+  private JsonNullable<NullableShape> nullableShape = JsonNullable.<NullableShape>undefined();
 
   public static final String JSON_PROPERTY_SHAPES = "shapes";
   private List<Shape> shapes = null;


### PR DESCRIPTION
When using composed schemas, `null` is generated as a default value, even if no default value is given. This bug is resides in `AbstractJavaCodegen` and is thus present in many generators extending the `AbstractJavaCodegen`.

Samples showing the buggy behavior already exist in `bin/configs/java-native-openapi3.yaml` and `bin/configs/java-jersey2-8.yaml` using `modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml`. Below is an excerpt of this yaml, showing the definition of the composed schemas. 

```yaml
Drawing:
  type: object
  properties:
    mainShape:
      # A property whose value is a 'oneOf' type, and the type is referenced instead
      # of being defined inline. The value cannot be null.
      $ref: '#/components/schemas/Shape'
    shapeOrNull:
      # A property whose value is a 'oneOf' type, and the type is referenced instead
      # of being defined inline. The value may be null because ShapeOrNull has 'null'
      # type as a child schema of 'oneOf'.
      $ref: '#/components/schemas/ShapeOrNull'
    nullableShape:
      # A property whose value is a 'oneOf' type, and the type is referenced instead
      # of being defined inline. The value may be null because NullableShape has the
      # 'nullable: true' attribute. For this specific scenario this is exactly the
      # same thing as 'shapeOrNull'.
      $ref: '#/components/schemas/NullableShape'
    shapes:
      type: array
      items:
        $ref: '#/components/schemas/Shape'
  additionalProperties:
    # Here the additional properties are specified using a referenced schema.
    # This is just to validate the generated code works when using $ref
    # under 'additionalProperties'.
    $ref: '#/components/schemas/fruit'
Shape:
  oneOf:
    - $ref: '#/components/schemas/Triangle'
    - $ref: '#/components/schemas/Quadrilateral'
  discriminator:
    propertyName: shapeType
ShapeOrNull:
  description: The value may be a shape or the 'null' value.
    This is introduced in OAS schema >= 3.1.
  oneOf:
    - type: 'null'
    - $ref: '#/components/schemas/Triangle'
    - $ref: '#/components/schemas/Quadrilateral'
  discriminator:
    propertyName: shapeType
NullableShape:
  description: The value may be a shape or the 'null' value.
    The 'nullable' attribute was introduced in OAS schema >= 3.0
    and has been deprecated in OAS schema >= 3.1.
  oneOf:
    - $ref: '#/components/schemas/Triangle'
    - $ref: '#/components/schemas/Quadrilateral'
  discriminator:
    propertyName: shapeType
  nullable: true
```

As the commit shows, after re-creating the samples, the default null values are gone.

cc: @wing328 @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @nmuesch

Thanks in advance!

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.