### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove trailing whitespace - All lines - 2

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RClientCodegen.java
@@ -199,7 +199,7 @@ public class RClientCodegen extends DefaultCodegen implements CodegenConfig {
         additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
         additionalProperties.put(CodegenConstants.PACKAGE_VERSION, packageVersion);
         additionalProperties.put(CodegenConstants.EXCEPTION_ON_FAILURE, returnExceptionOnFailure);
-        
+
         additionalProperties.put(USE_DEFAULT_EXCEPTION, this.useDefaultExceptionHandling);
         additionalProperties.put(USE_RLANG_EXCEPTION, this.useRlangExceptionHandling);
 
@@ -358,7 +358,7 @@ public class RClientCodegen extends DefaultCodegen implements CodegenConfig {
         if (ModelUtils.isArraySchema(p)) {
             ArraySchema ap = (ArraySchema) p;
             Schema inner = ap.getItems();
-            return getSchemaType(p) + "[" + getTypeDeclaration(inner)+ "]"; 
+            return getSchemaType(p) + "[" + getTypeDeclaration(inner)+ "]";
         } else if (ModelUtils.isMapSchema(p)) {
             Schema inner = getAdditionalProperties(p);
             return getSchemaType(p) + "(" + getTypeDeclaration(inner) + ")";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -224,7 +224,7 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
                         Map<String, Object> mas = new HashMap<>();
                         mas.put("modelName", camelize(mappedModel.getModelName()));
                         mas.put("mappingName", mappedModel.getMappingName());
-                        
+
                         // TODO: deleting the variable from the array was
                         // problematic; I don't know what this is supposed to do
                         // so I'm just cloning it for the moment

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift4Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift4Codegen.java
@@ -244,7 +244,7 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
                         + StringUtils.join(RESPONSE_LIBRARIES, ", ")
                         + " are available."));
         cliOptions.add(new CliOption(CodegenConstants.NON_PUBLIC_API,
-                CodegenConstants.NON_PUBLIC_API_DESC 
+                CodegenConstants.NON_PUBLIC_API_DESC
                         + "(default: false)"));
         cliOptions.add(new CliOption(UNWRAP_REQUIRED,
                 "Treat 'required' properties in response as non-optional "
@@ -429,8 +429,8 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
         supportingFiles.add(new SupportingFile("Cartfile.mustache",
                 "",
                 "Cartfile"));
-        supportingFiles.add(new SupportingFile("Package.swift.mustache", 
-                "", 
+        supportingFiles.add(new SupportingFile("Package.swift.mustache",
+                "",
                 "Package.swift"));
         supportingFiles.add(new SupportingFile("APIHelper.mustache",
                 sourceFolder,
@@ -460,8 +460,8 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
                 sourceFolder,
                 "JSONEncodingHelper.swift"));
         if (ArrayUtils.contains(responseAs, LIBRARY_RESULT)) {
-            supportingFiles.add(new SupportingFile("Result.mustache", 
-                    sourceFolder, 
+            supportingFiles.add(new SupportingFile("Result.mustache",
+                    sourceFolder,
                     "Result.swift"));
         }
         supportingFiles.add(new SupportingFile("git_push.sh.mustache",

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -41,7 +41,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     private static String FILE_NAME_SUFFIX_PATTERN = "^[a-zA-Z0-9.-]*$";
 
     public static enum QUERY_PARAM_OBJECT_FORMAT_TYPE {dot, json, key}
-    public static enum PROVIDED_IN_LEVEL {none, root, any, platform} 
+    public static enum PROVIDED_IN_LEVEL {none, root, any, platform}
 
     private static final String DEFAULT_IMPORT_PREFIX = "./";
 
@@ -190,7 +190,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
                 apiTemplateFiles.put("apiInterface.mustache", "Interface.ts");
             }
         }
-        
+
         if (additionalProperties.containsKey(USE_SINGLE_REQUEST_PARAMETER)) {
             this.setUseSingleRequestParameter(convertPropertyToBoolean(USE_SINGLE_REQUEST_PARAMETER));
         }
@@ -223,7 +223,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         additionalProperties.put("providedIn", providedIn);
         additionalProperties.put("isProvidedInNone", getIsProvidedInNone());
 
-        if (ngVersion.atLeast("9.0.0")) {                
+        if (ngVersion.atLeast("9.0.0")) {
             additionalProperties.put(ENFORCE_GENERIC_MODULE_WITH_PROVIDERS, true);
         } else {
             additionalProperties.put(ENFORCE_GENERIC_MODULE_WITH_PROVIDERS, false);
@@ -386,7 +386,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     public boolean isDataTypeFile(final String dataType) {
         return dataType != null && dataType.equals("Blob");
     }
- 
+
     @Override
     public String getTypeDeclaration(Schema p) {
         if (ModelUtils.isFileSchema(p)) {
@@ -739,10 +739,10 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         }
         return name;
     }
-    
+
     /**
      * Set the Injectable level
-     * 
+     *
      * @param level the wanted level
      */
     public void setProvidedIn (String level) {
@@ -757,9 +757,9 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
             throw new IllegalArgumentException(msg);
         }
     }
-    
+
     /**
-     * 
+     *
      */
     private boolean getIsProvidedInNone() {
         return PROVIDED_IN_LEVEL.none.equals(providedIn);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -58,9 +58,9 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
     private static final String USE_OBJECT_PARAMS_SWITCH = "useObjectParameters";
     private static final String USE_OBJECT_PARAMS_DESC = "Use aggregate parameter objects as function arguments for api operations instead of passing each parameter as a separate function argument.";
 
-    
+
     private final Map<String, String> frameworkToHttpLibMap;
-    
+
     // NPM Options
     private static final String SNAPSHOT = "snapshot";
     @SuppressWarnings("squid:S5164")
@@ -79,14 +79,14 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
 
     public TypeScriptClientCodegen() {
         super();
-            
+
         this.frameworkToHttpLibMap = new HashMap<>();
         this.frameworkToHttpLibMap.put("fetch-api", "isomorphic-fetch");
         this.frameworkToHttpLibMap.put("jquery", "jquery");
-        
-        
+
+
         this.generatorMetadata = GeneratorMetadata.newBuilder(generatorMetadata).stability(Stability.EXPERIMENTAL).build();
-        
+
         // clear import mapping (from default generator) as TS does not use it
         // at the moment
         importMapping.clear();
@@ -94,7 +94,7 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
         embeddedTemplateDir = templateDir = "typescript";
 
         supportsInheritance = true;
-        
+
         // NOTE: TypeScript uses camel cased reserved words, while models are title cased. We don't want lowercase comparisons.
         reservedWords.addAll(Arrays.asList(
                 // local variable names used in API methods (endpoints)
@@ -151,7 +151,7 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
         typeMapping.put("ByteArray", "string");
         typeMapping.put("UUID", "string");
         typeMapping.put("Error", "Error");
-                
+
 
         cliOptions.add(new CliOption(NPM_NAME, "The name under which you want to publish generated npm package." +
                 " Required to generate a full package"));
@@ -182,11 +182,11 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
         platformOption.defaultValue(PLATFORMS[0]);
 
         cliOptions.add(platformOption);
-        
+
         // Git
         supportingFiles.add(new SupportingFile(".gitignore.mustache", "", ".gitignore"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
-        
+
         // Util
         supportingFiles.add(new SupportingFile("util.mustache", "", "util.ts"));
         supportingFiles.add(new SupportingFile("api" + File.separator + "exception.mustache", "apis", "exception.ts"));
@@ -196,7 +196,7 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
 
         supportingFiles.add(new SupportingFile("configuration.mustache", "", "configuration.ts"));
         supportingFiles.add(new SupportingFile("auth" + File.separator + "auth.mustache", "auth", "auth.ts"));
-        
+
         supportingFiles.add(new SupportingFile("model" + File.separator + "models_all.mustache", "models", "all.ts"));
 
         supportingFiles.add(new SupportingFile("types" + File.separator + "PromiseAPI.mustache", "types", "PromiseAPI.ts"));
@@ -238,12 +238,12 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
     public void setNpmVersion(String npmVersion) {
         this.npmVersion = npmVersion;
     }
-    
+
     @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
-    
+
     @Override
     public void preprocessOpenAPI(OpenAPI openAPI) {
 
@@ -268,9 +268,9 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
 
         }
     }
-    
+
     @Override
-    public Map<String, Object> postProcessSupportingFileData(Map<String, Object> objs) {      
+    public Map<String, Object> postProcessSupportingFileData(Map<String, Object> objs) {
         final Object propFramework = additionalProperties.get(FRAMEWORK_SWITCH);
 
         Map<String, Boolean> frameworks = new HashMap<>();
@@ -284,27 +284,27 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
 
         return objs;
     }
-    
+
     @Override
-    public Map<String, Object> postProcessOperationsWithModels(Map<String, Object> operations, List<Object> models) {     
-        
+    public Map<String, Object> postProcessOperationsWithModels(Map<String, Object> operations, List<Object> models) {
+
         // Add additional filename information for model imports in the apis
         List<Map<String, Object>> imports = (List<Map<String, Object>>) operations.get("imports");
         for (Map<String, Object> im : imports) {
             im.put("filename", ((String) im.get("import")).replace(".", "/"));
             im.put("classname", getModelnameFromModelFilename(im.get("import").toString()));
         }
-        
+
         @SuppressWarnings("unchecked")
         Map<String, Object> operationsMap = (Map<String, Object>) operations.get("operations");
         List<CodegenOperation> operationList = (List<CodegenOperation>) operationsMap.get("operation");
         for (CodegenOperation operation: operationList) {
             List<CodegenResponse> responses = operation.responses;
-            operation.returnType = this.getReturnType(responses);          
+            operation.returnType = this.getReturnType(responses);
         }
         return operations;
     }
-    
+
     /**
      * Returns the correct return type based on all 2xx HTTP responses defined for an operation.
      * @param responses all CodegenResponses defined for one operation
@@ -321,19 +321,19 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
                 }
             }
         }
-        
+
         if (returnTypes.size() == 0) {
             return null;
-        } 
+        }
 
         return String.join(" | ", returnTypes);
     }
-    
+
     private String getModelnameFromModelFilename(String filename) {
         String name = filename.substring((modelPackage() + File.separator).length());
         return camelize(name);
     }
-    
+
     @Override
     public String escapeReservedWord(String name) {
         if (this.reservedWordsMappings().containsKey(name)) {
@@ -510,7 +510,7 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
         }
 
     }
-    
+
     @Override
     protected boolean isReservedWord(String word) {
         // NOTE: This differs from super's implementation in that TypeScript does _not_ want case insensitive matching.
@@ -735,7 +735,7 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
     public String escapeUnsafeCharacters(String input) {
         return input.replace("*/", "*_/").replace("/*", "/_*");
     }
-    
+
     @Override
     public String getName() {
         return "typescript";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
@@ -254,7 +254,7 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
         // This method will determine if there are required parameters and if there are list containers
         Map<String, Object> _operations = (Map<String, Object>) operations.get("operations");
         List<ExtendedCodegenOperation> operationList = (List<ExtendedCodegenOperation>) _operations.get("operation");
-        
+
         boolean hasRequiredParams = false;
         boolean hasListContainers = false;
         boolean hasHttpHeaders = false;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/features/LoggingFeatures.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/features/LoggingFeatures.java
@@ -20,7 +20,7 @@ package org.openapitools.codegen.languages.features;
 public interface LoggingFeatures extends BeanValidationFeatures {
 
     public static final String USE_LOGGING_FEATURE = "useLoggingFeature";
-    
+
     public void setUseLoggingFeature(boolean useLoggingFeature);
-    
+
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/Markdown.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/Markdown.java
@@ -32,7 +32,7 @@ public class Markdown {
     private final Parser parser = Parser.builder().build();
     private final HtmlRenderer renderer = HtmlRenderer.builder().build();
 
-    /** 
+    /**
      * Convert input markdown text to HTML.
      * Simple text is not wrapped in <p>...</p>.
      * @param markdown text with Markdown styles. If <code>null</code>, <code>""</code> is returned.
@@ -46,7 +46,7 @@ public class Markdown {
         html = unwrapped(html);
         return html;
     }
-    
+
     // The CommonMark library wraps the HTML with
     //  <p> ... html ... </p>\n
     // This method removes that markup wrapper if there are no other <p> elements,

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -399,7 +399,7 @@ public class ModelUtils {
 
         // see https://tools.ietf.org/html/rfc6901#section-3
         // Because the characters '~' (%x7E) and '/' (%x2F) have special meanings in
-        // JSON Pointer, '~' needs to be encoded as '~0' and '/' needs to be encoded 
+        // JSON Pointer, '~' needs to be encoded as '~0' and '/' needs to be encoded
         // as '~1' when these characters appear in a reference token.
         // This reverses that encoding.
         ref = ref.replace("~1", "/").replace("~0", "~");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OptionUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/OptionUtils.java
@@ -45,7 +45,7 @@ public class OptionUtils {
 
         return results;
     }
-   
+
     public static List<String> splitCommaSeparatedList(String input) {
 
         List<String> results = new ArrayList<String>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
@@ -265,9 +265,9 @@ public class StringUtils {
                     return character;
                 }
             }).reduce( (c1, c2) -> "" + c1 + c2).orElse(null);
-    
+
             if (result != null) return result;
-            throw new RuntimeException("Word '" + name + "' could not be escaped.");    
+            throw new RuntimeException("Word '" + name + "' could not be escaped.");
         });
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -90,7 +90,7 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
      * 'null' type is supported in OpenAPI Specification 3.1 and above. It is not supported in OpenAPI 3.0.x.
      * Note: the validator invokes checkNullType() for every top-level schema in the OAS document. The method
      * is not called for nested schemas that are defined inline.
-     * 
+     *
      * @param schema An input schema, regardless of the type of schema.
      * @return {@link ValidationRule.Pass} if the check succeeds, otherwise {@link ValidationRule.Fail}
      */
@@ -121,7 +121,7 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
      * JSON Schema uses the 'nullable' attribute.
      * <p>
      * The 'nullable' attribute is supported in OpenAPI Specification 3.0.x, but it is deprecated in OpenAPI 3.1 and above.
-     * 
+     *
      * @param schema An input schema, regardless of the type of schema
      * @return {@link ValidationRule.Pass} if the check succeeds, otherwise {@link ValidationRule.Fail}
      */
@@ -155,7 +155,7 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
      * Validate the OAS document uses supported values for the 'type' attribute.
      * <p>
      * The type must be one of the following values: null, boolean, object, array, number, string, integer.
-     * 
+     *
      * @param schema An input schema, regardless of the type of schema
      * @return {@link ValidationRule.Pass} if the check succeeds, otherwise {@link ValidationRule.Fail}
      */

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/RuleConfiguration.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/RuleConfiguration.java
@@ -96,7 +96,7 @@ public class RuleConfiguration {
     /**
      * Enable or Disable the recommendation check for schemas containing type definitions, specifically
      * for changes between OpenAPI 3.0.x and 3.1.
-     * 
+     *
      * <p>
      * For more details, see {@link RuleConfiguration#isEnableSchemaTypeRecommendation()}
      *
@@ -120,10 +120,10 @@ public class RuleConfiguration {
     public boolean isEnableSchemaTypeRecommendation() {
         return enableSchemaTypeRecommendation;
     }
-    
+
     /**
      * Enable or Disable the recommendation check for the 'nullable' attribute.
-     * 
+     *
      * <p>
      * For more details, see {@link RuleConfiguration#isEnableNullableAttributeRecommendation()}
      *
@@ -149,7 +149,7 @@ public class RuleConfiguration {
 
     /**
      * Enable or Disable the recommendation check for the 'type' attribute.
-     * 
+     *
      * <p>
      * For more details, see {@link RuleConfiguration#isEnableInvalidTypeRecommendation()}
      *

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/InlineModelResolverTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/InlineModelResolverTest.java
@@ -268,7 +268,7 @@ public class InlineModelResolverTest {
     public void testInlineResponseModelType() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/6150_model_json_inline.yaml");
         new InlineModelResolver().flatten(openAPI);
-        
+
         Schema InlineResponse200 = openAPI.getComponents().getSchemas().get("inline_response_200");
         assertEquals("object", InlineResponse200.getType());
         assertEquals("unknown", InlineResponse200.getFormat());

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocGeneratorTest.java
@@ -111,7 +111,7 @@ public class AsciidocGeneratorTest {
         Assert.assertTrue(markupFileGenerated, "index.adoc is not generated!");
 
     }
-    
+
 
     @Test
     public void testHeaderAttributesFlagRemovesAttributesFromMarkupHeaderSection() throws Exception {
@@ -146,6 +146,6 @@ public class AsciidocGeneratorTest {
             }
         }
         Assert.assertTrue(markupFileGenerated, "index.adoc is not generated!");
-    }    
+    }
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/bash/BashTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/bash/BashTest.java
@@ -99,57 +99,57 @@ public class BashTest {
 
         ((BashClientCodegen)codegen).setProcessMarkdown(false);
 
-        Assert.assertEquals(codegen.escapeText("__Bold text__"), 
+        Assert.assertEquals(codegen.escapeText("__Bold text__"),
                             "__Bold text__");
 
-        Assert.assertEquals(codegen.escapeText("**Bold text**"), 
+        Assert.assertEquals(codegen.escapeText("**Bold text**"),
                             "**Bold text**");
 
-        Assert.assertEquals(codegen.escapeText("*Italic text*"), 
+        Assert.assertEquals(codegen.escapeText("*Italic text*"),
                             "*Italic text*");
 
-        Assert.assertEquals(codegen.escapeText("_Italic text_"), 
+        Assert.assertEquals(codegen.escapeText("_Italic text_"),
                             "_Italic text_");
 
 
         ((BashClientCodegen)codegen).setProcessMarkdown(true);
 
-        Assert.assertEquals(codegen.escapeText("__Bold text__"), 
+        Assert.assertEquals(codegen.escapeText("__Bold text__"),
                             "$(tput bold) Bold text $(tput sgr0)");
 
-        Assert.assertEquals(codegen.escapeText("**Bold text**"), 
+        Assert.assertEquals(codegen.escapeText("**Bold text**"),
                             "$(tput bold) Bold text $(tput sgr0)");
 
-        Assert.assertEquals(codegen.escapeText("*Italic text*"), 
+        Assert.assertEquals(codegen.escapeText("*Italic text*"),
                             "$(tput dim) Italic text $(tput sgr0)");
 
-        Assert.assertEquals(codegen.escapeText("_Italic text_"), 
+        Assert.assertEquals(codegen.escapeText("_Italic text_"),
                             "$(tput dim) Italic text $(tput sgr0)");
 
-        Assert.assertEquals(codegen.escapeText("# SECTION NAME"), 
+        Assert.assertEquals(codegen.escapeText("# SECTION NAME"),
             "\n$(tput bold)$(tput setaf 7)SECTION NAME$(tput sgr0)");
 
-        Assert.assertEquals(codegen.escapeText("## SECTION NAME"), 
+        Assert.assertEquals(codegen.escapeText("## SECTION NAME"),
             "\n$(tput bold)$(tput setaf 7)SECTION NAME$(tput sgr0)");
 
-        Assert.assertEquals(codegen.escapeText("### SECTION NAME"), 
+        Assert.assertEquals(codegen.escapeText("### SECTION NAME"),
             "\n$(tput bold)$(tput setaf 7)SECTION NAME$(tput sgr0)");
 
         Assert.assertEquals(codegen.escapeText(
                                 "```\nnice -n 100 mvn test\n```"),
-                                "\n---\nnice -n 100 mvn test\n---"); 
+                                "\n---\nnice -n 100 mvn test\n---");
     }
 
     @Test(description = "test Bash client codegen escapeUnsafeCharacters method")
     public void escapeUnsafeCharactersTest() {
         final DefaultCodegen codegen = new BashClientCodegen();
 
-        Assert.assertEquals(codegen.escapeUnsafeCharacters("`no backticks`"), 
+        Assert.assertEquals(codegen.escapeUnsafeCharacters("`no backticks`"),
                                                           "'no backticks'");
 
 
     }
-    
+
     @Test(description = "test Bash client codegen escapeReservedWord method")
     public void escapeReservedWordTest() {
         final DefaultCodegen codegen = new BashClientCodegen();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/confluencewiki/ConfluenceWikiTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/confluencewiki/ConfluenceWikiTest.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ConfluenceWikiTest {
-    
+
     @Test(description = "convert a model with an enum")
     public void converterTest() {
         final StringSchema enumSchema = new StringSchema();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
@@ -65,7 +65,7 @@ public class DartDioClientCodegenTest {
         final DartDioClientCodegen codegen = new DartDioClientCodegen();
 
         List<String> reservedWordsList = new ArrayList<String>();
-        try {                                                                                   
+        try {
             BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("src/main/resources/dart/dart-keywords.txt"), Charset.forName("UTF-8")));
             while(reader.ready()) { reservedWordsList.add(reader.readLine()); }
             reader.close();
@@ -73,11 +73,11 @@ public class DartDioClientCodegenTest {
             String errorString = String.format(Locale.ROOT, "Error reading dart keywords: %s", e);
             Assert.fail(errorString, e);
         }
-        
+
         Assert.assertEquals(reservedWordsList.size() > 20, true);
         Assert.assertEquals(codegen.reservedWords().size() == reservedWordsList.size(), true);
         for(String keyword : reservedWordsList) {
-            // reserved words are stored in lowercase 
+            // reserved words are stored in lowercase
             Assert.assertEquals(codegen.reservedWords().contains(keyword.toLowerCase(Locale.ROOT)), true, String.format(Locale.ROOT, "%s, part of %s, was not found in %s", keyword, reservedWordsList, codegen.reservedWords().toString()));
         }
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioNextClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioNextClientCodegenTest.java
@@ -66,7 +66,7 @@ public class DartDioNextClientCodegenTest {
         final DartDioClientCodegen codegen = new DartDioClientCodegen();
 
         List<String> reservedWordsList = new ArrayList<String>();
-        try {                                                                                   
+        try {
             BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream("src/main/resources/dart/dart-keywords.txt"), Charset.forName("UTF-8")));
             while(reader.ready()) { reservedWordsList.add(reader.readLine()); }
             reader.close();
@@ -74,11 +74,11 @@ public class DartDioNextClientCodegenTest {
             String errorString = String.format(Locale.ROOT, "Error reading dart keywords: %s", e);
             Assert.fail(errorString, e);
         }
-        
+
         Assert.assertEquals(reservedWordsList.size() > 20, true);
         Assert.assertEquals(codegen.reservedWords().size() == reservedWordsList.size(), true);
         for(String keyword : reservedWordsList) {
-            // reserved words are stored in lowercase 
+            // reserved words are stored in lowercase
             Assert.assertEquals(codegen.reservedWords().contains(keyword.toLowerCase(Locale.ROOT)), true, String.format(Locale.ROOT, "%s, part of %s, was not found in %s", keyword, reservedWordsList, codegen.reservedWords().toString()));
         }
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/fsharp/FSharpServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/fsharp/FSharpServerCodegenTest.java
@@ -62,15 +62,15 @@ public class FSharpServerCodegenTest {
         models.put("wheel", Collections.singletonMap("models", Collections.singletonList(Collections.singletonMap("model", wheel))));
 
         Map<String,Object> sorted = codegen.postProcessDependencyOrders(models);
-        
+
         Object[] keys = sorted.keySet().toArray();
-        
+
         Assert.assertTrue("wheel".equals(keys[0]));
         Assert.assertTrue("bike".equals(keys[1]) || "car".equals(keys[1]));
         Assert.assertTrue("bike".equals(keys[2]) || "car".equals(keys[2]));
         Assert.assertEquals(keys[3], "parent");
         Assert.assertEquals(keys[4], "child");
-        
+
     }
 
     @Test(description = "modify model imports to explicit set namespace and package name")
@@ -79,10 +79,10 @@ public class FSharpServerCodegenTest {
           codegen.setPackageName("MyNamespace");
           codegen.setModelPackage("Model");
           String modified = codegen.toModelImport("Foo");
-          Assert.assertEquals(modified, "MyNamespace.Model.Foo");          
+          Assert.assertEquals(modified, "MyNamespace.Model.Foo");
     }
-    
+
     private static class P_AbstractFSharpCodegen extends AbstractFSharpCodegen {
-     
+
     }
 }


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveUnusedImport' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

@OpenAPITools/generator-core-team

Currently the last one!