### PR TITLE
[csharp][aspnetcore] Enable Consumes Tag for Specs where not every operation consumes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -453,10 +453,10 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                 List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
                 for (CodegenOperation operation : ops) {
                     if (operation.consumes == null) {
-                        break;
+                        continue;
                     }
                     if (operation.consumes.size() == 0) {
-                        break;
+                        continue;
                     }
 
                     // Build a consumes string for the operation we cannot iterate in the template as we need a ','

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -169,6 +169,7 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="405">Validation exception</response>
         [HttpPut]
         [Route("/v2/pet")]
+        [Consumes("application/json", "application/xml")]
         [ValidateModelState]
         [SwaggerOperation("UpdatePet")]
         public virtual IActionResult UpdatePet([FromBody]Pet body)
@@ -193,6 +194,7 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="405">Invalid input</response>
         [HttpPost]
         [Route("/v2/pet/{petId}")]
+        [Consumes("application/x-www-form-urlencoded")]
         [ValidateModelState]
         [SwaggerOperation("UpdatePetWithForm")]
         public virtual IActionResult UpdatePetWithForm([FromRoute (Name = "petId")][Required]long petId, [FromForm (Name = "name")]string name, [FromForm (Name = "status")]string status)
@@ -213,10 +215,11 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="200">successful operation</response>
         [HttpPost]
         [Route("/v2/pet/{petId}/uploadImage")]
+        [Consumes("multipart/form-data")]
         [ValidateModelState]
         [SwaggerOperation("UploadFile")]
         [SwaggerResponse(statusCode: 200, type: typeof(ApiResponse), description: "successful operation")]
-        public virtual IActionResult UploadFile([FromRoute (Name = "petId")][Required]long petId, [FromForm (Name = "additionalMetadata")]string additionalMetadata, System.IO.Stream file)
+        public virtual IActionResult UploadFile([FromRoute (Name = "petId")][Required]long petId, [FromForm (Name = "additionalMetadata")]string additionalMetadata, IFormFile file)
         { 
 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -169,6 +169,7 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="405">Validation exception</response>
         [HttpPut]
         [Route("/v2/pet")]
+        [Consumes("application/json", "application/xml")]
         [ValidateModelState]
         [SwaggerOperation("UpdatePet")]
         public virtual IActionResult UpdatePet([FromBody]Pet body)
@@ -193,6 +194,7 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="405">Invalid input</response>
         [HttpPost]
         [Route("/v2/pet/{petId}")]
+        [Consumes("application/x-www-form-urlencoded")]
         [ValidateModelState]
         [SwaggerOperation("UpdatePetWithForm")]
         public virtual IActionResult UpdatePetWithForm([FromRoute (Name = "petId")][Required]long petId, [FromForm (Name = "name")]string name, [FromForm (Name = "status")]string status)
@@ -213,10 +215,11 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="200">successful operation</response>
         [HttpPost]
         [Route("/v2/pet/{petId}/uploadImage")]
+        [Consumes("multipart/form-data")]
         [ValidateModelState]
         [SwaggerOperation("UploadFile")]
         [SwaggerResponse(statusCode: 200, type: typeof(ApiResponse), description: "successful operation")]
-        public virtual IActionResult UploadFile([FromRoute (Name = "petId")][Required]long petId, [FromForm (Name = "additionalMetadata")]string additionalMetadata, System.IO.Stream file)
+        public virtual IActionResult UploadFile([FromRoute (Name = "petId")][Required]long petId, [FromForm (Name = "additionalMetadata")]string additionalMetadata, IFormFile file)
         { 
 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -181,6 +181,7 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="405">Validation exception</response>
         [HttpPut]
         [Route("/v2/pet")]
+        [Consumes("application/json", "application/xml")]
         [ValidateModelState]
         [SwaggerOperation("UpdatePet")]
         [SwaggerResponse(statusCode: 200, type: typeof(Pet), description: "successful operation")]
@@ -215,6 +216,7 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="405">Invalid input</response>
         [HttpPost]
         [Route("/v2/pet/{petId}")]
+        [Consumes("application/x-www-form-urlencoded")]
         [ValidateModelState]
         [SwaggerOperation("UpdatePetWithForm")]
         public virtual IActionResult UpdatePetWithForm([FromRoute (Name = "petId")][Required]long petId, [FromForm (Name = "name")]string name, [FromForm (Name = "status")]string status)
@@ -235,10 +237,11 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="200">successful operation</response>
         [HttpPost]
         [Route("/v2/pet/{petId}/uploadImage")]
+        [Consumes("multipart/form-data")]
         [ValidateModelState]
         [SwaggerOperation("UploadFile")]
         [SwaggerResponse(statusCode: 200, type: typeof(ApiResponse), description: "successful operation")]
-        public virtual IActionResult UploadFile([FromRoute (Name = "petId")][Required]long petId, [FromForm (Name = "additionalMetadata")]string additionalMetadata, System.IO.Stream file)
+        public virtual IActionResult UploadFile([FromRoute (Name = "petId")][Required]long petId, [FromForm (Name = "additionalMetadata")]string additionalMetadata, IFormFile file)
         { 
 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -116,6 +116,7 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="400">Invalid Order</response>
         [HttpPost]
         [Route("/v2/store/order")]
+        [Consumes("application/json")]
         [ValidateModelState]
         [SwaggerOperation("PlaceOrder")]
         [SwaggerResponse(statusCode: 200, type: typeof(Order), description: "successful operation")]

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -201,6 +201,7 @@ namespace Org.OpenAPITools.Controllers
         [HttpPut]
         [Route("/v2/user/{username}")]
         [Authorize(Policy = "api_key")]
+        [Consumes("application/json")]
         [ValidateModelState]
         [SwaggerOperation("UpdateUser")]
         public virtual IActionResult UpdateUser([FromRoute (Name = "username")][Required]string username, [FromBody]User user)

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -169,6 +169,7 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="405">Validation exception</response>
         [HttpPut]
         [Route("/v2/pet")]
+        [Consumes("application/json", "application/xml")]
         [ValidateModelState]
         [SwaggerOperation("UpdatePet")]
         public virtual IActionResult UpdatePet([FromBody]Pet body)
@@ -193,6 +194,7 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="405">Invalid input</response>
         [HttpPost]
         [Route("/v2/pet/{petId}")]
+        [Consumes("application/x-www-form-urlencoded")]
         [ValidateModelState]
         [SwaggerOperation("UpdatePetWithForm")]
         public virtual IActionResult UpdatePetWithForm([FromRoute (Name = "petId")][Required]long petId, [FromForm (Name = "name")]string name, [FromForm (Name = "status")]string status)
@@ -213,10 +215,11 @@ namespace Org.OpenAPITools.Controllers
         /// <response code="200">successful operation</response>
         [HttpPost]
         [Route("/v2/pet/{petId}/uploadImage")]
+        [Consumes("multipart/form-data")]
         [ValidateModelState]
         [SwaggerOperation("UploadFile")]
         [SwaggerResponse(statusCode: 200, type: typeof(ApiResponse), description: "successful operation")]
-        public virtual IActionResult UploadFile([FromRoute (Name = "petId")][Required]long petId, [FromForm (Name = "additionalMetadata")]string additionalMetadata, System.IO.Stream file)
+        public virtual IActionResult UploadFile([FromRoute (Name = "petId")][Required]long petId, [FromForm (Name = "additionalMetadata")]string additionalMetadata, IFormFile file)
         { 
 
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

An error in the handling of the for loops caused it to early exit in case the spec contained entries without consuming properties.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)