### PR TITLE
[Java] add jackson annotations to setters

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
@@ -233,7 +233,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{^isReadOnly}}
-  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+{{#jackson}}{{> jackson_annotations}}{{/jackson}}  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-enum-as-string}}
     if (!{{{nameInSnakeCase}}}_VALUES.contains({{name}})) {
       throw new IllegalArgumentException({{name}} + " is invalid. Possible values for {{name}}: " + String.join(", ", {{{nameInSnakeCase}}}_VALUES));

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
@@ -233,7 +233,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{^isReadOnly}}
-{{#jackson}}{{> jackson_annotations}}{{/jackson}}  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+{{#jackson}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{> jackson_annotations}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{/jackson}}  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-enum-as-string}}
     if (!{{{nameInSnakeCase}}}_VALUES.contains({{name}})) {
       throw new IllegalArgumentException({{name}} + " is invalid. Possible values for {{name}}: " + String.join(", ", {{{nameInSnakeCase}}}_VALUES));

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
@@ -236,7 +236,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{^isReadOnly}}
-{{#jackson}}{{> jackson_annotations}}{{/jackson}}  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+{{#jackson}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{> jackson_annotations}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{/jackson}}  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-enum-as-string}}
     if (!{{{nameInSnakeCase}}}_VALUES.contains({{name}})) {
       throw new IllegalArgumentException({{name}} + " is invalid. Possible values for {{name}}: " + String.join(", ", {{{nameInSnakeCase}}}_VALUES));

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
@@ -236,7 +236,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{^isReadOnly}}
-  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+{{#jackson}}{{> jackson_annotations}}{{/jackson}}  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-enum-as-string}}
     if (!{{{nameInSnakeCase}}}_VALUES.contains({{name}})) {
       throw new IllegalArgumentException({{name}} + " is invalid. Possible values for {{name}}: " + String.join(", ", {{{nameInSnakeCase}}}_VALUES));

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -219,7 +219,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{^isReadOnly}}
-  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+{{#jackson}}{{> jackson_annotations}}{{/jackson}}  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-is-jackson-optional-nullable}}
     this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});
     {{/vendorExtensions.x-is-jackson-optional-nullable}}

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -219,7 +219,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#vendorE
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{^isReadOnly}}
-{{#jackson}}{{> jackson_annotations}}{{/jackson}}  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+{{#jackson}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{> jackson_annotations}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{/jackson}}  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.x-is-jackson-optional-nullable}}
     this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});
     {{/vendorExtensions.x-is-jackson-optional-nullable}}

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -61,6 +61,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -110,6 +110,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -143,6 +145,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -176,6 +180,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -209,6 +215,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -242,6 +250,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -275,6 +285,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -308,6 +320,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -341,6 +355,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -366,6 +382,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -391,6 +409,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -416,6 +436,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -61,6 +61,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Animal.java
@@ -73,6 +73,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -98,6 +100,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -69,6 +69,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -69,6 +69,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -77,6 +77,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -110,6 +112,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -143,6 +147,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/BigCat.java
@@ -103,6 +103,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -97,6 +97,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -78,6 +78,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -103,6 +105,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -128,6 +132,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -153,6 +159,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -178,6 +186,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -203,6 +213,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Cat.java
@@ -68,6 +68,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -58,6 +58,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Category.java
@@ -62,6 +62,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -59,6 +59,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Client.java
@@ -58,6 +58,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Dog.java
@@ -64,6 +64,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -58,6 +58,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -134,6 +134,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -167,6 +169,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -219,6 +219,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -243,6 +245,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -268,6 +272,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -293,6 +299,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -318,6 +326,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -64,6 +64,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -97,6 +99,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -117,6 +117,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -144,6 +146,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -169,6 +173,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -195,6 +201,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -222,6 +230,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -249,6 +259,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -274,6 +286,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -298,6 +312,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -323,6 +339,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -347,6 +365,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -372,6 +392,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -397,6 +419,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -421,6 +445,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -446,6 +472,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/MapTest.java
@@ -116,6 +116,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -149,6 +151,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -182,6 +186,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -215,6 +221,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -72,6 +72,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -97,6 +99,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -130,6 +134,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -63,6 +63,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -88,6 +90,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -66,6 +66,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -91,6 +93,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -116,6 +120,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -59,6 +59,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Name.java
@@ -70,6 +70,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -111,6 +113,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -59,6 +59,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Order.java
@@ -116,6 +116,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -141,6 +143,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -166,6 +170,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -191,6 +197,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -216,6 +224,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -241,6 +251,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -67,6 +67,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -92,6 +94,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -117,6 +121,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Pet.java
@@ -121,6 +121,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -146,6 +148,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -170,6 +174,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -199,6 +205,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -232,6 +240,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -257,6 +267,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -78,6 +78,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -58,6 +58,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Tag.java
@@ -62,6 +62,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -87,6 +89,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -76,6 +76,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,6 +102,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -124,6 +128,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -148,6 +154,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -177,6 +185,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -80,6 +80,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -104,6 +106,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -128,6 +132,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -152,6 +158,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -176,6 +184,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -205,6 +215,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/User.java
@@ -86,6 +86,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -111,6 +113,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -136,6 +140,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -161,6 +167,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -186,6 +194,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -211,6 +221,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -236,6 +248,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -261,6 +275,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -173,6 +173,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -198,6 +200,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -223,6 +227,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -248,6 +254,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -281,6 +289,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -306,6 +316,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -331,6 +343,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -356,6 +370,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -381,6 +397,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -414,6 +432,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -447,6 +467,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -472,6 +494,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -497,6 +521,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -522,6 +548,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -547,6 +575,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -580,6 +610,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -613,6 +645,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -638,6 +672,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -663,6 +699,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -688,6 +726,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -713,6 +753,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -746,6 +788,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -779,6 +823,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -804,6 +850,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -829,6 +877,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -854,6 +904,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -879,6 +931,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -912,6 +966,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -945,6 +1001,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -109,6 +109,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,6 +144,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -175,6 +179,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -208,6 +214,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -241,6 +249,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -274,6 +284,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -307,6 +319,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -340,6 +354,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -365,6 +381,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -390,6 +408,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -415,6 +435,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
@@ -72,6 +72,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -97,6 +99,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -76,6 +76,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -109,6 +111,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -142,6 +146,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/BigCat.java
@@ -102,6 +102,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -96,6 +96,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -77,6 +77,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -102,6 +104,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -127,6 +131,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -152,6 +158,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -177,6 +185,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -202,6 +212,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Cat.java
@@ -67,6 +67,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -57,6 +57,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Category.java
@@ -61,6 +61,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -58,6 +58,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Client.java
@@ -57,6 +57,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Dog.java
@@ -63,6 +63,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -57,6 +57,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,6 +133,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -166,6 +168,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -218,6 +218,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,6 +244,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -267,6 +271,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -292,6 +298,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,6 +325,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -63,6 +63,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -96,6 +98,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -116,6 +116,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -143,6 +145,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,6 +172,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -194,6 +200,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -221,6 +229,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -248,6 +258,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -273,6 +285,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -297,6 +311,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -322,6 +338,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -346,6 +364,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -371,6 +391,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -396,6 +418,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -420,6 +444,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -445,6 +471,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
@@ -115,6 +115,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,6 +150,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -181,6 +185,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -214,6 +220,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -71,6 +71,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -96,6 +98,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -129,6 +133,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -62,6 +62,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -87,6 +89,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -65,6 +65,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -90,6 +92,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -115,6 +119,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -58,6 +58,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Name.java
@@ -69,6 +69,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,6 +112,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -58,6 +58,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
@@ -115,6 +115,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -140,6 +142,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,6 +169,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -190,6 +196,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -215,6 +223,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,6 +250,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -66,6 +66,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -91,6 +93,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -116,6 +120,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
@@ -120,6 +120,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,6 +147,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,6 +173,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -198,6 +204,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -231,6 +239,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -256,6 +266,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -77,6 +77,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -57,6 +57,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Tag.java
@@ -61,6 +61,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -75,6 +75,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -99,6 +101,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -123,6 +127,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -147,6 +153,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -176,6 +184,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -79,6 +79,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -103,6 +105,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -127,6 +131,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -151,6 +157,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,6 +183,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -204,6 +214,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/User.java
@@ -85,6 +85,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -110,6 +112,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -135,6 +139,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -160,6 +166,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -185,6 +193,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -210,6 +220,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -235,6 +247,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -260,6 +274,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -172,6 +172,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,6 +199,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -222,6 +226,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -247,6 +253,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -280,6 +288,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -305,6 +315,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -330,6 +342,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -355,6 +369,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -380,6 +396,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -413,6 +431,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -446,6 +466,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -471,6 +493,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -496,6 +520,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -521,6 +547,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -546,6 +574,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -579,6 +609,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -612,6 +644,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -637,6 +671,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -662,6 +698,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -687,6 +725,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -712,6 +752,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -745,6 +787,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -778,6 +822,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -803,6 +849,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -828,6 +876,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -853,6 +903,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -878,6 +930,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -911,6 +965,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -944,6 +1000,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -109,6 +109,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,6 +144,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -175,6 +179,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -208,6 +214,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -241,6 +249,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -274,6 +284,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -307,6 +319,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -340,6 +354,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -365,6 +381,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -390,6 +408,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -415,6 +435,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
@@ -72,6 +72,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -97,6 +99,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -76,6 +76,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -109,6 +111,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -142,6 +146,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/BigCat.java
@@ -102,6 +102,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -96,6 +96,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -77,6 +77,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -102,6 +104,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -127,6 +131,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -152,6 +158,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -177,6 +185,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -202,6 +212,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
@@ -67,6 +67,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -57,6 +57,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Category.java
@@ -61,6 +61,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -58,6 +58,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Client.java
@@ -57,6 +57,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Dog.java
@@ -63,6 +63,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -57,6 +57,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,6 +133,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -166,6 +168,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -218,6 +218,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,6 +244,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -267,6 +271,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -292,6 +298,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,6 +325,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -63,6 +63,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -96,6 +98,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -116,6 +116,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -143,6 +145,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,6 +172,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -194,6 +200,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -221,6 +229,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -248,6 +258,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -273,6 +285,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -297,6 +311,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -322,6 +338,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -346,6 +364,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -371,6 +391,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -396,6 +418,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -420,6 +444,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -445,6 +471,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
@@ -115,6 +115,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,6 +150,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -181,6 +185,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -214,6 +220,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -71,6 +71,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -96,6 +98,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -129,6 +133,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -62,6 +62,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -87,6 +89,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -65,6 +65,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -90,6 +92,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -115,6 +119,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -58,6 +58,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Name.java
@@ -69,6 +69,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,6 +112,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -58,6 +58,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
@@ -115,6 +115,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -140,6 +142,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,6 +169,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -190,6 +196,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -215,6 +223,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,6 +250,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -66,6 +66,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -91,6 +93,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -116,6 +120,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
@@ -120,6 +120,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,6 +147,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,6 +173,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -198,6 +204,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -231,6 +239,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -256,6 +266,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -77,6 +77,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -57,6 +57,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Tag.java
@@ -61,6 +61,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -75,6 +75,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -99,6 +101,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -123,6 +127,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -147,6 +153,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -176,6 +184,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -79,6 +79,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -103,6 +105,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -127,6 +131,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -151,6 +157,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,6 +183,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -204,6 +214,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/User.java
@@ -85,6 +85,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -110,6 +112,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -135,6 +139,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -160,6 +166,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -185,6 +193,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -210,6 +220,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -235,6 +247,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -260,6 +274,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -172,6 +172,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,6 +199,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -222,6 +226,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -247,6 +253,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -280,6 +288,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -305,6 +315,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -330,6 +342,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -355,6 +369,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -380,6 +396,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -413,6 +431,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -446,6 +466,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -471,6 +493,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -496,6 +520,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -521,6 +547,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -546,6 +574,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -579,6 +609,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -612,6 +644,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -637,6 +671,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -662,6 +698,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -687,6 +725,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -712,6 +752,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -745,6 +787,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -778,6 +822,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -803,6 +849,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -828,6 +876,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -853,6 +903,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -878,6 +930,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -911,6 +965,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -944,6 +1000,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -109,6 +109,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,6 +144,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -175,6 +179,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -208,6 +214,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -241,6 +249,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -274,6 +284,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -307,6 +319,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -340,6 +354,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -365,6 +381,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -390,6 +408,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -415,6 +435,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
@@ -72,6 +72,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -97,6 +99,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -76,6 +76,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -109,6 +111,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -142,6 +146,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/BigCat.java
@@ -102,6 +102,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -96,6 +96,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -77,6 +77,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -102,6 +104,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -127,6 +131,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -152,6 +158,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -177,6 +185,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -202,6 +212,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
@@ -67,6 +67,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -57,6 +57,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
@@ -61,6 +61,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -58,6 +58,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
@@ -57,6 +57,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
@@ -63,6 +63,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -57,6 +57,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,6 +133,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -166,6 +168,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -218,6 +218,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,6 +244,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -267,6 +271,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -292,6 +298,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,6 +325,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -63,6 +63,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -96,6 +98,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -116,6 +116,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -143,6 +145,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,6 +172,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -194,6 +200,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -221,6 +229,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -248,6 +258,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -273,6 +285,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -297,6 +311,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -322,6 +338,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -346,6 +364,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -371,6 +391,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -396,6 +418,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -420,6 +444,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -445,6 +471,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
@@ -115,6 +115,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,6 +150,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -181,6 +185,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -214,6 +220,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -71,6 +71,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -96,6 +98,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -129,6 +133,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -62,6 +62,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -87,6 +89,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -65,6 +65,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -90,6 +92,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -115,6 +119,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -58,6 +58,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
@@ -69,6 +69,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,6 +112,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -58,6 +58,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
@@ -115,6 +115,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -140,6 +142,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,6 +169,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -190,6 +196,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -215,6 +223,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,6 +250,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -66,6 +66,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -91,6 +93,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -116,6 +120,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
@@ -120,6 +120,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,6 +147,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,6 +173,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -198,6 +204,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -231,6 +239,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -256,6 +266,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -77,6 +77,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -57,6 +57,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
@@ -61,6 +61,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -75,6 +75,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -99,6 +101,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -123,6 +127,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -147,6 +153,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -176,6 +184,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -79,6 +79,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -103,6 +105,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -127,6 +131,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -151,6 +157,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,6 +183,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -204,6 +214,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
@@ -85,6 +85,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -110,6 +112,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -135,6 +139,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -160,6 +166,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -185,6 +193,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -210,6 +220,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -235,6 +247,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -260,6 +274,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -172,6 +172,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,6 +199,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -222,6 +226,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -247,6 +253,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -280,6 +288,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -305,6 +315,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -330,6 +342,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -355,6 +369,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -380,6 +396,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -413,6 +431,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -446,6 +466,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -471,6 +493,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -496,6 +520,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -521,6 +547,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -546,6 +574,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -579,6 +609,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -612,6 +644,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -637,6 +671,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -662,6 +698,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -687,6 +725,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -712,6 +752,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -745,6 +787,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -778,6 +822,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -803,6 +849,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -828,6 +876,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -853,6 +903,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -878,6 +930,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -911,6 +965,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -944,6 +1000,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -63,6 +63,8 @@ public class AdditionalPropertiesAnyType {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesArray {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -63,6 +63,8 @@ public class AdditionalPropertiesBoolean {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -111,6 +111,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -143,6 +145,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -175,6 +179,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,6 +213,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -239,6 +247,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -271,6 +281,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -303,6 +315,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -335,6 +349,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -359,6 +375,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -383,6 +401,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -407,6 +427,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -63,6 +63,8 @@ public class AdditionalPropertiesInteger {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesNumber {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesObject {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -63,6 +63,8 @@ public class AdditionalPropertiesString {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Animal.java
@@ -74,6 +74,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -98,6 +100,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -70,6 +70,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -70,6 +70,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -78,6 +78,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -110,6 +112,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -142,6 +146,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/BigCat.java
@@ -104,6 +104,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -98,6 +98,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -79,6 +79,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -103,6 +105,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -127,6 +131,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,6 +157,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -175,6 +183,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -199,6 +209,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Cat.java
@@ -69,6 +69,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -59,6 +59,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Category.java
@@ -63,6 +63,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -60,6 +60,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Client.java
@@ -59,6 +59,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Dog.java
@@ -65,6 +65,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -59,6 +59,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -135,6 +135,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -167,6 +169,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -220,6 +220,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -243,6 +245,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -267,6 +271,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -291,6 +297,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -315,6 +323,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -65,6 +65,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -97,6 +99,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -118,6 +118,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -144,6 +146,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,6 +172,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -193,6 +199,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -219,6 +227,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -245,6 +255,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -269,6 +281,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -292,6 +306,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -316,6 +332,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -339,6 +357,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -363,6 +383,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(LocalDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -387,6 +409,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -410,6 +434,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -434,6 +460,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/MapTest.java
@@ -117,6 +117,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -149,6 +151,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -181,6 +185,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,6 +219,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -73,6 +73,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -97,6 +99,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(LocalDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -129,6 +133,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -64,6 +64,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -88,6 +90,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -67,6 +67,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -91,6 +93,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -115,6 +119,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -60,6 +60,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Name.java
@@ -71,6 +71,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -111,6 +113,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -60,6 +60,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Order.java
@@ -117,6 +117,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -141,6 +143,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,6 +169,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,6 +195,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(LocalDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -213,6 +221,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -237,6 +247,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -68,6 +68,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -92,6 +94,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -116,6 +120,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Pet.java
@@ -122,6 +122,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -146,6 +148,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,6 +173,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -197,6 +203,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -229,6 +237,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -253,6 +263,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -79,6 +79,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -59,6 +59,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/Tag.java
@@ -63,6 +63,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -87,6 +89,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -77,6 +77,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,6 +102,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -123,6 +127,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,6 +152,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -174,6 +182,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -81,6 +81,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -104,6 +106,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -127,6 +131,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -150,6 +156,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -173,6 +181,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -201,6 +211,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/User.java
@@ -87,6 +87,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -111,6 +113,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -135,6 +139,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,6 +165,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -183,6 +191,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -207,6 +217,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -231,6 +243,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -255,6 +269,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -174,6 +174,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -198,6 +200,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -222,6 +226,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,6 +252,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -278,6 +286,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -302,6 +312,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -326,6 +338,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -350,6 +364,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -374,6 +390,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -406,6 +424,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -438,6 +458,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -462,6 +484,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -486,6 +510,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -510,6 +536,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -534,6 +562,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -566,6 +596,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -598,6 +630,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -622,6 +656,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -646,6 +682,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -670,6 +708,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -694,6 +734,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -726,6 +768,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -758,6 +802,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -782,6 +828,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -806,6 +854,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -830,6 +880,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -854,6 +906,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -886,6 +940,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -918,6 +974,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -63,6 +63,8 @@ public class AdditionalPropertiesAnyType {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesArray {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -63,6 +63,8 @@ public class AdditionalPropertiesBoolean {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -111,6 +111,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -143,6 +145,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -175,6 +179,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,6 +213,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -239,6 +247,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -271,6 +281,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -303,6 +315,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -335,6 +349,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -359,6 +375,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -383,6 +401,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -407,6 +427,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -63,6 +63,8 @@ public class AdditionalPropertiesInteger {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesNumber {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesObject {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -63,6 +63,8 @@ public class AdditionalPropertiesString {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
@@ -74,6 +74,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -98,6 +100,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -70,6 +70,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -70,6 +70,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -78,6 +78,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -110,6 +112,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -142,6 +146,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BigCat.java
@@ -104,6 +104,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -98,6 +98,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -79,6 +79,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -103,6 +105,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -127,6 +131,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,6 +157,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -175,6 +183,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -199,6 +209,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
@@ -69,6 +69,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -59,6 +59,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
@@ -63,6 +63,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -60,6 +60,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
@@ -59,6 +59,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
@@ -65,6 +65,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -59,6 +59,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -135,6 +135,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -167,6 +169,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -220,6 +220,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -243,6 +245,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -267,6 +271,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -291,6 +297,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -315,6 +323,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -65,6 +65,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -97,6 +99,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -118,6 +118,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -144,6 +146,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,6 +172,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -193,6 +199,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -219,6 +227,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -245,6 +255,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -269,6 +281,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -292,6 +306,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -316,6 +332,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -339,6 +357,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -363,6 +383,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -387,6 +409,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -410,6 +434,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -434,6 +460,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
@@ -117,6 +117,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -149,6 +151,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -181,6 +185,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,6 +219,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -73,6 +73,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -97,6 +99,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -129,6 +133,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -64,6 +64,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -88,6 +90,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -67,6 +67,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -91,6 +93,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -115,6 +119,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -60,6 +60,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
@@ -71,6 +71,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -111,6 +113,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -60,6 +60,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
@@ -117,6 +117,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -141,6 +143,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,6 +169,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,6 +195,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -213,6 +221,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -237,6 +247,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -68,6 +68,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -92,6 +94,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -116,6 +120,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
@@ -122,6 +122,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -146,6 +148,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,6 +173,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -197,6 +203,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -229,6 +237,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -253,6 +263,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -79,6 +79,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -59,6 +59,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
@@ -63,6 +63,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -87,6 +89,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -77,6 +77,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,6 +102,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -123,6 +127,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,6 +152,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -174,6 +182,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -81,6 +81,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -104,6 +106,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -127,6 +131,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -150,6 +156,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -173,6 +181,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -201,6 +211,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
@@ -87,6 +87,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -111,6 +113,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -135,6 +139,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,6 +165,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -183,6 +191,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -207,6 +217,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -231,6 +243,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -255,6 +269,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -174,6 +174,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -198,6 +200,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -222,6 +226,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,6 +252,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -278,6 +286,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -302,6 +312,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -326,6 +338,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -350,6 +364,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -374,6 +390,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -406,6 +424,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -438,6 +458,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -462,6 +484,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -486,6 +510,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -510,6 +536,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -534,6 +562,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -566,6 +596,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -598,6 +630,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -622,6 +656,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -646,6 +682,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -670,6 +708,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -694,6 +734,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -726,6 +768,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -758,6 +802,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -782,6 +828,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -806,6 +854,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -830,6 +880,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -854,6 +906,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -886,6 +940,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -918,6 +974,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -65,6 +65,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -110,6 +110,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,6 +144,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -174,6 +178,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -206,6 +212,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -238,6 +246,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -270,6 +280,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -302,6 +314,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -334,6 +348,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -358,6 +374,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -382,6 +400,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -406,6 +426,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -65,6 +65,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Animal.java
@@ -74,6 +74,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -98,6 +100,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -69,6 +69,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -69,6 +69,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -77,6 +77,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -109,6 +111,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -141,6 +145,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/BigCat.java
@@ -104,6 +104,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -97,6 +97,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -78,6 +78,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -102,6 +104,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -126,6 +130,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -150,6 +156,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -174,6 +182,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -198,6 +208,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Cat.java
@@ -69,6 +69,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -58,6 +58,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Category.java
@@ -62,6 +62,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -59,6 +59,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Client.java
@@ -58,6 +58,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Dog.java
@@ -65,6 +65,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -58,6 +58,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -134,6 +134,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -166,6 +168,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -219,6 +219,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,6 +244,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -266,6 +270,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -290,6 +296,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -314,6 +322,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -64,6 +64,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -96,6 +98,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -117,6 +117,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -143,6 +145,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -167,6 +171,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -192,6 +198,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -218,6 +226,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -244,6 +254,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -268,6 +280,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -291,6 +305,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -315,6 +331,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -338,6 +356,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -362,6 +382,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -386,6 +408,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -409,6 +433,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -433,6 +459,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/MapTest.java
@@ -116,6 +116,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,6 +150,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -180,6 +184,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -212,6 +218,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -72,6 +72,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -96,6 +98,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -128,6 +132,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -63,6 +63,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -87,6 +89,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -66,6 +66,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -90,6 +92,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -114,6 +118,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -59,6 +59,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Name.java
@@ -70,6 +70,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,6 +112,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -59,6 +59,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Order.java
@@ -116,6 +116,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -140,6 +142,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -164,6 +168,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -188,6 +194,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -212,6 +220,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -236,6 +246,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -67,6 +67,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -91,6 +93,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -115,6 +119,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Pet.java
@@ -121,6 +121,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,6 +147,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -168,6 +172,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -196,6 +202,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -228,6 +236,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -252,6 +262,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -78,6 +78,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -58,6 +58,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/Tag.java
@@ -62,6 +62,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -76,6 +76,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -99,6 +101,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -122,6 +126,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -145,6 +151,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -173,6 +181,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -80,6 +80,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -103,6 +105,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -126,6 +130,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -149,6 +155,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -172,6 +180,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -200,6 +210,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/User.java
@@ -86,6 +86,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -110,6 +112,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -134,6 +138,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -158,6 +164,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -182,6 +190,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -206,6 +216,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -230,6 +242,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -254,6 +268,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -173,6 +173,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,6 +199,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -221,6 +225,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -245,6 +251,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -277,6 +285,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -301,6 +311,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -325,6 +337,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -349,6 +363,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -373,6 +389,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -405,6 +423,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -437,6 +457,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -461,6 +483,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -485,6 +509,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -509,6 +535,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -533,6 +561,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -565,6 +595,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -597,6 +629,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -621,6 +655,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -645,6 +681,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -669,6 +707,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -693,6 +733,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -725,6 +767,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -757,6 +801,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -781,6 +827,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -805,6 +853,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -829,6 +879,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -853,6 +905,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -885,6 +939,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -917,6 +973,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -65,6 +65,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -110,6 +110,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,6 +144,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -174,6 +178,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -206,6 +212,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -238,6 +246,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -270,6 +280,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -302,6 +314,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -334,6 +348,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -358,6 +374,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -382,6 +400,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -406,6 +426,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -65,6 +65,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -64,6 +64,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Animal.java
@@ -74,6 +74,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -98,6 +100,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -69,6 +69,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -69,6 +69,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -77,6 +77,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -109,6 +111,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -141,6 +145,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/BigCat.java
@@ -104,6 +104,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -97,6 +97,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -78,6 +78,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -102,6 +104,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -126,6 +130,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -150,6 +156,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -174,6 +182,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -198,6 +208,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Cat.java
@@ -69,6 +69,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -58,6 +58,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Category.java
@@ -62,6 +62,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -59,6 +59,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Client.java
@@ -58,6 +58,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Dog.java
@@ -65,6 +65,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -58,6 +58,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -134,6 +134,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -166,6 +168,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -219,6 +219,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,6 +244,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -266,6 +270,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -290,6 +296,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -314,6 +322,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -64,6 +64,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -96,6 +98,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -117,6 +117,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -143,6 +145,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -167,6 +171,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -192,6 +198,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -218,6 +226,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -244,6 +254,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -268,6 +280,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -291,6 +305,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -315,6 +331,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -338,6 +356,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -362,6 +382,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -386,6 +408,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -409,6 +433,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -433,6 +459,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MapTest.java
@@ -116,6 +116,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,6 +150,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -180,6 +184,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -212,6 +218,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -72,6 +72,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -96,6 +98,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -128,6 +132,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -63,6 +63,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -87,6 +89,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -66,6 +66,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -90,6 +92,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -114,6 +118,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -59,6 +59,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Name.java
@@ -70,6 +70,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,6 +112,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -59,6 +59,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Order.java
@@ -116,6 +116,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -140,6 +142,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -164,6 +168,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -188,6 +194,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -212,6 +220,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -236,6 +246,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -67,6 +67,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -91,6 +93,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -115,6 +119,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pet.java
@@ -121,6 +121,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,6 +147,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -168,6 +172,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -196,6 +202,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -228,6 +236,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -252,6 +262,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -78,6 +78,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -58,6 +58,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Tag.java
@@ -62,6 +62,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -76,6 +76,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -99,6 +101,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -122,6 +126,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -145,6 +151,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -173,6 +181,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -80,6 +80,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -103,6 +105,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -126,6 +130,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -149,6 +155,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -172,6 +180,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -200,6 +210,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/User.java
@@ -86,6 +86,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -110,6 +112,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -134,6 +138,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -158,6 +164,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -182,6 +190,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -206,6 +216,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -230,6 +242,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -254,6 +268,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -173,6 +173,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,6 +199,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -221,6 +225,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -245,6 +251,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -277,6 +285,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -301,6 +311,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -325,6 +337,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -349,6 +363,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -373,6 +389,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -405,6 +423,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -437,6 +457,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -461,6 +483,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -485,6 +509,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -509,6 +535,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -533,6 +561,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -565,6 +595,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -597,6 +629,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -621,6 +655,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -645,6 +681,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -669,6 +707,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -693,6 +733,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -725,6 +767,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -757,6 +801,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -781,6 +827,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -805,6 +853,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -829,6 +879,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -853,6 +905,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -885,6 +939,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -917,6 +973,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -62,6 +62,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -63,6 +63,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -62,6 +62,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -112,6 +112,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -146,6 +148,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -179,6 +183,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -212,6 +218,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -246,6 +254,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -280,6 +290,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -314,6 +326,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -348,6 +362,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -373,6 +389,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -398,6 +416,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -423,6 +443,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -62,6 +62,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -63,6 +63,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -62,6 +62,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -62,6 +62,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Animal.java
@@ -76,6 +76,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -101,6 +103,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -72,6 +72,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -72,6 +72,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -79,6 +79,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -113,6 +115,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -147,6 +151,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/BigCat.java
@@ -105,6 +105,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -99,6 +99,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -80,6 +80,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -105,6 +107,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -130,6 +134,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -155,6 +161,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -180,6 +188,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -205,6 +215,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Cat.java
@@ -70,6 +70,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -60,6 +60,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Category.java
@@ -64,6 +64,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -89,6 +91,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -61,6 +61,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Client.java
@@ -60,6 +60,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Dog.java
@@ -66,6 +66,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -60,6 +60,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -136,6 +136,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -169,6 +171,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -221,6 +221,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -246,6 +248,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -271,6 +275,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -296,6 +302,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -322,6 +330,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -67,6 +67,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -101,6 +103,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -119,6 +119,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -146,6 +148,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -171,6 +175,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -199,6 +205,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -226,6 +234,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -253,6 +263,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -278,6 +290,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -303,6 +317,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -329,6 +345,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -355,6 +373,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -381,6 +401,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -407,6 +429,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -432,6 +456,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -458,6 +484,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/MapTest.java
@@ -119,6 +119,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -152,6 +154,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -185,6 +189,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -218,6 +224,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -75,6 +75,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -101,6 +103,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -135,6 +139,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -65,6 +65,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -90,6 +92,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -68,6 +68,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -93,6 +95,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -118,6 +122,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -61,6 +61,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Name.java
@@ -73,6 +73,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -114,6 +116,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -62,6 +62,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Order.java
@@ -118,6 +118,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -143,6 +145,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -168,6 +172,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -194,6 +200,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -219,6 +227,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -244,6 +254,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -70,6 +70,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -95,6 +97,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -120,6 +124,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Pet.java
@@ -123,6 +123,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -149,6 +151,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -174,6 +178,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -204,6 +210,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -238,6 +246,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -263,6 +273,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -80,6 +80,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -60,6 +60,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Tag.java
@@ -64,6 +64,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -89,6 +91,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -79,6 +79,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -105,6 +107,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -130,6 +134,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -155,6 +161,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -185,6 +193,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -83,6 +83,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -109,6 +111,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -134,6 +138,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -159,6 +165,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -184,6 +192,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -214,6 +224,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/User.java
@@ -88,6 +88,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -113,6 +115,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -138,6 +142,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -163,6 +169,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -188,6 +196,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -213,6 +223,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -238,6 +250,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -263,6 +277,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -175,6 +175,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -201,6 +203,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -226,6 +230,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -251,6 +257,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -284,6 +292,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -309,6 +319,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -335,6 +347,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -360,6 +374,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -385,6 +401,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -418,6 +436,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -451,6 +471,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -476,6 +498,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -502,6 +526,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -527,6 +553,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -552,6 +580,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -585,6 +615,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -618,6 +650,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -643,6 +677,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -669,6 +705,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -694,6 +732,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -719,6 +759,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -752,6 +794,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -785,6 +829,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -810,6 +856,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -836,6 +884,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -861,6 +911,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -886,6 +938,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -919,6 +973,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -952,6 +1008,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -109,6 +109,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,6 +144,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -175,6 +179,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -208,6 +214,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -241,6 +249,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -274,6 +284,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -307,6 +319,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -340,6 +354,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -365,6 +381,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -390,6 +408,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -415,6 +435,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
@@ -72,6 +72,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -97,6 +99,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -76,6 +76,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -109,6 +111,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -142,6 +146,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/BigCat.java
@@ -102,6 +102,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -96,6 +96,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -77,6 +77,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -102,6 +104,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -127,6 +131,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -152,6 +158,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -177,6 +185,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -202,6 +212,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
@@ -67,6 +67,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -57,6 +57,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Category.java
@@ -61,6 +61,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -58,6 +58,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Client.java
@@ -57,6 +57,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Dog.java
@@ -63,6 +63,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -57,6 +57,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,6 +133,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -166,6 +168,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -218,6 +218,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,6 +244,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -267,6 +271,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -292,6 +298,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,6 +325,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -63,6 +63,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -96,6 +98,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -116,6 +116,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -143,6 +145,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,6 +172,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -194,6 +200,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -221,6 +229,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -248,6 +258,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -273,6 +285,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -297,6 +311,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -322,6 +338,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -346,6 +364,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -371,6 +391,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -396,6 +418,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -420,6 +444,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -445,6 +471,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
@@ -115,6 +115,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,6 +150,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -181,6 +185,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -214,6 +220,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -71,6 +71,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -96,6 +98,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -129,6 +133,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -62,6 +62,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -87,6 +89,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -65,6 +65,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -90,6 +92,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -115,6 +119,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -58,6 +58,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Name.java
@@ -69,6 +69,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,6 +112,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -58,6 +58,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
@@ -115,6 +115,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -140,6 +142,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,6 +169,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -190,6 +196,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -215,6 +223,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,6 +250,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -66,6 +66,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -91,6 +93,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -116,6 +120,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
@@ -120,6 +120,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,6 +147,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,6 +173,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -198,6 +204,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -231,6 +239,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -256,6 +266,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -77,6 +77,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -57,6 +57,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Tag.java
@@ -61,6 +61,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -75,6 +75,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -99,6 +101,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -123,6 +127,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -147,6 +153,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -176,6 +184,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -79,6 +79,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -103,6 +105,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -127,6 +131,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -151,6 +157,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,6 +183,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -204,6 +214,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/User.java
@@ -85,6 +85,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -110,6 +112,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -135,6 +139,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -160,6 +166,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -185,6 +193,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -210,6 +220,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -235,6 +247,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -260,6 +274,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -172,6 +172,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,6 +199,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -222,6 +226,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -247,6 +253,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -280,6 +288,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -305,6 +315,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -330,6 +342,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -355,6 +369,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -380,6 +396,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -413,6 +431,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -446,6 +466,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -471,6 +493,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -496,6 +520,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -521,6 +547,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -546,6 +574,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -579,6 +609,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -612,6 +644,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -637,6 +671,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -662,6 +698,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -687,6 +725,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -712,6 +752,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -745,6 +787,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -778,6 +822,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -803,6 +849,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -828,6 +876,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -853,6 +903,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -878,6 +930,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -911,6 +965,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -944,6 +1000,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -66,6 +66,9 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -67,6 +67,9 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -66,6 +66,9 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -149,6 +149,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -182,6 +184,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -215,6 +219,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -248,6 +254,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -281,6 +289,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -314,6 +324,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -347,6 +359,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -380,6 +394,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -406,6 +422,9 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "anytype_1")
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -432,6 +451,9 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "anytype_2")
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -458,6 +480,9 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "anytype_3")
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -66,6 +66,9 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -67,6 +67,9 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -66,6 +66,9 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -66,6 +66,9 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
@@ -80,6 +80,9 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "className")
   public void setClassName(String className) {
     this.className = className;
   }
@@ -106,6 +109,9 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "color")
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -77,6 +77,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -77,6 +77,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -93,6 +93,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -126,6 +128,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -159,6 +163,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/BigCat.java
@@ -115,6 +115,9 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "kind")
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -109,6 +109,9 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "kind")
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -89,6 +89,9 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "smallCamel")
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -115,6 +118,9 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "CapitalCamel")
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -141,6 +147,9 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "small_Snake")
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -167,6 +176,9 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "Capital_Snake")
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -193,6 +205,9 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "SCA_ETH_Flow_Points")
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -219,6 +234,9 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "ATT_NAME")
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
@@ -74,6 +74,9 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "declawed")
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -64,6 +64,9 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "declawed")
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
@@ -69,6 +69,9 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "id")
   public void setId(Long id) {
     this.id = id;
   }
@@ -94,6 +97,9 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -65,6 +65,9 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "_class")
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
@@ -64,6 +64,9 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "client")
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
@@ -70,6 +70,9 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "breed")
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -64,6 +64,9 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "breed")
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -152,6 +152,9 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "just_symbol")
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -185,6 +188,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -247,6 +247,9 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "enum_string")
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -272,6 +275,9 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "enum_string_required")
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -298,6 +304,9 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "enum_integer")
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -324,6 +333,9 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "enum_number")
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -350,6 +362,9 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "outerEnum")
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -74,6 +74,9 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "file")
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -107,6 +110,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -136,6 +136,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "integer")
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -164,6 +167,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "int32")
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -190,6 +196,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "int64")
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -217,6 +226,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "number")
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -245,6 +257,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "float")
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -273,6 +288,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "double")
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -299,6 +317,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "string")
   public void setString(String string) {
     this.string = string;
   }
