### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove unused imports

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractFSharpCodegen.java
@@ -30,8 +30,6 @@ import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.Exception;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.*;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.InputStreamReader;
 import java.io.IOException;
 import java.util.*;
 import java.util.regex.Matcher;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptApolloClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptApolloClientCodegen.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 
 import static org.openapitools.codegen.utils.StringUtils.*;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -39,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 import java.util.*;
 import java.util.Map.Entry;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalahttpclient/ScalaHttpClientModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalahttpclient/ScalaHttpClientModelTest.java
@@ -25,7 +25,6 @@ import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultCodegen;
 import org.openapitools.codegen.TestUtils;
-import org.openapitools.codegen.languages.ScalaAkkaClientCodegen;
 import org.openapitools.codegen.languages.ScalaHttpClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
@@ -30,11 +30,8 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.List;
 
 public class Swift5ClientCodegenTest {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5OptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5OptionsTest.java
@@ -20,7 +20,6 @@ package org.openapitools.codegen.swift5;
 import org.openapitools.codegen.AbstractOptionsTest;
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.languages.Swift5ClientCodegen;
-import org.openapitools.codegen.options.Swift4OptionsProvider;
 import org.openapitools.codegen.options.Swift5OptionsProvider;
 
 import static org.mockito.Mockito.mock;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypescriptNodeEnumIntegrationTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypescriptNodeEnumIntegrationTest.java
@@ -18,7 +18,6 @@ package org.openapitools.codegen.typescript.typescriptnode;
 
 import org.openapitools.codegen.AbstractIntegrationTest;
 import org.openapitools.codegen.CodegenConfig;
-import org.openapitools.codegen.languages.TypeScriptFetchClientCodegen;
 import org.openapitools.codegen.languages.TypeScriptNodeClientCodegen;
 import org.openapitools.codegen.testutils.IntegrationTestPathsConfig;
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/OnceLoggerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/OnceLoggerTest.java
@@ -1,6 +1,5 @@
 package org.openapitools.codegen.utils;
 
-import com.google.common.base.Ticker;
 import com.google.common.testing.FakeTicker;
 import org.mockito.Mockito;
 import org.openapitools.codegen.config.GlobalSettings;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/URLPathUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/URLPathUtilsTest.java
@@ -27,7 +27,6 @@ import org.testng.annotations.Test;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Map;
 
 public class URLPathUtilsTest {
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaTypeTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/validations/oas/OpenApiSchemaTypeTest.java
@@ -1,6 +1,5 @@
 package org.openapitools.codegen.validations.oas;
 
-import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.validation.Invalid;
@@ -9,7 +8,6 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/yaml/YamlGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/yaml/YamlGeneratorTest.java
@@ -19,10 +19,8 @@ package org.openapitools.codegen.yaml;
 
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.DefaultGenerator;
-import org.openapitools.codegen.MockDefaultGenerator;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.config.CodegenConfigurator;
-import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.languages.OpenAPIYamlGenerator;
 import org.testng.Assert;
 import org.testng.annotations.Test;


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveUnusedImport' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

@OpenAPITools/generator-core-team

Currently the last one of this kind!
