### PR TITLE
rust: better support for binary body parameters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -18,9 +18,11 @@
 package org.openapitools.codegen.languages;
 
 import com.google.common.base.Strings;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
@@ -501,6 +503,38 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
         }
 
         return StringUtils.underscore(sanitizedOperationId);
+    }
+
+    @Override
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+
+        // If this endpoint has a single binary body parameter, we want
+        // to accept a body argument with the trait bound Into<Body>.
+        // This requires a type parameter in the function definition,
+        // in advance of actual parameter, and is thus far easier to decide
+        // here than in the template.
+        if (REQWEST_LIBRARY.equals(getLibrary()) && op.bodyParams != null && op.bodyParams.size() == 1) {
+            CodegenParameter cp = op.bodyParams.get(0);
+
+            if (cp.isBinary) {
+                cp.baseType = cp.dataType = "B";
+                op.vendorExtensions.put("x-rust-type-parameter", "B: Into<reqwest::Body>");
+
+                // A copy of the body parameter will appear somewhere in the
+                // allParams list.  We need to doctor that one as well.
+                int seen = 0;
+                for (CodegenParameter ap : op.allParams) {
+                    if (ap.isBinary && ap.isBodyParam) {
+                        ap.baseType = ap.dataType = "B";
+                        seen++;
+                    }
+                }
+                assert seen == 1;
+            }
+        }
+
+        return op;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -88,7 +88,65 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
 
 {{/vendorExtensions.x-group-parameters}}
 {{^vendorExtensions.x-group-parameters}}
-pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: &configuration::Configuration, {{#allParams}}{{{paramName}}}: {{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{#isString}}{{#isArray}}Vec<{{/isArray}}&str{{#isArray}}>{{/isArray}}{{/isString}}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}&str{{#isArray}}>{{/isArray}}{{/isUuid}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}{{#isBodyParam}}crate::models::{{/isBodyParam}}{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) -> Result<{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleResponses}}, Error<{{{operationIdCamelCase}}}Error>> {
+pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}{{!
+    }}{{#vendorExtensions.x-rust-type-parameter}}{{!
+        }}<{{{vendorExtensions.x-rust-type-parameter}}}>{{!
+    }}{{/vendorExtensions.x-rust-type-parameter}}{{!
+    }}(
+    configuration: &configuration::Configuration,
+{{!
+    }}{{#allParams}}    {{{paramName}}}: {{!
+        !
+        ! If this is an optional parameter, or a required parameter that
+        ! is nullable, wrap the type in an Option<T>:
+        !
+        }}{{^required}}Option<{{/required}}{{!
+        }}{{#required}}{{!
+            }}{{#isNullable}}Option<{{/isNullable}}{{!
+        }}{{/required}}{{!
+
+        !
+        ! Represent a string as a string slice (&str).
+        ! TODO: Array should be a slice, not a Vector; i.e., &[&str].
+        !
+        }}{{#isString}}{{!
+            }}{{#isArray}}Vec<{{/isArray}}{{!
+            }}&str{{!
+            }}{{#isArray}}>{{/isArray}}{{!
+        }}{{/isString}}{{!
+
+        !
+        ! Represent a UUID as a string slice (&str).
+        ! TODO: Array should be a slice, not a Vector; i.e., &[&str].
+        !
+        }}{{#isUuid}}{{!
+            }}{{#isArray}}Vec<{{/isArray}}{{!
+            }}&str{{!
+            }}{{#isArray}}>{{/isArray}}{{!
+        }}{{/isUuid}}{{!
+
+        }}{{^isString}}{{^isUuid}}{{!
+            }}{{^isPrimitiveType}}{{^isContainer}}{{#isBodyParam}}{{!
+                !
+                ! Complex body parameters need a prefix to refer to the
+                ! struct we defined in the models module:
+                !
+                }}crate::models::{{!
+            }}{{/isBodyParam}}{{/isContainer}}{{/isPrimitiveType}}{{!
+            }}{{{dataType}}}{{!
+        }}{{/isUuid}}{{/isString}}{{!
+
+        !
+        ! Close out the Option<T> wrapper:
+        !
+        }}{{^required}}>{{/required}}{{!
+        }}{{#required}}{{!
+            }}{{#isNullable}}>{{/isNullable}}{{!
+        }}{{/required}}{{!
+        }},
+{{!
+    }}{{/allParams}}{{!
+}}) -> Result<{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{#returnType}}{{{returnType}}}{{/returnType}}{{/supportMultipleResponses}}, Error<{{{operationIdCamelCase}}}Error>> {
 {{/vendorExtensions.x-group-parameters}}
 
     let local_var_client = &configuration.client;
@@ -271,12 +329,33 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
     local_var_req_builder = local_var_req_builder.form(&local_var_form_params);
     {{/hasFormParams}}
     {{/isMultipart}}
-    {{#hasBodyParam}}
-    {{#bodyParams}}
-    local_var_req_builder = local_var_req_builder.json(&{{{paramName}}});
-    {{/bodyParams}}
-    {{/hasBodyParam}}
-
+{{!
+    !
+    ! Body parameter:
+    !
+    !}}{{#hasBodyParam}}{{!
+        }}{{#bodyParams}}{{!
+        !
+        ! If the body parameter is binary, we pass it to the reqwest body()
+        ! method.  This requires the body parameter argument to this function
+        ! to be generic, and match the Into<reqwest::Body> bound, allowing
+        ! a stream or a byte buffer to be used:
+        !
+        !}}{{#isBinary}}{{!
+            }}    local_var_req_builder = local_var_req_builder.body({{{paramName}}});
+{{!
+        }}{{/isBinary}}{{!
+        !
+        ! Otherwise, we assume the parameter has the Serializable trait, and
+        ! pass it to the reqwest json() method:
+        !
+        }}{{^isBinary}}{{!
+            }}    local_var_req_builder = local_var_req_builder.json(&{{{paramName}}});
+{{!
+        }}{{/isBinary}}{{!
+    }}{{/bodyParams}}{{!
+    }}{{/hasBodyParam}}{{!
+}}
     let local_var_req = local_var_req_builder.build()?;
     let {{^supportAsync}}mut {{/supportAsync}}local_var_resp = local_var_client.execute(local_var_req){{#supportAsync}}.await{{/supportAsync}}?;
 

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
@@ -82,7 +82,10 @@ pub enum UploadFileError {
 }
 
 
-pub fn add_pet(configuration: &configuration::Configuration, body: crate::models::Pet) -> Result<(), Error<AddPetError>> {
+pub fn add_pet(
+    configuration: &configuration::Configuration,
+    body: crate::models::Pet,
+) -> Result<(), Error<AddPetError>> {
 
     let local_var_client = &configuration.client;
 
@@ -112,7 +115,11 @@ pub fn add_pet(configuration: &configuration::Configuration, body: crate::models
     }
 }
 
-pub fn delete_pet(configuration: &configuration::Configuration, pet_id: i64, api_key: Option<&str>) -> Result<(), Error<DeletePetError>> {
+pub fn delete_pet(
+    configuration: &configuration::Configuration,
+    pet_id: i64,
+    api_key: Option<&str>,
+) -> Result<(), Error<DeletePetError>> {
 
     let local_var_client = &configuration.client;
 
@@ -145,7 +152,10 @@ pub fn delete_pet(configuration: &configuration::Configuration, pet_id: i64, api
 }
 
 /// Multiple status values can be provided with comma separated strings
-pub fn find_pets_by_status(configuration: &configuration::Configuration, status: Vec<String>) -> Result<Vec<crate::models::Pet>, Error<FindPetsByStatusError>> {
+pub fn find_pets_by_status(
+    configuration: &configuration::Configuration,
+    status: Vec<String>,
+) -> Result<Vec<crate::models::Pet>, Error<FindPetsByStatusError>> {
 
     let local_var_client = &configuration.client;
 
@@ -176,7 +186,10 @@ pub fn find_pets_by_status(configuration: &configuration::Configuration, status:
 }
 
 /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-pub fn find_pets_by_tags(configuration: &configuration::Configuration, tags: Vec<String>) -> Result<Vec<crate::models::Pet>, Error<FindPetsByTagsError>> {
+pub fn find_pets_by_tags(
+    configuration: &configuration::Configuration,
+    tags: Vec<String>,
+) -> Result<Vec<crate::models::Pet>, Error<FindPetsByTagsError>> {
 
     let local_var_client = &configuration.client;
 
@@ -207,7 +220,10 @@ pub fn find_pets_by_tags(configuration: &configuration::Configuration, tags: Vec
 }
 
 /// Returns a single pet
-pub fn get_pet_by_id(configuration: &configuration::Configuration, pet_id: i64) -> Result<crate::models::Pet, Error<GetPetByIdError>> {
+pub fn get_pet_by_id(
+    configuration: &configuration::Configuration,
+    pet_id: i64,
+) -> Result<crate::models::Pet, Error<GetPetByIdError>> {
 
     let local_var_client = &configuration.client;
 
@@ -241,7 +257,10 @@ pub fn get_pet_by_id(configuration: &configuration::Configuration, pet_id: i64) 
     }
 }
 
-pub fn update_pet(configuration: &configuration::Configuration, body: crate::models::Pet) -> Result<(), Error<UpdatePetError>> {
+pub fn update_pet(
+    configuration: &configuration::Configuration,
+    body: crate::models::Pet,
+) -> Result<(), Error<UpdatePetError>> {
 
     let local_var_client = &configuration.client;
 
@@ -271,7 +290,12 @@ pub fn update_pet(configuration: &configuration::Configuration, body: crate::mod
     }
 }
 
-pub fn update_pet_with_form(configuration: &configuration::Configuration, pet_id: i64, name: Option<&str>, status: Option<&str>) -> Result<(), Error<UpdatePetWithFormError>> {
+pub fn update_pet_with_form(
+    configuration: &configuration::Configuration,
+    pet_id: i64,
+    name: Option<&str>,
+    status: Option<&str>,
+) -> Result<(), Error<UpdatePetWithFormError>> {
 
     let local_var_client = &configuration.client;
 
@@ -308,7 +332,12 @@ pub fn update_pet_with_form(configuration: &configuration::Configuration, pet_id
     }
 }
 
-pub fn upload_file(configuration: &configuration::Configuration, pet_id: i64, additional_metadata: Option<&str>, file: Option<std::path::PathBuf>) -> Result<crate::models::ApiResponse, Error<UploadFileError>> {
+pub fn upload_file(
+    configuration: &configuration::Configuration,
+    pet_id: i64,
+    additional_metadata: Option<&str>,
+    file: Option<std::path::PathBuf>,
+) -> Result<crate::models::ApiResponse, Error<UploadFileError>> {
 
     let local_var_client = &configuration.client;
 

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/store_api.rs
@@ -50,7 +50,10 @@ pub enum PlaceOrderError {
 
 
 /// For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-pub fn delete_order(configuration: &configuration::Configuration, order_id: &str) -> Result<(), Error<DeleteOrderError>> {
+pub fn delete_order(
+    configuration: &configuration::Configuration,
+    order_id: &str,
+) -> Result<(), Error<DeleteOrderError>> {
 
     let local_var_client = &configuration.client;
 
@@ -77,7 +80,9 @@ pub fn delete_order(configuration: &configuration::Configuration, order_id: &str
 }
 
 /// Returns a map of status codes to quantities
-pub fn get_inventory(configuration: &configuration::Configuration, ) -> Result<::std::collections::HashMap<String, i32>, Error<GetInventoryError>> {
+pub fn get_inventory(
+    configuration: &configuration::Configuration,
+) -> Result<::std::collections::HashMap<String, i32>, Error<GetInventoryError>> {
 
     let local_var_client = &configuration.client;
 
@@ -112,7 +117,10 @@ pub fn get_inventory(configuration: &configuration::Configuration, ) -> Result<:
 }
 
 /// For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-pub fn get_order_by_id(configuration: &configuration::Configuration, order_id: i64) -> Result<crate::models::Order, Error<GetOrderByIdError>> {
+pub fn get_order_by_id(
+    configuration: &configuration::Configuration,
+    order_id: i64,
+) -> Result<crate::models::Order, Error<GetOrderByIdError>> {
 
     let local_var_client = &configuration.client;
 
@@ -138,7 +146,10 @@ pub fn get_order_by_id(configuration: &configuration::Configuration, order_id: i
     }
 }
 
-pub fn place_order(configuration: &configuration::Configuration, body: crate::models::Order) -> Result<crate::models::Order, Error<PlaceOrderError>> {
+pub fn place_order(
+    configuration: &configuration::Configuration,
+    body: crate::models::Order,
+) -> Result<crate::models::Order, Error<PlaceOrderError>> {
 
     let local_var_client = &configuration.client;
 

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/user_api.rs
@@ -84,7 +84,10 @@ pub enum UpdateUserError {
 
 
 /// This can only be done by the logged in user.
-pub fn create_user(configuration: &configuration::Configuration, body: crate::models::User) -> Result<(), Error<CreateUserError>> {
+pub fn create_user(
+    configuration: &configuration::Configuration,
+    body: crate::models::User,
+) -> Result<(), Error<CreateUserError>> {
 
     let local_var_client = &configuration.client;
 
@@ -111,7 +114,10 @@ pub fn create_user(configuration: &configuration::Configuration, body: crate::mo
     }
 }
 
-pub fn create_users_with_array_input(configuration: &configuration::Configuration, body: Vec<crate::models::User>) -> Result<(), Error<CreateUsersWithArrayInputError>> {
+pub fn create_users_with_array_input(
+    configuration: &configuration::Configuration,
+    body: Vec<crate::models::User>,
+) -> Result<(), Error<CreateUsersWithArrayInputError>> {
 
     let local_var_client = &configuration.client;
 
@@ -138,7 +144,10 @@ pub fn create_users_with_array_input(configuration: &configuration::Configuratio
     }
 }
 
-pub fn create_users_with_list_input(configuration: &configuration::Configuration, body: Vec<crate::models::User>) -> Result<(), Error<CreateUsersWithListInputError>> {
+pub fn create_users_with_list_input(
+    configuration: &configuration::Configuration,
+    body: Vec<crate::models::User>,
+) -> Result<(), Error<CreateUsersWithListInputError>> {
 
     let local_var_client = &configuration.client;
 
@@ -166,7 +175,10 @@ pub fn create_users_with_list_input(configuration: &configuration::Configuration
 }
 
 /// This can only be done by the logged in user.
-pub fn delete_user(configuration: &configuration::Configuration, username: &str) -> Result<(), Error<DeleteUserError>> {
+pub fn delete_user(
+    configuration: &configuration::Configuration,
+    username: &str,
+) -> Result<(), Error<DeleteUserError>> {
 
     let local_var_client = &configuration.client;
 
@@ -192,7 +204,10 @@ pub fn delete_user(configuration: &configuration::Configuration, username: &str)
     }
 }
 
-pub fn get_user_by_name(configuration: &configuration::Configuration, username: &str) -> Result<crate::models::User, Error<GetUserByNameError>> {
+pub fn get_user_by_name(
+    configuration: &configuration::Configuration,
+    username: &str,
+) -> Result<crate::models::User, Error<GetUserByNameError>> {
 
     let local_var_client = &configuration.client;
 
@@ -218,7 +233,11 @@ pub fn get_user_by_name(configuration: &configuration::Configuration, username: 
     }
 }
 
-pub fn login_user(configuration: &configuration::Configuration, username: &str, password: &str) -> Result<String, Error<LoginUserError>> {
+pub fn login_user(
+    configuration: &configuration::Configuration,
+    username: &str,
+    password: &str,
+) -> Result<String, Error<LoginUserError>> {
 
     let local_var_client = &configuration.client;
 
@@ -246,7 +265,9 @@ pub fn login_user(configuration: &configuration::Configuration, username: &str, 
     }
 }
 
-pub fn logout_user(configuration: &configuration::Configuration, ) -> Result<(), Error<LogoutUserError>> {
+pub fn logout_user(
+    configuration: &configuration::Configuration,
+) -> Result<(), Error<LogoutUserError>> {
 
     let local_var_client = &configuration.client;
 
@@ -273,7 +294,11 @@ pub fn logout_user(configuration: &configuration::Configuration, ) -> Result<(),
 }
 
 /// This can only be done by the logged in user.
-pub fn update_user(configuration: &configuration::Configuration, username: &str, body: crate::models::User) -> Result<(), Error<UpdateUserError>> {
+pub fn update_user(
+    configuration: &configuration::Configuration,
+    username: &str,
+    body: crate::models::User,
+) -> Result<(), Error<UpdateUserError>> {
 
     let local_var_client = &configuration.client;
 


### PR DESCRIPTION
The Rust-based reqwest client does not correctly handle a binary body
parameter today.  It creates a `PathBuf` parameter and attempts to pass
that to the `RequestBuilder` `json()` method, which sends the path itself
as the body of the request.

Instead, it would help to parameterise operations that accept a binary
body so that they may accept any object that implements the `Into<Body>`
trait.  This would allow the caller to pass a binary body in several
forms, such as a slice of bytes or a `Stream` that reads from some other
source.

Note possible related issue: #5218

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. (cc @ahl @frol @farcaller @richardwhiuk @paladinzh)