@@ -324,6 +345,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "byte")
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -350,6 +374,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "binary")
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -375,6 +402,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "date")
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -401,6 +431,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "dateTime")
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -427,6 +460,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "uuid")
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -452,6 +488,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -478,6 +517,9 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "BigDecimal")
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
@@ -140,6 +140,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -173,6 +175,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -206,6 +210,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -239,6 +245,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -83,6 +83,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "uuid")
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -109,6 +112,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "dateTime")
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -142,6 +148,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -70,6 +70,9 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -96,6 +99,9 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "class")
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -74,6 +74,9 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "code")
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -100,6 +103,9 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "type")
   public void setType(String type) {
     this.type = type;
   }
@@ -126,6 +132,9 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "message")
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -65,6 +65,9 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "return")
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
@@ -79,6 +79,9 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "name")
   public void setName(Integer name) {
     this.name = name;
   }
@@ -122,6 +125,9 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "property")
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -65,6 +65,9 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "JustNumber")
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
@@ -132,6 +132,9 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "id")
   public void setId(Long id) {
     this.id = id;
   }
@@ -158,6 +161,9 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "petId")
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -184,6 +190,9 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "quantity")
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -210,6 +219,9 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "shipDate")
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -236,6 +248,9 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "status")
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -262,6 +277,9 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "complete")
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -75,6 +75,9 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "my_number")
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -101,6 +104,9 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "my_string")
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -127,6 +133,9 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "my_boolean")
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
@@ -145,6 +145,9 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "id")
   public void setId(Long id) {
     this.id = id;
   }
