### PR TITLE
Store operation notes as multiple lines

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3679,6 +3679,9 @@ public class DefaultCodegen implements CodegenConfig {
         op.operationId = toOperationId(operationId);
         op.summary = escapeText(operation.getSummary());
         op.unescapedNotes = operation.getDescription();
+        if (op.unescapedNotes != null) {
+            op.vendorExtensions.put("x-multiline-notes", escapeTextWhileAllowingNewLines(op.unescapedNotes).split("\n"));
+        }
         op.notes = escapeText(operation.getDescription());
         op.hasConsumes = false;
         op.hasProduces = false;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -53,7 +53,10 @@ public class {{classname}} {
   {{^vendorExtensions.x-group-parameters}}
   /**
    * {{summary}}
-   * {{notes}}
+{{#vendorExtensions.x-multiline-notes}}
+   * {{.}}
+{{/vendorExtensions.x-multiline-notes}}
+   *
    {{#allParams}}
    * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
    {{/allParams}}
@@ -89,7 +92,10 @@ public class {{classname}} {
   {{^vendorExtensions.x-group-parameters}}
   /**
    * {{summary}}
-   * {{notes}}
+{{#vendorExtensions.x-multiline-notes}}
+   * {{.}}
+{{/vendorExtensions.x-multiline-notes}}
+   *
    {{#allParams}}
    * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
    {{/allParams}}

--- a/modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
@@ -250,7 +250,10 @@ paths:
       tags:
         - pet
       summary: uploads an image
-      description: ''
+      description: |-
+         Use this endpoint to upload an image.
+
+         This is a complex description that I'd like to see in docstrings.
       operationId: uploadFile
       parameters:
         - name: petId

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/docs/PetApi.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/docs/PetApi.md
@@ -541,6 +541,8 @@ void (empty response body)
 
 uploads an image
 
+Use this endpoint to upload an image.  This is a complex description that I'd like to see in docstrings.
+
 ### Example
 ```csharp
 using System.Collections.Generic;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/PetApi.cs
@@ -170,6 +170,9 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// uploads an image
         /// </summary>
+        /// <remarks>
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
+        /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
@@ -181,7 +184,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -391,7 +394,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -405,7 +408,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1589,7 +1592,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1603,7 +1606,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1659,7 +1662,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1674,7 +1677,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/docs/PetApi.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/docs/PetApi.md
@@ -541,6 +541,8 @@ void (empty response body)
 
 uploads an image
 
+Use this endpoint to upload an image.  This is a complex description that I'd like to see in docstrings.
+
 ### Example
 ```csharp
 using System.Collections.Generic;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Api/PetApi.cs
@@ -170,6 +170,9 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// uploads an image
         /// </summary>
+        /// <remarks>
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
+        /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
@@ -181,7 +184,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -391,7 +394,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -405,7 +408,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1589,7 +1592,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1603,7 +1606,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1659,7 +1662,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1674,7 +1677,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/docs/PetApi.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/docs/PetApi.md
@@ -541,6 +541,8 @@ void (empty response body)
 
 uploads an image
 
+Use this endpoint to upload an image.  This is a complex description that I'd like to see in docstrings.
+
 ### Example
 ```csharp
 using System.Collections.Generic;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/PetApi.cs
@@ -170,6 +170,9 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// uploads an image
         /// </summary>
+        /// <remarks>
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
+        /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
@@ -181,7 +184,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -391,7 +394,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -405,7 +408,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1589,7 +1592,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1603,7 +1606,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1659,7 +1662,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1674,7 +1677,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/PetApi.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/PetApi.md
@@ -541,6 +541,8 @@ void (empty response body)
 
 uploads an image
 
+Use this endpoint to upload an image.  This is a complex description that I'd like to see in docstrings.
+
 ### Example
 ```csharp
 using System.Collections.Generic;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
@@ -170,6 +170,9 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// uploads an image
         /// </summary>
+        /// <remarks>
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
+        /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
@@ -181,7 +184,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -391,7 +394,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -405,7 +408,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1589,7 +1592,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1603,7 +1606,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1659,7 +1662,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1674,7 +1677,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/PetApi.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/PetApi.md
@@ -541,6 +541,8 @@ void (empty response body)
 
 uploads an image
 
+Use this endpoint to upload an image.  This is a complex description that I'd like to see in docstrings.
+
 ### Example
 ```csharp
 using System.Collections.Generic;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/PetApi.cs
@@ -170,6 +170,9 @@ namespace Org.OpenAPITools.Api
         /// <summary>
         /// uploads an image
         /// </summary>
+        /// <remarks>
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
+        /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
@@ -181,7 +184,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -391,7 +394,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -405,7 +408,7 @@ namespace Org.OpenAPITools.Api
         /// uploads an image
         /// </summary>
         /// <remarks>
-        /// 
+        /// Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1589,7 +1592,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1603,7 +1606,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1659,7 +1662,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>
@@ -1674,7 +1677,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// uploads an image 
+        /// uploads an image Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to update</param>

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -48,6 +48,7 @@ public class AnotherFakeApi {
   /**
    * To test special tags
    * To test special tags and operation ID starting with number
+   *
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
@@ -64,6 +65,7 @@ public class AnotherFakeApi {
   /**
    * To test special tags
    * To test special tags and operation ID starting with number
+   *
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -56,6 +56,7 @@ public class FakeApi {
   /**
    * creates an XmlItem
    * this route creates an XmlItem
+   *
    * @param xmlItem XmlItem Body (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -71,6 +72,7 @@ public class FakeApi {
   /**
    * creates an XmlItem
    * this route creates an XmlItem
+   *
    * @param xmlItem XmlItem Body (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -120,6 +122,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer boolean types
+   *
    * @param body Input boolean as post body (optional)
    * @return Boolean
    * @throws ApiException if fails to make API call
@@ -136,6 +139,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer boolean types
+   *
    * @param body Input boolean as post body (optional)
    * @return ApiResponse&lt;Boolean&gt;
    * @throws ApiException if fails to make API call
@@ -182,6 +186,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of object with outer number type
+   *
    * @param body Input composite as post body (optional)
    * @return OuterComposite
    * @throws ApiException if fails to make API call
@@ -198,6 +203,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of object with outer number type
+   *
    * @param body Input composite as post body (optional)
    * @return ApiResponse&lt;OuterComposite&gt;
    * @throws ApiException if fails to make API call
@@ -244,6 +250,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer number types
+   *
    * @param body Input number as post body (optional)
    * @return BigDecimal
    * @throws ApiException if fails to make API call
@@ -260,6 +267,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer number types
+   *
    * @param body Input number as post body (optional)
    * @return ApiResponse&lt;BigDecimal&gt;
    * @throws ApiException if fails to make API call
@@ -306,6 +314,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer string types
+   *
    * @param body Input string as post body (optional)
    * @return String
    * @throws ApiException if fails to make API call
@@ -322,6 +331,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer string types
+   *
    * @param body Input string as post body (optional)
    * @return ApiResponse&lt;String&gt;
    * @throws ApiException if fails to make API call
@@ -368,6 +378,7 @@ public class FakeApi {
   /**
    * 
    * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
+   *
    * @param body  (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -383,6 +394,7 @@ public class FakeApi {
   /**
    * 
    * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
+   *
    * @param body  (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -431,7 +443,7 @@ public class FakeApi {
   }
   /**
    * 
-   * 
+   *
    * @param query  (required)
    * @param body  (required)
    * @throws ApiException if fails to make API call
@@ -447,7 +459,7 @@ public class FakeApi {
 
   /**
    * 
-   * 
+   *
    * @param query  (required)
    * @param body  (required)
    * @return ApiResponse&lt;Void&gt;
@@ -504,6 +516,7 @@ public class FakeApi {
   /**
    * To test \&quot;client\&quot; model
    * To test \&quot;client\&quot; model
+   *
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
@@ -520,6 +533,7 @@ public class FakeApi {
   /**
    * To test \&quot;client\&quot; model
    * To test \&quot;client\&quot; model
+   *
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call
@@ -570,7 +584,11 @@ public class FakeApi {
   }
   /**
    * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-   * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+   * Fake endpoint for testing various parameters
+   *  假端點
+   *  偽のエンドポイント
+   *  가짜 엔드 포인트
+   *
    * @param number None (required)
    * @param _double None (required)
    * @param patternWithoutDelimiter None (required)
@@ -599,7 +617,11 @@ public class FakeApi {
 
   /**
    * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-   * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+   * Fake endpoint for testing various parameters
+   *  假端點
+   *  偽のエンドポイント
+   *  가짜 엔드 포인트
+   *
    * @param number None (required)
    * @param _double None (required)
    * @param patternWithoutDelimiter None (required)
@@ -706,6 +728,7 @@ if (paramCallback != null)
   /**
    * To test enum parameters
    * To test enum parameters
+   *
    * @param enumHeaderStringArray Header parameter enum test (string array) (optional, default to new ArrayList&lt;&gt;())
    * @param enumHeaderString Header parameter enum test (string) (optional, default to -efg)
    * @param enumQueryStringArray Query parameter enum test (string array) (optional, default to new ArrayList&lt;&gt;())
@@ -729,6 +752,7 @@ if (paramCallback != null)
   /**
    * To test enum parameters
    * To test enum parameters
+   *
    * @param enumHeaderStringArray Header parameter enum test (string array) (optional, default to new ArrayList&lt;&gt;())
    * @param enumHeaderString Header parameter enum test (string) (optional, default to -efg)
    * @param enumQueryStringArray Query parameter enum test (string array) (optional, default to new ArrayList&lt;&gt;())
@@ -963,7 +987,7 @@ if (booleanGroup != null)
   }
   /**
    * test inline additionalProperties
-   * 
+   *
    * @param param request body (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -978,7 +1002,7 @@ if (booleanGroup != null)
 
   /**
    * test inline additionalProperties
-   * 
+   *
    * @param param request body (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -1027,7 +1051,7 @@ if (booleanGroup != null)
   }
   /**
    * test json serialization of form data
-   * 
+   *
    * @param param field1 (required)
    * @param param2 field2 (required)
    * @throws ApiException if fails to make API call
@@ -1043,7 +1067,7 @@ if (booleanGroup != null)
 
   /**
    * test json serialization of form data
-   * 
+   *
    * @param param field1 (required)
    * @param param2 field2 (required)
    * @return ApiResponse&lt;Void&gt;
@@ -1103,6 +1127,7 @@ if (param2 != null)
   /**
    * 
    * To test the collection format in query parameters
+   *
    * @param pipe  (required)
    * @param ioutil  (required)
    * @param http  (required)
@@ -1122,6 +1147,7 @@ if (param2 != null)
   /**
    * 
    * To test the collection format in query parameters
+   *
    * @param pipe  (required)
    * @param ioutil  (required)
    * @param http  (required)

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -48,6 +48,7 @@ public class FakeClassnameTags123Api {
   /**
    * To test class name in snake case
    * To test class name in snake case
+   *
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
@@ -64,6 +65,7 @@ public class FakeClassnameTags123Api {
   /**
    * To test class name in snake case
    * To test class name in snake case
+   *
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/PetApi.java
@@ -50,7 +50,7 @@ public class PetApi {
 
   /**
    * Add a new pet to the store
-   * 
+   *
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -66,7 +66,7 @@ public class PetApi {
 
   /**
    * Add a new pet to the store
-   * 
+   *
    * @param body Pet object that needs to be added to the store (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -116,7 +116,7 @@ public class PetApi {
   }
   /**
    * Deletes a pet
-   * 
+   *
    * @param petId Pet id to delete (required)
    * @param apiKey  (optional)
    * @throws ApiException if fails to make API call
@@ -133,7 +133,7 @@ public class PetApi {
 
   /**
    * Deletes a pet
-   * 
+   *
    * @param petId Pet id to delete (required)
    * @param apiKey  (optional)
    * @return ApiResponse&lt;Void&gt;
@@ -188,6 +188,7 @@ public class PetApi {
   /**
    * Finds Pets by status
    * Multiple status values can be provided with comma separated strings
+   *
    * @param status Status values that need to be considered for filter (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
@@ -205,6 +206,7 @@ public class PetApi {
   /**
    * Finds Pets by status
    * Multiple status values can be provided with comma separated strings
+   *
    * @param status Status values that need to be considered for filter (required)
    * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
    * @throws ApiException if fails to make API call
@@ -258,6 +260,7 @@ public class PetApi {
   /**
    * Finds Pets by tags
    * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+   *
    * @param tags Tags to filter by (required)
    * @return Set&lt;Pet&gt;
    * @throws ApiException if fails to make API call
@@ -277,6 +280,7 @@ public class PetApi {
   /**
    * Finds Pets by tags
    * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+   *
    * @param tags Tags to filter by (required)
    * @return ApiResponse&lt;Set&lt;Pet&gt;&gt;
    * @throws ApiException if fails to make API call
@@ -332,6 +336,7 @@ public class PetApi {
   /**
    * Find pet by ID
    * Returns a single pet
+   *
    * @param petId ID of pet to return (required)
    * @return Pet
    * @throws ApiException if fails to make API call
@@ -350,6 +355,7 @@ public class PetApi {
   /**
    * Find pet by ID
    * Returns a single pet
+   *
    * @param petId ID of pet to return (required)
    * @return ApiResponse&lt;Pet&gt;
    * @throws ApiException if fails to make API call
@@ -403,7 +409,7 @@ public class PetApi {
   }
   /**
    * Update an existing pet
-   * 
+   *
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -421,7 +427,7 @@ public class PetApi {
 
   /**
    * Update an existing pet
-   * 
+   *
    * @param body Pet object that needs to be added to the store (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -473,7 +479,7 @@ public class PetApi {
   }
   /**
    * Updates a pet in the store with form data
-   * 
+   *
    * @param petId ID of pet that needs to be updated (required)
    * @param name Updated name of the pet (optional)
    * @param status Updated status of the pet (optional)
@@ -490,7 +496,7 @@ public class PetApi {
 
   /**
    * Updates a pet in the store with form data
-   * 
+   *
    * @param petId ID of pet that needs to be updated (required)
    * @param name Updated name of the pet (optional)
    * @param status Updated status of the pet (optional)
@@ -546,7 +552,7 @@ if (status != null)
   }
   /**
    * uploads an image
-   * 
+   *
    * @param petId ID of pet to update (required)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @param file file to upload (optional)
@@ -564,7 +570,7 @@ if (status != null)
 
   /**
    * uploads an image
-   * 
+   *
    * @param petId ID of pet to update (required)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @param file file to upload (optional)
@@ -622,7 +628,7 @@ if (file != null)
   }
   /**
    * uploads an image (required)
-   * 
+   *
    * @param petId ID of pet to update (required)
    * @param requiredFile file to upload (required)
    * @param additionalMetadata Additional data to pass to server (optional)
@@ -640,7 +646,7 @@ if (file != null)
 
   /**
    * uploads an image (required)
-   * 
+   *
    * @param petId ID of pet to update (required)
    * @param requiredFile file to upload (required)
    * @param additionalMetadata Additional data to pass to server (optional)

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -48,6 +48,7 @@ public class StoreApi {
   /**
    * Delete purchase order by ID
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+   *
    * @param orderId ID of the order that needs to be deleted (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -64,6 +65,7 @@ public class StoreApi {
   /**
    * Delete purchase order by ID
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+   *
    * @param orderId ID of the order that needs to be deleted (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -115,6 +117,7 @@ public class StoreApi {
   /**
    * Returns pet inventories by status
    * Returns a map of status codes to quantities
+   *
    * @return Map&lt;String, Integer&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -130,6 +133,7 @@ public class StoreApi {
   /**
    * Returns pet inventories by status
    * Returns a map of status codes to quantities
+   *
    * @return ApiResponse&lt;Map&lt;String, Integer&gt;&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -175,6 +179,7 @@ public class StoreApi {
   /**
    * Find purchase order by ID
    * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+   *
    * @param orderId ID of pet that needs to be fetched (required)
    * @return Order
    * @throws ApiException if fails to make API call
@@ -193,6 +198,7 @@ public class StoreApi {
   /**
    * Find purchase order by ID
    * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+   *
    * @param orderId ID of pet that needs to be fetched (required)
    * @return ApiResponse&lt;Order&gt;
    * @throws ApiException if fails to make API call
@@ -246,7 +252,7 @@ public class StoreApi {
   }
   /**
    * Place an order for a pet
-   * 
+   *
    * @param body order placed for purchasing the pet (required)
    * @return Order
    * @throws ApiException if fails to make API call
@@ -263,7 +269,7 @@ public class StoreApi {
 
   /**
    * Place an order for a pet
-   * 
+   *
    * @param body order placed for purchasing the pet (required)
    * @return ApiResponse&lt;Order&gt;
    * @throws ApiException if fails to make API call

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/api/UserApi.java
@@ -48,6 +48,7 @@ public class UserApi {
   /**
    * Create user
    * This can only be done by the logged in user.
+   *
    * @param body Created user object (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -63,6 +64,7 @@ public class UserApi {
   /**
    * Create user
    * This can only be done by the logged in user.
+   *
    * @param body Created user object (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -111,7 +113,7 @@ public class UserApi {
   }
   /**
    * Creates list of users with given input array
-   * 
+   *
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -126,7 +128,7 @@ public class UserApi {
 
   /**
    * Creates list of users with given input array
-   * 
+   *
    * @param body List of user object (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -175,7 +177,7 @@ public class UserApi {
   }
   /**
    * Creates list of users with given input array
-   * 
+   *
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -190,7 +192,7 @@ public class UserApi {
 
   /**
    * Creates list of users with given input array
-   * 
+   *
    * @param body List of user object (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -240,6 +242,7 @@ public class UserApi {
   /**
    * Delete user
    * This can only be done by the logged in user.
+   *
    * @param username The name that needs to be deleted (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -256,6 +259,7 @@ public class UserApi {
   /**
    * Delete user
    * This can only be done by the logged in user.
+   *
    * @param username The name that needs to be deleted (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -306,7 +310,7 @@ public class UserApi {
   }
   /**
    * Get user by user name
-   * 
+   *
    * @param username The name that needs to be fetched. Use user1 for testing. (required)
    * @return User
    * @throws ApiException if fails to make API call
@@ -324,7 +328,7 @@ public class UserApi {
 
   /**
    * Get user by user name
-   * 
+   *
    * @param username The name that needs to be fetched. Use user1 for testing. (required)
    * @return ApiResponse&lt;User&gt;
    * @throws ApiException if fails to make API call
@@ -378,7 +382,7 @@ public class UserApi {
   }
   /**
    * Logs user into the system
-   * 
+   *
    * @param username The user name for login (required)
    * @param password The password for login in clear text (required)
    * @return String
@@ -396,7 +400,7 @@ public class UserApi {
 
   /**
    * Logs user into the system
-   * 
+   *
    * @param username The user name for login (required)
    * @param password The password for login in clear text (required)
    * @return ApiResponse&lt;String&gt;
@@ -456,7 +460,7 @@ public class UserApi {
   }
   /**
    * Logs out current logged in user session
-   * 
+   *
    * @throws ApiException if fails to make API call
    * @http.response.details
      <table summary="Response Details" border="1">
@@ -470,7 +474,7 @@ public class UserApi {
 
   /**
    * Logs out current logged in user session
-   * 
+   *
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -514,6 +518,7 @@ public class UserApi {
   /**
    * Updated user
    * This can only be done by the logged in user.
+   *
    * @param username name that need to be deleted (required)
    * @param body Updated user object (required)
    * @throws ApiException if fails to make API call
@@ -531,6 +536,7 @@ public class UserApi {
   /**
    * Updated user
    * This can only be done by the logged in user.
+   *
    * @param username name that need to be deleted (required)
    * @param body Updated user object (required)
    * @return ApiResponse&lt;Void&gt;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -48,6 +48,7 @@ public class AnotherFakeApi {
   /**
    * To test special tags
    * To test special tags and operation ID starting with number
+   *
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
@@ -64,6 +65,7 @@ public class AnotherFakeApi {
   /**
    * To test special tags
    * To test special tags and operation ID starting with number
+   *
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -56,6 +56,7 @@ public class FakeApi {
   /**
    * creates an XmlItem
    * this route creates an XmlItem
+   *
    * @param xmlItem XmlItem Body (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -71,6 +72,7 @@ public class FakeApi {
   /**
    * creates an XmlItem
    * this route creates an XmlItem
+   *
    * @param xmlItem XmlItem Body (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -120,6 +122,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer boolean types
+   *
    * @param body Input boolean as post body (optional)
    * @return Boolean
    * @throws ApiException if fails to make API call
@@ -136,6 +139,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer boolean types
+   *
    * @param body Input boolean as post body (optional)
    * @return ApiResponse&lt;Boolean&gt;
    * @throws ApiException if fails to make API call
@@ -182,6 +186,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of object with outer number type
+   *
    * @param body Input composite as post body (optional)
    * @return OuterComposite
    * @throws ApiException if fails to make API call
@@ -198,6 +203,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of object with outer number type
+   *
    * @param body Input composite as post body (optional)
    * @return ApiResponse&lt;OuterComposite&gt;
    * @throws ApiException if fails to make API call
@@ -244,6 +250,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer number types
+   *
    * @param body Input number as post body (optional)
    * @return BigDecimal
    * @throws ApiException if fails to make API call
@@ -260,6 +267,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer number types
+   *
    * @param body Input number as post body (optional)
    * @return ApiResponse&lt;BigDecimal&gt;
    * @throws ApiException if fails to make API call
@@ -306,6 +314,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer string types
+   *
    * @param body Input string as post body (optional)
    * @return String
    * @throws ApiException if fails to make API call
@@ -322,6 +331,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer string types
+   *
    * @param body Input string as post body (optional)
    * @return ApiResponse&lt;String&gt;
    * @throws ApiException if fails to make API call
@@ -368,6 +378,7 @@ public class FakeApi {
   /**
    * 
    * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
+   *
    * @param body  (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -383,6 +394,7 @@ public class FakeApi {
   /**
    * 
    * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
+   *
    * @param body  (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -431,7 +443,7 @@ public class FakeApi {
   }
   /**
    * 
-   * 
+   *
    * @param query  (required)
    * @param body  (required)
    * @throws ApiException if fails to make API call
@@ -447,7 +459,7 @@ public class FakeApi {
 
   /**
    * 
-   * 
+   *
    * @param query  (required)
    * @param body  (required)
    * @return ApiResponse&lt;Void&gt;
@@ -504,6 +516,7 @@ public class FakeApi {
   /**
    * To test \&quot;client\&quot; model
    * To test \&quot;client\&quot; model
+   *
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
@@ -520,6 +533,7 @@ public class FakeApi {
   /**
    * To test \&quot;client\&quot; model
    * To test \&quot;client\&quot; model
+   *
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call
@@ -570,7 +584,11 @@ public class FakeApi {
   }
   /**
    * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-   * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+   * Fake endpoint for testing various parameters
+   *  假端點
+   *  偽のエンドポイント
+   *  가짜 엔드 포인트
+   *
    * @param number None (required)
    * @param _double None (required)
    * @param patternWithoutDelimiter None (required)
@@ -599,7 +617,11 @@ public class FakeApi {
 
   /**
    * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-   * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+   * Fake endpoint for testing various parameters
+   *  假端點
+   *  偽のエンドポイント
+   *  가짜 엔드 포인트
+   *
    * @param number None (required)
    * @param _double None (required)
    * @param patternWithoutDelimiter None (required)
@@ -706,6 +728,7 @@ if (paramCallback != null)
   /**
    * To test enum parameters
    * To test enum parameters
+   *
    * @param enumHeaderStringArray Header parameter enum test (string array) (optional, default to new ArrayList&lt;&gt;())
    * @param enumHeaderString Header parameter enum test (string) (optional, default to -efg)
    * @param enumQueryStringArray Query parameter enum test (string array) (optional, default to new ArrayList&lt;&gt;())
@@ -729,6 +752,7 @@ if (paramCallback != null)
   /**
    * To test enum parameters
    * To test enum parameters
+   *
    * @param enumHeaderStringArray Header parameter enum test (string array) (optional, default to new ArrayList&lt;&gt;())
    * @param enumHeaderString Header parameter enum test (string) (optional, default to -efg)
    * @param enumQueryStringArray Query parameter enum test (string array) (optional, default to new ArrayList&lt;&gt;())
@@ -963,7 +987,7 @@ if (booleanGroup != null)
   }
   /**
    * test inline additionalProperties
-   * 
+   *
    * @param param request body (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -978,7 +1002,7 @@ if (booleanGroup != null)
 
   /**
    * test inline additionalProperties
-   * 
+   *
    * @param param request body (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -1027,7 +1051,7 @@ if (booleanGroup != null)
   }
   /**
    * test json serialization of form data
-   * 
+   *
    * @param param field1 (required)
    * @param param2 field2 (required)
    * @throws ApiException if fails to make API call
@@ -1043,7 +1067,7 @@ if (booleanGroup != null)
 
   /**
    * test json serialization of form data
-   * 
+   *
    * @param param field1 (required)
    * @param param2 field2 (required)
    * @return ApiResponse&lt;Void&gt;
@@ -1103,6 +1127,7 @@ if (param2 != null)
   /**
    * 
    * To test the collection format in query parameters
+   *
    * @param pipe  (required)
    * @param ioutil  (required)
    * @param http  (required)
@@ -1122,6 +1147,7 @@ if (param2 != null)
   /**
    * 
    * To test the collection format in query parameters
+   *
    * @param pipe  (required)
    * @param ioutil  (required)
    * @param http  (required)

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -48,6 +48,7 @@ public class FakeClassnameTags123Api {
   /**
    * To test class name in snake case
    * To test class name in snake case
+   *
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
@@ -64,6 +65,7 @@ public class FakeClassnameTags123Api {
   /**
    * To test class name in snake case
    * To test class name in snake case
+   *
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
@@ -50,7 +50,7 @@ public class PetApi {
 
   /**
    * Add a new pet to the store
-   * 
+   *
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -66,7 +66,7 @@ public class PetApi {
 
   /**
    * Add a new pet to the store
-   * 
+   *
    * @param body Pet object that needs to be added to the store (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -116,7 +116,7 @@ public class PetApi {
   }
   /**
    * Deletes a pet
-   * 
+   *
    * @param petId Pet id to delete (required)
    * @param apiKey  (optional)
    * @throws ApiException if fails to make API call
@@ -133,7 +133,7 @@ public class PetApi {
 
   /**
    * Deletes a pet
-   * 
+   *
    * @param petId Pet id to delete (required)
    * @param apiKey  (optional)
    * @return ApiResponse&lt;Void&gt;
@@ -188,6 +188,7 @@ public class PetApi {
   /**
    * Finds Pets by status
    * Multiple status values can be provided with comma separated strings
+   *
    * @param status Status values that need to be considered for filter (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
@@ -205,6 +206,7 @@ public class PetApi {
   /**
    * Finds Pets by status
    * Multiple status values can be provided with comma separated strings
+   *
    * @param status Status values that need to be considered for filter (required)
    * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
    * @throws ApiException if fails to make API call
@@ -258,6 +260,7 @@ public class PetApi {
   /**
    * Finds Pets by tags
    * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+   *
    * @param tags Tags to filter by (required)
    * @return Set&lt;Pet&gt;
    * @throws ApiException if fails to make API call
@@ -277,6 +280,7 @@ public class PetApi {
   /**
    * Finds Pets by tags
    * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+   *
    * @param tags Tags to filter by (required)
    * @return ApiResponse&lt;Set&lt;Pet&gt;&gt;
    * @throws ApiException if fails to make API call
@@ -332,6 +336,7 @@ public class PetApi {
   /**
    * Find pet by ID
    * Returns a single pet
+   *
    * @param petId ID of pet to return (required)
    * @return Pet
    * @throws ApiException if fails to make API call
@@ -350,6 +355,7 @@ public class PetApi {
   /**
    * Find pet by ID
    * Returns a single pet
+   *
    * @param petId ID of pet to return (required)
    * @return ApiResponse&lt;Pet&gt;
    * @throws ApiException if fails to make API call
@@ -403,7 +409,7 @@ public class PetApi {
   }
   /**
    * Update an existing pet
-   * 
+   *
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -421,7 +427,7 @@ public class PetApi {
 
   /**
    * Update an existing pet
-   * 
+   *
    * @param body Pet object that needs to be added to the store (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -473,7 +479,7 @@ public class PetApi {
   }
   /**
    * Updates a pet in the store with form data
-   * 
+   *
    * @param petId ID of pet that needs to be updated (required)
    * @param name Updated name of the pet (optional)
    * @param status Updated status of the pet (optional)
@@ -490,7 +496,7 @@ public class PetApi {
 
   /**
    * Updates a pet in the store with form data
-   * 
+   *
    * @param petId ID of pet that needs to be updated (required)
    * @param name Updated name of the pet (optional)
    * @param status Updated status of the pet (optional)
@@ -546,7 +552,7 @@ if (status != null)
   }
   /**
    * uploads an image
-   * 
+   *
    * @param petId ID of pet to update (required)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @param file file to upload (optional)
@@ -564,7 +570,7 @@ if (status != null)
 
   /**
    * uploads an image
-   * 
+   *
    * @param petId ID of pet to update (required)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @param file file to upload (optional)
@@ -622,7 +628,7 @@ if (file != null)
   }
   /**
    * uploads an image (required)
-   * 
+   *
    * @param petId ID of pet to update (required)
    * @param requiredFile file to upload (required)
    * @param additionalMetadata Additional data to pass to server (optional)
@@ -640,7 +646,7 @@ if (file != null)
 
   /**
    * uploads an image (required)
-   * 
+   *
    * @param petId ID of pet to update (required)
    * @param requiredFile file to upload (required)
    * @param additionalMetadata Additional data to pass to server (optional)

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -48,6 +48,7 @@ public class StoreApi {
   /**
    * Delete purchase order by ID
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+   *
    * @param orderId ID of the order that needs to be deleted (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -64,6 +65,7 @@ public class StoreApi {
   /**
    * Delete purchase order by ID
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+   *
    * @param orderId ID of the order that needs to be deleted (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -115,6 +117,7 @@ public class StoreApi {
   /**
    * Returns pet inventories by status
    * Returns a map of status codes to quantities
+   *
    * @return Map&lt;String, Integer&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -130,6 +133,7 @@ public class StoreApi {
   /**
    * Returns pet inventories by status
    * Returns a map of status codes to quantities
+   *
    * @return ApiResponse&lt;Map&lt;String, Integer&gt;&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -175,6 +179,7 @@ public class StoreApi {
   /**
    * Find purchase order by ID
    * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+   *
    * @param orderId ID of pet that needs to be fetched (required)
    * @return Order
    * @throws ApiException if fails to make API call
@@ -193,6 +198,7 @@ public class StoreApi {
   /**
    * Find purchase order by ID
    * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+   *
    * @param orderId ID of pet that needs to be fetched (required)
    * @return ApiResponse&lt;Order&gt;
    * @throws ApiException if fails to make API call
@@ -246,7 +252,7 @@ public class StoreApi {
   }
   /**
    * Place an order for a pet
-   * 
+   *
    * @param body order placed for purchasing the pet (required)
    * @return Order
    * @throws ApiException if fails to make API call
@@ -263,7 +269,7 @@ public class StoreApi {
 
   /**
    * Place an order for a pet
-   * 
+   *
    * @param body order placed for purchasing the pet (required)
    * @return ApiResponse&lt;Order&gt;
    * @throws ApiException if fails to make API call

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -48,6 +48,7 @@ public class UserApi {
   /**
    * Create user
    * This can only be done by the logged in user.
+   *
    * @param body Created user object (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -63,6 +64,7 @@ public class UserApi {
   /**
    * Create user
    * This can only be done by the logged in user.
+   *
    * @param body Created user object (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -111,7 +113,7 @@ public class UserApi {
   }
   /**
    * Creates list of users with given input array
-   * 
+   *
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -126,7 +128,7 @@ public class UserApi {
 
   /**
    * Creates list of users with given input array
-   * 
+   *
    * @param body List of user object (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -175,7 +177,7 @@ public class UserApi {
   }
   /**
    * Creates list of users with given input array
-   * 
+   *
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -190,7 +192,7 @@ public class UserApi {
 
   /**
    * Creates list of users with given input array
-   * 
+   *
    * @param body List of user object (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -240,6 +242,7 @@ public class UserApi {
   /**
    * Delete user
    * This can only be done by the logged in user.
+   *
    * @param username The name that needs to be deleted (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -256,6 +259,7 @@ public class UserApi {
   /**
    * Delete user
    * This can only be done by the logged in user.
+   *
    * @param username The name that needs to be deleted (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -306,7 +310,7 @@ public class UserApi {
   }
   /**
    * Get user by user name
-   * 
+   *
    * @param username The name that needs to be fetched. Use user1 for testing. (required)
    * @return User
    * @throws ApiException if fails to make API call
@@ -324,7 +328,7 @@ public class UserApi {
 
   /**
    * Get user by user name
-   * 
+   *
    * @param username The name that needs to be fetched. Use user1 for testing. (required)
    * @return ApiResponse&lt;User&gt;
    * @throws ApiException if fails to make API call
@@ -378,7 +382,7 @@ public class UserApi {
   }
   /**
    * Logs user into the system
-   * 
+   *
    * @param username The user name for login (required)
    * @param password The password for login in clear text (required)
    * @return String
@@ -396,7 +400,7 @@ public class UserApi {
 
   /**
    * Logs user into the system
-   * 
+   *
    * @param username The user name for login (required)
    * @param password The password for login in clear text (required)
    * @return ApiResponse&lt;String&gt;
@@ -456,7 +460,7 @@ public class UserApi {
   }
   /**
    * Logs out current logged in user session
-   * 
+   *
    * @throws ApiException if fails to make API call
    * @http.response.details
      <table summary="Response Details" border="1">
@@ -470,7 +474,7 @@ public class UserApi {
 
   /**
    * Logs out current logged in user session
-   * 
+   *
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -514,6 +518,7 @@ public class UserApi {
   /**
    * Updated user
    * This can only be done by the logged in user.
+   *
    * @param username name that need to be deleted (required)
    * @param body Updated user object (required)
    * @throws ApiException if fails to make API call
@@ -531,6 +536,7 @@ public class UserApi {
   /**
    * Updated user
    * This can only be done by the logged in user.
+   *
    * @param username name that need to be deleted (required)
    * @param body Updated user object (required)
    * @return ApiResponse&lt;Void&gt;

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/api/UsageApi.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/api/UsageApi.java
@@ -47,6 +47,7 @@ public class UsageApi {
   /**
    * Use any API key
    * Use any API key
+   *
    * @return Object
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -62,6 +63,7 @@ public class UsageApi {
   /**
    * Use any API key
    * Use any API key
+   *
    * @return ApiResponse&lt;Object&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -107,6 +109,7 @@ public class UsageApi {
   /**
    * Use both API keys
    * Use both API keys
+   *
    * @return Object
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -122,6 +125,7 @@ public class UsageApi {
   /**
    * Use both API keys
    * Use both API keys
+   *
    * @return ApiResponse&lt;Object&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -167,6 +171,7 @@ public class UsageApi {
   /**
    * Use API key in header
    * Use API key in header
+   *
    * @return Object
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -182,6 +187,7 @@ public class UsageApi {
   /**
    * Use API key in header
    * Use API key in header
+   *
    * @return ApiResponse&lt;Object&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -227,6 +233,7 @@ public class UsageApi {
   /**
    * Use API key in query
    * Use API key in query
+   *
    * @return Object
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -242,6 +249,7 @@ public class UsageApi {
   /**
    * Use API key in query
    * Use API key in query
+   *
    * @return ApiResponse&lt;Object&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -47,7 +47,7 @@ public class DefaultApi {
 
   /**
    * 
-   * 
+   *
    * @param mySchemaNameCharacters  (optional)
    * @return MySchemaNameCharacters
    * @throws ApiException if fails to make API call
@@ -63,7 +63,7 @@ public class DefaultApi {
 
   /**
    * 
-   * 
+   *
    * @param mySchemaNameCharacters  (optional)
    * @return ApiResponse&lt;MySchemaNameCharacters&gt;
    * @throws ApiException if fails to make API call

--- a/samples/openapi3/client/petstore/java/jersey2-java8/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/api/openapi.yaml
@@ -283,6 +283,10 @@ paths:
       x-accepts: application/json
   /pet/{petId}/uploadImage:
     post:
+      description: |-
+        Use this endpoint to upload an image.
+
+        This is a complex description that I'd like to see in docstrings.
       operationId: uploadFile
       parameters:
       - description: ID of pet to update

--- a/samples/openapi3/client/petstore/java/jersey2-java8/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/docs/PetApi.md
@@ -518,6 +518,10 @@ null (empty response body)
 
 uploads an image
 
+Use this endpoint to upload an image.
+
+This is a complex description that I'd like to see in docstrings.
+
 ### Example
 
 ```java

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -48,6 +48,7 @@ public class AnotherFakeApi {
   /**
    * To test special tags
    * To test special tags and operation ID starting with number
+   *
    * @param client client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
@@ -64,6 +65,7 @@ public class AnotherFakeApi {
   /**
    * To test special tags
    * To test special tags and operation ID starting with number
+   *
    * @param client client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -47,7 +47,7 @@ public class DefaultApi {
 
   /**
    * 
-   * 
+   *
    * @return InlineResponseDefault
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -62,7 +62,7 @@ public class DefaultApi {
 
   /**
    * 
-   * 
+   *
    * @return ApiResponse&lt;InlineResponseDefault&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -56,7 +56,7 @@ public class FakeApi {
 
   /**
    * Health check endpoint
-   * 
+   *
    * @return HealthCheckResult
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -71,7 +71,7 @@ public class FakeApi {
 
   /**
    * Health check endpoint
-   * 
+   *
    * @return ApiResponse&lt;HealthCheckResult&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -117,6 +117,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer boolean types
+   *
    * @param body Input boolean as post body (optional)
    * @return Boolean
    * @throws ApiException if fails to make API call
@@ -133,6 +134,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer boolean types
+   *
    * @param body Input boolean as post body (optional)
    * @return ApiResponse&lt;Boolean&gt;
    * @throws ApiException if fails to make API call
@@ -179,6 +181,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of object with outer number type
+   *
    * @param outerComposite Input composite as post body (optional)
    * @return OuterComposite
    * @throws ApiException if fails to make API call
@@ -195,6 +198,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of object with outer number type
+   *
    * @param outerComposite Input composite as post body (optional)
    * @return ApiResponse&lt;OuterComposite&gt;
    * @throws ApiException if fails to make API call
@@ -241,6 +245,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer number types
+   *
    * @param body Input number as post body (optional)
    * @return BigDecimal
    * @throws ApiException if fails to make API call
@@ -257,6 +262,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer number types
+   *
    * @param body Input number as post body (optional)
    * @return ApiResponse&lt;BigDecimal&gt;
    * @throws ApiException if fails to make API call
@@ -303,6 +309,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer string types
+   *
    * @param body Input string as post body (optional)
    * @return String
    * @throws ApiException if fails to make API call
@@ -319,6 +326,7 @@ public class FakeApi {
   /**
    * 
    * Test serialization of outer string types
+   *
    * @param body Input string as post body (optional)
    * @return ApiResponse&lt;String&gt;
    * @throws ApiException if fails to make API call
@@ -364,7 +372,7 @@ public class FakeApi {
   }
   /**
    * Array of Enums
-   * 
+   *
    * @return List&lt;OuterEnum&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -379,7 +387,7 @@ public class FakeApi {
 
   /**
    * Array of Enums
-   * 
+   *
    * @return ApiResponse&lt;List&lt;OuterEnum&gt;&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -425,6 +433,7 @@ public class FakeApi {
   /**
    * 
    * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
+   *
    * @param fileSchemaTestClass  (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -440,6 +449,7 @@ public class FakeApi {
   /**
    * 
    * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
+   *
    * @param fileSchemaTestClass  (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -488,7 +498,7 @@ public class FakeApi {
   }
   /**
    * 
-   * 
+   *
    * @param query  (required)
    * @param user  (required)
    * @throws ApiException if fails to make API call
@@ -504,7 +514,7 @@ public class FakeApi {
 
   /**
    * 
-   * 
+   *
    * @param query  (required)
    * @param user  (required)
    * @return ApiResponse&lt;Void&gt;
@@ -561,6 +571,7 @@ public class FakeApi {
   /**
    * To test \&quot;client\&quot; model
    * To test \&quot;client\&quot; model
+   *
    * @param client client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
@@ -577,6 +588,7 @@ public class FakeApi {
   /**
    * To test \&quot;client\&quot; model
    * To test \&quot;client\&quot; model
+   *
    * @param client client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call
@@ -627,7 +639,11 @@ public class FakeApi {
   }
   /**
    * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-   * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+   * Fake endpoint for testing various parameters
+   * 假端點
+   * 偽のエンドポイント
+   * 가짜 엔드 포인트
+   *
    * @param number None (required)
    * @param _double None (required)
    * @param patternWithoutDelimiter None (required)
@@ -656,7 +672,11 @@ public class FakeApi {
 
   /**
    * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-   * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+   * Fake endpoint for testing various parameters
+   * 假端點
+   * 偽のエンドポイント
+   * 가짜 엔드 포인트
+   *
    * @param number None (required)
    * @param _double None (required)
    * @param patternWithoutDelimiter None (required)
@@ -763,6 +783,7 @@ if (paramCallback != null)
   /**
    * To test enum parameters
    * To test enum parameters
+   *
    * @param enumHeaderStringArray Header parameter enum test (string array) (optional, default to new ArrayList&lt;&gt;())
    * @param enumHeaderString Header parameter enum test (string) (optional, default to -efg)
    * @param enumQueryStringArray Query parameter enum test (string array) (optional, default to new ArrayList&lt;&gt;())
@@ -786,6 +807,7 @@ if (paramCallback != null)
   /**
    * To test enum parameters
    * To test enum parameters
+   *
    * @param enumHeaderStringArray Header parameter enum test (string array) (optional, default to new ArrayList&lt;&gt;())
    * @param enumHeaderString Header parameter enum test (string) (optional, default to -efg)
    * @param enumQueryStringArray Query parameter enum test (string array) (optional, default to new ArrayList&lt;&gt;())
@@ -1020,7 +1042,7 @@ if (booleanGroup != null)
   }
   /**
    * test inline additionalProperties
-   * 
+   *
    * @param requestBody request body (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -1035,7 +1057,7 @@ if (booleanGroup != null)
 
   /**
    * test inline additionalProperties
-   * 
+   *
    * @param requestBody request body (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -1084,7 +1106,7 @@ if (booleanGroup != null)
   }
   /**
    * test json serialization of form data
-   * 
+   *
    * @param param field1 (required)
    * @param param2 field2 (required)
    * @throws ApiException if fails to make API call
@@ -1100,7 +1122,7 @@ if (booleanGroup != null)
 
   /**
    * test json serialization of form data
-   * 
+   *
    * @param param field1 (required)
    * @param param2 field2 (required)
    * @return ApiResponse&lt;Void&gt;
@@ -1160,6 +1182,7 @@ if (param2 != null)
   /**
    * 
    * To test the collection format in query parameters
+   *
    * @param pipe  (required)
    * @param ioutil  (required)
    * @param http  (required)
@@ -1179,6 +1202,7 @@ if (param2 != null)
   /**
    * 
    * To test the collection format in query parameters
+   *
    * @param pipe  (required)
    * @param ioutil  (required)
    * @param http  (required)

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -48,6 +48,7 @@ public class FakeClassnameTags123Api {
   /**
    * To test class name in snake case
    * To test class name in snake case
+   *
    * @param client client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
@@ -64,6 +65,7 @@ public class FakeClassnameTags123Api {
   /**
    * To test class name in snake case
    * To test class name in snake case
+   *
    * @param client client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
@@ -49,7 +49,7 @@ public class PetApi {
 
   /**
    * Add a new pet to the store
-   * 
+   *
    * @param pet Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -64,7 +64,7 @@ public class PetApi {
 
   /**
    * Add a new pet to the store
-   * 
+   *
    * @param pet Pet object that needs to be added to the store (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -113,7 +113,7 @@ public class PetApi {
   }
   /**
    * Deletes a pet
-   * 
+   *
    * @param petId Pet id to delete (required)
    * @param apiKey  (optional)
    * @throws ApiException if fails to make API call
@@ -129,7 +129,7 @@ public class PetApi {
 
   /**
    * Deletes a pet
-   * 
+   *
    * @param petId Pet id to delete (required)
    * @param apiKey  (optional)
    * @return ApiResponse&lt;Void&gt;
@@ -183,6 +183,7 @@ public class PetApi {
   /**
    * Finds Pets by status
    * Multiple status values can be provided with comma separated strings
+   *
    * @param status Status values that need to be considered for filter (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
@@ -200,6 +201,7 @@ public class PetApi {
   /**
    * Finds Pets by status
    * Multiple status values can be provided with comma separated strings
+   *
    * @param status Status values that need to be considered for filter (required)
    * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
    * @throws ApiException if fails to make API call
@@ -253,6 +255,7 @@ public class PetApi {
   /**
    * Finds Pets by tags
    * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+   *
    * @param tags Tags to filter by (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
@@ -272,6 +275,7 @@ public class PetApi {
   /**
    * Finds Pets by tags
    * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+   *
    * @param tags Tags to filter by (required)
    * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
    * @throws ApiException if fails to make API call
@@ -327,6 +331,7 @@ public class PetApi {
   /**
    * Find pet by ID
    * Returns a single pet
+   *
    * @param petId ID of pet to return (required)
    * @return Pet
    * @throws ApiException if fails to make API call
@@ -345,6 +350,7 @@ public class PetApi {
   /**
    * Find pet by ID
    * Returns a single pet
+   *
    * @param petId ID of pet to return (required)
    * @return ApiResponse&lt;Pet&gt;
    * @throws ApiException if fails to make API call
@@ -398,7 +404,7 @@ public class PetApi {
   }
   /**
    * Update an existing pet
-   * 
+   *
    * @param pet Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -415,7 +421,7 @@ public class PetApi {
 
   /**
    * Update an existing pet
-   * 
+   *
    * @param pet Pet object that needs to be added to the store (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -466,7 +472,7 @@ public class PetApi {
   }
   /**
    * Updates a pet in the store with form data
-   * 
+   *
    * @param petId ID of pet that needs to be updated (required)
    * @param name Updated name of the pet (optional)
    * @param status Updated status of the pet (optional)
@@ -483,7 +489,7 @@ public class PetApi {
 
   /**
    * Updates a pet in the store with form data
-   * 
+   *
    * @param petId ID of pet that needs to be updated (required)
    * @param name Updated name of the pet (optional)
    * @param status Updated status of the pet (optional)
@@ -539,7 +545,10 @@ if (status != null)
   }
   /**
    * uploads an image
+   * Use this endpoint to upload an image.
    * 
+   * This is a complex description that I&#39;d like to see in docstrings.
+   *
    * @param petId ID of pet to update (required)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @param file file to upload (optional)
@@ -557,7 +566,10 @@ if (status != null)
 
   /**
    * uploads an image
+   * Use this endpoint to upload an image.
    * 
+   * This is a complex description that I&#39;d like to see in docstrings.
+   *
    * @param petId ID of pet to update (required)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @param file file to upload (optional)
@@ -615,7 +627,7 @@ if (file != null)
   }
   /**
    * uploads an image (required)
-   * 
+   *
    * @param petId ID of pet to update (required)
    * @param requiredFile file to upload (required)
    * @param additionalMetadata Additional data to pass to server (optional)
@@ -633,7 +645,7 @@ if (file != null)
 
   /**
    * uploads an image (required)
-   * 
+   *
    * @param petId ID of pet to update (required)
    * @param requiredFile file to upload (required)
    * @param additionalMetadata Additional data to pass to server (optional)

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -48,6 +48,7 @@ public class StoreApi {
   /**
    * Delete purchase order by ID
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+   *
    * @param orderId ID of the order that needs to be deleted (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -64,6 +65,7 @@ public class StoreApi {
   /**
    * Delete purchase order by ID
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+   *
    * @param orderId ID of the order that needs to be deleted (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -115,6 +117,7 @@ public class StoreApi {
   /**
    * Returns pet inventories by status
    * Returns a map of status codes to quantities
+   *
    * @return Map&lt;String, Integer&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -130,6 +133,7 @@ public class StoreApi {
   /**
    * Returns pet inventories by status
    * Returns a map of status codes to quantities
+   *
    * @return ApiResponse&lt;Map&lt;String, Integer&gt;&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -175,6 +179,7 @@ public class StoreApi {
   /**
    * Find purchase order by ID
    * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+   *
    * @param orderId ID of pet that needs to be fetched (required)
    * @return Order
    * @throws ApiException if fails to make API call
@@ -193,6 +198,7 @@ public class StoreApi {
   /**
    * Find purchase order by ID
    * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+   *
    * @param orderId ID of pet that needs to be fetched (required)
    * @return ApiResponse&lt;Order&gt;
    * @throws ApiException if fails to make API call
@@ -246,7 +252,7 @@ public class StoreApi {
   }
   /**
    * Place an order for a pet
-   * 
+   *
    * @param order order placed for purchasing the pet (required)
    * @return Order
    * @throws ApiException if fails to make API call
@@ -263,7 +269,7 @@ public class StoreApi {
 
   /**
    * Place an order for a pet
-   * 
+   *
    * @param order order placed for purchasing the pet (required)
    * @return ApiResponse&lt;Order&gt;
    * @throws ApiException if fails to make API call

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -48,6 +48,7 @@ public class UserApi {
   /**
    * Create user
    * This can only be done by the logged in user.
+   *
    * @param user Created user object (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -63,6 +64,7 @@ public class UserApi {
   /**
    * Create user
    * This can only be done by the logged in user.
+   *
    * @param user Created user object (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -111,7 +113,7 @@ public class UserApi {
   }
   /**
    * Creates list of users with given input array
-   * 
+   *
    * @param user List of user object (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -126,7 +128,7 @@ public class UserApi {
 
   /**
    * Creates list of users with given input array
-   * 
+   *
    * @param user List of user object (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -175,7 +177,7 @@ public class UserApi {
   }
   /**
    * Creates list of users with given input array
-   * 
+   *
    * @param user List of user object (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -190,7 +192,7 @@ public class UserApi {
 
   /**
    * Creates list of users with given input array
-   * 
+   *
    * @param user List of user object (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -240,6 +242,7 @@ public class UserApi {
   /**
    * Delete user
    * This can only be done by the logged in user.
+   *
    * @param username The name that needs to be deleted (required)
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -256,6 +259,7 @@ public class UserApi {
   /**
    * Delete user
    * This can only be done by the logged in user.
+   *
    * @param username The name that needs to be deleted (required)
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
@@ -306,7 +310,7 @@ public class UserApi {
   }
   /**
    * Get user by user name
-   * 
+   *
    * @param username The name that needs to be fetched. Use user1 for testing. (required)
    * @return User
    * @throws ApiException if fails to make API call
@@ -324,7 +328,7 @@ public class UserApi {
 
   /**
    * Get user by user name
-   * 
+   *
    * @param username The name that needs to be fetched. Use user1 for testing. (required)
    * @return ApiResponse&lt;User&gt;
    * @throws ApiException if fails to make API call
@@ -378,7 +382,7 @@ public class UserApi {
   }
   /**
    * Logs user into the system
-   * 
+   *
    * @param username The user name for login (required)
    * @param password The password for login in clear text (required)
    * @return String
@@ -396,7 +400,7 @@ public class UserApi {
 
   /**
    * Logs user into the system
-   * 
+   *
    * @param username The user name for login (required)
    * @param password The password for login in clear text (required)
    * @return ApiResponse&lt;String&gt;
@@ -456,7 +460,7 @@ public class UserApi {
   }
   /**
    * Logs out current logged in user session
-   * 
+   *
    * @throws ApiException if fails to make API call
    * @http.response.details
      <table summary="Response Details" border="1">
@@ -470,7 +474,7 @@ public class UserApi {
 
   /**
    * Logs out current logged in user session
-   * 
+   *
    * @return ApiResponse&lt;Void&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -514,6 +518,7 @@ public class UserApi {
   /**
    * Updated user
    * This can only be done by the logged in user.
+   *
    * @param username name that need to be deleted (required)
    * @param user Updated user object (required)
    * @throws ApiException if fails to make API call
@@ -531,6 +536,7 @@ public class UserApi {
   /**
    * Updated user
    * This can only be done by the logged in user.
+   *
    * @param username name that need to be deleted (required)
    * @param user Updated user object (required)
    * @return ApiResponse&lt;Void&gt;

--- a/samples/openapi3/client/petstore/java/native/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/java/native/api/openapi.yaml
@@ -283,6 +283,10 @@ paths:
       x-accepts: application/json
   /pet/{petId}/uploadImage:
     post:
+      description: |-
+        Use this endpoint to upload an image.
+
+        This is a complex description that I'd like to see in docstrings.
       operationId: uploadFile
       parameters:
       - description: ID of pet to update

--- a/samples/openapi3/client/petstore/java/native/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/java/native/docs/PetApi.md
@@ -1051,6 +1051,8 @@ ApiResponse<Void>
 
 uploads an image
 
+Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
+
 ### Example
 
 ```java
@@ -1122,6 +1124,8 @@ Name | Type | Description  | Notes
 > ApiResponse<ModelApiResponse> uploadFile uploadFileWithHttpInfo(petId, additionalMetadata, file)
 
 uploads an image
+
+Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
 
 ### Example
 

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
@@ -597,7 +597,7 @@ public class PetApi {
   }
   /**
    * uploads an image
-   * 
+   * Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
    * @param petId ID of pet to update (required)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @param file file to upload (optional)
@@ -611,7 +611,7 @@ public class PetApi {
 
   /**
    * uploads an image
-   * 
+   * Use this endpoint to upload an image.  This is a complex description that I&#39;d like to see in docstrings.
    * @param petId ID of pet to update (required)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @param file file to upload (optional)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This adds an extension to store operation notes as an array, so that we can
iterate line by line and preserve line breaks from spec documentation in API
documentation.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.