### PR TITLE
Fixes type null not handled properly in [python] toExampleValue

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonLegacyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonLegacyClientCodegen.java
@@ -17,6 +17,7 @@
 
 package org.openapitools.codegen.languages;
 
+import io.swagger.v3.oas.models.media.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
@@ -430,5 +431,4 @@ public class PythonLegacyClientCodegen extends AbstractPythonCodegen implements 
     public String generatePackageName(String packageName) {
         return underscore(packageName.replaceAll("[^\\w]+", ""));
     }
-
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
@@ -460,7 +460,7 @@ public class PythonClientTest {
         expectedValue = expectedValue.replaceAll("\\r\\n", "\n");
 
 
-        Assert.assertEquals(expectedValue.trim(), exampleValue.trim());
+        Assert.assertEquals(exampleValue.trim(), expectedValue.trim());
 
     }
 

--- a/modules/openapi-generator/src/test/resources/3_0/issue_8052_recursive_model_expected_value.txt
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_8052_recursive_model_expected_value.txt
@@ -1,9 +1,6 @@
 GeoJsonGeometry(
         type="GeometryCollection",
         geometries=[
-            GeoJsonGeometry(
-                type="GeometryCollection",
-                geometries=[],
-            ),
+            GeoJsonGeometry(),
         ],
     )

--- a/samples/client/petstore/python/docs/FakeApi.md
+++ b/samples/client/petstore/python/docs/FakeApi.md
@@ -842,13 +842,13 @@ with petstore_api.ApiClient(configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
     number = 32.1 # float | None
     double = 67.8 # float | None
-    pattern_without_delimiter = "AUR,rZ#UM/?R,Fp^l6$ARjbhJk C" # str | None
+    pattern_without_delimiter = "Aj" # str | None
     byte = 'YQ==' # str | None
     integer = 10 # int | None (optional)
     int32 = 20 # int | None (optional)
     int64 = 1 # int | None (optional)
     float = 3.14 # float | None (optional)
-    string = "a" # str | None (optional)
+    string = "A" # str | None (optional)
     binary = open('/path/to/file', 'rb') # file_type | None (optional)
     date = dateutil_parser('1970-01-01').date() # date | None (optional)
     date_time = dateutil_parser('1970-01-01T00:00:00.00Z') # datetime | None (optional)

--- a/samples/openapi3/client/petstore/python/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python/docs/FakeApi.md
@@ -1146,13 +1146,13 @@ with petstore_api.ApiClient(configuration) as api_client:
     api_instance = fake_api.FakeApi(api_client)
     number = 32.1 # float | None
     double = 67.8 # float | None
-    pattern_without_delimiter = "AUR,rZ#UM/?R,Fp^l6$ARjbhJk C" # str | None
+    pattern_without_delimiter = "Aj" # str | None
     byte = 'YQ==' # str | None
     integer = 10 # int | None (optional)
     int32 = 20 # int | None (optional)
     int64 = 1 # int | None (optional)
     float = 3.14 # float | None (optional)
-    string = "a" # str | None (optional)
+    string = "A" # str | None (optional)
     binary = open('/path/to/file', 'rb') # file_type | None (optional)
     date = dateutil_parser('1970-01-01').date() # date | None (optional)
     date_time = dateutil_parser('2020-02-02T20:20:20.22222Z') # datetime | None (optional) if omitted the server will use the default value of dateutil_parser('2010-02-01T10:20:10.11111+01:00')


### PR DESCRIPTION
Fixes type null not handled properly in [python] toExampleValue
Improves regex example setting in the python client generator

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