@@ -171,6 +174,9 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "category")
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -196,6 +202,9 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }
@@ -227,6 +236,10 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  // items.xmlName=
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "photoUrls")
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -262,6 +275,10 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "tags")
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -288,6 +305,9 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "status")
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -86,6 +86,9 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "baz")
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -64,6 +64,9 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "$special[property.name]")
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
@@ -69,6 +69,9 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "id")
   public void setId(Long id) {
     this.id = id;
   }
@@ -95,6 +98,9 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -89,6 +89,9 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -114,6 +117,9 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -139,6 +145,9 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -164,6 +173,9 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -193,6 +205,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -94,6 +94,9 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "string_item")
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -119,6 +122,9 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "number_item")
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -144,6 +150,9 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "float_item")
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -169,6 +178,9 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "integer_item")
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -194,6 +206,9 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "bool_item")
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -223,6 +238,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
@@ -99,6 +99,9 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "id")
   public void setId(Long id) {
     this.id = id;
   }
@@ -125,6 +128,9 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "username")
   public void setUsername(String username) {
     this.username = username;
   }
@@ -151,6 +157,9 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "firstName")
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -177,6 +186,9 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "lastName")
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -203,6 +215,9 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "email")
   public void setEmail(String email) {
     this.email = email;
   }
@@ -229,6 +244,9 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "password")
   public void setPassword(String password) {
     this.password = password;
   }
