### PR TITLE
[Java][webclient] Fix deprecation warning: BodyInserters.fromObject

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -517,7 +517,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         } else if(MediaType.MULTIPART_FORM_DATA.equals(contentType)) {
             return BodyInserters.fromMultipartData(formParams);
         } else {
-            return obj != null ? BodyInserters.fromObject(obj) : null;
+            return obj != null ? BodyInserters.fromValue(obj) : null;
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
@@ -124,7 +124,7 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.6.2"
-    spring_web_version = "5.0.16.RELEASE"
+    spring_web_version = "5.2.13.RELEASE"
     jackson_version = "2.11.3"
     jackson_databind_version = "2.11.3"
     {{#openApiNullable}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
@@ -149,7 +149,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.2</swagger-annotations-version>
-        <spring-web-version>5.0.16.RELEASE</spring-web-version>
+        <spring-web-version>5.2.13.RELEASE</spring-web-version>
         <jackson-version>2.11.3</jackson-version>
         <jackson-databind-version>2.11.3</jackson-databind-version>
         {{#openApiNullable}}

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -112,7 +112,7 @@ if(hasProperty('target') && target == 'android') {
 
 ext {
     swagger_annotations_version = "1.6.2"
-    spring_web_version = "5.0.16.RELEASE"
+    spring_web_version = "5.2.13.RELEASE"
     jackson_version = "2.11.3"
     jackson_databind_version = "2.11.3"
     jackson_databind_nullable_version = "0.2.1"

--- a/samples/client/petstore/java/webclient/pom.xml
+++ b/samples/client/petstore/java/webclient/pom.xml
@@ -126,7 +126,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.6.2</swagger-annotations-version>
-        <spring-web-version>5.0.16.RELEASE</spring-web-version>
+        <spring-web-version>5.2.13.RELEASE</spring-web-version>
         <jackson-version>2.11.3</jackson-version>
         <jackson-databind-version>2.11.3</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -502,7 +502,7 @@ public class ApiClient extends JavaTimeFormatter {
         } else if(MediaType.MULTIPART_FORM_DATA.equals(contentType)) {
             return BodyInserters.fromMultipartData(formParams);
         } else {
-            return obj != null ? BodyInserters.fromObject(obj) : null;
+            return obj != null ? BodyInserters.fromValue(obj) : null;
         }
     }
 


### PR DESCRIPTION
See #8553 fro more information.
To validate this run the java generator with the webclient library no deprecation warning should be displayed anymore

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @nmuesch (2021/01)
Closes #8553