### PR TITLE
[cleanup] erefactor/EclipseJdt - Evaluate without null check

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -429,7 +429,7 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
             // Create a variable to display the correct return type in comments for interfaces
             if (op.returnType != null) {
                 op.vendorExtensions.put("x-comment-type", op.returnType);
-                if (op.returnContainer != null && "array".equals(op.returnContainer)) {
+                if ("array".equals(op.returnContainer)) {
                     op.vendorExtensions.put("x-comment-type", op.returnType + "[]");
                 }
             } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1560,12 +1560,12 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
 
             LOGGER.trace("Post processing model: {}", cm);
 
-            if (cm.dataType != null && "object".equals(cm.dataType)) {
+            if ("object".equals(cm.dataType)) {
                 // Object isn't a sensible default. Instead, we set it to
                 // 'null'. This ensures that we treat this model as a struct
                 // with multiple parameters.
                 cm.dataType = null;
-            } else if (cm.dataType != null && "map".equals(cm.dataType)) {
+            } else if ("map".equals(cm.dataType)) {
                 if (!cm.allVars.isEmpty() || cm.additionalPropertiesType == null) {
                     // We don't yet support `additionalProperties` that also have
                     // properties. If we see variables, we ignore the

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift4Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift4Codegen.java
@@ -534,12 +534,12 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public boolean isDataTypeFile(String dataType) {
-        return dataType != null && "URL".equals(dataType);
+        return "URL".equals(dataType);
     }
 
     @Override
     public boolean isDataTypeBinary(final String dataType) {
-        return dataType != null && "Data".equals(dataType);
+        return "Data".equals(dataType);
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
@@ -546,12 +546,12 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
 
     @Override
     public boolean isDataTypeFile(String dataType) {
-        return dataType != null && "URL".equals(dataType);
+        return "URL".equals(dataType);
     }
 
     @Override
     public boolean isDataTypeBinary(final String dataType) {
-        return dataType != null && "Data".equals(dataType);
+        return "Data".equals(dataType);
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -384,7 +384,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
     @Override
     public boolean isDataTypeFile(final String dataType) {
-        return dataType != null && "Blob".equals(dataType);
+        return "Blob".equals(dataType);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptInversifyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptInversifyClientCodegen.java
@@ -141,7 +141,7 @@ public class TypeScriptInversifyClientCodegen extends AbstractTypeScriptClientCo
 
     @Override
     public boolean isDataTypeFile(final String dataType) {
-        return dataType != null && "Blob".equals(dataType);
+        return "Blob".equals(dataType);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNestjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNestjsClientCodegen.java
@@ -216,7 +216,7 @@ public class TypeScriptNestjsClientCodegen extends AbstractTypeScriptClientCodeg
 
     @Override
     public boolean isDataTypeFile(final String dataType) {
-        return dataType != null && "Blob".equals(dataType);
+        return "Blob".equals(dataType);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
@@ -82,7 +82,7 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
 
     @Override
     public boolean isDataTypeFile(final String dataType) {
-        return dataType != null && "RequestFile".equals(dataType);
+        return "RequestFile".equals(dataType);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
@@ -98,7 +98,7 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
 
     @Override
     public boolean isDataTypeFile(final String dataType) {
-        return dataType != null && "Blob".equals(dataType);
+        return "Blob".equals(dataType);
     }
 
     @Override


### PR DESCRIPTION
EclipseJdt cleanup 'EvaluateNullable' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor

@OpenAPITools/generator-core-team