@@ -255,6 +273,9 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "phone")
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -281,6 +302,9 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "userStatus")
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -239,6 +239,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(isAttribute = true, localName = "attribute_string")
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -265,6 +268,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(isAttribute = true, localName = "attribute_number")
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -291,6 +297,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(isAttribute = true, localName = "attribute_integer")
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -317,6 +326,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(isAttribute = true, localName = "attribute_boolean")
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -352,6 +364,10 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "wrappedArray")
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -378,6 +394,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "xml_name_string")
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -404,6 +423,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "xml_name_number")
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -430,6 +452,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "xml_name_integer")
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -456,6 +481,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "xml_name_boolean")
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -489,6 +517,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -524,6 +554,10 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=xml_name_wrapped_array_item
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "xml_name_wrapped_array_item")
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -550,6 +584,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "prefix_string")
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -576,6 +613,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "prefix_number")
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -602,6 +642,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "prefix_integer")
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -628,6 +671,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "prefix_boolean")
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -661,6 +707,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -696,6 +744,10 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "prefixWrappedArray")
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -722,6 +774,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://a.com/schema", localName = "namespace_string")
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -748,6 +803,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://b.com/schema", localName = "namespace_number")
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -774,6 +832,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://c.com/schema", localName = "namespace_integer")
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -800,6 +861,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://d.com/schema", localName = "namespace_boolean")
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -833,6 +897,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -868,6 +934,10 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlElementWrapper(useWrapping = true, namespace="http://f.com/schema", localName = "namespaceWrappedArray")
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -894,6 +964,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://a.com/schema", localName = "prefix_ns_string")
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -920,6 +993,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://b.com/schema", localName = "prefix_ns_number")
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -946,6 +1022,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://c.com/schema", localName = "prefix_ns_integer")
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -972,6 +1051,9 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://d.com/schema", localName = "prefix_ns_boolean")
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -1005,6 +1087,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -1040,6 +1124,10 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlElementWrapper(useWrapping = true, namespace="http://f.com/schema", localName = "prefixNsWrappedArray")
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -109,6 +109,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,6 +144,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -175,6 +179,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -208,6 +214,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -241,6 +249,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -274,6 +284,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -307,6 +319,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -340,6 +354,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -365,6 +381,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -390,6 +408,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -415,6 +435,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
@@ -72,6 +72,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -97,6 +99,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -76,6 +76,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -109,6 +111,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -142,6 +146,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/BigCat.java
@@ -102,6 +102,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -96,6 +96,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -77,6 +77,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -102,6 +104,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -127,6 +131,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -152,6 +158,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -177,6 +185,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -202,6 +212,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
@@ -67,6 +67,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -57,6 +57,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
@@ -61,6 +61,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -58,6 +58,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
@@ -57,6 +57,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
@@ -63,6 +63,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -57,6 +57,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,6 +133,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -166,6 +168,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -218,6 +218,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,6 +244,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -267,6 +271,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -292,6 +298,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,6 +325,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -63,6 +63,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -96,6 +98,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -116,6 +116,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -143,6 +145,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,6 +172,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -194,6 +200,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -221,6 +229,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -248,6 +258,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -273,6 +285,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -297,6 +311,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -322,6 +338,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -346,6 +364,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -371,6 +391,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -396,6 +418,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -420,6 +444,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -445,6 +471,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
@@ -115,6 +115,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,6 +150,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -181,6 +185,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -214,6 +220,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -71,6 +71,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -96,6 +98,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -129,6 +133,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -62,6 +62,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -87,6 +89,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -65,6 +65,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -90,6 +92,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -115,6 +119,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -58,6 +58,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
@@ -69,6 +69,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,6 +112,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -58,6 +58,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
@@ -115,6 +115,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -140,6 +142,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,6 +169,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -190,6 +196,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -215,6 +223,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,6 +250,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -66,6 +66,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -91,6 +93,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -116,6 +120,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
@@ -120,6 +120,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,6 +147,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,6 +173,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -198,6 +204,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -231,6 +239,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -256,6 +266,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -77,6 +77,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -57,6 +57,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
@@ -61,6 +61,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -75,6 +75,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -99,6 +101,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -123,6 +127,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -147,6 +153,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -176,6 +184,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -79,6 +79,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -103,6 +105,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -127,6 +131,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -151,6 +157,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,6 +183,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -204,6 +214,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
@@ -85,6 +85,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -110,6 +112,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -135,6 +139,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -160,6 +166,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -185,6 +193,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -210,6 +220,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -235,6 +247,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -260,6 +274,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -172,6 +172,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,6 +199,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -222,6 +226,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -247,6 +253,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -280,6 +288,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -305,6 +315,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -330,6 +342,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -355,6 +369,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -380,6 +396,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -413,6 +431,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -446,6 +466,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -471,6 +493,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -496,6 +520,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -521,6 +547,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -546,6 +574,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -579,6 +609,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -612,6 +644,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -637,6 +671,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -662,6 +698,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -687,6 +725,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -712,6 +752,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -745,6 +787,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -778,6 +822,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -803,6 +849,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -828,6 +876,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -853,6 +903,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -878,6 +930,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -911,6 +965,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -944,6 +1000,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -61,6 +61,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -62,6 +62,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -61,6 +61,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -111,6 +111,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -145,6 +147,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -178,6 +182,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -211,6 +217,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -245,6 +253,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -279,6 +289,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -313,6 +325,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -347,6 +361,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -372,6 +388,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -397,6 +415,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -422,6 +442,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -61,6 +61,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -62,6 +62,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -61,6 +61,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -61,6 +61,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Animal.java
@@ -75,6 +75,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -100,6 +102,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -71,6 +71,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -71,6 +71,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -78,6 +78,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -112,6 +114,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -146,6 +150,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/BigCat.java
@@ -104,6 +104,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -98,6 +98,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -79,6 +79,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -104,6 +106,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -129,6 +133,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -154,6 +160,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -179,6 +187,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -204,6 +214,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Cat.java
@@ -69,6 +69,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -59,6 +59,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Category.java
@@ -63,6 +63,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -88,6 +90,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -60,6 +60,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Client.java
@@ -59,6 +59,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Dog.java
@@ -65,6 +65,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -59,6 +59,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -135,6 +135,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -168,6 +170,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -220,6 +220,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -245,6 +247,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -270,6 +274,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -295,6 +301,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -321,6 +329,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -66,6 +66,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -100,6 +102,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -118,6 +118,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -145,6 +147,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -170,6 +174,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -198,6 +204,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -225,6 +233,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -252,6 +262,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,6 +289,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -302,6 +316,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -328,6 +344,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -354,6 +372,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -380,6 +400,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -406,6 +428,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -431,6 +455,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -457,6 +483,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MapTest.java
@@ -118,6 +118,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -151,6 +153,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -184,6 +188,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -217,6 +223,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -74,6 +74,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -100,6 +102,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -134,6 +138,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -64,6 +64,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -89,6 +91,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -67,6 +67,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -92,6 +94,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -117,6 +121,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -60,6 +60,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Name.java
@@ -72,6 +72,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -113,6 +115,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -61,6 +61,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Order.java
@@ -117,6 +117,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -142,6 +144,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -167,6 +171,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -193,6 +199,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -218,6 +226,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -243,6 +253,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -69,6 +69,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -94,6 +96,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -119,6 +123,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Pet.java
@@ -122,6 +122,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -148,6 +150,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -173,6 +177,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -203,6 +209,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -237,6 +245,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -262,6 +272,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -79,6 +79,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -59,6 +59,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Tag.java
@@ -63,6 +63,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -88,6 +90,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -78,6 +78,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -104,6 +106,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -129,6 +133,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -154,6 +160,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -184,6 +192,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -82,6 +82,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -108,6 +110,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -133,6 +137,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -158,6 +164,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -183,6 +191,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -213,6 +223,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/User.java
@@ -87,6 +87,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -112,6 +114,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -137,6 +141,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -162,6 +168,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -187,6 +195,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -212,6 +222,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -237,6 +249,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -262,6 +276,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -174,6 +174,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -200,6 +202,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -225,6 +229,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -250,6 +256,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -283,6 +291,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -308,6 +318,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -334,6 +346,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -359,6 +373,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -384,6 +400,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -417,6 +435,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -450,6 +470,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -475,6 +497,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -501,6 +525,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -526,6 +552,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -551,6 +579,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -584,6 +614,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -617,6 +649,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -642,6 +676,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -668,6 +704,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -693,6 +731,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -718,6 +758,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -751,6 +793,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -784,6 +828,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -809,6 +855,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -835,6 +883,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -860,6 +910,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -885,6 +937,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -918,6 +972,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -951,6 +1007,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -109,6 +109,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,6 +144,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -175,6 +179,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -208,6 +214,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -241,6 +249,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -274,6 +284,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -307,6 +319,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -340,6 +354,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -365,6 +381,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -390,6 +408,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -415,6 +435,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Animal.java
@@ -72,6 +72,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -97,6 +99,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -76,6 +76,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -109,6 +111,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -142,6 +146,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/BigCat.java
@@ -102,6 +102,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -96,6 +96,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -77,6 +77,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -102,6 +104,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -127,6 +131,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -152,6 +158,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -177,6 +185,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -202,6 +212,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Cat.java
@@ -67,6 +67,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -57,6 +57,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Category.java
@@ -61,6 +61,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -58,6 +58,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Client.java
@@ -57,6 +57,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Dog.java
@@ -63,6 +63,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -57,6 +57,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,6 +133,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -166,6 +168,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -218,6 +218,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,6 +244,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -267,6 +271,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -292,6 +298,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,6 +325,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -63,6 +63,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -96,6 +98,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -116,6 +116,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -143,6 +145,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,6 +172,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -194,6 +200,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -221,6 +229,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -248,6 +258,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -273,6 +285,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -297,6 +311,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -322,6 +338,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(AsyncFile binary) {
     this.binary = binary;
   }
@@ -346,6 +364,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -371,6 +391,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -396,6 +418,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -420,6 +444,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -445,6 +471,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/MapTest.java
@@ -115,6 +115,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,6 +150,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -181,6 +185,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -214,6 +220,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -71,6 +71,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -96,6 +98,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -129,6 +133,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -62,6 +62,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -87,6 +89,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -65,6 +65,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -90,6 +92,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -115,6 +119,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -58,6 +58,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Name.java
@@ -69,6 +69,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,6 +112,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -58,6 +58,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Order.java
@@ -115,6 +115,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -140,6 +142,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,6 +169,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -190,6 +196,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -215,6 +223,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,6 +250,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -66,6 +66,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -91,6 +93,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -116,6 +120,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Pet.java
@@ -120,6 +120,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,6 +147,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,6 +173,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -198,6 +204,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -231,6 +239,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -256,6 +266,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -77,6 +77,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -57,6 +57,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Tag.java
@@ -61,6 +61,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -75,6 +75,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -99,6 +101,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -123,6 +127,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -147,6 +153,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -176,6 +184,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -79,6 +79,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -103,6 +105,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -127,6 +131,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -151,6 +157,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,6 +183,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -204,6 +214,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/User.java
@@ -85,6 +85,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -110,6 +112,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -135,6 +139,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -160,6 +166,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -185,6 +193,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -210,6 +220,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -235,6 +247,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -260,6 +274,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -172,6 +172,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,6 +199,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -222,6 +226,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -247,6 +253,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -280,6 +288,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -305,6 +315,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -330,6 +342,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -355,6 +369,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -380,6 +396,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -413,6 +431,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -446,6 +466,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -471,6 +493,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -496,6 +520,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -521,6 +547,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -546,6 +574,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -579,6 +609,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -612,6 +644,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -637,6 +671,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -662,6 +698,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -687,6 +725,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -712,6 +752,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -745,6 +787,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -778,6 +822,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -803,6 +849,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -828,6 +876,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -853,6 +903,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -878,6 +930,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -911,6 +965,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -944,6 +1000,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -109,6 +109,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,6 +144,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -175,6 +179,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -208,6 +214,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -241,6 +249,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -274,6 +284,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -307,6 +319,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -340,6 +354,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -365,6 +381,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -390,6 +408,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -415,6 +435,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
@@ -72,6 +72,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -97,6 +99,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -76,6 +76,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -109,6 +111,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -142,6 +146,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/BigCat.java
@@ -102,6 +102,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -96,6 +96,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -77,6 +77,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -102,6 +104,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -127,6 +131,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -152,6 +158,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -177,6 +185,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -202,6 +212,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
@@ -67,6 +67,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -57,6 +57,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Category.java
@@ -61,6 +61,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -58,6 +58,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Client.java
@@ -57,6 +57,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Dog.java
@@ -63,6 +63,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -57,6 +57,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,6 +133,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -166,6 +168,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -218,6 +218,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,6 +244,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -267,6 +271,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -292,6 +298,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,6 +325,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -63,6 +63,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -96,6 +98,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -116,6 +116,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -143,6 +145,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,6 +172,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -194,6 +200,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -221,6 +229,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -248,6 +258,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -273,6 +285,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -297,6 +311,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -322,6 +338,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(AsyncFile binary) {
     this.binary = binary;
   }
