### PR TITLE
[scala-akka-http-server] allows generation of managed sources only

### DIFF
--- a/docs/generators/scala-akka-http-server.md
+++ b/docs/generators/scala-akka-http-server.md
@@ -12,6 +12,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |apiPackage|package for generated api classes| |null|
 |artifactId|artifactId| |openapi-scala-akka-http-server|
 |artifactVersion|artifact version in generated pom.xml. This also becomes part of the generated library's filename| |1.0.0|
+|asManagedSources|Wether we want to generate an autonomous akka project, or sources to be included in sbt Managed Sources | If false, an autonomous project will be generated. If true, only source files to be added in ManagedSources will be generated|false]
 |dateLibrary|Option. Date library to use|<dl><dt>**joda**</dt><dd>Joda (for legacy app)</dd><dt>**java8**</dt><dd>Java 8 native JSR310 (prefered for JDK 1.8+)</dd></dl>|java8|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaHttpServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaHttpServerCodegen.java
@@ -40,10 +40,15 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
     protected String invokerPackage;
 
     protected String akkaHttpVersion;
+    protected boolean generateAsManagedSources;
 
     public static final String AKKA_HTTP_VERSION = "akkaHttpVersion";
     public static final String AKKA_HTTP_VERSION_DESC = "The version of akka-http";
     public static final String DEFAULT_AKKA_HTTP_VERSION = "10.1.10";
+
+    public static final String GENERATE_AS_MANAGED_SOURCES = "asManagedSources";
+    public static final String GENERATE_AS_MANAGED_SOURCES_DESC = "Resulting files cab be used as managed resources. No build files or default controllers will be generated";
+    public static final boolean DEFAULT_GENERATE_AS_MANAGED_SOURCES = false;
 
     static final Logger LOGGER = LoggerFactory.getLogger(ScalaAkkaHttpServerCodegen.class);
 
@@ -99,6 +104,7 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
         modelPackage = "org.openapitools.server.model";
         invokerPackage = "org.openapitools.server";
         akkaHttpVersion = DEFAULT_AKKA_HTTP_VERSION;
+        generateAsManagedSources = DEFAULT_GENERATE_AS_MANAGED_SOURCES;
 
         setReservedWordsLowerCase(
                 Arrays.asList(
@@ -114,6 +120,7 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
         cliOptions.add(CliOption.newString(CodegenConstants.ARTIFACT_ID, CodegenConstants.ARTIFACT_ID).defaultValue(artifactId));
         cliOptions.add(CliOption.newString(CodegenConstants.ARTIFACT_VERSION, CodegenConstants.ARTIFACT_VERSION_DESC).defaultValue(artifactVersion));
         cliOptions.add(CliOption.newString(AKKA_HTTP_VERSION, AKKA_HTTP_VERSION_DESC).defaultValue(akkaHttpVersion));
+        cliOptions.add(CliOption.newBoolean(GENERATE_AS_MANAGED_SOURCES, GENERATE_AS_MANAGED_SOURCES_DESC).defaultValue(Boolean.valueOf(DEFAULT_GENERATE_AS_MANAGED_SOURCES).toString()));
 
         importMapping.remove("Seq");
         importMapping.remove("List");
@@ -141,8 +148,6 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
 
         instantiationTypes.put("array", "ListBuffer");
         instantiationTypes.put("map", "Map");
-
-        supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
     }
 
     @Override
@@ -181,9 +186,19 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
 
         parseAkkaHttpVersion();
 
-        supportingFiles.add(new SupportingFile("build.sbt.mustache", "", "build.sbt"));
-        supportingFiles.add(new SupportingFile("controller.mustache",
-                (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "Controller.scala"));
+
+        if (additionalProperties.containsKey(GENERATE_AS_MANAGED_SOURCES)) {
+            generateAsManagedSources = Boolean.parseBoolean(additionalProperties.get(GENERATE_AS_MANAGED_SOURCES).toString());
+        } else {
+            additionalProperties.put(GENERATE_AS_MANAGED_SOURCES, Boolean.valueOf(generateAsManagedSources).toString());
+        }
+
+        if (!generateAsManagedSources) {
+            supportingFiles.add(new SupportingFile("build.sbt.mustache", "", "build.sbt"));
+            supportingFiles.add(new SupportingFile("controller.mustache",
+                    (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "Controller.scala"));
+            supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
+        }
         supportingFiles.add(new SupportingFile("helper.mustache",
                 (sourceFolder + File.separator + invokerPackage).replace(".", java.io.File.separator), "AkkaHttpHelper.scala"));
         supportingFiles.add(new SupportingFile("stringDirectives.mustache",


### PR DESCRIPTION
When the official OpenAPITools / sbt-openapi-generator sbt plugin is used to generate a scala-akka-http-server stub, the resulting files are a project in their own right, including:
- a build file
- a README.md file
- a default controller (controller.scala)

The problem is that it can be interesting not to generate a project, but just the source files needed to compile a project.
By generating just scala files, which are placed in the managedSources of sbt, one can automate the generation of models and APIs within a project, without having to filter unnecessary files that prevent compilation.

This is what this modification allows.
By adding the **asManagedSources** parameter in the additional properties of the generator, the build.sbt, README.md and controller.scala files will be ignored.

It is then possible, in the build file of the project, to simply define sbt-openapi-generator as a source generator:

```
openApiAdditionalProperties := Map("asManagedSources" -> "true")
Compile / sourceGenerators += openApiGenerate
```
By doing that, not a single manual operation is needed when openapi specification changes.
Just by recompiling the project, the developer will see the templates and APIs updated and compiled at the same time.

Btw, syntax is far from perfect, due to the usage of a string to express the Boolean, but this is all due to sbt-openapi-generator...
