### PR TITLE
[DART] Add standard generated classes as reserved

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -164,8 +164,7 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
                 "File",
                 "Client",
                 "Future",
-                "Response",
-                "StreamedRequest"
+                "Response"
         );
 
         cliOptions.add(new CliOption(PUB_LIBRARY, "Library name in generated code"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -164,7 +164,8 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
                 "File",
                 "Client",
                 "Future",
-                "Response"
+                "Response",
+                "StreamedRequest"
         );
 
         cliOptions.add(new CliOption(PUB_LIBRARY, "Library name in generated code"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
@@ -17,6 +17,7 @@
 
 package org.openapitools.codegen.languages;
 
+import com.google.common.collect.Sets;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.SupportingFile;
@@ -36,6 +37,18 @@ public class DartClientCodegen extends AbstractDartCodegen {
 
     public DartClientCodegen() {
         super();
+
+        additionalReservedWords.addAll(
+                Sets.newHashSet(
+                        "ApiClient",
+                        "QueryParam",
+                        "Authentication",
+                        "HttpBasicAuth",
+                        "HttpBearerAuth",
+                        "ApiKeyAuth",
+                        "OAuth"
+                )
+        );
 
         final CliOption serializationLibrary = new CliOption(CodegenConstants.SERIALIZATION_LIBRARY,
                 "Specify serialization library");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
@@ -40,6 +40,7 @@ public class DartClientCodegen extends AbstractDartCodegen {
 
         additionalReservedWords.addAll(
                 Sets.newHashSet(
+                        "StreamedRequest",
                         "ApiClient",
                         "QueryParam",
                         "Authentication",


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

A friend create a specification with a model named `ApiClient` which resulted for me in two classes with the same name which doesn't compile. So I thought it might be handy to mark the default included classes also as reserved.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)