### PR TITLE
Fix #8971 Updating pubspec.yaml template for dart2 generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
@@ -9,15 +9,15 @@ authors:
   - '{{{pubAuthor}}} <{{{pubAuthorEmail}}}>'
 homepage: '{{{pubHomepage}}}'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  http: '>=0.12.0 <0.13.0'
-  intl: '^0.16.1'
-  meta: '^1.1.8'
+  http: '^0.13.0'
+  intl: '^0.17.0'
+  meta: '^1.3.0'
 {{#json_serializable}}
-  json_annotation: '^3.1.1'{{/json_serializable}}
+  json_annotation: '^4.0.0'{{/json_serializable}}
 dev_dependencies:
-  test: '>=1.3.0 <1.16.0'
+  test: '^1.16.8'
 {{#json_serializable}}
-  build_runner: '^1.0.0'
-  json_serializable: '^3.5.1'{{/json_serializable}}
+  build_runner: '^1.12.1'
+  json_serializable: '^4.0.2'{{/json_serializable}}

--- a/samples/client/petstore/dart2/petstore_client_lib/pubspec.yaml
+++ b/samples/client/petstore/dart2/petstore_client_lib/pubspec.yaml
@@ -9,12 +9,12 @@ authors:
   - 'Author <author@homepage>'
 homepage: 'homepage'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  http: '>=0.12.0 <0.13.0'
-  intl: '^0.16.1'
-  meta: '^1.1.8'
+  http: '^0.13.0'
+  intl: '^0.17.0'
+  meta: '^1.3.0'
 
 dev_dependencies:
-  test: '>=1.3.0 <1.16.0'
+  test: '^1.16.8'
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
@@ -9,12 +9,12 @@ authors:
   - 'Author <author@homepage>'
 homepage: 'homepage'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  http: '>=0.12.0 <0.13.0'
-  intl: '^0.16.1'
-  meta: '^1.1.8'
+  http: '^0.13.0'
+  intl: '^0.17.0'
+  meta: '^1.3.0'
 
 dev_dependencies:
-  test: '>=1.3.0 <1.16.0'
+  test: '^1.16.8'
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
@@ -9,12 +9,12 @@ authors:
   - 'Author <author@homepage>'
 homepage: 'homepage'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  http: '>=0.12.0 <0.13.0'
-  intl: '^0.16.1'
-  meta: '^1.1.8'
+  http: '^0.13.0'
+  intl: '^0.17.0'
+  meta: '^1.3.0'
 
 dev_dependencies:
-  test: '>=1.3.0 <1.16.0'
+  test: '^1.16.8'
 

--- a/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/pubspec.yaml
@@ -9,13 +9,13 @@ authors:
   - 'Author <author@homepage>'
 homepage: 'homepage'
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  http: '>=0.12.0 <0.13.0'
-  intl: '^0.16.1'
-  meta: '^1.1.8'
-  json_annotation: '^3.1.1'
+  http: '^0.13.0'
+  intl: '^0.17.0'
+  meta: '^1.3.0'
+  json_annotation: '^4.0.0'
 dev_dependencies:
-  test: '>=1.3.0 <1.16.0'
-  build_runner: '^1.0.0'
-  json_serializable: '^3.5.1'
+  test: '^1.16.8'
+  build_runner: '^1.12.1'
+  json_serializable: '^4.0.2'


### PR DESCRIPTION
Fix #8971 Update for pubspec.yaml tamplate for Dart2 generator so it can be used with Flutter 2.0.

### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ x] If your PR is targeting a particular programming language, @mention the [technical committee]
@swipesight @jaumard @josh-burton @amondnet @sbu-WBT @kuhnroyal @agilob (https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
