### PR TITLE
[C++][Qt]Replace usage of QVariant with a more intuitive optional wrapper 

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -1,6 +1,5 @@
 {{>licenseInfo}}
 #include "{{classname}}.h"
-#include "{{prefix}}Helpers.h"
 #include "{{prefix}}ServerConfiguration.h"
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -21,7 +20,6 @@ namespace {{this}} {
 }
 
 void {{classname}}::initializeServerConfigs(){
-
     //Default server
     QList<{{prefix}}ServerConfiguration> defaultConf = QList<{{prefix}}ServerConfiguration>();
     //varying endpoint server
@@ -224,7 +222,7 @@ QString {{classname}}::getParamStyleDelimiter(QString style, QString name, bool 
 
 {{#operations}}
 {{#operation}}
-void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}} &{{/required}}{{^required}}const QVariant &{{/required}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) {
+void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}} &{{/required}}{{^required}}const ::{{cppNamespace}}::OptionalParam<{{{dataType}}}> &{{/required}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) {
     QString fullPath = QString(_serverConfigs["{{nickname}}"][_serverIndices.value("{{nickname}}")].URL()+"{{{path}}}");
     {{#authMethods}}{{#isApiKey}}{{#isKeyInHeader}}
     if(_apiKeys.contains("{{name}}")){
@@ -247,9 +245,8 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         b64.append(_username.toUtf8() + ":" + _password.toUtf8());
         addHeaders("Authorization","Basic " + b64.toBase64());
     }{{/isBasicBasic}}{{/authMethods}}
-
     {{#pathParams}}
-    {{^required}}if(!{{paramName}}.isNull()){{/required}}
+    {{^required}}if({{paramName}}.hasValue()){{/required}}
     {
         QString {{paramName}}PathParam("{");
         {{paramName}}PathParam.append("{{baseName}}").append("}");
@@ -263,7 +260,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     {{^collectionFormat}}
         {{^isPrimitiveType}}
         QString paramString = (pathStyle == "matrix" && {{isExplode}}) ? pathPrefix : pathPrefix+"{{baseName}}"+pathSuffix;
-        QJsonObject parameter = {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}.asJsonObject();
+        QJsonObject parameter = {{paramName}}{{^required}}.value(){{/required}}.asJsonObject();
         qint32 count = 0;
         foreach(const QString& key, parameter.keys()) {
             if (count > 0) {
@@ -307,14 +304,14 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         {{/isPrimitiveType}}
         {{#isPrimitiveType}}
         QString paramString = (pathStyle == "matrix") ? pathPrefix+"{{baseName}}"+pathSuffix : pathPrefix;
-        fullPath.replace({{paramName}}PathParam, paramString+QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}})));
+        fullPath.replace({{paramName}}PathParam, paramString+QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value(){{/required}})));
         {{/isPrimitiveType}}
-    {{/collectionFormat}}
-    {{#collectionFormat}}
-        if ({{{paramName}}}{{^required}}.value<{{{dataType}}}>(){{/required}}.size() > 0) {
+{{/collectionFormat}}
+{{#collectionFormat}}
+        if({{{paramName}}}{{^required}}.value(){{/required}}.size() > 0) {
             QString paramString = (pathStyle == "matrix") ? pathPrefix+"{{baseName}}"+pathSuffix : pathPrefix;
             qint32 count = 0;
-            foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}) {
+            foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
                 if (count > 0) {
                     fullPath.append(pathDelimiter);
                 }
@@ -325,13 +322,12 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         }
     {{/collectionFormat}}
     }
-
     {{/pathParams}}
     {{#hasQueryParams}}
     QString queryPrefix, querySuffix, queryDelimiter, queryStyle;
     {{/hasQueryParams}}
     {{#queryParams}}
-    {{^required}}if(!{{paramName}}.isNull()){{/required}}
+    {{^required}}if({{paramName}}.hasValue()){{/required}}
     {
         queryStyle = "{{style}}";
         if(queryStyle == "")
@@ -346,7 +342,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
             fullPath.append("?");
         {{^isPrimitiveType}}
         QString paramString = (queryStyle == "form" && {{isExplode}}) ? "" : (queryStyle == "form" && !({{isExplode}})) ? "{{baseName}}"+querySuffix : "";
-        QJsonObject parameter = {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}.asJsonObject();
+        QJsonObject parameter = {{paramName}}{{^required}}.value(){{/required}}.asJsonObject();
         qint32 count = 0;
         foreach(const QString& key, parameter.keys()) {
             if (count > 0) {
@@ -392,13 +388,13 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         }
         fullPath.append(paramString);
         {{/isPrimitiveType}}{{#isPrimitiveType}}
-        fullPath.append(QUrl::toPercentEncoding("{{baseName}}")).append(querySuffix).append(QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}})));
-    {{/isPrimitiveType}}
-    {{/collectionFormat}}
-    {{#collectionFormat}}
-        if ({{{paramName}}}{{^required}}.value<{{{dataType}}}>(){{/required}}.size() > 0) {
+        fullPath.append(QUrl::toPercentEncoding("{{baseName}}")).append(querySuffix).append(QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value(){{/required}})));
+{{/isPrimitiveType}}
+{{/collectionFormat}}
+{{#collectionFormat}}
+        if({{{paramName}}}{{^required}}.value(){{/required}}.size() > 0) {
             if (QString("{{collectionFormat}}").indexOf("multi") == 0) {
-                foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}) {
+                foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
                     if (fullPath.indexOf("?") > 0)
                         fullPath.append(queryPrefix);
                     else
@@ -411,7 +407,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
                 else
                     fullPath.append("?").append(queryPrefix).append("{{baseName}}").append(querySuffix);
                 qint32 count = 0;
-                foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}) {
+                foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
                     if (count > 0) {
                         fullPath.append(({{isExplode}})? queryDelimiter : QUrl::toPercentEncoding(queryDelimiter));
                     }
@@ -424,7 +420,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
                 else
                     fullPath.append("?").append(queryPrefix).append("{{baseName}}").append(querySuffix);
                 qint32 count = 0;
-                foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}) {
+                foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
                     if (count > 0) {
                         fullPath.append("\t");
                     }
@@ -437,7 +433,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
                 else
                     fullPath.append("?").append(queryPrefix).append("{{baseName}}").append(querySuffix);
                 qint32 count = 0;
-                foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}) {
+                foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
                     if (count > 0) {
                         fullPath.append(queryDelimiter);
                     }
@@ -450,7 +446,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
                 else
                     fullPath.append("?").append(queryPrefix).append("{{baseName}}").append(querySuffix);
                 qint32 count = 0;
-                foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}) {
+                foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
                     if (count > 0) {
                         fullPath.append(queryDelimiter);
                     }
@@ -463,7 +459,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
                 else
                     fullPath.append("?").append(queryPrefix).append("{{baseName}}").append(querySuffix);
                 qint32 count = 0;
-                foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}) {
+                foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
                     if (count > 0) {
                         fullPath.append(queryDelimiter);
                     }
@@ -474,7 +470,6 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         }
     {{/collectionFormat}}
     }
-
 {{/queryParams}}
     {{prefix}}HttpRequestWorker *worker = new {{prefix}}HttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
@@ -493,39 +488,38 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     formSuffix = getParamStyleSuffix(formStyle);
     formDelimiter = getParamStyleDelimiter(formStyle, "{{baseName}}", {{isExplode}});
     {{/first}}
-
-    {{^required}}if(!{{paramName}}.isNull()){{/required}}
+    {{^required}}if({{paramName}}.hasValue()){{/required}}
     {
 {{^isFile}}
-        input.add_var("{{baseName}}", ::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}));
+        input.add_var("{{baseName}}", ::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value(){{/required}}));
 {{/isFile}}
 {{#isFile}}
-        input.add_file("{{baseName}}", {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}.local_filename, {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}.request_filename, {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}.mime_type);
+        input.add_file("{{baseName}}", {{paramName}}{{^required}}.value(){{/required}}.local_filename, {{paramName}}{{^required}}.value(){{/required}}.request_filename, {{paramName}}{{^required}}.value(){{/required}}.mime_type);
 {{/isFile}}
     }
-
 {{/formParams}}
 {{#bodyParams}}
+    {{^required}}if({{paramName}}.hasValue()){{/required}}{
 {{#isContainer}}
 {{#isArray}}
-    QJsonDocument doc(::{{cppNamespace}}::toJsonValue({{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}).toArray());{{/isArray}}{{#isMap}}
-    QJsonDocument doc(::{{cppNamespace}}::toJsonValue({{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}).toObject());{{/isMap}}
-    QByteArray bytes = doc.toJson();
-    input.request_body.append(bytes);
+        QJsonDocument doc(::{{cppNamespace}}::toJsonValue({{paramName}}{{^required}}.value(){{/required}}).toArray());{{/isArray}}{{#isMap}}
+        QJsonDocument doc(::{{cppNamespace}}::toJsonValue({{paramName}}{{^required}}.value(){{/required}}).toObject());{{/isMap}}
+        QByteArray bytes = doc.toJson();
+        input.request_body.append(bytes);
 {{/isContainer}}{{^isContainer}}{{#isString}}
-    QByteArray output = {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}.toUtf8();{{/isString}}{{#isByteArray}}QByteArray output({{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}});{{/isByteArray}}{{^isString}}{{^isByteArray}}{{^isFile}}
-    QByteArray output = {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}.asJson().toUtf8();{{/isFile}}{{/isByteArray}}{{/isString}}{{#isFile}}{{#hasConsumes}}input.headers.insert("Content-Type", {{#consumes}}{{^-first}}, {{/-first}}"{{mediaType}}"{{/consumes}});{{/hasConsumes}}
-    QByteArray output = {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}.asByteArray();{{/isFile}}
-    input.request_body.append(output);
+        QByteArray output = {{paramName}}{{^required}}.value(){{/required}}.toUtf8();{{/isString}}{{#isByteArray}}QByteArray output({{paramName}}{{^required}}.value(){{/required}});{{/isByteArray}}{{^isString}}{{^isByteArray}}{{^isFile}}
+        QByteArray output = {{paramName}}{{^required}}.value(){{/required}}.asJson().toUtf8();{{/isFile}}{{/isByteArray}}{{/isString}}{{#isFile}}{{#hasConsumes}}input.headers.insert("Content-Type", {{#consumes}}{{^-first}}, {{/-first}}"{{mediaType}}"{{/consumes}});{{/hasConsumes}}
+        QByteArray output = {{paramName}}{{^required}}.value(){{/required}}.asByteArray();{{/isFile}}
+        input.request_body.append(output);
 {{/isContainer}}
-{{/bodyParams}}
+    }{{/bodyParams}}
 {{#headerParams}}
-    {{^required}}if(!{{paramName}}.isNull()){{/required}}
+    {{^required}}if({{paramName}}.hasValue()){{/required}}
     {
     {{^collectionFormat}}
     {{^isPrimitiveType}}
         QString headerString;
-        QJsonObject parameter = {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}.asJsonObject();
+        QJsonObject parameter = {{paramName}}{{^required}}.value(){{/required}}.asJsonObject();
         qint32 count = 0;
         foreach(const QString& key, parameter.keys()) {
             if (count > 0) {
@@ -567,14 +561,14 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         input.headers.insert("{{baseName}}", headerString);
     {{/isPrimitiveType}}
     {{#isPrimitiveType}}
-        if (!::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}).isEmpty()) {
-            input.headers.insert("{{baseName}}", ::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}));
+        if (!::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value(){{/required}}).isEmpty()) {
+            input.headers.insert("{{baseName}}", ::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value(){{/required}}));
         }
     {{/isPrimitiveType}}{{/collectionFormat}}{{#collectionFormat}}
         QString headerString;
-        if ({{{paramName}}}{{^required}}.value<{{{dataType}}}>(){{/required}}.size() > 0) {
+        if ({{{paramName}}}{{^required}}.value(){{/required}}.size() > 0) {
         qint32 count = 0;
-        foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}) {
+        foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
             if (count > 0) {
                 headerString.append(",");
             }
@@ -584,17 +578,17 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         input.headers.insert("{{baseName}}", headerString);
         }
     {{/collectionFormat}}
-}
+    }
 {{/headerParams}}
 {{#cookieParams}}
-    {{^required}}if(!{{paramName}}.isNull()){{/required}}
+    {{^required}}if({{paramName}}.hasValue()){{/required}}
     {
         if(QString("{{style}}").indexOf("form") == 0){
         {{^collectionFormat}}
         {{^isPrimitiveType}}
         {{^isExplode}}
             QString cookieString = "{{baseName}}=";
-            QJsonObject parameter = {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}.asJsonObject();
+            QJsonObject parameter = {{paramName}}{{^required}}.value(){{/required}}.asJsonObject();
             qint32 count = 0;
             foreach(const QString& key, parameter.keys()) {
                 if (count > 0) {
@@ -636,8 +630,8 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         {{/isExplode}}
         {{/isPrimitiveType}}
         {{#isPrimitiveType}}
-            if (!::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}).isEmpty()) {
-                input.headers.insert("Cookie", "{{baseName}}="+::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}));
+            if(!::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value(){{/required}}).isEmpty()) {
+                input.headers.insert("Cookie", "{{baseName}}="+::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value(){{/required}}));
             }
         {{/isPrimitiveType}}
         {{/collectionFormat}}
@@ -646,7 +640,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
             QString cookieString = "{{baseName}}=";
             if ({{{paramName}}}.size() > 0) {
             qint32 count = 0;
-            foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value<{{{dataType}}}>(){{/required}}) {
+            foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
                 if (count > 0) {
                     cookieString.append(",");
                 }

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -36,8 +36,8 @@ void {{classname}}::initializeServerConfigs(){
 {{#operations}}
    {{#operation}}
    {{^servers}}
-    _serverConfigs.insert("{{nickname}}",defaultConf);
-    _serverIndices.insert("{{nickname}}",0);
+    _serverConfigs.insert("{{nickname}}", defaultConf);
+    _serverIndices.insert("{{nickname}}", 0);
     {{/servers}}
     {{#servers}}
     serverConf.append({{prefix}}ServerConfiguration(
@@ -47,8 +47,8 @@ void {{classname}}::initializeServerConfigs(){
     {"{{{name}}}", {{prefix}}ServerVariable("{{{description}}}{{^description}}No description provided{{/description}}","{{{defaultValue}}}",
     QSet<QString>{ {{#enumValues}}{"{{{.}}}"}{{#-last}} })}, {{/-last}}{{^-last}},{{/-last}}{{/enumValues}}{{^enumValues}}{"{{defaultValue}}"} })},{{/enumValues}}{{#-last}} }));{{/-last}}
     {{/variables}}{{^variables}}QMap<QString, {{prefix}}ServerVariable>()));{{/variables}}
-    {{#-last}}_serverConfigs.insert("{{nickname}}",serverConf);
-    _serverIndices.insert("{{nickname}}",0);{{/-last}}
+    {{#-last}}_serverConfigs.insert("{{nickname}}", serverConf);
+    _serverIndices.insert("{{nickname}}", 0);{{/-last}}
 {{/servers}}
 {{/operation}}
 {{/operations}}
@@ -567,15 +567,15 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     {{/isPrimitiveType}}{{/collectionFormat}}{{#collectionFormat}}
         QString headerString;
         if ({{{paramName}}}{{^required}}.value(){{/required}}.size() > 0) {
-        qint32 count = 0;
-        foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
-            if (count > 0) {
-                headerString.append(",");
+            qint32 count = 0;
+            foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
+                if (count > 0) {
+                    headerString.append(",");
+                }
+                headerString.append(::{{cppNamespace}}::toStringValue(t));
+                count++;
             }
-            headerString.append(::{{cppNamespace}}::toStringValue(t));
-            count++;
-        }
-        input.headers.insert("{{baseName}}", headerString);
+            input.headers.insert("{{baseName}}", headerString);
         }
     {{/collectionFormat}}
     }
@@ -658,7 +658,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     connect(worker, &{{prefix}}HttpRequestWorker::on_execution_finished, this, &{{classname}}::{{nickname}}Callback);
     connect(this, &{{classname}}::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<{{prefix}}HttpRequestWorker>().count() == 0){
+        if(findChildren<{{prefix}}HttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
@@ -2,6 +2,7 @@
 #ifndef {{prefix}}_{{classname}}_H
 #define {{prefix}}_{{classname}}_H
 
+#include "{{prefix}}Helpers.h"
 #include "{{prefix}}HttpRequest.h"
 #include "{{prefix}}ServerConfiguration.h"
 
@@ -13,7 +14,6 @@
 #include <QStringList>
 #include <QList>
 #include <QNetworkAccessManager>
-#include <QVariant>
 
 {{#cppNamespaceDeclarations}}
 namespace {{this}} {
@@ -57,7 +57,7 @@ public:
     {{/required}}
     {{/allParams}}
     */{{/hasParams}}
-    {{#isDeprecated}}Q_DECL_DEPRECATED {{/isDeprecated}}void {{nickname}}({{#allParams}}{{#required}}const {{{dataType}}} &{{/required}}{{^required}}const QVariant &{{/required}}{{paramName}}{{^required}} = QVariant(){{/required}}{{^-last}}, {{/-last}}{{/allParams}});
+    {{#isDeprecated}}Q_DECL_DEPRECATED {{/isDeprecated}}void {{nickname}}({{#allParams}}{{#required}}const {{{dataType}}} &{{/required}}{{^required}}const ::{{cppNamespace}}::OptionalParam<{{{dataType}}}> &{{/required}}{{paramName}}{{^required}} = ::{{cppNamespace}}::OptionalParam<{{{dataType}}}>(){{/required}}{{^-last}}, {{/-last}}{{/allParams}});
 {{/operation}}{{/operations}}
 
 private:
@@ -86,7 +86,7 @@ signals:
 {{#operations}}{{#operation}}
     void {{nickname}}SignalEFull({{prefix}}HttpRequestWorker *worker, QNetworkReply::NetworkError error_type, QString error_str);{{/operation}}{{/operations}}
 
-    void abortRequestsSignal(); 
+    void abortRequestsSignal();
     void allPendingRequestsCompleted();
 };
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-header.mustache
@@ -11,7 +11,6 @@
 #include <QList>
 #include <QMap>
 #include <QSet>
-#include <QVariant>
 
 #include "{{prefix}}Enum.h"
 #include "{{prefix}}HttpFileElement.h"
@@ -20,6 +19,27 @@
 {{#cppNamespaceDeclarations}}
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
+
+template <typename T>
+class OptionalParam {
+public:
+    T m_Value;
+    bool m_hasValue;
+public:
+    OptionalParam(){
+        m_hasValue = false;
+    }
+    OptionalParam(const T &val){
+        m_hasValue = true;
+        m_Value = val;
+    }
+    bool hasValue() const {
+        return m_hasValue;
+    }
+    T value() const{
+        return m_Value;
+    }
+};
 
 bool setDateTimeFormat(const QString&);
 

--- a/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.cpp
@@ -217,6 +217,7 @@ void PetApiTests::updatePetWithFormTest() {
     // fetch it
     bool petUpdated2 = false;
     connect(&api, &PFXPetApi::getPetByIdSignal, [&](PFXPet pet) {
+        Q_UNUSED(pet);
         petUpdated2 = true;
 //      QVERIFY(pet.getName().compare(QString("gorilla")) == 0);
         QTimer::singleShot(0, &loop, &QEventLoop::quit);

--- a/samples/client/petstore/cpp-qt5/client/PFXHelpers.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXHelpers.h
@@ -21,13 +21,33 @@
 #include <QList>
 #include <QMap>
 #include <QSet>
-#include <QVariant>
 
 #include "PFXEnum.h"
 #include "PFXHttpFileElement.h"
 #include "PFXObject.h"
 
 namespace test_namespace {
+
+template <typename T>
+class OptionalParam {
+public:
+    T m_Value;
+    bool m_hasValue;
+public:
+    OptionalParam(){
+        m_hasValue = false;
+    }
+    OptionalParam(const T &val){
+        m_hasValue = true;
+        m_Value = val;
+    }
+    bool hasValue() const {
+        return m_hasValue;
+    }
+    T value() const{
+        return m_Value;
+    }
+};
 
 bool setDateTimeFormat(const QString&);
 

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
@@ -10,7 +10,6 @@
  */
 
 #include "PFXPetApi.h"
-#include "PFXHelpers.h"
 #include "PFXServerConfiguration.h"
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -29,7 +28,6 @@ PFXPetApi::~PFXPetApi() {
 }
 
 void PFXPetApi::initializeServerConfigs(){
-
     //Default server
     QList<PFXServerConfiguration> defaultConf = QList<PFXServerConfiguration>();
     //varying endpoint server
@@ -225,15 +223,16 @@ QString PFXPetApi::getParamStyleDelimiter(QString style, QString name, bool isEx
 void PFXPetApi::addPet(const PFXPet &body) {
     QString fullPath = QString(_serverConfigs["addPet"][_serverIndices.value("addPet")].URL()+"/pet");
     
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
+    {
 
-    QByteArray output = body.asJson().toUtf8();
-    input.request_body.append(output);
+        QByteArray output = body.asJson().toUtf8();
+        input.request_body.append(output);
+    }
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXPetApi::addPetCallback);
@@ -269,10 +268,9 @@ void PFXPetApi::addPetCallback(PFXHttpRequestWorker *worker) {
     }
 }
 
-void PFXPetApi::deletePet(const qint64 &pet_id, const QVariant &api_key) {
+void PFXPetApi::deletePet(const qint64 &pet_id, const ::test_namespace::OptionalParam<QString> &api_key) {
     QString fullPath = QString(_serverConfigs["deletePet"][_serverIndices.value("deletePet")].URL()+"/pet/{petId}");
     
-
     
     {
         QString pet_idPathParam("{");
@@ -287,18 +285,18 @@ void PFXPetApi::deletePet(const qint64 &pet_id, const QVariant &api_key) {
         QString paramString = (pathStyle == "matrix") ? pathPrefix+"petId"+pathSuffix : pathPrefix;
         fullPath.replace(pet_idPathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
     }
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "DELETE");
 
-    if(!api_key.isNull())
+
+    if(api_key.hasValue())
     {
-        if (!::test_namespace::toStringValue(api_key.value<QString>()).isEmpty()) {
-            input.headers.insert("api_key", ::test_namespace::toStringValue(api_key.value<QString>()));
+        if (!::test_namespace::toStringValue(api_key.value()).isEmpty()) {
+            input.headers.insert("api_key", ::test_namespace::toStringValue(api_key.value()));
         }
-    }
+        }
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXPetApi::deletePetCallback);
@@ -337,7 +335,6 @@ void PFXPetApi::deletePetCallback(PFXHttpRequestWorker *worker) {
 void PFXPetApi::findPetsByStatus(const QList<QString> &status) {
     QString fullPath = QString(_serverConfigs["findPetsByStatus"][_serverIndices.value("findPetsByStatus")].URL()+"/pet/findByStatus");
     
-
     QString queryPrefix, querySuffix, queryDelimiter, queryStyle;
     
     {
@@ -347,7 +344,7 @@ void PFXPetApi::findPetsByStatus(const QList<QString> &status) {
         queryPrefix = getParamStylePrefix(queryStyle);
         querySuffix = getParamStyleSuffix(queryStyle);
         queryDelimiter = getParamStyleDelimiter(queryStyle, "status", false);
-        if (status.size() > 0) {
+        if(status.size() > 0) {
             if (QString("csv").indexOf("multi") == 0) {
                 foreach (QString t, status) {
                     if (fullPath.indexOf("?") > 0)
@@ -424,11 +421,11 @@ void PFXPetApi::findPetsByStatus(const QList<QString> &status) {
             }
         }
     }
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
+
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
@@ -478,7 +475,6 @@ void PFXPetApi::findPetsByStatusCallback(PFXHttpRequestWorker *worker) {
 void PFXPetApi::findPetsByTags(const QList<QString> &tags) {
     QString fullPath = QString(_serverConfigs["findPetsByTags"][_serverIndices.value("findPetsByTags")].URL()+"/pet/findByTags");
     
-
     QString queryPrefix, querySuffix, queryDelimiter, queryStyle;
     
     {
@@ -488,7 +484,7 @@ void PFXPetApi::findPetsByTags(const QList<QString> &tags) {
         queryPrefix = getParamStylePrefix(queryStyle);
         querySuffix = getParamStyleSuffix(queryStyle);
         queryDelimiter = getParamStyleDelimiter(queryStyle, "tags", false);
-        if (tags.size() > 0) {
+        if(tags.size() > 0) {
             if (QString("csv").indexOf("multi") == 0) {
                 foreach (QString t, tags) {
                     if (fullPath.indexOf("?") > 0)
@@ -565,11 +561,11 @@ void PFXPetApi::findPetsByTags(const QList<QString> &tags) {
             }
         }
     }
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
+
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
@@ -623,7 +619,6 @@ void PFXPetApi::getPetById(const qint64 &pet_id) {
         addHeaders("api_key",_apiKeys.find("api_key").value());
     }
     
-
     
     {
         QString pet_idPathParam("{");
@@ -638,11 +633,11 @@ void PFXPetApi::getPetById(const qint64 &pet_id) {
         QString paramString = (pathStyle == "matrix") ? pathPrefix+"petId"+pathSuffix : pathPrefix;
         fullPath.replace(pet_idPathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
     }
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
+
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
@@ -683,15 +678,16 @@ void PFXPetApi::getPetByIdCallback(PFXHttpRequestWorker *worker) {
 void PFXPetApi::updatePet(const PFXPet &body) {
     QString fullPath = QString(_serverConfigs["updatePet"][_serverIndices.value("updatePet")].URL()+"/pet");
     
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "PUT");
 
+    {
 
-    QByteArray output = body.asJson().toUtf8();
-    input.request_body.append(output);
+        QByteArray output = body.asJson().toUtf8();
+        input.request_body.append(output);
+    }
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXPetApi::updatePetCallback);
@@ -727,10 +723,9 @@ void PFXPetApi::updatePetCallback(PFXHttpRequestWorker *worker) {
     }
 }
 
-void PFXPetApi::updatePetWithForm(const qint64 &pet_id, const QVariant &name, const QVariant &status) {
+void PFXPetApi::updatePetWithForm(const qint64 &pet_id, const ::test_namespace::OptionalParam<QString> &name, const ::test_namespace::OptionalParam<QString> &status) {
     QString fullPath = QString(_serverConfigs["updatePetWithForm"][_serverIndices.value("updatePetWithForm")].URL()+"/pet/{petId}");
     
-
     
     {
         QString pet_idPathParam("{");
@@ -745,22 +740,18 @@ void PFXPetApi::updatePetWithForm(const qint64 &pet_id, const QVariant &name, co
         QString paramString = (pathStyle == "matrix") ? pathPrefix+"petId"+pathSuffix : pathPrefix;
         fullPath.replace(pet_idPathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
     }
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
-
-    if(!name.isNull())
+    if(name.hasValue())
     {
-        input.add_var("name", ::test_namespace::toStringValue(name.value<QString>()));
+        input.add_var("name", ::test_namespace::toStringValue(name.value()));
     }
-
-
-    if(!status.isNull())
+    if(status.hasValue())
     {
-        input.add_var("status", ::test_namespace::toStringValue(status.value<QString>()));
+        input.add_var("status", ::test_namespace::toStringValue(status.value()));
     }
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
@@ -798,10 +789,9 @@ void PFXPetApi::updatePetWithFormCallback(PFXHttpRequestWorker *worker) {
     }
 }
 
-void PFXPetApi::uploadFile(const qint64 &pet_id, const QVariant &additional_metadata, const QVariant &file) {
+void PFXPetApi::uploadFile(const qint64 &pet_id, const ::test_namespace::OptionalParam<QString> &additional_metadata, const ::test_namespace::OptionalParam<PFXHttpFileElement> &file) {
     QString fullPath = QString(_serverConfigs["uploadFile"][_serverIndices.value("uploadFile")].URL()+"/pet/{petId}/uploadImage");
     
-
     
     {
         QString pet_idPathParam("{");
@@ -816,22 +806,18 @@ void PFXPetApi::uploadFile(const qint64 &pet_id, const QVariant &additional_meta
         QString paramString = (pathStyle == "matrix") ? pathPrefix+"petId"+pathSuffix : pathPrefix;
         fullPath.replace(pet_idPathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
     }
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
-
-    if(!additional_metadata.isNull())
+    if(additional_metadata.hasValue())
     {
-        input.add_var("additionalMetadata", ::test_namespace::toStringValue(additional_metadata.value<QString>()));
+        input.add_var("additionalMetadata", ::test_namespace::toStringValue(additional_metadata.value()));
     }
-
-
-    if(!file.isNull())
+    if(file.hasValue())
     {
-        input.add_file("file", file.value<PFXHttpFileElement>().local_filename, file.value<PFXHttpFileElement>().request_filename, file.value<PFXHttpFileElement>().mime_type);
+        input.add_file("file", file.value().local_filename, file.value().request_filename, file.value().mime_type);
     }
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
@@ -36,22 +36,22 @@ void PFXPetApi::initializeServerConfigs(){
     QUrl("http://petstore.swagger.io/v2"),
     "No description provided",
     QMap<QString, PFXServerVariable>()));
-    _serverConfigs.insert("addPet",defaultConf);
-    _serverIndices.insert("addPet",0);
-    _serverConfigs.insert("deletePet",defaultConf);
-    _serverIndices.insert("deletePet",0);
-    _serverConfigs.insert("findPetsByStatus",defaultConf);
-    _serverIndices.insert("findPetsByStatus",0);
-    _serverConfigs.insert("findPetsByTags",defaultConf);
-    _serverIndices.insert("findPetsByTags",0);
-    _serverConfigs.insert("getPetById",defaultConf);
-    _serverIndices.insert("getPetById",0);
-    _serverConfigs.insert("updatePet",defaultConf);
-    _serverIndices.insert("updatePet",0);
-    _serverConfigs.insert("updatePetWithForm",defaultConf);
-    _serverIndices.insert("updatePetWithForm",0);
-    _serverConfigs.insert("uploadFile",defaultConf);
-    _serverIndices.insert("uploadFile",0);
+    _serverConfigs.insert("addPet", defaultConf);
+    _serverIndices.insert("addPet", 0);
+    _serverConfigs.insert("deletePet", defaultConf);
+    _serverIndices.insert("deletePet", 0);
+    _serverConfigs.insert("findPetsByStatus", defaultConf);
+    _serverIndices.insert("findPetsByStatus", 0);
+    _serverConfigs.insert("findPetsByTags", defaultConf);
+    _serverIndices.insert("findPetsByTags", 0);
+    _serverConfigs.insert("getPetById", defaultConf);
+    _serverIndices.insert("getPetById", 0);
+    _serverConfigs.insert("updatePet", defaultConf);
+    _serverIndices.insert("updatePet", 0);
+    _serverConfigs.insert("updatePetWithForm", defaultConf);
+    _serverIndices.insert("updatePetWithForm", 0);
+    _serverConfigs.insert("uploadFile", defaultConf);
+    _serverIndices.insert("uploadFile", 0);
 }
 
 /**
@@ -238,7 +238,7 @@ void PFXPetApi::addPet(const PFXPet &body) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXPetApi::addPetCallback);
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -302,7 +302,7 @@ void PFXPetApi::deletePet(const qint64 &pet_id, const ::test_namespace::Optional
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXPetApi::deletePetCallback);
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -432,7 +432,7 @@ void PFXPetApi::findPetsByStatus(const QList<QString> &status) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXPetApi::findPetsByStatusCallback);
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -572,7 +572,7 @@ void PFXPetApi::findPetsByTags(const QList<QString> &tags) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXPetApi::findPetsByTagsCallback);
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -644,7 +644,7 @@ void PFXPetApi::getPetById(const qint64 &pet_id) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXPetApi::getPetByIdCallback);
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -693,7 +693,7 @@ void PFXPetApi::updatePet(const PFXPet &body) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXPetApi::updatePetCallback);
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -759,7 +759,7 @@ void PFXPetApi::updatePetWithForm(const qint64 &pet_id, const ::test_namespace::
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXPetApi::updatePetWithFormCallback);
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -825,7 +825,7 @@ void PFXPetApi::uploadFile(const qint64 &pet_id, const ::test_namespace::Optiona
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXPetApi::uploadFileCallback);
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
@@ -12,6 +12,7 @@
 #ifndef PFX_PFXPetApi_H
 #define PFX_PFXPetApi_H
 
+#include "PFXHelpers.h"
 #include "PFXHttpRequest.h"
 #include "PFXServerConfiguration.h"
 
@@ -25,7 +26,6 @@
 #include <QStringList>
 #include <QList>
 #include <QNetworkAccessManager>
-#include <QVariant>
 
 namespace test_namespace {
 
@@ -66,7 +66,7 @@ public:
     * @param[in]  pet_id qint64 [required]
     * @param[in]  api_key QString [optional]
     */
-    void deletePet(const qint64 &pet_id, const QVariant &api_key = QVariant());
+    void deletePet(const qint64 &pet_id, const ::test_namespace::OptionalParam<QString> &api_key = ::test_namespace::OptionalParam<QString>());
 
     /**
     * @param[in]  status QList<QString> [required]
@@ -93,14 +93,14 @@ public:
     * @param[in]  name QString [optional]
     * @param[in]  status QString [optional]
     */
-    void updatePetWithForm(const qint64 &pet_id, const QVariant &name = QVariant(), const QVariant &status = QVariant());
+    void updatePetWithForm(const qint64 &pet_id, const ::test_namespace::OptionalParam<QString> &name = ::test_namespace::OptionalParam<QString>(), const ::test_namespace::OptionalParam<QString> &status = ::test_namespace::OptionalParam<QString>());
 
     /**
     * @param[in]  pet_id qint64 [required]
     * @param[in]  additional_metadata QString [optional]
     * @param[in]  file PFXHttpFileElement [optional]
     */
-    void uploadFile(const qint64 &pet_id, const QVariant &additional_metadata = QVariant(), const QVariant &file = QVariant());
+    void uploadFile(const qint64 &pet_id, const ::test_namespace::OptionalParam<QString> &additional_metadata = ::test_namespace::OptionalParam<QString>(), const ::test_namespace::OptionalParam<PFXHttpFileElement> &file = ::test_namespace::OptionalParam<PFXHttpFileElement>());
 
 
 private:
@@ -164,7 +164,7 @@ signals:
     void updatePetWithFormSignalEFull(PFXHttpRequestWorker *worker, QNetworkReply::NetworkError error_type, QString error_str);
     void uploadFileSignalEFull(PFXHttpRequestWorker *worker, QNetworkReply::NetworkError error_type, QString error_str);
 
-    void abortRequestsSignal(); 
+    void abortRequestsSignal();
     void allPendingRequestsCompleted();
 };
 

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
@@ -36,14 +36,14 @@ void PFXStoreApi::initializeServerConfigs(){
     QUrl("http://petstore.swagger.io/v2"),
     "No description provided",
     QMap<QString, PFXServerVariable>()));
-    _serverConfigs.insert("deleteOrder",defaultConf);
-    _serverIndices.insert("deleteOrder",0);
-    _serverConfigs.insert("getInventory",defaultConf);
-    _serverIndices.insert("getInventory",0);
-    _serverConfigs.insert("getOrderById",defaultConf);
-    _serverIndices.insert("getOrderById",0);
-    _serverConfigs.insert("placeOrder",defaultConf);
-    _serverIndices.insert("placeOrder",0);
+    _serverConfigs.insert("deleteOrder", defaultConf);
+    _serverIndices.insert("deleteOrder", 0);
+    _serverConfigs.insert("getInventory", defaultConf);
+    _serverIndices.insert("getInventory", 0);
+    _serverConfigs.insert("getOrderById", defaultConf);
+    _serverIndices.insert("getOrderById", 0);
+    _serverConfigs.insert("placeOrder", defaultConf);
+    _serverIndices.insert("placeOrder", 0);
 }
 
 /**
@@ -240,7 +240,7 @@ void PFXStoreApi::deleteOrder(const QString &order_id) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXStoreApi::deleteOrderCallback);
     connect(this, &PFXStoreApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -288,7 +288,7 @@ void PFXStoreApi::getInventory() {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXStoreApi::getInventoryCallback);
     connect(this, &PFXStoreApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -356,7 +356,7 @@ void PFXStoreApi::getOrderById(const qint64 &order_id) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXStoreApi::getOrderByIdCallback);
     connect(this, &PFXStoreApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -405,7 +405,7 @@ void PFXStoreApi::placeOrder(const PFXOrder &body) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXStoreApi::placeOrderCallback);
     connect(this, &PFXStoreApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
@@ -10,7 +10,6 @@
  */
 
 #include "PFXStoreApi.h"
-#include "PFXHelpers.h"
 #include "PFXServerConfiguration.h"
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -29,7 +28,6 @@ PFXStoreApi::~PFXStoreApi() {
 }
 
 void PFXStoreApi::initializeServerConfigs(){
-
     //Default server
     QList<PFXServerConfiguration> defaultConf = QList<PFXServerConfiguration>();
     //varying endpoint server
@@ -217,7 +215,6 @@ QString PFXStoreApi::getParamStyleDelimiter(QString style, QString name, bool is
 void PFXStoreApi::deleteOrder(const QString &order_id) {
     QString fullPath = QString(_serverConfigs["deleteOrder"][_serverIndices.value("deleteOrder")].URL()+"/store/order/{orderId}");
     
-
     
     {
         QString order_idPathParam("{");
@@ -232,11 +229,11 @@ void PFXStoreApi::deleteOrder(const QString &order_id) {
         QString paramString = (pathStyle == "matrix") ? pathPrefix+"orderId"+pathSuffix : pathPrefix;
         fullPath.replace(order_idPathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(order_id)));
     }
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "DELETE");
+
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
@@ -280,11 +277,11 @@ void PFXStoreApi::getInventory() {
         addHeaders("api_key",_apiKeys.find("api_key").value());
     }
     
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
+
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
@@ -334,7 +331,6 @@ void PFXStoreApi::getInventoryCallback(PFXHttpRequestWorker *worker) {
 void PFXStoreApi::getOrderById(const qint64 &order_id) {
     QString fullPath = QString(_serverConfigs["getOrderById"][_serverIndices.value("getOrderById")].URL()+"/store/order/{orderId}");
     
-
     
     {
         QString order_idPathParam("{");
@@ -349,11 +345,11 @@ void PFXStoreApi::getOrderById(const qint64 &order_id) {
         QString paramString = (pathStyle == "matrix") ? pathPrefix+"orderId"+pathSuffix : pathPrefix;
         fullPath.replace(order_idPathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(order_id)));
     }
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
+
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
@@ -394,15 +390,16 @@ void PFXStoreApi::getOrderByIdCallback(PFXHttpRequestWorker *worker) {
 void PFXStoreApi::placeOrder(const PFXOrder &body) {
     QString fullPath = QString(_serverConfigs["placeOrder"][_serverIndices.value("placeOrder")].URL()+"/store/order");
     
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
+    {
 
-    QByteArray output = body.asJson().toUtf8();
-    input.request_body.append(output);
+        QByteArray output = body.asJson().toUtf8();
+        input.request_body.append(output);
+    }
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXStoreApi::placeOrderCallback);

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
@@ -12,6 +12,7 @@
 #ifndef PFX_PFXStoreApi_H
 #define PFX_PFXStoreApi_H
 
+#include "PFXHelpers.h"
 #include "PFXHttpRequest.h"
 #include "PFXServerConfiguration.h"
 
@@ -24,7 +25,6 @@
 #include <QStringList>
 #include <QList>
 #include <QNetworkAccessManager>
-#include <QVariant>
 
 namespace test_namespace {
 
@@ -116,7 +116,7 @@ signals:
     void getOrderByIdSignalEFull(PFXHttpRequestWorker *worker, QNetworkReply::NetworkError error_type, QString error_str);
     void placeOrderSignalEFull(PFXHttpRequestWorker *worker, QNetworkReply::NetworkError error_type, QString error_str);
 
-    void abortRequestsSignal(); 
+    void abortRequestsSignal();
     void allPendingRequestsCompleted();
 };
 

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
@@ -36,22 +36,22 @@ void PFXUserApi::initializeServerConfigs(){
     QUrl("http://petstore.swagger.io/v2"),
     "No description provided",
     QMap<QString, PFXServerVariable>()));
-    _serverConfigs.insert("createUser",defaultConf);
-    _serverIndices.insert("createUser",0);
-    _serverConfigs.insert("createUsersWithArrayInput",defaultConf);
-    _serverIndices.insert("createUsersWithArrayInput",0);
-    _serverConfigs.insert("createUsersWithListInput",defaultConf);
-    _serverIndices.insert("createUsersWithListInput",0);
-    _serverConfigs.insert("deleteUser",defaultConf);
-    _serverIndices.insert("deleteUser",0);
-    _serverConfigs.insert("getUserByName",defaultConf);
-    _serverIndices.insert("getUserByName",0);
-    _serverConfigs.insert("loginUser",defaultConf);
-    _serverIndices.insert("loginUser",0);
-    _serverConfigs.insert("logoutUser",defaultConf);
-    _serverIndices.insert("logoutUser",0);
-    _serverConfigs.insert("updateUser",defaultConf);
-    _serverIndices.insert("updateUser",0);
+    _serverConfigs.insert("createUser", defaultConf);
+    _serverIndices.insert("createUser", 0);
+    _serverConfigs.insert("createUsersWithArrayInput", defaultConf);
+    _serverIndices.insert("createUsersWithArrayInput", 0);
+    _serverConfigs.insert("createUsersWithListInput", defaultConf);
+    _serverIndices.insert("createUsersWithListInput", 0);
+    _serverConfigs.insert("deleteUser", defaultConf);
+    _serverIndices.insert("deleteUser", 0);
+    _serverConfigs.insert("getUserByName", defaultConf);
+    _serverIndices.insert("getUserByName", 0);
+    _serverConfigs.insert("loginUser", defaultConf);
+    _serverIndices.insert("loginUser", 0);
+    _serverConfigs.insert("logoutUser", defaultConf);
+    _serverIndices.insert("logoutUser", 0);
+    _serverConfigs.insert("updateUser", defaultConf);
+    _serverIndices.insert("updateUser", 0);
 }
 
 /**
@@ -238,7 +238,7 @@ void PFXUserApi::createUser(const PFXUser &body) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::createUserCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -286,7 +286,7 @@ void PFXUserApi::createUsersWithArrayInput(const QList<PFXUser> &body) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::createUsersWithArrayInputCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -334,7 +334,7 @@ void PFXUserApi::createUsersWithListInput(const QList<PFXUser> &body) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::createUsersWithListInputCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -392,7 +392,7 @@ void PFXUserApi::deleteUser(const QString &username) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::deleteUserCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -450,7 +450,7 @@ void PFXUserApi::getUserByName(const QString &username) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::getUserByNameCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -526,7 +526,7 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::loginUserCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -572,7 +572,7 @@ void PFXUserApi::logoutUser() {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::logoutUserCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });
@@ -634,7 +634,7 @@ void PFXUserApi::updateUser(const QString &username, const PFXUser &body) {
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::updateUserCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker>().count() == 0){
+        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
             emit allPendingRequestsCompleted();
         }
     });

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
@@ -10,7 +10,6 @@
  */
 
 #include "PFXUserApi.h"
-#include "PFXHelpers.h"
 #include "PFXServerConfiguration.h"
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -29,7 +28,6 @@ PFXUserApi::~PFXUserApi() {
 }
 
 void PFXUserApi::initializeServerConfigs(){
-
     //Default server
     QList<PFXServerConfiguration> defaultConf = QList<PFXServerConfiguration>();
     //varying endpoint server
@@ -225,15 +223,16 @@ QString PFXUserApi::getParamStyleDelimiter(QString style, QString name, bool isE
 void PFXUserApi::createUser(const PFXUser &body) {
     QString fullPath = QString(_serverConfigs["createUser"][_serverIndices.value("createUser")].URL()+"/user");
     
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
+    {
 
-    QByteArray output = body.asJson().toUtf8();
-    input.request_body.append(output);
+        QByteArray output = body.asJson().toUtf8();
+        input.request_body.append(output);
+    }
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::createUserCallback);
@@ -272,15 +271,16 @@ void PFXUserApi::createUserCallback(PFXHttpRequestWorker *worker) {
 void PFXUserApi::createUsersWithArrayInput(const QList<PFXUser> &body) {
     QString fullPath = QString(_serverConfigs["createUsersWithArrayInput"][_serverIndices.value("createUsersWithArrayInput")].URL()+"/user/createWithArray");
     
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
-    QJsonDocument doc(::test_namespace::toJsonValue(body).toArray());
-    QByteArray bytes = doc.toJson();
-    input.request_body.append(bytes);
+    {
+        QJsonDocument doc(::test_namespace::toJsonValue(body).toArray());
+        QByteArray bytes = doc.toJson();
+        input.request_body.append(bytes);
+    }
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::createUsersWithArrayInputCallback);
@@ -319,15 +319,16 @@ void PFXUserApi::createUsersWithArrayInputCallback(PFXHttpRequestWorker *worker)
 void PFXUserApi::createUsersWithListInput(const QList<PFXUser> &body) {
     QString fullPath = QString(_serverConfigs["createUsersWithListInput"][_serverIndices.value("createUsersWithListInput")].URL()+"/user/createWithList");
     
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
-    QJsonDocument doc(::test_namespace::toJsonValue(body).toArray());
-    QByteArray bytes = doc.toJson();
-    input.request_body.append(bytes);
+    {
+        QJsonDocument doc(::test_namespace::toJsonValue(body).toArray());
+        QByteArray bytes = doc.toJson();
+        input.request_body.append(bytes);
+    }
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::createUsersWithListInputCallback);
@@ -366,7 +367,6 @@ void PFXUserApi::createUsersWithListInputCallback(PFXHttpRequestWorker *worker) 
 void PFXUserApi::deleteUser(const QString &username) {
     QString fullPath = QString(_serverConfigs["deleteUser"][_serverIndices.value("deleteUser")].URL()+"/user/{username}");
     
-
     
     {
         QString usernamePathParam("{");
@@ -381,11 +381,11 @@ void PFXUserApi::deleteUser(const QString &username) {
         QString paramString = (pathStyle == "matrix") ? pathPrefix+"username"+pathSuffix : pathPrefix;
         fullPath.replace(usernamePathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
     }
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "DELETE");
+
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
@@ -425,7 +425,6 @@ void PFXUserApi::deleteUserCallback(PFXHttpRequestWorker *worker) {
 void PFXUserApi::getUserByName(const QString &username) {
     QString fullPath = QString(_serverConfigs["getUserByName"][_serverIndices.value("getUserByName")].URL()+"/user/{username}");
     
-
     
     {
         QString usernamePathParam("{");
@@ -440,11 +439,11 @@ void PFXUserApi::getUserByName(const QString &username) {
         QString paramString = (pathStyle == "matrix") ? pathPrefix+"username"+pathSuffix : pathPrefix;
         fullPath.replace(usernamePathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
     }
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
+
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
@@ -485,7 +484,6 @@ void PFXUserApi::getUserByNameCallback(PFXHttpRequestWorker *worker) {
 void PFXUserApi::loginUser(const QString &username, const QString &password) {
     QString fullPath = QString(_serverConfigs["loginUser"][_serverIndices.value("loginUser")].URL()+"/user/login");
     
-
     QString queryPrefix, querySuffix, queryDelimiter, queryStyle;
     
     {
@@ -502,7 +500,6 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
 
         fullPath.append(QUrl::toPercentEncoding("username")).append(querySuffix).append(QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
     }
-
     
     {
         queryStyle = "";
@@ -518,11 +515,11 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
 
         fullPath.append(QUrl::toPercentEncoding("password")).append(querySuffix).append(QUrl::toPercentEncoding(::test_namespace::toStringValue(password)));
     }
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
+
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
@@ -564,11 +561,11 @@ void PFXUserApi::loginUserCallback(PFXHttpRequestWorker *worker) {
 void PFXUserApi::logoutUser() {
     QString fullPath = QString(_serverConfigs["logoutUser"][_serverIndices.value("logoutUser")].URL()+"/user/logout");
     
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
+
 
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
@@ -608,7 +605,6 @@ void PFXUserApi::logoutUserCallback(PFXHttpRequestWorker *worker) {
 void PFXUserApi::updateUser(const QString &username, const PFXUser &body) {
     QString fullPath = QString(_serverConfigs["updateUser"][_serverIndices.value("updateUser")].URL()+"/user/{username}");
     
-
     
     {
         QString usernamePathParam("{");
@@ -623,15 +619,16 @@ void PFXUserApi::updateUser(const QString &username, const PFXUser &body) {
         QString paramString = (pathStyle == "matrix") ? pathPrefix+"username"+pathSuffix : pathPrefix;
         fullPath.replace(usernamePathParam, paramString+QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
     }
-
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "PUT");
 
+    {
 
-    QByteArray output = body.asJson().toUtf8();
-    input.request_body.append(output);
+        QByteArray output = body.asJson().toUtf8();
+        input.request_body.append(output);
+    }
     foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::updateUserCallback);

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
@@ -12,6 +12,7 @@
 #ifndef PFX_PFXUserApi_H
 #define PFX_PFXUserApi_H
 
+#include "PFXHelpers.h"
 #include "PFXHttpRequest.h"
 #include "PFXServerConfiguration.h"
 
@@ -24,7 +25,6 @@
 #include <QStringList>
 #include <QList>
 #include <QNetworkAccessManager>
-#include <QVariant>
 
 namespace test_namespace {
 
@@ -158,7 +158,7 @@ signals:
     void logoutUserSignalEFull(PFXHttpRequestWorker *worker, QNetworkReply::NetworkError error_type, QString error_str);
     void updateUserSignalEFull(PFXHttpRequestWorker *worker, QNetworkReply::NetworkError error_type, QString error_str);
 
-    void abortRequestsSignal(); 
+    void abortRequestsSignal();
     void allPendingRequestsCompleted();
 };
 


### PR DESCRIPTION
Fixes #8934

Issue was due to `Optional` support with `QVariant` here #8733

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

**Changes**
- **QVariant cannot construct user types hence it is not suitable for all cases**
- A more intuitive approach is provided, which also shows the type of optional in the api instead of plain `QVariant`
- Added handling of optional `body`

Function declaration now looks like this 
```C++
void deletePet(const qint64 &pet_id, const OptionalParam<QString> &api_key = OptionalParam<QString>());
void updatePetWithForm(const qint64 &pet_id, const OptionalParam<QString> &name = OptionalParam<QString>(), 
           const OptionalParam<QString> &status = OptionalParam<QString>());
```
instead of this

```C++
void deletePet(const qint64 &pet_id, const QVariant &api_key = QVariant());
void updatePetWithForm(const qint64 &pet_id, const QVariant &name = QVariant(), const QVariant &status = QVariant());
```

User types are supported like this 
```C++
    QList<OAIObject> list;
    QMap<QString, OAIObject> map;
    QList<QString> strl;
    list.append(OAIObject());
    api->notifyTopicV1(list);
    api->notifyTopicV1();
    api->notifyTopicV2();
    api->notifyTopicV2(map);
    api->notifyTopicV3();
    api->notifyTopicV3(strl);

```
cc @ravinikam @stkrwork @MartinDelille  @muttleyxd

@xconverge 
I had to rework this due to side effects, made a more simpler and intuitive approach.
