### PR TITLE
Gradle - @Input and @Internal should not be apply on the same property

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -81,9 +81,8 @@ open class GenerateTask : DefaultTask() {
     val outputDir = project.objects.property<String>()
 
     @Suppress("unused")
-    @get:Internal
     @set:Option(option = "input", description = "The input specification.")
-    @Input
+    @Internal
     var input: String? = null
         set(value) {
             inputSpec.set(value)


### PR DESCRIPTION
Motivation:

In Gradle 7.0 apply @Input and @Internal on property is forbidden.
Before Gradle 7.0 applying both on the same property is confusing. According to the documentation:

* @Input: Attached to a task property to indicate that the property specifies some input value for the task.
* @Internal: Attached to a task property to indicate that the property is not to be taken into account for up-to-date checking

Note: Gradle 7.0 is not release yet 2021-03-24

# Step to reproduce
build.gradle.kts
```
plugins {
  id("org.openapi.generator") version ("5.1.0")
}
```
with the command line `./gradlew openApiGenerate` will cause

```
Type 'GenerateTask' property 'input' annotated with @Internal should not be also annotated with @Input.
    
    Reason: A property is ignored but also has input annotations.
    
    Possible solutions:
      1. Remove the input annotations.
      2. Remove the @Internal annotation.
```
