### PR TITLE
[cleanup] erefactor/EclipseJdt - Make inner class static

### DIFF
--- a/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/validation/ValidationRuleTest.java
+++ b/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/validation/ValidationRuleTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 public class ValidationRuleTest {
-    class Sample {
+    static class Sample {
         private String name;
 
         public Sample(String name) {

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/OpenAPI2SpringBoot.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/OpenAPI2SpringBoot.java
@@ -42,7 +42,7 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
         new SpringApplication(OpenAPI2SpringBoot.class).run(args);
     }
 
-    class ExitException extends RuntimeException implements ExitCodeGenerator {
+    static class ExitException extends RuntimeException implements ExitCodeGenerator {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNancyFXServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNancyFXServerCodegen.java
@@ -423,7 +423,7 @@ public class CSharpNancyFXServerCodegen extends AbstractCSharpCodegen {
         return ImmutableSet.of("LocalTime?", "LocalDate?", "ZonedDateTime?");
     }
 
-    private class DependencyInfo {
+    private static class DependencyInfo {
         private final String version;
         private final String framework;
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaPKMSTServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaPKMSTServerCodegen.java
@@ -658,7 +658,7 @@ public class JavaPKMSTServerCodegen extends AbstractJavaCodegen {
         void setReturnContainer(String returnContainer);
     }
 
-    private class ResourcePath {
+    private static class ResourcePath {
 
         private String path;
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KtormSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KtormSchemaCodegen.java
@@ -61,7 +61,7 @@ public class KtormSchemaCodegen extends AbstractKotlinCodegen {
     protected Map<String, String> sqlTypeMapping = new HashMap<String, String>();
 
     // https://ktorm.liuwj.me/api-docs/me.liuwj.ktorm.schema/index.html
-    protected class SqlType {
+    protected static class SqlType {
         protected static final String Blob = "blob";
         protected static final String Boolean = "boolean";
         protected static final String Bytes = "bytes";
@@ -335,7 +335,7 @@ public class KtormSchemaCodegen extends AbstractKotlinCodegen {
         return objs;
     }
 
-    private class KtormSchema extends HashMap<String, Object> {
+    private static class KtormSchema extends HashMap<String, Object> {
         private static final long serialVersionUID = -9159755928980443880L;
     }
 
@@ -763,7 +763,7 @@ public class KtormSchemaCodegen extends AbstractKotlinCodegen {
         return input.substring(0, 1).toLowerCase(Locale.ROOT) + input.substring(1);
     }
 
-    private class SqlTypeArgs {
+    private static class SqlTypeArgs {
         // type classes
         public boolean isPrimitive;
         public boolean isNumeric;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/JsonCache.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/JsonCache.java
@@ -58,7 +58,7 @@ public interface JsonCache {
     /**
      * Exception thrown by cache operations. Not intended to be created by client code.
      */
-    class CacheException extends Exception {
+    static class CacheException extends Exception {
         private static final long serialVersionUID = -1215367978375557620L;
 
         CacheException(String message) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -76,7 +76,7 @@ public class AbstractKotlinCodegenTest {
         assertEquals(codegen.toEnumValue("data", "Something"), "\"data\"");
     }
 
-    private class P_AbstractKotlinCodegen extends AbstractKotlinCodegen {
+    private static class P_AbstractKotlinCodegen extends AbstractKotlinCodegen {
         @Override
         public CodegenType getTag() {
             return null;


### PR DESCRIPTION
EclipseJdt cleanup 'MakeInnerClassStatic' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

@OpenAPITools/generator-core-team

