### PR TITLE
[C][Client] Generate API and module documents automatically

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
@@ -50,9 +50,6 @@ public class CLibcurlClientCodegen extends DefaultCodegen implements CodegenConf
     public CLibcurlClientCodegen() {
         super();
 
-        // TODO: c maintainer review
-        // Assumes that C community considers api/model header files as documentation.
-        // Generator supports Basic, OAuth, and API key explicitly. Bearer is excluded although clients are able to set headers directly.
         modifyFeatureSet(features -> features
                 .includeDocumentationFeatures(
                         DocumentationFeature.Readme
@@ -82,8 +79,8 @@ public class CLibcurlClientCodegen extends DefaultCodegen implements CodegenConf
         modelTemplateFiles.put("model-body.mustache", ".c");
         apiTemplateFiles.put("api-header.mustache", ".h");
         apiTemplateFiles.put("api-body.mustache", ".c");
-        //modelDocTemplateFiles.put("model_doc.mustache", ".md");
-        //apiDocTemplateFiles.put("api_doc.mustache", ".md");
+        modelDocTemplateFiles.put("model_doc.mustache", ".md");
+        apiDocTemplateFiles.put("api_doc.mustache", ".md");
         embeddedTemplateDir = templateDir = "C-libcurl";
 
         // TODO add auto-generated test files

--- a/modules/openapi-generator/src/main/resources/C-libcurl/README.md.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/README.md.mustache
@@ -64,6 +64,55 @@ Once compiled, you can run it with ``` ./main ```
 
 Note: You don't need to specify includes for models and include folder seperately as they are path linked. You just have to import the api.h file in your code, the include linking will work.
 
+## Documentation for API Endpoints
+
+All URIs are relative to *{{basePath}}*
+
+Category | Method | HTTP request | Description
+------------ | ------------- | ------------- | -------------
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{classname}}* | [**{{classname}}_{{operationId}}**]({{apiDocPath}}{{classname}}.md#{{classname}}_{{operationId}}) | **{{httpMethod}}** {{path}} | {{#summary}}{{{summary}}}{{/summary}}
+{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
+
+## Documentation for Models
+
+{{#models}}{{#model}} - [{{classname}}_t]({{modelDocPath}}{{classname}}.md)
+{{/model}}{{/models}}
+
+## Documentation for Authorization
+
+{{^authMethods}}
+All endpoints do not require authorization.
+{{/authMethods}}
+{{#authMethods}}
+{{#last}}
+Authentication schemes defined for the API:
+{{/last}}
+{{/authMethods}}
+{{#authMethods}}
+
+### {{name}}
+
+{{#isApiKey}}- **Type**: API key
+
+- **API key parameter name**: {{keyParamName}}
+- **Location**: {{#isKeyInQuery}}URL query string{{/isKeyInQuery}}{{#isKeyInHeader}}HTTP header{{/isKeyInHeader}}
+{{/isApiKey}}
+{{#isBasic}}
+
+- **Type**: HTTP basic authentication
+{{/isBasic}}
+{{#isOAuth}}
+
+- **Type**: OAuth
+- **Flow**: {{flow}}
+- **Authorization URL**: {{authorizationUrl}}
+- **Scopes**: {{^scopes}}N/A{{/scopes}}
+{{#scopes}}  - {{scope}}: {{description}}
+{{/scopes}}
+{{/isOAuth}}
+
+{{/authMethods}}
+
 ## Author
 
 {{#apiInfo}}{{#apis}}{{#-last}}{{infoEmail}}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api_doc.mustache
@@ -1,0 +1,60 @@
+# {{classname}}{{#description}}
+{{description}}{{/description}}
+
+All URIs are relative to *{{basePath}}*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+{{#operations}}{{#operation}}[**{{classname}}_{{operationId}}**]({{classname}}.md#{{classname}}_{{operationId}}) | **{{httpMethod}}** {{path}} | {{#summary}}{{summary}}{{/summary}}
+{{/operation}}{{/operations}}
+
+{{#operations}}
+{{#operation}}
+# **{{classname}}_{{{operationId}}}**
+```c
+{{#summary}}
+// {{{summary}}}
+//
+{{/summary}}
+{{#notes}}
+// {{{notes}}}
+//
+{{/notes}}
+{{#returnType}}{{#returnTypeIsPrimitive}}{{#returnSimpleType}}{{{.}}}*{{/returnSimpleType}}{{^returnSimpleType}}{{#isArray}}{{{.}}}_t*{{/isArray}}{{#isMap}}{{{.}}}{{/isMap}}{{/returnSimpleType}}{{/returnTypeIsPrimitive}}{{^returnTypeIsPrimitive}}{{{.}}}_t*{{/returnTypeIsPrimitive}}{{/returnType}}{{^returnType}}void{{/returnType}} {{{classname}}}_{{{operationId}}}(apiClient_t *apiClient{{#allParams}}, {{#isPrimitiveType}}{{#isNumber}}{{{dataType}}}{{/isNumber}}{{#isLong}}{{{dataType}}}{{/isLong}}{{#isInteger}}{{{dataType}}}{{/isInteger}}{{#isDouble}}{{{dataType}}}{{/isDouble}}{{#isFloat}}{{{dataType}}}{{/isFloat}}{{#isBoolean}}{{dataType}}{{/isBoolean}}{{#isEnum}}{{#isString}}{{projectName}}_{{operationId}}_{{baseName}}_e{{/isString}}{{/isEnum}}{{^isEnum}}{{#isString}}{{{dataType}}} *{{/isString}}{{/isEnum}}{{#isByteArray}}{{{dataType}}}{{/isByteArray}}{{#isDate}}{{{dataType}}}{{/isDate}}{{#isDateTime}}{{{dataType}}}{{/isDateTime}}{{#isFile}}{{{dataType}}}{{/isFile}}{{#isFreeFormObject}}{{dataType}}_t *{{/isFreeFormObject}}{{/isPrimitiveType}}{{^isArray}}{{^isPrimitiveType}}{{#isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{^isEnum}}{{{dataType}}}_t *{{/isEnum}}{{/isModel}}{{^isModel}}{{#isEnum}}{{datatypeWithEnum}}_e{{/isEnum}}{{/isModel}}{{#isUuid}}{{dataType}} *{{/isUuid}}{{#isEmail}}{{dataType}}{{/isEmail}}{{/isPrimitiveType}}{{/isArray}}{{#isContainer}}{{#isArray}}{{dataType}}_t *{{/isArray}}{{#isMap}}{{dataType}}{{/isMap}}{{/isContainer}} {{{paramName}}}{{/allParams}});
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+{{#allParams}}
+**{{paramName}}** | {{#isPrimitiveType}}{{#isNumber}}**{{{dataType}}}**{{/isNumber}}{{#isLong}}**{{{dataType}}}**{{/isLong}}{{#isInteger}}**{{{dataType}}}**{{/isInteger}}{{#isDouble}}**{{{dataType}}}**{{/isDouble}}{{#isFloat}}**{{{dataType}}}**{{/isFloat}}{{#isBoolean}}**{{dataType}}**{{/isBoolean}}{{#isEnum}}{{#isString}}**{{projectName}}_{{operationId}}_{{baseName}}_e**{{/isString}}{{/isEnum}}{{^isEnum}}{{#isString}}**{{{dataType}}} \***{{/isString}}{{/isEnum}}{{#isByteArray}}**{{{dataType}}}**{{/isByteArray}}{{#isDate}}**{{{dataType}}}**{{/isDate}}{{#isDateTime}}**{{{dataType}}}**{{/isDateTime}}{{#isFile}}**{{{dataType}}}**{{/isFile}}{{#isFreeFormObject}}**[{{dataType}}_t]({{baseType}}.md) \***{{/isFreeFormObject}}{{/isPrimitiveType}}{{^isArray}}{{^isPrimitiveType}}{{#isModel}}{{#isEnum}}**{{datatypeWithEnum}}_e**{{/isEnum}}{{^isEnum}}**[{{{dataType}}}_t]({{{baseType}}}.md) \***{{/isEnum}}{{/isModel}}{{^isModel}}{{#isEnum}}**{{datatypeWithEnum}}_e**{{/isEnum}}{{/isModel}}{{#isUuid}}**{{dataType}} \***{{/isUuid}}{{#isEmail}}**{{dataType}}**{{/isEmail}}{{/isPrimitiveType}}{{/isArray}}{{#isContainer}}{{#isArray}}**[{{dataType}}_t]({{baseType}}.md) \***{{/isArray}}{{#isMap}}**{{dataType}}**{{/isMap}}{{/isContainer}} | {{description}} | {{^required}}[optional] {{/required}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
+{{/allParams}}
+
+### Return type
+
+{{#returnType}}
+{{#returnTypeIsPrimitive}}
+{{#returnSimpleType}}{{{.}}}*{{/returnSimpleType}}
+{{^returnSimpleType}}
+{{#isArray}}[{{{.}}}_t]({{returnBaseType}}.md) *{{/isArray}}
+{{#isMap}}{{{.}}}{{/isMap}}
+{{/returnSimpleType}}
+{{/returnTypeIsPrimitive}}
+{{^returnTypeIsPrimitive}}[{{{.}}}_t]({{returnBaseType}}.md) *{{/returnTypeIsPrimitive}}
+{{/returnType}}
+{{^returnType}}void{{/returnType}}
+
+### Authorization
+
+{{^authMethods}}No authorization required{{/authMethods}}{{#authMethods}}[{{{name}}}](../README.md#{{{name}}}){{^-last}}, {{/-last}}{{/authMethods}}
+
+### HTTP request headers
+
+ - **Content-Type**: {{#consumes}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/consumes}}{{^consumes}}Not defined{{/consumes}}
+ - **Accept**: {{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}{{^produces}}Not defined{{/produces}}
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+{{/operation}}
+{{/operations}}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model_doc.mustache
@@ -1,0 +1,12 @@
+{{#models}}{{#model}}# {{classname}}_t
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+{{#vars}}
+**{{name}}** | {{^isContainer}}{{^isPrimitiveType}}{{#isModel}}{{#isEnum}}**{{projectName}}_{{classVarName}}_{{enumName}}_e**{{/isEnum}}{{^isEnum}}[**{{datatype}}_t**]({{complexType}}.md) \*{{/isEnum}}{{/isModel}}{{#isUuid}}**{{datatype}} \***{{/isUuid}}{{#isEmail}}**{{datatype}} \***{{/isEmail}}{{#isFreeFormObject}}[**{{datatype}}_t**]({{complexType}}.md) \*{{/isFreeFormObject}}{{/isPrimitiveType}}{{#isPrimitiveType}}{{#isNumeric}}**{{datatype}}**{{/isNumeric}}{{#isBoolean}}**{{datatype}}**{{/isBoolean}}{{#isEnum}}{{#isString}}**{{projectName}}_{{classVarName}}_{{enumName}}_e**{{/isString}}{{/isEnum}}{{^isEnum}}{{#isString}}**{{datatype}} \***{{/isString}}{{/isEnum}}{{#isByteArray}}**{{datatype}}**{{/isByteArray}}{{#isBinary}}**{{datatype}}**{{/isBinary}}{{#isDate}}**{{datatype}} \***{{/isDate}}{{#isDateTime}}**{{datatype}} \***{{/isDateTime}}{{/isPrimitiveType}}{{/isContainer}}{{#isContainer}}{{#isArray}}{{#isPrimitiveType}}**{{datatype}}_t \***{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{datatype}}_t**]({{complexType}}.md) \*{{/isPrimitiveType}}{{/isArray}}{{#isMap}}**{{datatype}}**{{/isMap}}{{/isContainer}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{/vars}}
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+{{/model}}{{/models}}

--- a/samples/client/petstore/c/.openapi-generator/FILES
+++ b/samples/client/petstore/c/.openapi-generator/FILES
@@ -5,6 +5,15 @@ api/StoreAPI.c
 api/StoreAPI.h
 api/UserAPI.c
 api/UserAPI.h
+docs/PetAPI.md
+docs/StoreAPI.md
+docs/UserAPI.md
+docs/api_response.md
+docs/category.md
+docs/order.md
+docs/pet.md
+docs/tag.md
+docs/user.md
 external/cJSON.c
 external/cJSON.h
 external/cJSON.licence

--- a/samples/client/petstore/c/README.md
+++ b/samples/client/petstore/c/README.md
@@ -58,6 +58,66 @@ Once compiled, you can run it with ``` ./main ```
 
 Note: You don't need to specify includes for models and include folder seperately as they are path linked. You just have to import the api.h file in your code, the include linking will work.
 
+## Documentation for API Endpoints
+
+All URIs are relative to *http://petstore.swagger.io/v2*
+
+Category | Method | HTTP request | Description
+------------ | ------------- | ------------- | -------------
+*PetAPI* | [**PetAPI_addPet**](docs/PetAPI.md#PetAPI_addPet) | **POST** /pet | Add a new pet to the store
+*PetAPI* | [**PetAPI_deletePet**](docs/PetAPI.md#PetAPI_deletePet) | **DELETE** /pet/{petId} | Deletes a pet
+*PetAPI* | [**PetAPI_findPetsByStatus**](docs/PetAPI.md#PetAPI_findPetsByStatus) | **GET** /pet/findByStatus | Finds Pets by status
+*PetAPI* | [**PetAPI_findPetsByTags**](docs/PetAPI.md#PetAPI_findPetsByTags) | **GET** /pet/findByTags | Finds Pets by tags
+*PetAPI* | [**PetAPI_getPetById**](docs/PetAPI.md#PetAPI_getPetById) | **GET** /pet/{petId} | Find pet by ID
+*PetAPI* | [**PetAPI_updatePet**](docs/PetAPI.md#PetAPI_updatePet) | **PUT** /pet | Update an existing pet
+*PetAPI* | [**PetAPI_updatePetWithForm**](docs/PetAPI.md#PetAPI_updatePetWithForm) | **POST** /pet/{petId} | Updates a pet in the store with form data
+*PetAPI* | [**PetAPI_uploadFile**](docs/PetAPI.md#PetAPI_uploadFile) | **POST** /pet/{petId}/uploadImage | uploads an image
+*StoreAPI* | [**StoreAPI_deleteOrder**](docs/StoreAPI.md#StoreAPI_deleteOrder) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
+*StoreAPI* | [**StoreAPI_getInventory**](docs/StoreAPI.md#StoreAPI_getInventory) | **GET** /store/inventory | Returns pet inventories by status
+*StoreAPI* | [**StoreAPI_getOrderById**](docs/StoreAPI.md#StoreAPI_getOrderById) | **GET** /store/order/{orderId} | Find purchase order by ID
+*StoreAPI* | [**StoreAPI_placeOrder**](docs/StoreAPI.md#StoreAPI_placeOrder) | **POST** /store/order | Place an order for a pet
+*UserAPI* | [**UserAPI_createUser**](docs/UserAPI.md#UserAPI_createUser) | **POST** /user | Create user
+*UserAPI* | [**UserAPI_createUsersWithArrayInput**](docs/UserAPI.md#UserAPI_createUsersWithArrayInput) | **POST** /user/createWithArray | Creates list of users with given input array
+*UserAPI* | [**UserAPI_createUsersWithListInput**](docs/UserAPI.md#UserAPI_createUsersWithListInput) | **POST** /user/createWithList | Creates list of users with given input array
+*UserAPI* | [**UserAPI_deleteUser**](docs/UserAPI.md#UserAPI_deleteUser) | **DELETE** /user/{username} | Delete user
+*UserAPI* | [**UserAPI_getUserByName**](docs/UserAPI.md#UserAPI_getUserByName) | **GET** /user/{username} | Get user by user name
+*UserAPI* | [**UserAPI_loginUser**](docs/UserAPI.md#UserAPI_loginUser) | **GET** /user/login | Logs user into the system
+*UserAPI* | [**UserAPI_logoutUser**](docs/UserAPI.md#UserAPI_logoutUser) | **GET** /user/logout | Logs out current logged in user session
+*UserAPI* | [**UserAPI_updateUser**](docs/UserAPI.md#UserAPI_updateUser) | **PUT** /user/{username} | Updated user
+
+
+## Documentation for Models
+
+ - [api_response_t](docs/api_response.md)
+ - [category_t](docs/category.md)
+ - [order_t](docs/order.md)
+ - [pet_t](docs/pet.md)
+ - [tag_t](docs/tag.md)
+ - [user_t](docs/user.md)
+
+
+## Documentation for Authorization
+
+
+### api_key
+
+- **Type**: API key
+
+- **API key parameter name**: api_key
+- **Location**: HTTP header
+
+
+### petstore_auth
+
+
+- **Type**: OAuth
+- **Flow**: implicit
+- **Authorization URL**: http://petstore.swagger.io/api/oauth/dialog
+- **Scopes**: 
+  - write:pets: modify pets in your account
+  - read:pets: read your pets
+
+
 ## Author
 
 

--- a/samples/client/petstore/c/docs/PetAPI.md
+++ b/samples/client/petstore/c/docs/PetAPI.md
@@ -1,0 +1,255 @@
+# PetAPI
+
+All URIs are relative to *http://petstore.swagger.io/v2*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**PetAPI_addPet**](PetAPI.md#PetAPI_addPet) | **POST** /pet | Add a new pet to the store
+[**PetAPI_deletePet**](PetAPI.md#PetAPI_deletePet) | **DELETE** /pet/{petId} | Deletes a pet
+[**PetAPI_findPetsByStatus**](PetAPI.md#PetAPI_findPetsByStatus) | **GET** /pet/findByStatus | Finds Pets by status
+[**PetAPI_findPetsByTags**](PetAPI.md#PetAPI_findPetsByTags) | **GET** /pet/findByTags | Finds Pets by tags
+[**PetAPI_getPetById**](PetAPI.md#PetAPI_getPetById) | **GET** /pet/{petId} | Find pet by ID
+[**PetAPI_updatePet**](PetAPI.md#PetAPI_updatePet) | **PUT** /pet | Update an existing pet
+[**PetAPI_updatePetWithForm**](PetAPI.md#PetAPI_updatePetWithForm) | **POST** /pet/{petId} | Updates a pet in the store with form data
+[**PetAPI_uploadFile**](PetAPI.md#PetAPI_uploadFile) | **POST** /pet/{petId}/uploadImage | uploads an image
+
+
+# **PetAPI_addPet**
+```c
+// Add a new pet to the store
+//
+void PetAPI_addPet(apiClient_t *apiClient, pet_t * body);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**body** | **[pet_t](pet.md) \*** | Pet object that needs to be added to the store | 
+
+### Return type
+
+void
+
+### Authorization
+
+[petstore_auth](../README.md#petstore_auth)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json, application/xml
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **PetAPI_deletePet**
+```c
+// Deletes a pet
+//
+void PetAPI_deletePet(apiClient_t *apiClient, long petId, char * api_key);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**petId** | **long** | Pet id to delete | 
+**api_key** | **char \*** |  | [optional] 
+
+### Return type
+
+void
+
+### Authorization
+
+[petstore_auth](../README.md#petstore_auth)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **PetAPI_findPetsByStatus**
+```c
+// Finds Pets by status
+//
+// Multiple status values can be provided with comma separated strings
+//
+list_t* PetAPI_findPetsByStatus(apiClient_t *apiClient, list_t * status);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**status** | **[list_t](char.md) \*** | Status values that need to be considered for filter | 
+
+### Return type
+
+[list_t](pet.md) *
+
+
+### Authorization
+
+[petstore_auth](../README.md#petstore_auth)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/xml, application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **PetAPI_findPetsByTags**
+```c
+// Finds Pets by tags
+//
+// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+//
+list_t* PetAPI_findPetsByTags(apiClient_t *apiClient, list_t * tags);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**tags** | **[list_t](char.md) \*** | Tags to filter by | 
+
+### Return type
+
+[list_t](pet.md) *
+
+
+### Authorization
+
+[petstore_auth](../README.md#petstore_auth)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/xml, application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **PetAPI_getPetById**
+```c
+// Find pet by ID
+//
+// Returns a single pet
+//
+pet_t* PetAPI_getPetById(apiClient_t *apiClient, long petId);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**petId** | **long** | ID of pet to return | 
+
+### Return type
+
+[pet_t](pet.md) *
+
+
+### Authorization
+
+[api_key](../README.md#api_key)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/xml, application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **PetAPI_updatePet**
+```c
+// Update an existing pet
+//
+void PetAPI_updatePet(apiClient_t *apiClient, pet_t * body);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**body** | **[pet_t](pet.md) \*** | Pet object that needs to be added to the store | 
+
+### Return type
+
+void
+
+### Authorization
+
+[petstore_auth](../README.md#petstore_auth)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json, application/xml
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **PetAPI_updatePetWithForm**
+```c
+// Updates a pet in the store with form data
+//
+void PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char * name, char * status);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**petId** | **long** | ID of pet that needs to be updated | 
+**name** | **char \*** | Updated name of the pet | [optional] 
+**status** | **char \*** | Updated status of the pet | [optional] 
+
+### Return type
+
+void
+
+### Authorization
+
+[petstore_auth](../README.md#petstore_auth)
+
+### HTTP request headers
+
+ - **Content-Type**: application/x-www-form-urlencoded
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **PetAPI_uploadFile**
+```c
+// uploads an image
+//
+api_response_t* PetAPI_uploadFile(apiClient_t *apiClient, long petId, char * additionalMetadata, binary_t* file);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**petId** | **long** | ID of pet to update | 
+**additionalMetadata** | **char \*** | Additional data to pass to server | [optional] 
+**file** | **binary_t*** | file to upload | [optional] 
+
+### Return type
+
+[api_response_t](api_response.md) *
+
+
+### Authorization
+
+[petstore_auth](../README.md#petstore_auth)
+
+### HTTP request headers
+
+ - **Content-Type**: multipart/form-data
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+

--- a/samples/client/petstore/c/docs/StoreAPI.md
+++ b/samples/client/petstore/c/docs/StoreAPI.md
@@ -1,0 +1,135 @@
+# StoreAPI
+
+All URIs are relative to *http://petstore.swagger.io/v2*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**StoreAPI_deleteOrder**](StoreAPI.md#StoreAPI_deleteOrder) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
+[**StoreAPI_getInventory**](StoreAPI.md#StoreAPI_getInventory) | **GET** /store/inventory | Returns pet inventories by status
+[**StoreAPI_getOrderById**](StoreAPI.md#StoreAPI_getOrderById) | **GET** /store/order/{orderId} | Find purchase order by ID
+[**StoreAPI_placeOrder**](StoreAPI.md#StoreAPI_placeOrder) | **POST** /store/order | Place an order for a pet
+
+
+# **StoreAPI_deleteOrder**
+```c
+// Delete purchase order by ID
+//
+// For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+//
+void StoreAPI_deleteOrder(apiClient_t *apiClient, char * orderId);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**orderId** | **char \*** | ID of the order that needs to be deleted | 
+
+### Return type
+
+void
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **StoreAPI_getInventory**
+```c
+// Returns pet inventories by status
+//
+// Returns a map of status codes to quantities
+//
+list_t* StoreAPI_getInventory(apiClient_t *apiClient);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+
+### Return type
+
+
+
+list_t*
+
+
+
+### Authorization
+
+[api_key](../README.md#api_key)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **StoreAPI_getOrderById**
+```c
+// Find purchase order by ID
+//
+// For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+//
+order_t* StoreAPI_getOrderById(apiClient_t *apiClient, long orderId);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**orderId** | **long** | ID of pet that needs to be fetched | 
+
+### Return type
+
+[order_t](order.md) *
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/xml, application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **StoreAPI_placeOrder**
+```c
+// Place an order for a pet
+//
+order_t* StoreAPI_placeOrder(apiClient_t *apiClient, order_t * body);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**body** | **[order_t](order.md) \*** | order placed for purchasing the pet | 
+
+### Return type
+
+[order_t](order.md) *
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/xml, application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+

--- a/samples/client/petstore/c/docs/UserAPI.md
+++ b/samples/client/petstore/c/docs/UserAPI.md
@@ -1,0 +1,250 @@
+# UserAPI
+
+All URIs are relative to *http://petstore.swagger.io/v2*
+
+Method | HTTP request | Description
+------------- | ------------- | -------------
+[**UserAPI_createUser**](UserAPI.md#UserAPI_createUser) | **POST** /user | Create user
+[**UserAPI_createUsersWithArrayInput**](UserAPI.md#UserAPI_createUsersWithArrayInput) | **POST** /user/createWithArray | Creates list of users with given input array
+[**UserAPI_createUsersWithListInput**](UserAPI.md#UserAPI_createUsersWithListInput) | **POST** /user/createWithList | Creates list of users with given input array
+[**UserAPI_deleteUser**](UserAPI.md#UserAPI_deleteUser) | **DELETE** /user/{username} | Delete user
+[**UserAPI_getUserByName**](UserAPI.md#UserAPI_getUserByName) | **GET** /user/{username} | Get user by user name
+[**UserAPI_loginUser**](UserAPI.md#UserAPI_loginUser) | **GET** /user/login | Logs user into the system
+[**UserAPI_logoutUser**](UserAPI.md#UserAPI_logoutUser) | **GET** /user/logout | Logs out current logged in user session
+[**UserAPI_updateUser**](UserAPI.md#UserAPI_updateUser) | **PUT** /user/{username} | Updated user
+
+
+# **UserAPI_createUser**
+```c
+// Create user
+//
+// This can only be done by the logged in user.
+//
+void UserAPI_createUser(apiClient_t *apiClient, user_t * body);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**body** | **[user_t](user.md) \*** | Created user object | 
+
+### Return type
+
+void
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **UserAPI_createUsersWithArrayInput**
+```c
+// Creates list of users with given input array
+//
+void UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t * body);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**body** | **[list_t](user.md) \*** | List of user object | 
+
+### Return type
+
+void
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **UserAPI_createUsersWithListInput**
+```c
+// Creates list of users with given input array
+//
+void UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t * body);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**body** | **[list_t](user.md) \*** | List of user object | 
+
+### Return type
+
+void
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **UserAPI_deleteUser**
+```c
+// Delete user
+//
+// This can only be done by the logged in user.
+//
+void UserAPI_deleteUser(apiClient_t *apiClient, char * username);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**username** | **char \*** | The name that needs to be deleted | 
+
+### Return type
+
+void
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **UserAPI_getUserByName**
+```c
+// Get user by user name
+//
+user_t* UserAPI_getUserByName(apiClient_t *apiClient, char * username);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**username** | **char \*** | The name that needs to be fetched. Use user1 for testing. | 
+
+### Return type
+
+[user_t](user.md) *
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/xml, application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **UserAPI_loginUser**
+```c
+// Logs user into the system
+//
+char* UserAPI_loginUser(apiClient_t *apiClient, char * username, char * password);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**username** | **char \*** | The user name for login | 
+**password** | **char \*** | The password for login in clear text | 
+
+### Return type
+
+char*
+
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/xml, application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **UserAPI_logoutUser**
+```c
+// Logs out current logged in user session
+//
+void UserAPI_logoutUser(apiClient_t *apiClient);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+
+### Return type
+
+void
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **UserAPI_updateUser**
+```c
+// Updated user
+//
+// This can only be done by the logged in user.
+//
+void UserAPI_updateUser(apiClient_t *apiClient, char * username, user_t * body);
+```
+
+### Parameters
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**apiClient** | **apiClient_t \*** | context containing the client configuration | 
+**username** | **char \*** | name that need to be deleted | 
+**body** | **[user_t](user.md) \*** | Updated user object | 
+
+### Return type
+
+void
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+

--- a/samples/client/petstore/c/docs/api_response.md
+++ b/samples/client/petstore/c/docs/api_response.md
@@ -1,0 +1,12 @@
+# api_response_t
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**code** | **int** |  | [optional] 
+**type** | **char \*** |  | [optional] 
+**message** | **char \*** |  | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/client/petstore/c/docs/category.md
+++ b/samples/client/petstore/c/docs/category.md
@@ -1,0 +1,11 @@
+# category_t
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **long** |  | [optional] 
+**name** | **char \*** |  | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/client/petstore/c/docs/order.md
+++ b/samples/client/petstore/c/docs/order.md
@@ -1,0 +1,15 @@
+# order_t
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **long** |  | [optional] 
+**pet_id** | **long** |  | [optional] 
+**quantity** | **int** |  | [optional] 
+**ship_date** | **char \*** |  | [optional] 
+**status** | **openapi_petstore_order_STATUS_e** | Order Status | [optional] 
+**complete** | **int** |  | [optional] [default to false]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/client/petstore/c/docs/pet.md
+++ b/samples/client/petstore/c/docs/pet.md
@@ -1,0 +1,15 @@
+# pet_t
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **long** |  | [optional] 
+**category** | [**category_t**](category.md) \* |  | [optional] 
+**name** | **char \*** |  | 
+**photo_urls** | **list_t \*** |  | 
+**tags** | [**list_t**](tag.md) \* |  | [optional] 
+**status** | **openapi_petstore_pet_STATUS_e** | pet status in the store | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/client/petstore/c/docs/tag.md
+++ b/samples/client/petstore/c/docs/tag.md
@@ -1,0 +1,11 @@
+# tag_t
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **long** |  | [optional] 
+**name** | **char \*** |  | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/client/petstore/c/docs/user.md
+++ b/samples/client/petstore/c/docs/user.md
@@ -1,0 +1,17 @@
+# user_t
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **long** |  | [optional] 
+**username** | **char \*** |  | [optional] 
+**first_name** | **char \*** |  | [optional] 
+**last_name** | **char \*** |  | [optional] 
+**email** | **char \*** |  | [optional] 
+**password** | **char \*** |  | [optional] 
+**phone** | **char \*** |  | [optional] 
+**user_status** | **int** | User Status | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Hi @wing328 @zhemant @michelealbano

This PR will add the feature of generating API and module documents automatically.

To fix https://github.com/OpenAPITools/openapi-generator/issues/8426

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
