### PR TITLE
[C++] remove pthread from CMakeLists.txt

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/cmake-lists.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/cmake-lists.mustache
@@ -39,7 +39,6 @@ else()
 
     find_package(cpprestsdk REQUIRED)
     find_package(Boost REQUIRED)
-    find_package(pthreads REQUIRED)
 endif()
 
 # Manually set the cpprestsdk paths when not using package manager
@@ -68,9 +67,9 @@ target_link_directories(
 )
 
 if (UNIX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE cpprest pthread ${Boost_LIBRARIES} crypto)
+    target_link_libraries(${PROJECT_NAME} PRIVATE cpprest ${Boost_LIBRARIES} crypto)
 else()
-    target_link_libraries(${PROJECT_NAME} PRIVATE cpprestsdk::cpprest ${pthreads_LIBRARIES} ${Boost_LIBRARIES} bcrypt)
+    target_link_libraries(${PROJECT_NAME} PRIVATE cpprestsdk::cpprest ${Boost_LIBRARIES} bcrypt)
 endif()
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)

--- a/samples/client/petstore/cpp-restsdk/client/CMakeLists.txt
+++ b/samples/client/petstore/cpp-restsdk/client/CMakeLists.txt
@@ -39,7 +39,6 @@ else()
 
     find_package(cpprestsdk REQUIRED)
     find_package(Boost REQUIRED)
-    find_package(pthreads REQUIRED)
 endif()
 
 # Manually set the cpprestsdk paths when not using package manager
@@ -68,9 +67,9 @@ target_link_directories(
 )
 
 if (UNIX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE cpprest pthread ${Boost_LIBRARIES} crypto)
+    target_link_libraries(${PROJECT_NAME} PRIVATE cpprest ${Boost_LIBRARIES} crypto)
 else()
-    target_link_libraries(${PROJECT_NAME} PRIVATE cpprestsdk::cpprest ${pthreads_LIBRARIES} ${Boost_LIBRARIES} bcrypt)
+    target_link_libraries(${PROJECT_NAME} PRIVATE cpprestsdk::cpprest ${Boost_LIBRARIES} bcrypt)
 endif()
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)


### PR DESCRIPTION
Remove `pthread` from CMakeLists.txt as it's not used in the client (`pthread` not found in the code)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @ravinikam (2017/07) @stkrwork (2017/07) @etherealjoy (2018/02) @martindelille (2018/03) @muttleyxd (2019/08)


