### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove trailing whitespace - All lines - 1

### DIFF
--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/ZipUtil.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/ZipUtil.java
@@ -30,7 +30,7 @@ import java.util.zip.ZipOutputStream;
 /**
  * This utility compresses a list of files to standard ZIP format file. It is able to compresses all
  * sub files and sub directories, recursively.
- * 
+ *
  * @author Ha Minh Nam
  *
  */
@@ -42,7 +42,7 @@ public class ZipUtil {
 
     /**
      * Compresses a collection of files to a destination zip file.
-     * 
+     *
      * @param listFiles A collection of files and directories
      * @param destZipFile The path of the destination zip file
      * @throws FileNotFoundException if file not found
@@ -67,7 +67,7 @@ public class ZipUtil {
 
     /**
      * Adds a directory to the current zip output stream.
-     * 
+     *
      * @param folder the directory to be added
      * @param parentFolder the path of parent directory
      * @param zos the current zip output stream
@@ -99,7 +99,7 @@ public class ZipUtil {
 
     /**
      * Adds a file to the current zip output stream.
-     * 
+     *
      * @param file the file to be added
      * @param zos the current zip output stream
      * @throws FileNotFoundException if file not found

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CliOption.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CliOption.java
@@ -77,7 +77,7 @@ public class CliOption {
     public String getOptValue() {
         return this.optValue;
     }
-    
+
     public void setOptValue(String optValue) {
         if (this.enumValues!=null && this.enumValues.containsKey(optValue)) {
             this.optValue = optValue;
@@ -106,7 +106,7 @@ public class CliOption {
 
     /**
      * Create new boolean command line option with a default of false
-     * 
+     *
      * @param opt Option name
      * @param description Option description
      * @return the CliOption created
@@ -117,7 +117,7 @@ public class CliOption {
 
     /**
      * Create new boolean command line option with the provided value as default
-     * 
+     *
      * @param opt Option name
      * @param description Option description
      * @param defaultValue the default value to use if option not specified

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -123,9 +123,9 @@ public interface CodegenConfig {
     List<CodegenSecurity> fromSecurity(Map<String, SecurityScheme> schemas);
 
     List<CodegenServer> fromServers(List<Server> servers);
-  
+
     List<CodegenServerVariable> fromServerVariables(Map<String, ServerVariable> variables);
-    
+
     Set<String> defaultIncludes();
 
     Map<String, String> typeMapping();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -53,7 +53,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
     public String name;
     // The language-specific name of the class that implements this schema.
     // The name of the class is derived from the OpenAPI schema name with formatting rules applied.
-    // The classname is derived from the OpenAPI schema name, with sanitization and escaping rules applied. 
+    // The classname is derived from the OpenAPI schema name, with sanitization and escaping rules applied.
     public String classname;
     // The value of the 'title' attribute in the OpenAPI document.
     public String title;
@@ -109,7 +109,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
     /**
      * The type of the value for the additionalProperties keyword in the OAS document.
      * Used in map like objects, including composed schemas.
-     * 
+     *
      * In most programming languages, the additional (undeclared) properties are stored
      * in a map data structure, such as HashMap in Java, map in golang, or a dict in Python.
      * There are multiple ways to implement the additionalProperties keyword, depending
@@ -122,7 +122,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
      *
      * For example, in the OAS schema below, the schema has a declared 'id' property
      * and additional, undeclared properties of type 'integer' are allowed.
-     * 
+     *
      * type: object
      * properties:
      *   id:
@@ -232,7 +232,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
      * Return true if the classname property is sanitized, false if it is the same as the OpenAPI schema name.
      * The OpenAPI schema name may be any valid JSON schema name, including non-ASCII characters.
      * The name of the class may have to be sanitized with character escaping.
-     * 
+     *
      * @return true if the classname property is sanitized
      */
     public boolean getIsClassnameSanitized() {
@@ -273,7 +273,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
 
     /**
      * Returns the discriminator for this schema object, or null if no discriminator has been specified.
-     * 
+     *
      * The list of all possible schema discriminator mapping values is obtained
      * from explicit discriminator mapping values in the OpenAPI document, and from
      * inherited discriminators through oneOf, allOf, anyOf.
@@ -283,7 +283,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
      * 'objectType' properties are 'Dog' and 'Cat'.
      * The allowed discriminator mapping value for the Dog schema is 'Dog'.
      * The allowed discriminator mapping value for the Cat schema is 'Dog'.
-     * 
+     *
      * Pet:
      *   type: object
      *   discriminator:
@@ -307,7 +307,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
      *     properties:
      *       p2:
      *         type: string
-     * 
+     *
      * @return the discriminator.
      */
     public CodegenDiscriminator getDiscriminator() {
@@ -323,7 +323,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
      * In the OpenAPI document, the discriminator may be specified in the local schema or
      * it may be inherited, such as through a 'allOf' schema which references another schema
      * that has a discriminator, recursively.
-     * 
+     *
      * @return the name of the discriminator property.
      */
     public String getDiscriminatorName() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -31,7 +31,7 @@ public class CodegenOperation {
             isRestfulIndex, isRestfulShow, isRestfulCreate, isRestfulUpdate, isRestfulDestroy,
             isRestful, isDeprecated, isCallbackRequest, uniqueItems;
     public String path, operationId, returnType, returnFormat, httpMethod, returnBaseType,
-            returnContainer, summary, unescapedNotes, notes, baseName, defaultResponse; 
+            returnContainer, summary, unescapedNotes, notes, baseName, defaultResponse;
     public CodegenDiscriminator discriminator;
     public List<Map<String, String>> consumes, produces, prioritizedContentTypes;
     public List<CodegenServer> servers = new ArrayList<CodegenServer>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -157,7 +157,7 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
     public Map<String, Object> allowableValues;
     // If 'additionalProperties' is not set, items is null.
     // If 'additionalProperties' is set to a type or refers to a type, 'items' provides the type information for
-    // the undeclared properties. 
+    // the undeclared properties.
     public CodegenProperty items;
     public CodegenProperty additionalProperties;
     public List<CodegenProperty> vars = new ArrayList<CodegenProperty>(); // all properties (without parent's properties)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -461,7 +461,7 @@ public class DefaultCodegen implements CodegenConfig {
 
     /**
      * Return a map from model name to Schema for efficient lookup.
-     * 
+     *
      * @return map from model name to Schema.
      */
     protected Map<String, Schema> getModelNameToSchemaCache() {
@@ -3090,7 +3090,7 @@ public class DefaultCodegen implements CodegenConfig {
 
     /**
      * Convert OAS Property object to Codegen Property object.
-     * 
+     *
      * The return value is cached. An internal cache is looked up to determine
      * if the CodegenProperty return value has already been instantiated for
      * the (String name, Schema p) arguments.
@@ -4723,13 +4723,13 @@ public class DefaultCodegen implements CodegenConfig {
      * of the 'additionalProperties' keyword. Some language generator use class inheritance
      * to implement additional properties. For example, in Java the generated model class
      * has 'extends HashMap' to represent the additional properties.
-     * 
+     *
      * TODO: it's not a good idea to use single class inheritance to implement
      * additionalProperties. That may work for non-composed schemas, but that does not
      * work for composed 'allOf' schemas. For example, in Java, if additionalProperties
      * is set to true (which it should be by default, per OAS spec), then the generated
      * code has extends HashMap. That wouldn't work for composed 'allOf' schemas.
-     * 
+     *
      * @param model the codegen representation of the OAS schema.
      * @param name the name of the model.
      * @param schema the input OAS schema.
@@ -6612,7 +6612,7 @@ public class DefaultCodegen implements CodegenConfig {
 
     /**
      * Returns the additionalProperties Schema for the specified input schema.
-     * 
+     *
      * The additionalProperties keyword is used to control the handling of additional, undeclared
      * properties, that is, properties whose names are not listed in the properties keyword.
      * The additionalProperties keyword may be either a boolean or an object.
@@ -6620,7 +6620,7 @@ public class DefaultCodegen implements CodegenConfig {
      * By default when the additionalProperties keyword is not specified in the input schema,
      * any additional properties are allowed. This is equivalent to setting additionalProperties
      * to the boolean value True or setting additionalProperties: {}
-     * 
+     *
      * @param schema the input schema that may or may not have the additionalProperties keyword.
      * @return the Schema of the additionalProperties. The null value is returned if no additional
      *         properties are allowed.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfiguratorUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfiguratorUtils.java
@@ -38,7 +38,7 @@ import java.util.*;
  * </ul>
  * <p>
  *     The corresponding {@code add...} method on the passed configurator is called for each key-value pair (or value).
- * </p>  
+ * </p>
  */
 public final class CodegenConfiguratorUtils {
 
@@ -60,7 +60,7 @@ public final class CodegenConfiguratorUtils {
             applyInstantiationTypesKvp(propString, configurator);
         }
     }
-    
+
     public static void applyInstantiationTypesKvp(String instantiationTypes, CodegenConfigurator configurator) {
         final Map<String, String> map = createMapFromKeyValuePairs(instantiationTypes);
         for (Map.Entry<String, String> entry : map.entrySet()) {
@@ -143,9 +143,9 @@ public final class CodegenConfiguratorUtils {
         final Map<String, String> map = createMapFromKeyValuePairs(reservedWordMappings);
         for (Map.Entry<String, String> entry : map.entrySet()) {
             configurator.addAdditionalReservedWordMapping(entry.getKey(), entry.getValue());
-        }        
+        }
     }
-        
+
     private static Set<String> createSetFromCsvList(String csvProperty) {
         final List<String> values = OptionUtils.splitCommaSeparatedList(csvProperty);
         return new HashSet<String>(values);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/GlobalSettings.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/GlobalSettings.java
@@ -25,7 +25,7 @@ import java.util.Properties;
  *
  * This provides a set of properties specific to the executing thread, such that the generator may not modify system properties
  * consumed by other threads.
- * 
+ *
  * @author gndrm
  * @since 2018
  */

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractEiffelCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractEiffelCodegen.java
@@ -90,7 +90,7 @@ public abstract class AbstractEiffelCodegen extends DefaultCodegen implements Co
         instantiationTypes.put("array", "ARRAYED_LIST");
         instantiationTypes.put("list", "ARRAYED_LIST");
         instantiationTypes.put("map", "STRING_TABLE");
-        
+
         importMapping.put("List", "LIST");
         importMapping.put("Set", "SET");
         importMapping.put("file", "FILE");
@@ -152,7 +152,7 @@ public abstract class AbstractEiffelCodegen extends DefaultCodegen implements Co
             name = escapeReservedWord(name);
         }
 
-        // for reserved word or word starting with number, append 
+        // for reserved word or word starting with number, append
         if (name.matches("^\\d.*")) {
             name = escapeReservedWord(name);
         }
@@ -348,7 +348,7 @@ public abstract class AbstractEiffelCodegen extends DefaultCodegen implements Co
                     + camelize("call_" + operationId));
             sanitizedOperationId = "call_" + sanitizedOperationId;
         }
-        
+
         // operationId starts with a number
         if (operationId.matches("^\\d.*")) {
             LOGGER.warn(operationId + " (starting with a number) cannot be used as method sname. Renamed to " + camelize("call_" + operationId), true);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -595,7 +595,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         // The 'go-experimental/model.mustache' template conditionally generates accessor methods.
         // For primitive types and custom types (e.g. interface{}, map[string]interface{}...),
         // the generated code has a wrapper type and a Get() function to access the underlying type.
-        // For containers (e.g. Array, Map), the generated code returns the type directly. 
+        // For containers (e.g. Array, Map), the generated code returns the type directly.
         if (property.isContainer || property.isFreeFormObject || property.isAnyType) {
             property.vendorExtensions.put("x-golang-is-container", true);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1874,7 +1874,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel, Schema schema) {
         if (!supportsAdditionalPropertiesWithComposedSchema) {
             // The additional (undeclared) propertiees are modeled in Java as a HashMap.
-            // 
+            //
             // 1. supportsAdditionalPropertiesWithComposedSchema is set to false:
             //    The generated model class extends from the HashMap. That does not work
             //    with composed schemas that also use a discriminator because the model class

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ApexClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ApexClientCodegen.java
@@ -106,8 +106,8 @@ public class ApexClientCodegen extends AbstractApexCodegen {
                         "hint", "if", "implements", "import", "in", "inner", "insert", "instanceof", "int", "integer",
                         "interface", "into", "join", "like", "limit", "list", "long", "loop", "map", "merge", "new",
                         "not", "null", "nulls", "number", "object", "of", "on", "or", "outer", "override", "package", "parallel",
-                        "pragma", "private", "protected", "public", "retrieve", "return", 
-                        "rollback", "select", "set", "short", "sObject", "sort", "static", "string", 
+                        "pragma", "private", "protected", "public", "retrieve", "return",
+                        "rollback", "select", "set", "short", "sObject", "sort", "static", "string",
                         "super", "switch", "synchronized", "system", "testmethod", "then", "this",
                         "throw", "time", "transaction", "trigger", "true", "try", "undelete", "update", "upsert", "using",
                         "virtual", "void", "webservice", "when", "where", "while"

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -651,7 +651,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         postProcessPattern(parameter.pattern, parameter.vendorExtensions);
         postProcessEmitDefaultValue(parameter.vendorExtensions);
         super.postProcessParameter(parameter);
-        
+
         if (nullableType.contains(parameter.dataType)) {
             if (!parameter.required) { //optional
                 parameter.dataType = parameter.dataType + "?";
@@ -666,7 +666,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         postProcessPattern(property.pattern, property.vendorExtensions);
         postProcessEmitDefaultValue(property.vendorExtensions);
         super.postProcessModelProperty(model, property);
-        
+
         if (!property.isContainer && (nullableType.contains(property.dataType) || property.isEnum)) {
             property.vendorExtensions.put("x-csharp-value-type", true);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ConfluenceWikiCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ConfluenceWikiCodegen.java
@@ -128,7 +128,7 @@ public class ConfluenceWikiCodegen extends DefaultCodegen implements CodegenConf
     public Map<String, Object> postProcessModels(Map<String, Object> objs) {
         return postProcessModelsEnum(objs);
     }
-    
+
     @Override
     public String escapeQuotationMark(String input) {
         // just return the original string
@@ -140,13 +140,13 @@ public class ConfluenceWikiCodegen extends DefaultCodegen implements CodegenConf
         // just return the original string
         return input;
     }
-    
+
     @Override
     public String escapeText(String input) {
         if (input == null) {
             return input;
         }
-        
+
         // chomp tailing newline because it breaks the tables and keep all other sign to show documentation properly
         return StringUtils.chomp(input);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5ClientCodegen.java
@@ -97,7 +97,7 @@ public class CppQt5ClientCodegen extends CppQt5AbstractCodegen implements Codege
         supportingFiles.add(new SupportingFile("ServerConfiguration.mustache", sourceFolder, PREFIX +"ServerConfiguration.h"));
         supportingFiles.add(new SupportingFile("ServerVariable.mustache", sourceFolder, PREFIX +"ServerVariable.h"));
         supportingFiles.add(new SupportingFile("README.mustache", "","README.md"));
-        supportingFiles.add(new SupportingFile("CMakeLists.txt.mustache", sourceFolder, "CMakeLists.txt"));       
+        supportingFiles.add(new SupportingFile("CMakeLists.txt.mustache", sourceFolder, "CMakeLists.txt"));
         if (optionalProjectFileFlag) {
             supportingFiles.add(new SupportingFile("Project.mustache", sourceFolder, "client.pri"));
         }
@@ -122,14 +122,14 @@ public class CppQt5ClientCodegen extends CppQt5AbstractCodegen implements Codege
             supportingFiles.add(new SupportingFile("HttpRequest.h.mustache", sourceFolder, modelNamePrefix + "HttpRequest.h"));
             supportingFiles.add(new SupportingFile("HttpRequest.cpp.mustache", sourceFolder, modelNamePrefix + "HttpRequest.cpp"));
             supportingFiles.add(new SupportingFile("HttpFileElement.h.mustache", sourceFolder, modelNamePrefix + "HttpFileElement.h"));
-            supportingFiles.add(new SupportingFile("HttpFileElement.cpp.mustache", sourceFolder, modelNamePrefix + "HttpFileElement.cpp"));           
+            supportingFiles.add(new SupportingFile("HttpFileElement.cpp.mustache", sourceFolder, modelNamePrefix + "HttpFileElement.cpp"));
             supportingFiles.add(new SupportingFile("object.mustache", sourceFolder, modelNamePrefix + "Object.h"));
             supportingFiles.add(new SupportingFile("enum.mustache", sourceFolder, modelNamePrefix + "Enum.h"));
             supportingFiles.add(new SupportingFile("ServerConfiguration.mustache", sourceFolder, modelNamePrefix + "ServerConfiguration.h"));
             supportingFiles.add(new SupportingFile("ServerVariable.mustache", sourceFolder, modelNamePrefix + "ServerVariable.h"));
             supportingFiles.add(new SupportingFile("README.mustache", "","README.md"));
             supportingFiles.add(new SupportingFile("CMakeLists.txt.mustache", sourceFolder, "CMakeLists.txt"));
-           
+
 
             typeMapping.put("file", modelNamePrefix + "HttpFileElement");
             importMapping.put(modelNamePrefix + "HttpFileElement", "#include \"" + modelNamePrefix + "HttpFileElement.h\"");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppUE4ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppUE4ClientCodegen.java
@@ -509,7 +509,7 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
         if (isReservedWord(name) || name.matches("^\\d.*")) {
             name = escapeReservedWord(name);
         }
-        
+
         return name;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
@@ -391,7 +391,7 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     static class ParameterSorter implements Comparator<CodegenParameter> {
-        public int compare(final CodegenParameter p1, final CodegenParameter p2) { 
+        public int compare(final CodegenParameter p1, final CodegenParameter p2) {
             return index(p1) - index(p2);
         }
 
@@ -410,8 +410,8 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
             }
             return 5;
         }
-    }   
-    
+    }
+
     @Override
     public String toDefaultValue(Schema p) {
         if (ModelUtils.isStringSchema(p)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
@@ -450,7 +450,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
         for (CodegenParameter param : pathParams) {
             captureTypes.put(param.baseName, param.dataType);
         }
-        
+
         // Properly handle root-only routes (#3256)
         if (path.contentEquals("/")) {
             return new ArrayList<>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLumenServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLumenServerCodegen.java
@@ -175,7 +175,7 @@ public class PhpLumenServerCodegen extends AbstractPhpCodegen {
             op.httpMethod = op.httpMethod.toLowerCase(Locale.ROOT);
         }
 
-        // sort the endpoints in ascending to avoid the route priority issure. 
+        // sort the endpoints in ascending to avoid the route priority issure.
         Collections.sort(operations, new Comparator<CodegenOperation>() {
             @Override
             public int compare(CodegenOperation lhs, CodegenOperation rhs) {


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveAllTrailingWhitespace' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

@OpenAPITools/generator-core-team

