### PR TITLE
[Bash] Update client.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/bash/client.mustache
+++ b/modules/openapi-generator/src/main/resources/bash/client.mustache
@@ -245,7 +245,7 @@ url_escape() {
        -e 's/(/%28/g' \
        -e 's/)/%29/g' \
        -e 's/:/%3A/g' \
-       -e 's/\t/%09/g' \
+       -e 's/\\t/%09/g' \
        -e 's/?/%3F/g' <<<"$raw_url");
 
     echo "$value"


### PR DESCRIPTION
Bash Client Escapes parameters with a 't' to %09 and leaves tabs unescaped
Fixes https://github.com/OpenAPITools/openapi-generator/issues/7303

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Bash Client Escapes parameters with a 't' to %09 and leaves tabs unescaped

openapitools/openapi-generator-cli Version 5.0.0-SNAPSHOT

Command used to generate:

```bash
docker run --rm -v $(git rev-parse --show-toplevel)/lt-frontend/:/local openapitools/openapi-generator-cli generate \
     -i /local/spec/frontend-api.yml \
     -g bash \
     --enable-post-process-file  -o /local/clients/cli/ -p apiKeyAuthEnvironmentVariable=API_KEY,generateBashCompletion=true,hostEnvironmentVariable=API_HOST,scriptName=api,generateZshCompletion=true
```

Example:
```bash
API_HOST=https://load-test-int.test.ops.company.se ./api --dry-run getTestJobByName job=systest-stress-pc
curl     -X GET "https://load-test-int.test.ops.company.se/api/v1/tests/sys%09es%09-s%09ress-pc"
```
should be 

```bash
API_HOST=https://load-test-int.test.ops.company.se ./api --dry-run getTestJobByName job=systest-stress-pc
curl     -X GET "https://load-test-int.test.ops.company.se/api/v1/tests/systest-stress-pc"
```

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
