### PR TITLE
[C#][netcore] Set EmitDefaultValue to true for boolean property

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
@@ -30,7 +30,7 @@
         {{#description}}
         /// <value>{{description}}</value>
         {{/description}}
-        [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = true{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/vendorExtensions.x-emit-default-value}})]
+        [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = true{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#isBoolean}}true{{/isBoolean}}{{^isBoolean}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/vendorExtensions.x-emit-default-value}})]
         public {{#complexType}}{{{complexType}}}{{/complexType}}{{^complexType}}{{{datatypeWithEnum}}}{{/complexType}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}} {{name}} { get; set; }
         {{#isReadOnly}}
 
@@ -120,7 +120,7 @@
         /// {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
         /// </summary>{{#description}}
         /// <value>{{description}}</value>{{/description}}
-        [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = true{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/vendorExtensions.x-emit-default-value}})]
+        [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = true{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#isBoolean}}true{{/isBoolean}}{{^isBoolean}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/vendorExtensions.x-emit-default-value}})]
         {{#isDate}}
         [JsonConverter(typeof(OpenAPIDateConverter))]
         {{/isDate}}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Mealy
         /// </summary>
-        [DataMember(Name = "mealy", EmitDefaultValue = false)]
+        [DataMember(Name = "mealy", EmitDefaultValue = true)]
         public bool Mealy { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Sweet
         /// </summary>
-        [DataMember(Name = "sweet", EmitDefaultValue = false)]
+        [DataMember(Name = "sweet", EmitDefaultValue = true)]
         public bool Sweet { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Cat.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Declawed
         /// </summary>
-        [DataMember(Name = "declawed", EmitDefaultValue = false)]
+        [DataMember(Name = "declawed", EmitDefaultValue = true)]
         public bool Declawed { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Declawed
         /// </summary>
-        [DataMember(Name = "declawed", EmitDefaultValue = false)]
+        [DataMember(Name = "declawed", EmitDefaultValue = true)]
         public bool Declawed { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Order.cs
@@ -112,7 +112,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
-        [DataMember(Name = "complete", EmitDefaultValue = false)]
+        [DataMember(Name = "complete", EmitDefaultValue = true)]
         public bool Complete { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets MyBoolean
         /// </summary>
-        [DataMember(Name = "my_boolean", EmitDefaultValue = false)]
+        [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
         public bool MyBoolean { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Whale.cs
@@ -58,13 +58,13 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets HasBaleen
         /// </summary>
-        [DataMember(Name = "hasBaleen", EmitDefaultValue = false)]
+        [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
         public bool HasBaleen { get; set; }
 
         /// <summary>
         /// Gets or Sets HasTeeth
         /// </summary>
-        [DataMember(Name = "hasTeeth", EmitDefaultValue = false)]
+        [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
         public bool HasTeeth { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Mealy
         /// </summary>
-        [DataMember(Name = "mealy", EmitDefaultValue = false)]
+        [DataMember(Name = "mealy", EmitDefaultValue = true)]
         public bool Mealy { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Sweet
         /// </summary>
-        [DataMember(Name = "sweet", EmitDefaultValue = false)]
+        [DataMember(Name = "sweet", EmitDefaultValue = true)]
         public bool Sweet { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Cat.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Declawed
         /// </summary>
-        [DataMember(Name = "declawed", EmitDefaultValue = false)]
+        [DataMember(Name = "declawed", EmitDefaultValue = true)]
         public bool Declawed { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Declawed
         /// </summary>
-        [DataMember(Name = "declawed", EmitDefaultValue = false)]
+        [DataMember(Name = "declawed", EmitDefaultValue = true)]
         public bool Declawed { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Order.cs
@@ -112,7 +112,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
-        [DataMember(Name = "complete", EmitDefaultValue = false)]
+        [DataMember(Name = "complete", EmitDefaultValue = true)]
         public bool Complete { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets MyBoolean
         /// </summary>
-        [DataMember(Name = "my_boolean", EmitDefaultValue = false)]
+        [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
         public bool MyBoolean { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Whale.cs
@@ -58,13 +58,13 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets HasBaleen
         /// </summary>
-        [DataMember(Name = "hasBaleen", EmitDefaultValue = false)]
+        [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
         public bool HasBaleen { get; set; }
 
         /// <summary>
         /// Gets or Sets HasTeeth
         /// </summary>
-        [DataMember(Name = "hasTeeth", EmitDefaultValue = false)]
+        [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
         public bool HasTeeth { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Mealy
         /// </summary>
-        [DataMember(Name = "mealy", EmitDefaultValue = false)]
+        [DataMember(Name = "mealy", EmitDefaultValue = true)]
         public bool Mealy { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Sweet
         /// </summary>
-        [DataMember(Name = "sweet", EmitDefaultValue = false)]
+        [DataMember(Name = "sweet", EmitDefaultValue = true)]
         public bool Sweet { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Cat.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Declawed
         /// </summary>
-        [DataMember(Name = "declawed", EmitDefaultValue = false)]
+        [DataMember(Name = "declawed", EmitDefaultValue = true)]
         public bool Declawed { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Declawed
         /// </summary>
-        [DataMember(Name = "declawed", EmitDefaultValue = false)]
+        [DataMember(Name = "declawed", EmitDefaultValue = true)]
         public bool Declawed { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Order.cs
@@ -112,7 +112,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
-        [DataMember(Name = "complete", EmitDefaultValue = false)]
+        [DataMember(Name = "complete", EmitDefaultValue = true)]
         public bool Complete { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets MyBoolean
         /// </summary>
-        [DataMember(Name = "my_boolean", EmitDefaultValue = false)]
+        [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
         public bool MyBoolean { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Whale.cs
@@ -58,13 +58,13 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets HasBaleen
         /// </summary>
-        [DataMember(Name = "hasBaleen", EmitDefaultValue = false)]
+        [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
         public bool HasBaleen { get; set; }
 
         /// <summary>
         /// Gets or Sets HasTeeth
         /// </summary>
-        [DataMember(Name = "hasTeeth", EmitDefaultValue = false)]
+        [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
         public bool HasTeeth { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs
@@ -144,6 +144,12 @@ namespace Org.OpenAPITools.Test
             // test to ensure both Cat and Animal (parent) can have "AdditionalProperties", which result in warnings
             Cat c = JsonConvert.DeserializeObject<Cat>("{\"className\":\"cat\",\"bar\":\"from json bar\"}");
             Assert.Equal("from json bar", c.AdditionalProperties["bar"]);
+
+            Cat c2 = new Cat();
+            c2.Color = "red";
+            c2.Declawed = false;
+            Assert.Equal("{\"declawed\":false,\"className\":\"Cat\",\"color\":\"red\"}", JsonConvert.SerializeObject(c2));
+
         }
 
         /// <summary>
@@ -156,7 +162,7 @@ namespace Org.OpenAPITools.Test
 
             Assert.NotNull(f.GetType().GetProperty("AdditionalProperties"));
             Assert.Null(f.GetType().GetProperty("unknown_property"));
-
         }
+
     }
 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs
@@ -149,7 +149,6 @@ namespace Org.OpenAPITools.Test
             c2.Color = "red";
             c2.Declawed = false;
             Assert.Equal("{\"declawed\":false,\"className\":\"Cat\",\"color\":\"red\"}", JsonConvert.SerializeObject(c2));
-
         }
 
         /// <summary>
@@ -159,7 +158,6 @@ namespace Org.OpenAPITools.Test
         public void TestAdditionalProperties()
         {
             Foo f = new Foo();
-
             Assert.NotNull(f.GetType().GetProperty("AdditionalProperties"));
             Assert.Null(f.GetType().GetProperty("unknown_property"));
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Mealy
         /// </summary>
-        [DataMember(Name = "mealy", EmitDefaultValue = false)]
+        [DataMember(Name = "mealy", EmitDefaultValue = true)]
         public bool Mealy { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Sweet
         /// </summary>
-        [DataMember(Name = "sweet", EmitDefaultValue = false)]
+        [DataMember(Name = "sweet", EmitDefaultValue = true)]
         public bool Sweet { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Cat.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Declawed
         /// </summary>
-        [DataMember(Name = "declawed", EmitDefaultValue = false)]
+        [DataMember(Name = "declawed", EmitDefaultValue = true)]
         public bool Declawed { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Declawed
         /// </summary>
-        [DataMember(Name = "declawed", EmitDefaultValue = false)]
+        [DataMember(Name = "declawed", EmitDefaultValue = true)]
         public bool Declawed { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
@@ -112,7 +112,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
-        [DataMember(Name = "complete", EmitDefaultValue = false)]
+        [DataMember(Name = "complete", EmitDefaultValue = true)]
         public bool Complete { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets MyBoolean
         /// </summary>
-        [DataMember(Name = "my_boolean", EmitDefaultValue = false)]
+        [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
         public bool MyBoolean { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Whale.cs
@@ -58,13 +58,13 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets HasBaleen
         /// </summary>
-        [DataMember(Name = "hasBaleen", EmitDefaultValue = false)]
+        [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
         public bool HasBaleen { get; set; }
 
         /// <summary>
         /// Gets or Sets HasTeeth
         /// </summary>
-        [DataMember(Name = "hasTeeth", EmitDefaultValue = false)]
+        [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
         public bool HasTeeth { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Mealy
         /// </summary>
-        [DataMember(Name = "mealy", EmitDefaultValue = false)]
+        [DataMember(Name = "mealy", EmitDefaultValue = true)]
         public bool Mealy { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Sweet
         /// </summary>
-        [DataMember(Name = "sweet", EmitDefaultValue = false)]
+        [DataMember(Name = "sweet", EmitDefaultValue = true)]
         public bool Sweet { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Cat.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Declawed
         /// </summary>
-        [DataMember(Name = "declawed", EmitDefaultValue = false)]
+        [DataMember(Name = "declawed", EmitDefaultValue = true)]
         public bool Declawed { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/CatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/CatAllOf.cs
@@ -44,7 +44,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Declawed
         /// </summary>
-        [DataMember(Name = "declawed", EmitDefaultValue = false)]
+        [DataMember(Name = "declawed", EmitDefaultValue = true)]
         public bool Declawed { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Order.cs
@@ -111,7 +111,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
-        [DataMember(Name = "complete", EmitDefaultValue = false)]
+        [DataMember(Name = "complete", EmitDefaultValue = true)]
         public bool Complete { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets MyBoolean
         /// </summary>
-        [DataMember(Name = "my_boolean", EmitDefaultValue = false)]
+        [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
         public bool MyBoolean { get; set; }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Whale.cs
@@ -54,13 +54,13 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Gets or Sets HasBaleen
         /// </summary>
-        [DataMember(Name = "hasBaleen", EmitDefaultValue = false)]
+        [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
         public bool HasBaleen { get; set; }
 
         /// <summary>
         /// Gets or Sets HasTeeth
         /// </summary>
-        [DataMember(Name = "hasTeeth", EmitDefaultValue = false)]
+        [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
         public bool HasTeeth { get; set; }
 
         /// <summary>


### PR DESCRIPTION
- To fix https://github.com/OpenAPITools/openapi-generator/issues/8998
- Add a [test](https://github.com/OpenAPITools/openapi-generator/pull/9042/files#diff-bb3f5242aa81b6a3b96631d0dd6ba27fe5c84087d77642adf0b2603136d3a75fR151)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


cc @mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02) @Blackclaws (2021/03)



