### PR TITLE
Add a unit test for missing ref targets.

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiEvaluatorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiEvaluatorTest.java
@@ -1,0 +1,40 @@
+package org.openapitools.codegen.validations.oas;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.validation.Invalid;
+import org.openapitools.codegen.validation.ValidationResult;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OpenApiEvaluatorTest {
+    @Test(dataProvider = "missingRef", description = "Error when a reference target is missing.")
+    public void testMissingRef(final OpenAPI openAPI) {
+        RuleConfiguration config = new RuleConfiguration();
+        config.setEnableRecommendations(true);
+        OpenApiEvaluator validator = new OpenApiEvaluator(config);
+
+        // Perform validation.
+        ValidationResult result = validator.validate(openAPI);
+
+        // No warnings are expected.
+        Assert.assertTrue(result.getWarnings().isEmpty());
+
+        // Errors are expected.
+        Assert.assertFalse(result.getErrors().isEmpty());
+
+        // Valid results are expected.
+        Assert.assertFalse(result.getValid().isEmpty());
+    }
+
+    @DataProvider(name = "missingRef")
+    public Object[][] missingRef() {
+        return new Object[][]{
+                {TestUtils.parseFlattenSpec("src/test/resources/3_1/issue_9047.yaml")}
+        };
+    }
+}

--- a/modules/openapi-generator/src/test/resources/3_1/issue_9047.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_9047.yaml
@@ -1,0 +1,101 @@
+openapi: 3.0.2 # This should be 3.1, but the parser does not accept that version yet.
+servers:
+  - url: 'http://petstore.swagger.io/v2'
+info:
+  description: >-
+    This is a sample server Petstore server. For this sample, you can use the api key
+    `special-key` to test the authorization filters.
+  version: 1.0.0
+  title: OpenAPI Petstore
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: pet
+    description: Everything about your Pets
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '405':
+          description: Invalid input
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+components:
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+      required: true
+  schemas:
+    Tag:
+      title: Pet Tag
+      description: A tag for a pet
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      title: a Pet
+      description: A pet for sale in the pet store
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          $ref: '#/components/schemas/Category'
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet


### PR DESCRIPTION
This draft PR currently just adds a failing unit test for issue #9047. It contains a subset of `petstore.yaml` with `Pet` and `Tag` defined, but `Category` is missing.

```yaml
      properties:
        category:
          $ref: '#/components/schemas/Category'
```

does not throw any error as we might expect.

I'll start looking into a custom rule, or seeing why `swagger-parse` is allowing this in the first place.