### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove redundant semicolons

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -266,7 +266,7 @@ public class DefaultCodegenTest {
         CodegenProperty map_string_cp = null;
         Schema map_with_additional_properties_sc = modelPropSchems.get("map_with_additional_properties");
         CodegenProperty map_with_additional_properties_cp = null;
-        Schema map_without_additional_properties_sc = modelPropSchems.get("map_without_additional_properties");;
+        Schema map_without_additional_properties_sc = modelPropSchems.get("map_without_additional_properties");
         CodegenProperty map_without_additional_properties_cp = null;
 
         for(CodegenProperty cp: cm.vars) {
@@ -355,7 +355,7 @@ public class DefaultCodegenTest {
         CodegenProperty map_string_cp = null;
         Schema map_with_additional_properties_sc = modelPropSchems.get("map_with_additional_properties");
         CodegenProperty map_with_additional_properties_cp = null;
-        Schema map_without_additional_properties_sc = modelPropSchems.get("map_without_additional_properties");;
+        Schema map_without_additional_properties_sc = modelPropSchems.get("map_without_additional_properties");
         CodegenProperty map_without_additional_properties_cp = null;
 
         for(CodegenProperty cp: cm.vars) {


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveRedundantSemicolons' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

@OpenAPITools/generator-core-team