### PR TITLE
[Bug-9070] Typescript fetch URLEncoding for nested JSON object

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -220,7 +220,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
                 return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
             }
             if (value instanceof Object) {
-                return querystring(value as HTTPQuery, fullKey);
+                return `${encodeURIComponent(fullKey)}=${encodeURIComponent(JSON.stringify(value))}`;
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -231,7 +231,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
                 return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
             }
             if (value instanceof Object) {
-                return querystring(value as HTTPQuery, fullKey);
+                return `${encodeURIComponent(fullKey)}=${encodeURIComponent(JSON.stringify(value))}`;
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -231,7 +231,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
                 return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
             }
             if (value instanceof Object) {
-                return querystring(value as HTTPQuery, fullKey);
+                return `${encodeURIComponent(fullKey)}=${encodeURIComponent(JSON.stringify(value))}`;
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -231,7 +231,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
                 return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
             }
             if (value instanceof Object) {
-                return querystring(value as HTTPQuery, fullKey);
+                return `${encodeURIComponent(fullKey)}=${encodeURIComponent(JSON.stringify(value))}`;
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -231,7 +231,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
                 return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
             }
             if (value instanceof Object) {
-                return querystring(value as HTTPQuery, fullKey);
+                return `${encodeURIComponent(fullKey)}=${encodeURIComponent(JSON.stringify(value))}`;
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -231,7 +231,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
                 return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
             }
             if (value instanceof Object) {
-                return querystring(value as HTTPQuery, fullKey);
+                return `${encodeURIComponent(fullKey)}=${encodeURIComponent(JSON.stringify(value))}`;
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -231,7 +231,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
                 return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
             }
             if (value instanceof Object) {
-                return querystring(value as HTTPQuery, fullKey);
+                return `${encodeURIComponent(fullKey)}=${encodeURIComponent(JSON.stringify(value))}`;
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
@@ -231,7 +231,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
                 return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
             }
             if (value instanceof Object) {
-                return querystring(value as HTTPQuery, fullKey);
+                return `${encodeURIComponent(fullKey)}=${encodeURIComponent(JSON.stringify(value))}`;
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -231,7 +231,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
                 return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
             }
             if (value instanceof Object) {
-                return querystring(value as HTTPQuery, fullKey);
+                return `${encodeURIComponent(fullKey)}=${encodeURIComponent(JSON.stringify(value))}`;
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -231,7 +231,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
                 return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
             }
             if (value instanceof Object) {
-                return querystring(value as HTTPQuery, fullKey);
+                return `${encodeURIComponent(fullKey)}=${encodeURIComponent(JSON.stringify(value))}`;
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -231,7 +231,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
                 return `${encodeURIComponent(fullKey)}=${encodeURIComponent(value.toISOString())}`;
             }
             if (value instanceof Object) {
-                return querystring(value as HTTPQuery, fullKey);
+                return `${encodeURIComponent(fullKey)}=${encodeURIComponent(JSON.stringify(value))}`;
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })


### PR DESCRIPTION
This PR is to update the issue #9070 This updates the URL encoding to percent when using nested objects 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 

- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
Review: 
 @macjohnny @topce @akehir @petejohansonxo @amakhrov