@@ -346,6 +364,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -371,6 +391,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -396,6 +418,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -420,6 +444,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -445,6 +471,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
@@ -115,6 +115,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,6 +150,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -181,6 +185,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -214,6 +220,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -71,6 +71,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -96,6 +98,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -129,6 +133,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -62,6 +62,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -87,6 +89,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -65,6 +65,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -90,6 +92,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -115,6 +119,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -58,6 +58,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Name.java
@@ -69,6 +69,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,6 +112,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -58,6 +58,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
@@ -115,6 +115,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -140,6 +142,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,6 +169,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -190,6 +196,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -215,6 +223,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,6 +250,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -66,6 +66,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -91,6 +93,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -116,6 +120,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
@@ -120,6 +120,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,6 +147,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,6 +173,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -198,6 +204,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -231,6 +239,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -256,6 +266,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -77,6 +77,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -57,6 +57,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Tag.java
@@ -61,6 +61,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -75,6 +75,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -99,6 +101,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -123,6 +127,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -147,6 +153,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -176,6 +184,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -79,6 +79,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -103,6 +105,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -127,6 +131,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -151,6 +157,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,6 +183,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -204,6 +214,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/User.java
@@ -85,6 +85,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -110,6 +112,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -135,6 +139,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -160,6 +166,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -185,6 +193,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -210,6 +220,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -235,6 +247,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -260,6 +274,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -172,6 +172,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,6 +199,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -222,6 +226,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -247,6 +253,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -280,6 +288,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -305,6 +315,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -330,6 +342,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -355,6 +369,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -380,6 +396,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -413,6 +431,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -446,6 +466,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -471,6 +493,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -496,6 +520,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -521,6 +547,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -546,6 +574,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -579,6 +609,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -612,6 +644,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -637,6 +671,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -662,6 +698,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -687,6 +725,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -712,6 +752,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -745,6 +787,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -778,6 +822,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -803,6 +849,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -828,6 +876,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -853,6 +903,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -878,6 +930,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -911,6 +965,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -944,6 +1000,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -109,6 +109,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,6 +144,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
@@ -175,6 +179,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -208,6 +214,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
@@ -241,6 +249,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -274,6 +284,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
@@ -307,6 +319,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -340,6 +354,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -365,6 +381,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
@@ -390,6 +408,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -415,6 +435,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -60,6 +60,8 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -59,6 +59,8 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
@@ -72,6 +72,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -97,6 +99,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -68,6 +68,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -76,6 +76,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -109,6 +111,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -142,6 +146,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/BigCat.java
@@ -102,6 +102,8 @@ public class BigCat extends Cat {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -96,6 +96,8 @@ public class BigCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_KIND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setKind(KindEnum kind) {
     this.kind = kind;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -77,6 +77,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -102,6 +104,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -127,6 +131,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -152,6 +158,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -177,6 +185,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -202,6 +212,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Cat.java
@@ -67,6 +67,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -57,6 +57,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Category.java
@@ -61,6 +61,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -58,6 +58,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Client.java
@@ -57,6 +57,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Dog.java
@@ -63,6 +63,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -57,6 +57,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,6 +133,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -166,6 +168,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -218,6 +218,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,6 +244,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -267,6 +271,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -292,6 +298,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,6 +325,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -63,6 +63,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -96,6 +98,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -116,6 +116,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -143,6 +145,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,6 +172,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -194,6 +200,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -221,6 +229,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -248,6 +258,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -273,6 +285,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -297,6 +311,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -322,6 +338,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -346,6 +364,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -371,6 +391,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -396,6 +418,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -420,6 +444,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -445,6 +471,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBigDecimal(BigDecimal bigDecimal) {
     this.bigDecimal = bigDecimal;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
@@ -115,6 +115,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,6 +150,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -181,6 +185,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -214,6 +220,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -71,6 +71,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -96,6 +98,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -129,6 +133,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -62,6 +62,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -87,6 +89,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -65,6 +65,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -90,6 +92,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -115,6 +119,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -58,6 +58,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Name.java
@@ -69,6 +69,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,6 +112,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -58,6 +58,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
@@ -115,6 +115,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -140,6 +142,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,6 +169,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -190,6 +196,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -215,6 +223,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,6 +250,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -66,6 +66,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -91,6 +93,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -116,6 +120,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
@@ -120,6 +120,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,6 +147,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,6 +173,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -198,6 +204,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(Set<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -231,6 +239,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -256,6 +266,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -77,6 +77,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -57,6 +57,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Tag.java
@@ -61,6 +61,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -75,6 +75,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -99,6 +101,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -123,6 +127,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -147,6 +153,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -176,6 +184,8 @@ public class TypeHolderDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -79,6 +79,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -103,6 +105,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
@@ -127,6 +131,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -151,6 +157,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,6 +183,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
@@ -204,6 +214,8 @@ public class TypeHolderExample {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/User.java
@@ -85,6 +85,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -110,6 +112,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -135,6 +139,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -160,6 +166,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -185,6 +193,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -210,6 +220,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -235,6 +247,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -260,6 +274,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -172,6 +172,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,6 +199,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
@@ -222,6 +226,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -247,6 +253,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
@@ -280,6 +288,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -305,6 +315,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
@@ -330,6 +342,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -355,6 +369,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -380,6 +396,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
@@ -413,6 +431,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -446,6 +466,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -471,6 +493,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
@@ -496,6 +520,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -521,6 +547,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -546,6 +574,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
@@ -579,6 +609,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -612,6 +644,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -637,6 +671,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
@@ -662,6 +698,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -687,6 +725,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -712,6 +752,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
@@ -745,6 +787,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -778,6 +822,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -803,6 +849,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
@@ -828,6 +876,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -853,6 +903,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -878,6 +930,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
@@ -911,6 +965,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -944,6 +1000,8 @@ public class XmlItem {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/ChildSchema.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/ChildSchema.java
@@ -70,6 +70,8 @@ public class ChildSchema extends Parent {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROP1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProp1(String prop1) {
     this.prop1 = prop1;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/ChildSchemaAllOf.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/ChildSchemaAllOf.java
@@ -59,6 +59,8 @@ public class ChildSchemaAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROP1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProp1(String prop1) {
     this.prop1 = prop1;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/MySchemaNameCharacters.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/MySchemaNameCharacters.java
@@ -71,6 +71,8 @@ public class MySchemaNameCharacters extends Parent {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROP2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProp2(String prop2) {
     this.prop2 = prop2;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/MySchemaNameCharactersAllOf.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/MySchemaNameCharactersAllOf.java
@@ -59,6 +59,8 @@ public class MySchemaNameCharactersAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROP2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProp2(String prop2) {
     this.prop2 = prop2;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/Parent.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/model/Parent.java
@@ -69,6 +69,8 @@ public class Parent {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OBJECT_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectType(String objectType) {
     this.objectType = objectType;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -101,6 +101,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapProperty(Map<String, String> mapProperty) {
     this.mapProperty = mapProperty;
   }
@@ -133,6 +135,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_MAP_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfMapProperty(Map<String, Map<String, String>> mapOfMapProperty) {
     this.mapOfMapProperty = mapOfMapProperty;
   }
@@ -167,6 +171,8 @@ public class AdditionalPropertiesClass {
     this.anytype1 = anytype1;
   }
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = JsonNullable.<Object>of(anytype1);
   }
@@ -191,6 +197,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapWithUndeclaredPropertiesAnytype1(Object mapWithUndeclaredPropertiesAnytype1) {
     this.mapWithUndeclaredPropertiesAnytype1 = mapWithUndeclaredPropertiesAnytype1;
   }
@@ -215,6 +223,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapWithUndeclaredPropertiesAnytype2(Object mapWithUndeclaredPropertiesAnytype2) {
     this.mapWithUndeclaredPropertiesAnytype2 = mapWithUndeclaredPropertiesAnytype2;
   }
@@ -247,6 +257,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_ANYTYPE3)
+  @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapWithUndeclaredPropertiesAnytype3(Map<String, Object> mapWithUndeclaredPropertiesAnytype3) {
     this.mapWithUndeclaredPropertiesAnytype3 = mapWithUndeclaredPropertiesAnytype3;
   }
@@ -271,6 +283,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMPTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmptyMap(Object emptyMap) {
     this.emptyMap = emptyMap;
   }
@@ -303,6 +317,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapWithUndeclaredPropertiesString(Map<String, String> mapWithUndeclaredPropertiesString) {
     this.mapWithUndeclaredPropertiesString = mapWithUndeclaredPropertiesString;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -171,8 +171,6 @@ public class AdditionalPropertiesClass {
     this.anytype1 = anytype1;
   }
 
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = JsonNullable.<Object>of(anytype1);
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
@@ -72,6 +72,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -96,6 +98,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Apple.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Apple.java
@@ -63,6 +63,8 @@ public class Apple {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CULTIVAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCultivar(String cultivar) {
     this.cultivar = cultivar;
   }
@@ -87,6 +89,8 @@ public class Apple {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ORIGIN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOrigin(String origin) {
     this.origin = origin;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AppleReq.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AppleReq.java
@@ -62,6 +62,8 @@ public class AppleReq {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CULTIVAR)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setCultivar(String cultivar) {
     this.cultivar = cultivar;
   }
@@ -86,6 +88,8 @@ public class AppleReq {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MEALY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMealy(Boolean mealy) {
     this.mealy = mealy;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -70,6 +70,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -70,6 +70,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -78,6 +78,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -110,6 +112,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -142,6 +146,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Banana.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Banana.java
@@ -60,6 +60,8 @@ public class Banana {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LENGTH_CM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLengthCm(BigDecimal lengthCm) {
     this.lengthCm = lengthCm;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BananaReq.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BananaReq.java
@@ -63,6 +63,8 @@ public class BananaReq {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LENGTH_CM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setLengthCm(BigDecimal lengthCm) {
     this.lengthCm = lengthCm;
   }
@@ -87,6 +89,8 @@ public class BananaReq {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SWEET)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSweet(Boolean sweet) {
     this.sweet = sweet;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BasquePig.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/BasquePig.java
@@ -58,6 +58,8 @@ public class BasquePig {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -79,6 +79,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -103,6 +105,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -127,6 +131,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,6 +157,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -175,6 +183,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -199,6 +209,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
@@ -69,6 +69,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -59,6 +59,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
@@ -63,6 +63,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCat.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCat.java
@@ -75,6 +75,8 @@ public class ChildCat extends ParentPet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }
@@ -106,6 +108,8 @@ public class ChildCat extends ParentPet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPetType(String petType) {
     if (!PET_TYPE_VALUES.contains(petType)) {
       throw new IllegalArgumentException(petType + " is invalid. Possible values for petType: " + String.join(", ", PET_TYPE_VALUES));

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCatAllOf.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ChildCatAllOf.java
@@ -65,6 +65,8 @@ public class ChildCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }
@@ -97,6 +99,8 @@ public class ChildCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetType(String petType) {
     if (!PET_TYPE_VALUES.contains(petType)) {
       throw new IllegalArgumentException(petType + " is invalid. Possible values for petType: " + String.join(", ", PET_TYPE_VALUES));

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -60,6 +60,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
@@ -59,6 +59,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
@@ -68,6 +68,8 @@ public class ComplexQuadrilateral {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setShapeType(String shapeType) {
     this.shapeType = shapeType;
   }
@@ -91,6 +93,8 @@ public class ComplexQuadrilateral {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUADRILATERAL_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setQuadrilateralType(String quadrilateralType) {
     this.quadrilateralType = quadrilateralType;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DanishPig.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DanishPig.java
@@ -58,6 +58,8 @@ public class DanishPig {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
@@ -69,6 +69,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -59,6 +59,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Drawing.java
@@ -84,6 +84,8 @@ public class Drawing {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAIN_SHAPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMainShape(Shape mainShape) {
     this.mainShape = mainShape;
   }
@@ -108,6 +110,8 @@ public class Drawing {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_OR_NULL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShapeOrNull(ShapeOrNull shapeOrNull) {
     this.shapeOrNull = shapeOrNull;
   }
@@ -142,6 +146,8 @@ public class Drawing {
     this.nullableShape = nullableShape;
   }
 
+  @JsonProperty(JSON_PROPERTY_NULLABLE_SHAPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNullableShape(NullableShape nullableShape) {
     this.nullableShape = JsonNullable.<NullableShape>of(nullableShape);
   }
@@ -174,6 +180,8 @@ public class Drawing {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShapes(List<Shape> shapes) {
     this.shapes = shapes;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Drawing.java
@@ -146,8 +146,6 @@ public class Drawing {
     this.nullableShape = nullableShape;
   }
 
-  @JsonProperty(JSON_PROPERTY_NULLABLE_SHAPE)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNullableShape(NullableShape nullableShape) {
     this.nullableShape = JsonNullable.<NullableShape>of(nullableShape);
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -135,6 +135,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -167,6 +169,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -238,6 +238,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -261,6 +263,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -285,6 +289,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -309,6 +315,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -343,6 +351,8 @@ public class EnumTest {
     this.outerEnum = outerEnum;
   }
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = JsonNullable.<OuterEnum>of(outerEnum);
   }
@@ -367,6 +377,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnumInteger(OuterEnumInteger outerEnumInteger) {
     this.outerEnumInteger = outerEnumInteger;
   }
@@ -391,6 +403,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM_DEFAULT_VALUE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnumDefaultValue(OuterEnumDefaultValue outerEnumDefaultValue) {
     this.outerEnumDefaultValue = outerEnumDefaultValue;
   }
@@ -415,6 +429,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM_INTEGER_DEFAULT_VALUE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnumIntegerDefaultValue(OuterEnumIntegerDefaultValue outerEnumIntegerDefaultValue) {
     this.outerEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -351,8 +351,6 @@ public class EnumTest {
     this.outerEnum = outerEnum;
   }
 
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = JsonNullable.<OuterEnum>of(outerEnum);
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
@@ -68,6 +68,8 @@ public class EquilateralTriangle {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setShapeType(String shapeType) {
     this.shapeType = shapeType;
   }
@@ -91,6 +93,8 @@ public class EquilateralTriangle {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TRIANGLE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setTriangleType(String triangleType) {
     this.triangleType = triangleType;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -65,6 +65,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -97,6 +99,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Foo.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Foo.java
@@ -59,6 +59,8 @@ public class Foo {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBar(String bar) {
     this.bar = bar;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -126,6 +126,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -152,6 +154,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -176,6 +180,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -201,6 +207,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -227,6 +235,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -253,6 +263,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,6 +289,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDecimal(BigDecimal decimal) {
     this.decimal = decimal;
   }
@@ -301,6 +315,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -324,6 +340,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -348,6 +366,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -371,6 +391,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -395,6 +417,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -419,6 +443,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -442,6 +468,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -466,6 +494,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PATTERN_WITH_DIGITS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPatternWithDigits(String patternWithDigits) {
     this.patternWithDigits = patternWithDigits;
   }
@@ -490,6 +520,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PATTERN_WITH_DIGITS_AND_DELIMITER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPatternWithDigitsAndDelimiter(String patternWithDigitsAndDelimiter) {
     this.patternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
@@ -68,6 +68,8 @@ public class GrandparentAnimal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPetType(String petType) {
     this.petType = petType;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HealthCheckResult.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HealthCheckResult.java
@@ -73,6 +73,8 @@ public class HealthCheckResult {
     this.nullableMessage = nullableMessage;
   }
 
+  @JsonProperty(JSON_PROPERTY_NULLABLE_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNullableMessage(String nullableMessage) {
     this.nullableMessage = JsonNullable.<String>of(nullableMessage);
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HealthCheckResult.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HealthCheckResult.java
@@ -73,8 +73,6 @@ public class HealthCheckResult {
     this.nullableMessage = nullableMessage;
   }
 
-  @JsonProperty(JSON_PROPERTY_NULLABLE_MESSAGE)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNullableMessage(String nullableMessage) {
     this.nullableMessage = JsonNullable.<String>of(nullableMessage);
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineResponseDefault.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/InlineResponseDefault.java
@@ -60,6 +60,8 @@ public class InlineResponseDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(Foo string) {
     this.string = string;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/IsoscelesTriangle.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/IsoscelesTriangle.java
@@ -64,6 +64,8 @@ public class IsoscelesTriangle {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setShapeType(String shapeType) {
     this.shapeType = shapeType;
   }
@@ -87,6 +89,8 @@ public class IsoscelesTriangle {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TRIANGLE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setTriangleType(String triangleType) {
     this.triangleType = triangleType;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
@@ -117,6 +117,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -149,6 +151,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -181,6 +185,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,6 +219,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -73,6 +73,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -97,6 +99,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -129,6 +133,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -64,6 +64,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -88,6 +90,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -67,6 +67,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -91,6 +93,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -115,6 +119,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -60,6 +60,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
@@ -71,6 +71,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -111,6 +113,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -127,8 +127,6 @@ public class NullableClass {
     this.integerProp = integerProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_INTEGER_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIntegerProp(Integer integerProp) {
     this.integerProp = JsonNullable.<Integer>of(integerProp);
   }
@@ -163,8 +161,6 @@ public class NullableClass {
     this.numberProp = numberProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_NUMBER_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNumberProp(BigDecimal numberProp) {
     this.numberProp = JsonNullable.<BigDecimal>of(numberProp);
   }
@@ -199,8 +195,6 @@ public class NullableClass {
     this.booleanProp = booleanProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_BOOLEAN_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBooleanProp(Boolean booleanProp) {
     this.booleanProp = JsonNullable.<Boolean>of(booleanProp);
   }
@@ -235,8 +229,6 @@ public class NullableClass {
     this.stringProp = stringProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_STRING_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStringProp(String stringProp) {
     this.stringProp = JsonNullable.<String>of(stringProp);
   }
@@ -271,8 +263,6 @@ public class NullableClass {
     this.dateProp = dateProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_DATE_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateProp(LocalDate dateProp) {
     this.dateProp = JsonNullable.<LocalDate>of(dateProp);
   }
@@ -307,8 +297,6 @@ public class NullableClass {
     this.datetimeProp = datetimeProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_DATETIME_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDatetimeProp(OffsetDateTime datetimeProp) {
     this.datetimeProp = JsonNullable.<OffsetDateTime>of(datetimeProp);
   }
@@ -355,8 +343,6 @@ public class NullableClass {
     this.arrayNullableProp = arrayNullableProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_ARRAY_NULLABLE_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNullableProp(List<Object> arrayNullableProp) {
     this.arrayNullableProp = JsonNullable.<List<Object>>of(arrayNullableProp);
   }
@@ -403,8 +389,6 @@ public class NullableClass {
     this.arrayAndItemsNullableProp = arrayAndItemsNullableProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_ARRAY_AND_ITEMS_NULLABLE_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayAndItemsNullableProp(List<Object> arrayAndItemsNullableProp) {
     this.arrayAndItemsNullableProp = JsonNullable.<List<Object>>of(arrayAndItemsNullableProp);
   }
@@ -485,8 +469,6 @@ public class NullableClass {
     this.objectNullableProp = objectNullableProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_OBJECT_NULLABLE_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectNullableProp(Map<String, Object> objectNullableProp) {
     this.objectNullableProp = JsonNullable.<Map<String, Object>>of(objectNullableProp);
   }
@@ -533,8 +515,6 @@ public class NullableClass {
     this.objectAndItemsNullableProp = objectAndItemsNullableProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_OBJECT_AND_ITEMS_NULLABLE_PROP)
-  @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectAndItemsNullableProp(Map<String, Object> objectAndItemsNullableProp) {
     this.objectAndItemsNullableProp = JsonNullable.<Map<String, Object>>of(objectAndItemsNullableProp);
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -127,6 +127,8 @@ public class NullableClass {
     this.integerProp = integerProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIntegerProp(Integer integerProp) {
     this.integerProp = JsonNullable.<Integer>of(integerProp);
   }
@@ -161,6 +163,8 @@ public class NullableClass {
     this.numberProp = numberProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNumberProp(BigDecimal numberProp) {
     this.numberProp = JsonNullable.<BigDecimal>of(numberProp);
   }
@@ -195,6 +199,8 @@ public class NullableClass {
     this.booleanProp = booleanProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_BOOLEAN_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBooleanProp(Boolean booleanProp) {
     this.booleanProp = JsonNullable.<Boolean>of(booleanProp);
   }
@@ -229,6 +235,8 @@ public class NullableClass {
     this.stringProp = stringProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_STRING_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStringProp(String stringProp) {
     this.stringProp = JsonNullable.<String>of(stringProp);
   }
@@ -263,6 +271,8 @@ public class NullableClass {
     this.dateProp = dateProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_DATE_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateProp(LocalDate dateProp) {
     this.dateProp = JsonNullable.<LocalDate>of(dateProp);
   }
@@ -297,6 +307,8 @@ public class NullableClass {
     this.datetimeProp = datetimeProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_DATETIME_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDatetimeProp(OffsetDateTime datetimeProp) {
     this.datetimeProp = JsonNullable.<OffsetDateTime>of(datetimeProp);
   }
@@ -343,6 +355,8 @@ public class NullableClass {
     this.arrayNullableProp = arrayNullableProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NULLABLE_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNullableProp(List<Object> arrayNullableProp) {
     this.arrayNullableProp = JsonNullable.<List<Object>>of(arrayNullableProp);
   }
@@ -389,6 +403,8 @@ public class NullableClass {
     this.arrayAndItemsNullableProp = arrayAndItemsNullableProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_AND_ITEMS_NULLABLE_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayAndItemsNullableProp(List<Object> arrayAndItemsNullableProp) {
     this.arrayAndItemsNullableProp = JsonNullable.<List<Object>>of(arrayAndItemsNullableProp);
   }
@@ -421,6 +437,8 @@ public class NullableClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEMS_NULLABLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayItemsNullable(List<Object> arrayItemsNullable) {
     this.arrayItemsNullable = arrayItemsNullable;
   }
@@ -467,6 +485,8 @@ public class NullableClass {
     this.objectNullableProp = objectNullableProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_OBJECT_NULLABLE_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectNullableProp(Map<String, Object> objectNullableProp) {
     this.objectNullableProp = JsonNullable.<Map<String, Object>>of(objectNullableProp);
   }
@@ -513,6 +533,8 @@ public class NullableClass {
     this.objectAndItemsNullableProp = objectAndItemsNullableProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_OBJECT_AND_ITEMS_NULLABLE_PROP)
+  @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectAndItemsNullableProp(Map<String, Object> objectAndItemsNullableProp) {
     this.objectAndItemsNullableProp = JsonNullable.<Map<String, Object>>of(objectAndItemsNullableProp);
   }
@@ -545,6 +567,8 @@ public class NullableClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OBJECT_ITEMS_NULLABLE)
+  @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectItemsNullable(Map<String, Object> objectItemsNullable) {
     this.objectItemsNullable = objectItemsNullable;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -60,6 +60,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
@@ -117,6 +117,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -141,6 +143,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,6 +169,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,6 +195,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -213,6 +221,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -237,6 +247,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -68,6 +68,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -92,6 +94,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -116,6 +120,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
@@ -120,6 +120,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -144,6 +146,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -167,6 +171,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -195,6 +201,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -227,6 +235,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -251,6 +261,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/QuadrilateralInterface.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/QuadrilateralInterface.java
@@ -58,6 +58,8 @@ public class QuadrilateralInterface {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUADRILATERAL_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setQuadrilateralType(String quadrilateralType) {
     this.quadrilateralType = quadrilateralType;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -79,6 +79,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
@@ -68,6 +68,8 @@ public class ScaleneTriangle {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setShapeType(String shapeType) {
     this.shapeType = shapeType;
   }
@@ -91,6 +93,8 @@ public class ScaleneTriangle {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TRIANGLE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setTriangleType(String triangleType) {
     this.triangleType = triangleType;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ShapeInterface.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ShapeInterface.java
@@ -58,6 +58,8 @@ public class ShapeInterface {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setShapeType(String shapeType) {
     this.shapeType = shapeType;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
@@ -68,6 +68,8 @@ public class SimpleQuadrilateral {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setShapeType(String shapeType) {
     this.shapeType = shapeType;
   }
@@ -91,6 +93,8 @@ public class SimpleQuadrilateral {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUADRILATERAL_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setQuadrilateralType(String quadrilateralType) {
     this.quadrilateralType = quadrilateralType;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -59,6 +59,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
@@ -63,6 +63,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -87,6 +89,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TriangleInterface.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TriangleInterface.java
@@ -58,6 +58,8 @@ public class TriangleInterface {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TRIANGLE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setTriangleType(String triangleType) {
     this.triangleType = triangleType;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
@@ -106,6 +106,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -130,6 +132,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -154,6 +158,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -178,6 +184,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -202,6 +210,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -226,6 +236,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -250,6 +262,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -274,6 +288,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }
@@ -298,6 +314,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OBJECT_WITH_NO_DECLARED_PROPS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectWithNoDeclaredProps(Object objectWithNoDeclaredProps) {
     this.objectWithNoDeclaredProps = objectWithNoDeclaredProps;
   }
@@ -332,6 +350,8 @@ public class User {
     this.objectWithNoDeclaredPropsNullable = objectWithNoDeclaredPropsNullable;
   }
 
+  @JsonProperty(JSON_PROPERTY_OBJECT_WITH_NO_DECLARED_PROPS_NULLABLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectWithNoDeclaredPropsNullable(Object objectWithNoDeclaredPropsNullable) {
     this.objectWithNoDeclaredPropsNullable = JsonNullable.<Object>of(objectWithNoDeclaredPropsNullable);
   }
@@ -366,6 +386,8 @@ public class User {
     this.anyTypeProp = anyTypeProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnyTypeProp(Object anyTypeProp) {
     this.anyTypeProp = JsonNullable.<Object>of(anyTypeProp);
   }
@@ -400,6 +422,8 @@ public class User {
     this.anyTypePropNullable = anyTypePropNullable;
   }
 
+  @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP_NULLABLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnyTypePropNullable(Object anyTypePropNullable) {
     this.anyTypePropNullable = JsonNullable.<Object>of(anyTypePropNullable);
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
@@ -350,8 +350,6 @@ public class User {
     this.objectWithNoDeclaredPropsNullable = objectWithNoDeclaredPropsNullable;
   }
 
-  @JsonProperty(JSON_PROPERTY_OBJECT_WITH_NO_DECLARED_PROPS_NULLABLE)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectWithNoDeclaredPropsNullable(Object objectWithNoDeclaredPropsNullable) {
     this.objectWithNoDeclaredPropsNullable = JsonNullable.<Object>of(objectWithNoDeclaredPropsNullable);
   }
@@ -386,8 +384,6 @@ public class User {
     this.anyTypeProp = anyTypeProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnyTypeProp(Object anyTypeProp) {
     this.anyTypeProp = JsonNullable.<Object>of(anyTypeProp);
   }
@@ -422,8 +418,6 @@ public class User {
     this.anyTypePropNullable = anyTypePropNullable;
   }
 
-  @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP_NULLABLE)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnyTypePropNullable(Object anyTypePropNullable) {
     this.anyTypePropNullable = JsonNullable.<Object>of(anyTypePropNullable);
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Whale.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Whale.java
@@ -67,6 +67,8 @@ public class Whale {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_HAS_BALEEN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setHasBaleen(Boolean hasBaleen) {
     this.hasBaleen = hasBaleen;
   }
@@ -91,6 +93,8 @@ public class Whale {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_HAS_TEETH)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setHasTeeth(Boolean hasTeeth) {
     this.hasTeeth = hasTeeth;
   }
@@ -114,6 +118,8 @@ public class Whale {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Zebra.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Zebra.java
@@ -104,6 +104,8 @@ public class Zebra {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(TypeEnum type) {
     this.type = type;
   }
@@ -127,6 +129,8 @@ public class Zebra {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -170,8 +170,6 @@ public class AdditionalPropertiesClass {
     this.anytype1 = anytype1;
   }
 
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = JsonNullable.<Object>of(anytype1);
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -100,6 +100,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapProperty(Map<String, String> mapProperty) {
     this.mapProperty = mapProperty;
   }
@@ -132,6 +134,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_MAP_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfMapProperty(Map<String, Map<String, String>> mapOfMapProperty) {
     this.mapOfMapProperty = mapOfMapProperty;
   }
@@ -166,6 +170,8 @@ public class AdditionalPropertiesClass {
     this.anytype1 = anytype1;
   }
 
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnytype1(Object anytype1) {
     this.anytype1 = JsonNullable.<Object>of(anytype1);
   }
@@ -190,6 +196,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapWithUndeclaredPropertiesAnytype1(Object mapWithUndeclaredPropertiesAnytype1) {
     this.mapWithUndeclaredPropertiesAnytype1 = mapWithUndeclaredPropertiesAnytype1;
   }
@@ -214,6 +222,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapWithUndeclaredPropertiesAnytype2(Object mapWithUndeclaredPropertiesAnytype2) {
     this.mapWithUndeclaredPropertiesAnytype2 = mapWithUndeclaredPropertiesAnytype2;
   }
@@ -246,6 +256,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_ANYTYPE3)
+  @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapWithUndeclaredPropertiesAnytype3(Map<String, Object> mapWithUndeclaredPropertiesAnytype3) {
     this.mapWithUndeclaredPropertiesAnytype3 = mapWithUndeclaredPropertiesAnytype3;
   }
@@ -270,6 +282,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMPTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmptyMap(Object emptyMap) {
     this.emptyMap = emptyMap;
   }
@@ -302,6 +316,8 @@ public class AdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_WITH_UNDECLARED_PROPERTIES_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapWithUndeclaredPropertiesString(Map<String, String> mapWithUndeclaredPropertiesString) {
     this.mapWithUndeclaredPropertiesString = mapWithUndeclaredPropertiesString;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Animal.java
@@ -72,6 +72,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }
@@ -96,6 +98,8 @@ public class Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setColor(String color) {
     this.color = color;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Apple.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Apple.java
@@ -62,6 +62,8 @@ public class Apple {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CULTIVAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCultivar(String cultivar) {
     this.cultivar = cultivar;
   }
@@ -86,6 +88,8 @@ public class Apple {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ORIGIN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOrigin(String origin) {
     this.origin = origin;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/AppleReq.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/AppleReq.java
@@ -61,6 +61,8 @@ public class AppleReq {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CULTIVAR)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setCultivar(String cultivar) {
     this.cultivar = cultivar;
   }
@@ -85,6 +87,8 @@ public class AppleReq {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MEALY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMealy(Boolean mealy) {
     this.mealy = mealy;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -69,6 +69,8 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -69,6 +69,8 @@ public class ArrayOfNumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -77,6 +77,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -109,6 +111,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -141,6 +145,8 @@ public class ArrayTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Banana.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Banana.java
@@ -59,6 +59,8 @@ public class Banana {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LENGTH_CM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLengthCm(BigDecimal lengthCm) {
     this.lengthCm = lengthCm;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/BananaReq.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/BananaReq.java
@@ -62,6 +62,8 @@ public class BananaReq {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LENGTH_CM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setLengthCm(BigDecimal lengthCm) {
     this.lengthCm = lengthCm;
   }
@@ -86,6 +88,8 @@ public class BananaReq {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SWEET)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSweet(Boolean sweet) {
     this.sweet = sweet;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/BasquePig.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/BasquePig.java
@@ -57,6 +57,8 @@ public class BasquePig {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -78,6 +78,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -102,6 +104,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
@@ -126,6 +130,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -150,6 +156,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
@@ -174,6 +182,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -198,6 +208,8 @@ public class Capitalization {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Cat.java
@@ -65,6 +65,8 @@ public class Cat extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -58,6 +58,8 @@ public class CatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Category.java
@@ -62,6 +62,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,6 +87,8 @@ public class Category {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ChildCat.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ChildCat.java
@@ -71,6 +71,8 @@ public class ChildCat extends ParentPet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }
@@ -102,6 +104,8 @@ public class ChildCat extends ParentPet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPetType(String petType) {
     if (!PET_TYPE_VALUES.contains(petType)) {
       throw new IllegalArgumentException(petType + " is invalid. Possible values for petType: " + String.join(", ", PET_TYPE_VALUES));

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ChildCatAllOf.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ChildCatAllOf.java
@@ -64,6 +64,8 @@ public class ChildCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }
@@ -96,6 +98,8 @@ public class ChildCatAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetType(String petType) {
     if (!PET_TYPE_VALUES.contains(petType)) {
       throw new IllegalArgumentException(petType + " is invalid. Possible values for petType: " + String.join(", ", PET_TYPE_VALUES));

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -59,6 +59,8 @@ public class ClassModel {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Client.java
@@ -58,6 +58,8 @@ public class Client {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ComplexQuadrilateral.java
@@ -63,6 +63,8 @@ public class ComplexQuadrilateral {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setShapeType(String shapeType) {
     this.shapeType = shapeType;
   }
@@ -86,6 +88,8 @@ public class ComplexQuadrilateral {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUADRILATERAL_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setQuadrilateralType(String quadrilateralType) {
     this.quadrilateralType = quadrilateralType;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/DanishPig.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/DanishPig.java
@@ -57,6 +57,8 @@ public class DanishPig {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Dog.java
@@ -65,6 +65,8 @@ public class Dog extends Animal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -58,6 +58,8 @@ public class DogAllOf {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Drawing.java
@@ -147,8 +147,6 @@ public class Drawing extends HashMap<String, Fruit> {
     this.nullableShape = nullableShape;
   }
 
-  @JsonProperty(JSON_PROPERTY_NULLABLE_SHAPE)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNullableShape(NullableShape nullableShape) {
     this.nullableShape = JsonNullable.<NullableShape>of(nullableShape);
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Drawing.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Drawing.java
@@ -85,6 +85,8 @@ public class Drawing extends HashMap<String, Fruit> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAIN_SHAPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMainShape(Shape mainShape) {
     this.mainShape = mainShape;
   }
@@ -109,6 +111,8 @@ public class Drawing extends HashMap<String, Fruit> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_OR_NULL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShapeOrNull(ShapeOrNull shapeOrNull) {
     this.shapeOrNull = shapeOrNull;
   }
@@ -143,6 +147,8 @@ public class Drawing extends HashMap<String, Fruit> {
     this.nullableShape = nullableShape;
   }
 
+  @JsonProperty(JSON_PROPERTY_NULLABLE_SHAPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNullableShape(NullableShape nullableShape) {
     this.nullableShape = JsonNullable.<NullableShape>of(nullableShape);
   }
@@ -175,6 +181,8 @@ public class Drawing extends HashMap<String, Fruit> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShapes(List<Shape> shapes) {
     this.shapes = shapes;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -134,6 +134,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -166,6 +168,8 @@ public class EnumArrays {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -350,8 +350,6 @@ public class EnumTest {
     this.outerEnum = outerEnum;
   }
 
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = JsonNullable.<OuterEnum>of(outerEnum);
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -237,6 +237,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -260,6 +262,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
@@ -284,6 +288,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -308,6 +314,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -342,6 +350,8 @@ public class EnumTest {
     this.outerEnum = outerEnum;
   }
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = JsonNullable.<OuterEnum>of(outerEnum);
   }
@@ -366,6 +376,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnumInteger(OuterEnumInteger outerEnumInteger) {
     this.outerEnumInteger = outerEnumInteger;
   }
@@ -390,6 +402,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM_DEFAULT_VALUE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnumDefaultValue(OuterEnumDefaultValue outerEnumDefaultValue) {
     this.outerEnumDefaultValue = outerEnumDefaultValue;
   }
@@ -414,6 +428,8 @@ public class EnumTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM_INTEGER_DEFAULT_VALUE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setOuterEnumIntegerDefaultValue(OuterEnumIntegerDefaultValue outerEnumIntegerDefaultValue) {
     this.outerEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/EquilateralTriangle.java
@@ -63,6 +63,8 @@ public class EquilateralTriangle {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setShapeType(String shapeType) {
     this.shapeType = shapeType;
   }
@@ -86,6 +88,8 @@ public class EquilateralTriangle {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TRIANGLE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setTriangleType(String triangleType) {
     this.triangleType = triangleType;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -64,6 +64,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -96,6 +98,8 @@ public class FileSchemaTestClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFiles(List<java.io.File> files) {
     this.files = files;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Foo.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Foo.java
@@ -58,6 +58,8 @@ public class Foo {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBar(String bar) {
     this.bar = bar;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -125,6 +125,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -151,6 +153,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -175,6 +179,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
@@ -200,6 +206,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -226,6 +234,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -252,6 +262,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -276,6 +288,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDecimal(BigDecimal decimal) {
     this.decimal = decimal;
   }
@@ -300,6 +314,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(String string) {
     this.string = string;
   }
@@ -323,6 +339,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
@@ -347,6 +365,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -370,6 +390,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setDate(LocalDate date) {
     this.date = date;
   }
@@ -394,6 +416,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -418,6 +442,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -441,6 +467,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -465,6 +493,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PATTERN_WITH_DIGITS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPatternWithDigits(String patternWithDigits) {
     this.patternWithDigits = patternWithDigits;
   }
@@ -489,6 +519,8 @@ public class FormatTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PATTERN_WITH_DIGITS_AND_DELIMITER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPatternWithDigitsAndDelimiter(String patternWithDigitsAndDelimiter) {
     this.patternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/GrandparentAnimal.java
@@ -68,6 +68,8 @@ public class GrandparentAnimal {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPetType(String petType) {
     this.petType = petType;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/HealthCheckResult.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/HealthCheckResult.java
@@ -72,8 +72,6 @@ public class HealthCheckResult {
     this.nullableMessage = nullableMessage;
   }
 
-  @JsonProperty(JSON_PROPERTY_NULLABLE_MESSAGE)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNullableMessage(String nullableMessage) {
     this.nullableMessage = JsonNullable.<String>of(nullableMessage);
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/HealthCheckResult.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/HealthCheckResult.java
@@ -72,6 +72,8 @@ public class HealthCheckResult {
     this.nullableMessage = nullableMessage;
   }
 
+  @JsonProperty(JSON_PROPERTY_NULLABLE_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNullableMessage(String nullableMessage) {
     this.nullableMessage = JsonNullable.<String>of(nullableMessage);
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/InlineResponseDefault.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/InlineResponseDefault.java
@@ -59,6 +59,8 @@ public class InlineResponseDefault {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setString(Foo string) {
     this.string = string;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/IsoscelesTriangle.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/IsoscelesTriangle.java
@@ -63,6 +63,8 @@ public class IsoscelesTriangle {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setShapeType(String shapeType) {
     this.shapeType = shapeType;
   }
@@ -86,6 +88,8 @@ public class IsoscelesTriangle {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TRIANGLE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setTriangleType(String triangleType) {
     this.triangleType = triangleType;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/MapTest.java
@@ -116,6 +116,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,6 +150,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
@@ -180,6 +184,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -212,6 +218,8 @@ public class MapTest {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -72,6 +72,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -96,6 +98,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -128,6 +132,8 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMap(Map<String, Animal> map) {
     this.map = map;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -63,6 +63,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -87,6 +89,8 @@ public class Model200Response {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -66,6 +66,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -90,6 +92,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(String type) {
     this.type = type;
   }
@@ -114,6 +118,8 @@ public class ModelApiResponse {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMessage(String message) {
     this.message = message;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -59,6 +59,8 @@ public class ModelReturn {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Name.java
@@ -70,6 +70,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,6 +112,8 @@ public class Name {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setProperty(String property) {
     this.property = property;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -126,8 +126,6 @@ public class NullableClass extends HashMap<String, Object> {
     this.integerProp = integerProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_INTEGER_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIntegerProp(Integer integerProp) {
     this.integerProp = JsonNullable.<Integer>of(integerProp);
   }
@@ -162,8 +160,6 @@ public class NullableClass extends HashMap<String, Object> {
     this.numberProp = numberProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_NUMBER_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNumberProp(BigDecimal numberProp) {
     this.numberProp = JsonNullable.<BigDecimal>of(numberProp);
   }
@@ -198,8 +194,6 @@ public class NullableClass extends HashMap<String, Object> {
     this.booleanProp = booleanProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_BOOLEAN_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBooleanProp(Boolean booleanProp) {
     this.booleanProp = JsonNullable.<Boolean>of(booleanProp);
   }
@@ -234,8 +228,6 @@ public class NullableClass extends HashMap<String, Object> {
     this.stringProp = stringProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_STRING_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStringProp(String stringProp) {
     this.stringProp = JsonNullable.<String>of(stringProp);
   }
@@ -270,8 +262,6 @@ public class NullableClass extends HashMap<String, Object> {
     this.dateProp = dateProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_DATE_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateProp(LocalDate dateProp) {
     this.dateProp = JsonNullable.<LocalDate>of(dateProp);
   }
@@ -306,8 +296,6 @@ public class NullableClass extends HashMap<String, Object> {
     this.datetimeProp = datetimeProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_DATETIME_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDatetimeProp(OffsetDateTime datetimeProp) {
     this.datetimeProp = JsonNullable.<OffsetDateTime>of(datetimeProp);
   }
@@ -354,8 +342,6 @@ public class NullableClass extends HashMap<String, Object> {
     this.arrayNullableProp = arrayNullableProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_ARRAY_NULLABLE_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNullableProp(List<Object> arrayNullableProp) {
     this.arrayNullableProp = JsonNullable.<List<Object>>of(arrayNullableProp);
   }
@@ -402,8 +388,6 @@ public class NullableClass extends HashMap<String, Object> {
     this.arrayAndItemsNullableProp = arrayAndItemsNullableProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_ARRAY_AND_ITEMS_NULLABLE_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayAndItemsNullableProp(List<Object> arrayAndItemsNullableProp) {
     this.arrayAndItemsNullableProp = JsonNullable.<List<Object>>of(arrayAndItemsNullableProp);
   }
@@ -484,8 +468,6 @@ public class NullableClass extends HashMap<String, Object> {
     this.objectNullableProp = objectNullableProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_OBJECT_NULLABLE_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectNullableProp(Map<String, Object> objectNullableProp) {
     this.objectNullableProp = JsonNullable.<Map<String, Object>>of(objectNullableProp);
   }
@@ -532,8 +514,6 @@ public class NullableClass extends HashMap<String, Object> {
     this.objectAndItemsNullableProp = objectAndItemsNullableProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_OBJECT_AND_ITEMS_NULLABLE_PROP)
-  @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectAndItemsNullableProp(Map<String, Object> objectAndItemsNullableProp) {
     this.objectAndItemsNullableProp = JsonNullable.<Map<String, Object>>of(objectAndItemsNullableProp);
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -126,6 +126,8 @@ public class NullableClass extends HashMap<String, Object> {
     this.integerProp = integerProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_INTEGER_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setIntegerProp(Integer integerProp) {
     this.integerProp = JsonNullable.<Integer>of(integerProp);
   }
@@ -160,6 +162,8 @@ public class NullableClass extends HashMap<String, Object> {
     this.numberProp = numberProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_NUMBER_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setNumberProp(BigDecimal numberProp) {
     this.numberProp = JsonNullable.<BigDecimal>of(numberProp);
   }
@@ -194,6 +198,8 @@ public class NullableClass extends HashMap<String, Object> {
     this.booleanProp = booleanProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_BOOLEAN_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBooleanProp(Boolean booleanProp) {
     this.booleanProp = JsonNullable.<Boolean>of(booleanProp);
   }
@@ -228,6 +234,8 @@ public class NullableClass extends HashMap<String, Object> {
     this.stringProp = stringProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_STRING_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStringProp(String stringProp) {
     this.stringProp = JsonNullable.<String>of(stringProp);
   }
@@ -262,6 +270,8 @@ public class NullableClass extends HashMap<String, Object> {
     this.dateProp = dateProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_DATE_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDateProp(LocalDate dateProp) {
     this.dateProp = JsonNullable.<LocalDate>of(dateProp);
   }
@@ -296,6 +306,8 @@ public class NullableClass extends HashMap<String, Object> {
     this.datetimeProp = datetimeProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_DATETIME_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setDatetimeProp(OffsetDateTime datetimeProp) {
     this.datetimeProp = JsonNullable.<OffsetDateTime>of(datetimeProp);
   }
@@ -342,6 +354,8 @@ public class NullableClass extends HashMap<String, Object> {
     this.arrayNullableProp = arrayNullableProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_NULLABLE_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayNullableProp(List<Object> arrayNullableProp) {
     this.arrayNullableProp = JsonNullable.<List<Object>>of(arrayNullableProp);
   }
@@ -388,6 +402,8 @@ public class NullableClass extends HashMap<String, Object> {
     this.arrayAndItemsNullableProp = arrayAndItemsNullableProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_AND_ITEMS_NULLABLE_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayAndItemsNullableProp(List<Object> arrayAndItemsNullableProp) {
     this.arrayAndItemsNullableProp = JsonNullable.<List<Object>>of(arrayAndItemsNullableProp);
   }
@@ -420,6 +436,8 @@ public class NullableClass extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEMS_NULLABLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setArrayItemsNullable(List<Object> arrayItemsNullable) {
     this.arrayItemsNullable = arrayItemsNullable;
   }
@@ -466,6 +484,8 @@ public class NullableClass extends HashMap<String, Object> {
     this.objectNullableProp = objectNullableProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_OBJECT_NULLABLE_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectNullableProp(Map<String, Object> objectNullableProp) {
     this.objectNullableProp = JsonNullable.<Map<String, Object>>of(objectNullableProp);
   }
@@ -512,6 +532,8 @@ public class NullableClass extends HashMap<String, Object> {
     this.objectAndItemsNullableProp = objectAndItemsNullableProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_OBJECT_AND_ITEMS_NULLABLE_PROP)
+  @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectAndItemsNullableProp(Map<String, Object> objectAndItemsNullableProp) {
     this.objectAndItemsNullableProp = JsonNullable.<Map<String, Object>>of(objectAndItemsNullableProp);
   }
@@ -544,6 +566,8 @@ public class NullableClass extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OBJECT_ITEMS_NULLABLE)
+  @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectItemsNullable(Map<String, Object> objectItemsNullable) {
     this.objectItemsNullable = objectItemsNullable;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -59,6 +59,8 @@ public class NumberOnly {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Order.java
@@ -116,6 +116,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -140,6 +142,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -164,6 +168,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -188,6 +194,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -212,6 +220,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -236,6 +246,8 @@ public class Order {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -67,6 +67,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -91,6 +93,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -115,6 +119,8 @@ public class OuterComposite {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pet.java
@@ -119,6 +119,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -143,6 +145,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -166,6 +170,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -194,6 +200,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
@@ -226,6 +234,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -250,6 +260,8 @@ public class Pet {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setStatus(StatusEnum status) {
     this.status = status;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/QuadrilateralInterface.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/QuadrilateralInterface.java
@@ -57,6 +57,8 @@ public class QuadrilateralInterface {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUADRILATERAL_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setQuadrilateralType(String quadrilateralType) {
     this.quadrilateralType = quadrilateralType;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -78,6 +78,8 @@ public class ReadOnlyFirst {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ScaleneTriangle.java
@@ -63,6 +63,8 @@ public class ScaleneTriangle {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setShapeType(String shapeType) {
     this.shapeType = shapeType;
   }
@@ -86,6 +88,8 @@ public class ScaleneTriangle {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TRIANGLE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setTriangleType(String triangleType) {
     this.triangleType = triangleType;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ShapeInterface.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ShapeInterface.java
@@ -57,6 +57,8 @@ public class ShapeInterface {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setShapeType(String shapeType) {
     this.shapeType = shapeType;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/SimpleQuadrilateral.java
@@ -63,6 +63,8 @@ public class SimpleQuadrilateral {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_SHAPE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setShapeType(String shapeType) {
     this.shapeType = shapeType;
   }
@@ -86,6 +88,8 @@ public class SimpleQuadrilateral {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_QUADRILATERAL_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setQuadrilateralType(String quadrilateralType) {
     this.quadrilateralType = quadrilateralType;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -58,6 +58,8 @@ public class SpecialModelName {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Tag.java
@@ -62,6 +62,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -86,6 +88,8 @@ public class Tag {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/TriangleInterface.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/TriangleInterface.java
@@ -57,6 +57,8 @@ public class TriangleInterface {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TRIANGLE_TYPE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setTriangleType(String triangleType) {
     this.triangleType = triangleType;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/User.java
@@ -105,6 +105,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setId(Long id) {
     this.id = id;
   }
@@ -129,6 +131,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUsername(String username) {
     this.username = username;
   }
@@ -153,6 +157,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -177,6 +183,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
@@ -201,6 +209,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEmail(String email) {
     this.email = email;
   }
@@ -225,6 +235,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPassword(String password) {
     this.password = password;
   }
@@ -249,6 +261,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -273,6 +287,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }
@@ -297,6 +313,8 @@ public class User {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_OBJECT_WITH_NO_DECLARED_PROPS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectWithNoDeclaredProps(Object objectWithNoDeclaredProps) {
     this.objectWithNoDeclaredProps = objectWithNoDeclaredProps;
   }
@@ -331,6 +349,8 @@ public class User {
     this.objectWithNoDeclaredPropsNullable = objectWithNoDeclaredPropsNullable;
   }
 
+  @JsonProperty(JSON_PROPERTY_OBJECT_WITH_NO_DECLARED_PROPS_NULLABLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectWithNoDeclaredPropsNullable(Object objectWithNoDeclaredPropsNullable) {
     this.objectWithNoDeclaredPropsNullable = JsonNullable.<Object>of(objectWithNoDeclaredPropsNullable);
   }
@@ -365,6 +385,8 @@ public class User {
     this.anyTypeProp = anyTypeProp;
   }
 
+  @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnyTypeProp(Object anyTypeProp) {
     this.anyTypeProp = JsonNullable.<Object>of(anyTypeProp);
   }
@@ -399,6 +421,8 @@ public class User {
     this.anyTypePropNullable = anyTypePropNullable;
   }
 
+  @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP_NULLABLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnyTypePropNullable(Object anyTypePropNullable) {
     this.anyTypePropNullable = JsonNullable.<Object>of(anyTypePropNullable);
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/User.java
@@ -349,8 +349,6 @@ public class User {
     this.objectWithNoDeclaredPropsNullable = objectWithNoDeclaredPropsNullable;
   }
 
-  @JsonProperty(JSON_PROPERTY_OBJECT_WITH_NO_DECLARED_PROPS_NULLABLE)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setObjectWithNoDeclaredPropsNullable(Object objectWithNoDeclaredPropsNullable) {
     this.objectWithNoDeclaredPropsNullable = JsonNullable.<Object>of(objectWithNoDeclaredPropsNullable);
   }
@@ -385,8 +383,6 @@ public class User {
     this.anyTypeProp = anyTypeProp;
   }
 
-  @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnyTypeProp(Object anyTypeProp) {
     this.anyTypeProp = JsonNullable.<Object>of(anyTypeProp);
   }
@@ -421,8 +417,6 @@ public class User {
     this.anyTypePropNullable = anyTypePropNullable;
   }
 
-  @JsonProperty(JSON_PROPERTY_ANY_TYPE_PROP_NULLABLE)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setAnyTypePropNullable(Object anyTypePropNullable) {
     this.anyTypePropNullable = JsonNullable.<Object>of(anyTypePropNullable);
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Whale.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Whale.java
@@ -66,6 +66,8 @@ public class Whale {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_HAS_BALEEN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setHasBaleen(Boolean hasBaleen) {
     this.hasBaleen = hasBaleen;
   }
@@ -90,6 +92,8 @@ public class Whale {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_HAS_TEETH)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setHasTeeth(Boolean hasTeeth) {
     this.hasTeeth = hasTeeth;
   }
@@ -113,6 +117,8 @@ public class Whale {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Zebra.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Zebra.java
@@ -105,6 +105,8 @@ public class Zebra extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setType(TypeEnum type) {
     this.type = type;
   }
@@ -128,6 +130,8 @@ public class Zebra extends HashMap<String, Object> {
   }
 
 
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setClassName(String className) {
     this.className = className;
   }


### PR DESCRIPTION
Closes #6856

Jackson deserialization fails with the message "Problem deserializing 'setterless' property" if json keys are not in camel case. This commit fixes that problem by adding `@JsonProprety` to setters.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @nmuesch