### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove trailing whitespace - All lines

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -440,7 +440,7 @@ public class AbstractJavaCodegenTest {
         ModelUtils.setGenerateAliasAsModel(true);
         defaultValue = codegen.toDefaultValue(schema);
         Assert.assertEquals(defaultValue, "new HashMap<String, NestedArray>()");
-        
+
         // Test default value for date format
         DateSchema dateSchema = new DateSchema();
         LocalDate defaultLocalDate = LocalDate.of(2019,2,15);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ktorm/KtormSchemaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ktorm/KtormSchemaCodegenTest.java
@@ -55,19 +55,19 @@ public class KtormSchemaCodegenTest {
         codegen.postProcessModels(toObjs(cm));
         return cm;
     }
-    
+
     private Map<String, Object> getExtension(CodegenProperty property) {
-        return (Map<String, Object>) 
+        return (Map<String, Object>)
             property.vendorExtensions.get(KtormSchemaCodegen.VENDOR_EXTENSION_SCHEMA);
     }
-    
+
     private Map<String, Object> getColumnDefinition(Map<String, Object> schema) {
-        return (Map<String, Object>) 
+        return (Map<String, Object>)
             schema.get("columnDefinition");
     }
 
     private Map<String, Object> getRelationDefinition(Map<String, Object> schema) {
-        return (Map<String, Object>) 
+        return (Map<String, Object>)
             schema.get("relationDefinition");
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/objc/ObjcModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/objc/ObjcModelTest.java
@@ -44,12 +44,12 @@ public class ObjcModelTest {
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
         codegen.setOpenAPI(openAPI);
         final CodegenModel cm = codegen.fromModel("sample", model);
-        
+
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "OAISample");
         Assert.assertEquals(cm.description, "a sample model");
         Assert.assertEquals(cm.vars.size(), 1);
-        
+
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "translations");
         Assert.assertEquals(property1.dataType, "NSDictionary<NSString*, NSDictionary<NSString*, NSString*>*>*");
@@ -59,7 +59,7 @@ public class ObjcModelTest {
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
     }
-    
+
     @Test(description = "convert a simple java model")
     public void simpleModelTest() {
         final Schema model = new Schema()
@@ -177,7 +177,7 @@ public class ObjcModelTest {
         Assert.assertTrue(property1.isPrimitiveType);
     }
 
-    
+
     @Test(description = "convert a model with complex property")
     public void complexPropertyTest() {
         final Schema model = new Schema()

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/BashClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/BashClientOptionsProvider.java
@@ -30,11 +30,11 @@ public class BashClientOptionsProvider implements OptionsProvider {
     public static final String SCRIPT_NAME = "petstore-cli";
     public static final String GENERATE_BASH_COMPLETION = "true";
     public static final String GENERATE_ZSH_COMPLETION = "false";
-    public static final String HOST_ENVIRONMENT_VARIABLE_NAME 
+    public static final String HOST_ENVIRONMENT_VARIABLE_NAME
                                 = "PETSTORE_HOSTNAME";
-    public static final String BASIC_AUTH_ENVIRONMENT_VARIABLE_NAME 
+    public static final String BASIC_AUTH_ENVIRONMENT_VARIABLE_NAME
                                 = "PETSTORE_BASIC_AUTH";
-    public static final String APIKEY_AUTH_ENVIRONMENT_VARIABLE_NAME 
+    public static final String APIKEY_AUTH_ENVIRONMENT_VARIABLE_NAME
                                 = "PETSTORE_APIKEY";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE
                                 = "false";
@@ -47,23 +47,23 @@ public class BashClientOptionsProvider implements OptionsProvider {
 
     @Override
     public Map<String, String> createOptions() {
-        
-        ImmutableMap.Builder<String, String> builder 
+
+        ImmutableMap.Builder<String, String> builder
             = new ImmutableMap.Builder<String, String>();
 
         return builder
                 .put(BashClientCodegen.CURL_OPTIONS, CURL_OPTIONS)
                 .put(BashClientCodegen.SCRIPT_NAME, SCRIPT_NAME)
                 .put(BashClientCodegen.PROCESS_MARKDOWN, PROCESS_MARKDOWN)
-                .put(BashClientCodegen.GENERATE_BASH_COMPLETION, 
+                .put(BashClientCodegen.GENERATE_BASH_COMPLETION,
                         GENERATE_BASH_COMPLETION)
-                .put(BashClientCodegen.GENERATE_ZSH_COMPLETION, 
+                .put(BashClientCodegen.GENERATE_ZSH_COMPLETION,
                         GENERATE_ZSH_COMPLETION)
-                .put(BashClientCodegen.HOST_ENVIRONMENT_VARIABLE_NAME, 
+                .put(BashClientCodegen.HOST_ENVIRONMENT_VARIABLE_NAME,
                         HOST_ENVIRONMENT_VARIABLE_NAME)
-                .put(BashClientCodegen.BASIC_AUTH_ENVIRONMENT_VARIABLE_NAME, 
+                .put(BashClientCodegen.BASIC_AUTH_ENVIRONMENT_VARIABLE_NAME,
                         BASIC_AUTH_ENVIRONMENT_VARIABLE_NAME)
-                .put(BashClientCodegen.APIKEY_AUTH_ENVIRONMENT_VARIABLE_NAME, 
+                .put(BashClientCodegen.APIKEY_AUTH_ENVIRONMENT_VARIABLE_NAME,
                         APIKEY_AUTH_ENVIRONMENT_VARIABLE_NAME)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, "false")
                 .put(CodegenConstants.SORT_MODEL_PROPERTIES_BY_REQUIRED_FLAG, "false")
@@ -73,13 +73,13 @@ public class BashClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
                 .build();
-    
+
     }
 
     @Override
     public boolean isServer() {
-    
+
         return false;
-    
+
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/serializer/SerializerUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/serializer/SerializerUtilsTest.java
@@ -179,7 +179,7 @@ public class SerializerUtilsTest {
                 "      operationId: pingOp\n" +
                 "      responses:\n" +
                 "        \"200\":\n" +
-                "          description: Ok\n"; 
+                "          description: Ok\n";
         assertEquals(content, expected);
     }
 
@@ -210,7 +210,7 @@ public class SerializerUtilsTest {
                 "      }\n" +
                 "    }\n" +
                 "  }\n" +
-                "}"; 
+                "}";
         assertEquals(content, expected);
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/JsonCacheTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/JsonCacheTest.java
@@ -347,7 +347,7 @@ public class JsonCacheTest {
 
 //    private void assertEquals(String string, float f, float float1, float minValue) {
 //        // TODO Auto-generated method stub
-//        
+//
 //    }
 
     @Test


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveAllTrailingWhitespace' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

@OpenAPITools/generator-core-team
