### PR TITLE
[C#] fix integer enum without format

### DIFF
--- a/bin/utils/test_file_list.yaml
+++ b/bin/utils/test_file_list.yaml
@@ -1,7 +1,7 @@
 ---
 # csharp-netcore test files and image for upload
 - filename: "samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs"
-  sha256: ec34838fbbb1abb9f762949d510503b6237b607400a85c848c234c39d013a776
+  sha256: 95e40cace36e7cd1608fa494161f06291f4cfb8f859ec4196ae9939f520b152a
 - filename: "samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/Api/PetApiTests.cs"
   sha256: dae985015ba461297927d544a78267f2def35e07c3f14ca66468fd61e1fd1c26
 - filename: "samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/linux-logo.png"

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -576,7 +576,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                 var.isString = false;
                 var.isLong = false;
                 var.isInteger = false;
-            } else if ("int32".equals(var.dataFormat)) {
+            } else if ("int".equals(var.dataType) || "int32".equals(var.dataFormat)) {
                 var.isInteger = true;
                 var.isString = false;
                 var.isLong = false;

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
@@ -24,6 +24,7 @@
         {{/complexType}}
         {{/isEnum}}
         {{#isEnum}}
+
         /// <summary>
         /// {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
         /// </summary>

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelInnerEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelInnerEnum.mustache
@@ -24,4 +24,3 @@
             {{/allowableValues}}
         }
         {{/isContainer}}
-

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelInnerEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelInnerEnum.mustache
@@ -24,3 +24,4 @@
             {{/allowableValues}}
         }
         {{/isContainer}}
+

--- a/modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/java/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
@@ -1546,6 +1546,11 @@ components:
           enum:
             - 1
             - -1
+        enum_integer_only:
+          type: integer
+          enum:
+            - 2
+            - -2
         enum_number:
           type: number
           format: double

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/docs/EnumTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/docs/EnumTest.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **EnumString** | **string** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
 **EnumInteger** | **int** |  | [optional] 
+**EnumIntegerOnly** | **int** |  | [optional] 
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -48,6 +48,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -48,7 +48,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -46,6 +46,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,6 +52,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -76,6 +77,7 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
+
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,7 +52,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -77,8 +76,6 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
-
-
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,6 +52,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -76,6 +77,8 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
+
+
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -89,6 +90,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -111,11 +113,35 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
         [DataMember(Name = "enum_integer", EmitDefaultValue = false)]
         public EnumIntegerEnum? EnumInteger { get; set; }
+        /// <summary>
+        /// Defines EnumIntegerOnly
+        /// </summary>
+        public enum EnumIntegerOnlyEnum
+        {
+            /// <summary>
+            /// Enum NUMBER_2 for value: 2
+            /// </summary>
+            NUMBER_2 = 2,
+
+            /// <summary>
+            /// Enum NUMBER_MINUS_2 for value: -2
+            /// </summary>
+            NUMBER_MINUS_2 = -2
+
+        }
+
+
+        /// <summary>
+        /// Gets or Sets EnumIntegerOnly
+        /// </summary>
+        [DataMember(Name = "enum_integer_only", EmitDefaultValue = false)]
+        public EnumIntegerOnlyEnum? EnumIntegerOnly { get; set; }
         /// <summary>
         /// Defines EnumNumber
         /// </summary>
@@ -135,6 +161,7 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_1_DOT_2 = 2
 
         }
+
 
         /// <summary>
         /// Gets or Sets EnumNumber
@@ -175,16 +202,18 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumString">enumString.</param>
         /// <param name="enumStringRequired">enumStringRequired (required).</param>
         /// <param name="enumInteger">enumInteger.</param>
+        /// <param name="enumIntegerOnly">enumIntegerOnly.</param>
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
         /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
         /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
+        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? enumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;
             this.EnumInteger = enumInteger;
+            this.EnumIntegerOnly = enumIntegerOnly;
             this.EnumNumber = enumNumber;
             this.OuterEnum = outerEnum;
             this.OuterEnumInteger = outerEnumInteger;
@@ -210,6 +239,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("  EnumString: ").Append(EnumString).Append("\n");
             sb.Append("  EnumStringRequired: ").Append(EnumStringRequired).Append("\n");
             sb.Append("  EnumInteger: ").Append(EnumInteger).Append("\n");
+            sb.Append("  EnumIntegerOnly: ").Append(EnumIntegerOnly).Append("\n");
             sb.Append("  EnumNumber: ").Append(EnumNumber).Append("\n");
             sb.Append("  OuterEnum: ").Append(OuterEnum).Append("\n");
             sb.Append("  OuterEnumInteger: ").Append(OuterEnumInteger).Append("\n");
@@ -261,6 +291,7 @@ namespace Org.OpenAPITools.Model
                 hashCode = hashCode * 59 + this.EnumString.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumStringRequired.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumInteger.GetHashCode();
+                hashCode = hashCode * 59 + this.EnumIntegerOnly.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumNumber.GetHashCode();
                 hashCode = hashCode * 59 + this.OuterEnum.GetHashCode();
                 hashCode = hashCode * 59 + this.OuterEnumInteger.GetHashCode();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -89,6 +90,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -111,6 +113,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
@@ -132,6 +135,7 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_2 = -2
 
         }
+
 
         /// <summary>
         /// Gets or Sets EnumIntegerOnly
@@ -158,26 +162,31 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumNumber
         /// </summary>
         [DataMember(Name = "enum_number", EmitDefaultValue = false)]
         public EnumNumberEnum? EnumNumber { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnum
         /// </summary>
         [DataMember(Name = "outerEnum", EmitDefaultValue = true)]
         public OuterEnum? OuterEnum { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumInteger
         /// </summary>
         [DataMember(Name = "outerEnumInteger", EmitDefaultValue = false)]
         public OuterEnumInteger? OuterEnumInteger { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumDefaultValue
         /// </summary>
         [DataMember(Name = "outerEnumDefaultValue", EmitDefaultValue = false)]
         public OuterEnumDefaultValue? OuterEnumDefaultValue { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumIntegerDefaultValue
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,7 +58,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -90,7 +89,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -113,7 +111,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
@@ -135,7 +132,6 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_2 = -2
 
         }
-
 
         /// <summary>
         /// Gets or Sets EnumIntegerOnly
@@ -161,7 +157,6 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_1_DOT_2 = 2
 
         }
-
 
         /// <summary>
         /// Gets or Sets EnumNumber

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,6 +53,7 @@ namespace Org.OpenAPITools.Model
         }
 
 
+
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,6 +53,8 @@ namespace Org.OpenAPITools.Model
         }
 
 
+
+
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,8 +53,6 @@ namespace Org.OpenAPITools.Model
         }
 
 
-
-
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Order.cs
@@ -59,6 +59,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Order Status
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Order.cs
@@ -59,7 +59,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Order Status
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Pet.cs
@@ -59,6 +59,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// pet status in the store
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Pet.cs
@@ -59,7 +59,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// pet status in the store
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Zebra.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets Type
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Zebra.cs
@@ -58,7 +58,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets Type
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/docs/EnumTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/docs/EnumTest.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **EnumString** | **string** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
 **EnumInteger** | **int** |  | [optional] 
+**EnumIntegerOnly** | **int** |  | [optional] 
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -48,6 +48,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -48,7 +48,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -46,6 +46,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,6 +52,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -76,6 +77,7 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
+
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,7 +52,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -77,8 +76,6 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
-
-
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,6 +52,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -76,6 +77,8 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
+
+
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -89,6 +90,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -111,11 +113,35 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
         [DataMember(Name = "enum_integer", EmitDefaultValue = false)]
         public EnumIntegerEnum? EnumInteger { get; set; }
+        /// <summary>
+        /// Defines EnumIntegerOnly
+        /// </summary>
+        public enum EnumIntegerOnlyEnum
+        {
+            /// <summary>
+            /// Enum NUMBER_2 for value: 2
+            /// </summary>
+            NUMBER_2 = 2,
+
+            /// <summary>
+            /// Enum NUMBER_MINUS_2 for value: -2
+            /// </summary>
+            NUMBER_MINUS_2 = -2
+
+        }
+
+
+        /// <summary>
+        /// Gets or Sets EnumIntegerOnly
+        /// </summary>
+        [DataMember(Name = "enum_integer_only", EmitDefaultValue = false)]
+        public EnumIntegerOnlyEnum? EnumIntegerOnly { get; set; }
         /// <summary>
         /// Defines EnumNumber
         /// </summary>
@@ -135,6 +161,7 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_1_DOT_2 = 2
 
         }
+
 
         /// <summary>
         /// Gets or Sets EnumNumber
@@ -175,16 +202,18 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumString">enumString.</param>
         /// <param name="enumStringRequired">enumStringRequired (required).</param>
         /// <param name="enumInteger">enumInteger.</param>
+        /// <param name="enumIntegerOnly">enumIntegerOnly.</param>
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
         /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
         /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
+        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? enumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;
             this.EnumInteger = enumInteger;
+            this.EnumIntegerOnly = enumIntegerOnly;
             this.EnumNumber = enumNumber;
             this.OuterEnum = outerEnum;
             this.OuterEnumInteger = outerEnumInteger;
@@ -210,6 +239,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("  EnumString: ").Append(EnumString).Append("\n");
             sb.Append("  EnumStringRequired: ").Append(EnumStringRequired).Append("\n");
             sb.Append("  EnumInteger: ").Append(EnumInteger).Append("\n");
+            sb.Append("  EnumIntegerOnly: ").Append(EnumIntegerOnly).Append("\n");
             sb.Append("  EnumNumber: ").Append(EnumNumber).Append("\n");
             sb.Append("  OuterEnum: ").Append(OuterEnum).Append("\n");
             sb.Append("  OuterEnumInteger: ").Append(OuterEnumInteger).Append("\n");
@@ -261,6 +291,7 @@ namespace Org.OpenAPITools.Model
                 hashCode = hashCode * 59 + this.EnumString.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumStringRequired.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumInteger.GetHashCode();
+                hashCode = hashCode * 59 + this.EnumIntegerOnly.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumNumber.GetHashCode();
                 hashCode = hashCode * 59 + this.OuterEnum.GetHashCode();
                 hashCode = hashCode * 59 + this.OuterEnumInteger.GetHashCode();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -89,6 +90,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -111,6 +113,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
@@ -132,6 +135,7 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_2 = -2
 
         }
+
 
         /// <summary>
         /// Gets or Sets EnumIntegerOnly
@@ -158,26 +162,31 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumNumber
         /// </summary>
         [DataMember(Name = "enum_number", EmitDefaultValue = false)]
         public EnumNumberEnum? EnumNumber { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnum
         /// </summary>
         [DataMember(Name = "outerEnum", EmitDefaultValue = true)]
         public OuterEnum? OuterEnum { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumInteger
         /// </summary>
         [DataMember(Name = "outerEnumInteger", EmitDefaultValue = false)]
         public OuterEnumInteger? OuterEnumInteger { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumDefaultValue
         /// </summary>
         [DataMember(Name = "outerEnumDefaultValue", EmitDefaultValue = false)]
         public OuterEnumDefaultValue? OuterEnumDefaultValue { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumIntegerDefaultValue
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,7 +58,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -90,7 +89,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -113,7 +111,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
@@ -135,7 +132,6 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_2 = -2
 
         }
-
 
         /// <summary>
         /// Gets or Sets EnumIntegerOnly
@@ -161,7 +157,6 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_1_DOT_2 = 2
 
         }
-
 
         /// <summary>
         /// Gets or Sets EnumNumber

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,6 +53,7 @@ namespace Org.OpenAPITools.Model
         }
 
 
+
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,6 +53,8 @@ namespace Org.OpenAPITools.Model
         }
 
 
+
+
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,8 +53,6 @@ namespace Org.OpenAPITools.Model
         }
 
 
-
-
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Order.cs
@@ -59,6 +59,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Order Status
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Order.cs
@@ -59,7 +59,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Order Status
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Pet.cs
@@ -59,6 +59,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// pet status in the store
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Pet.cs
@@ -59,7 +59,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// pet status in the store
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Zebra.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets Type
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Zebra.cs
@@ -58,7 +58,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets Type
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/docs/EnumTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/docs/EnumTest.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **EnumString** | **string** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
 **EnumInteger** | **int** |  | [optional] 
+**EnumIntegerOnly** | **int** |  | [optional] 
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -48,6 +48,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -48,7 +48,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -46,6 +46,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,6 +52,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -76,6 +77,7 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
+
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,7 +52,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -77,8 +76,6 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
-
-
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,6 +52,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -76,6 +77,8 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
+
+
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -89,6 +90,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -111,11 +113,35 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
         [DataMember(Name = "enum_integer", EmitDefaultValue = false)]
         public EnumIntegerEnum? EnumInteger { get; set; }
+        /// <summary>
+        /// Defines EnumIntegerOnly
+        /// </summary>
+        public enum EnumIntegerOnlyEnum
+        {
+            /// <summary>
+            /// Enum NUMBER_2 for value: 2
+            /// </summary>
+            NUMBER_2 = 2,
+
+            /// <summary>
+            /// Enum NUMBER_MINUS_2 for value: -2
+            /// </summary>
+            NUMBER_MINUS_2 = -2
+
+        }
+
+
+        /// <summary>
+        /// Gets or Sets EnumIntegerOnly
+        /// </summary>
+        [DataMember(Name = "enum_integer_only", EmitDefaultValue = false)]
+        public EnumIntegerOnlyEnum? EnumIntegerOnly { get; set; }
         /// <summary>
         /// Defines EnumNumber
         /// </summary>
@@ -135,6 +161,7 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_1_DOT_2 = 2
 
         }
+
 
         /// <summary>
         /// Gets or Sets EnumNumber
@@ -175,16 +202,18 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumString">enumString.</param>
         /// <param name="enumStringRequired">enumStringRequired (required).</param>
         /// <param name="enumInteger">enumInteger.</param>
+        /// <param name="enumIntegerOnly">enumIntegerOnly.</param>
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
         /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
         /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
+        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? enumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;
             this.EnumInteger = enumInteger;
+            this.EnumIntegerOnly = enumIntegerOnly;
             this.EnumNumber = enumNumber;
             this.OuterEnum = outerEnum;
             this.OuterEnumInteger = outerEnumInteger;
@@ -210,6 +239,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("  EnumString: ").Append(EnumString).Append("\n");
             sb.Append("  EnumStringRequired: ").Append(EnumStringRequired).Append("\n");
             sb.Append("  EnumInteger: ").Append(EnumInteger).Append("\n");
+            sb.Append("  EnumIntegerOnly: ").Append(EnumIntegerOnly).Append("\n");
             sb.Append("  EnumNumber: ").Append(EnumNumber).Append("\n");
             sb.Append("  OuterEnum: ").Append(OuterEnum).Append("\n");
             sb.Append("  OuterEnumInteger: ").Append(OuterEnumInteger).Append("\n");
@@ -261,6 +291,7 @@ namespace Org.OpenAPITools.Model
                 hashCode = hashCode * 59 + this.EnumString.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumStringRequired.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumInteger.GetHashCode();
+                hashCode = hashCode * 59 + this.EnumIntegerOnly.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumNumber.GetHashCode();
                 hashCode = hashCode * 59 + this.OuterEnum.GetHashCode();
                 hashCode = hashCode * 59 + this.OuterEnumInteger.GetHashCode();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -89,6 +90,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -111,6 +113,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
@@ -132,6 +135,7 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_2 = -2
 
         }
+
 
         /// <summary>
         /// Gets or Sets EnumIntegerOnly
@@ -158,26 +162,31 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumNumber
         /// </summary>
         [DataMember(Name = "enum_number", EmitDefaultValue = false)]
         public EnumNumberEnum? EnumNumber { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnum
         /// </summary>
         [DataMember(Name = "outerEnum", EmitDefaultValue = true)]
         public OuterEnum? OuterEnum { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumInteger
         /// </summary>
         [DataMember(Name = "outerEnumInteger", EmitDefaultValue = false)]
         public OuterEnumInteger? OuterEnumInteger { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumDefaultValue
         /// </summary>
         [DataMember(Name = "outerEnumDefaultValue", EmitDefaultValue = false)]
         public OuterEnumDefaultValue? OuterEnumDefaultValue { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumIntegerDefaultValue
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,7 +58,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -90,7 +89,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -113,7 +111,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
@@ -135,7 +132,6 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_2 = -2
 
         }
-
 
         /// <summary>
         /// Gets or Sets EnumIntegerOnly
@@ -161,7 +157,6 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_1_DOT_2 = 2
 
         }
-
 
         /// <summary>
         /// Gets or Sets EnumNumber

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,6 +53,7 @@ namespace Org.OpenAPITools.Model
         }
 
 
+
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,6 +53,8 @@ namespace Org.OpenAPITools.Model
         }
 
 
+
+
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,8 +53,6 @@ namespace Org.OpenAPITools.Model
         }
 
 
-
-
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Order.cs
@@ -59,6 +59,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Order Status
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Order.cs
@@ -59,7 +59,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Order Status
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -59,6 +59,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// pet status in the store
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -59,7 +59,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// pet status in the store
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Zebra.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets Type
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Zebra.cs
@@ -58,7 +58,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets Type
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/EnumTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/EnumTest.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **EnumString** | **string** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
 **EnumInteger** | **int** |  | [optional] 
+**EnumIntegerOnly** | **int** |  | [optional] 
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools.Test/JSONComposedSchemaTests.cs
@@ -171,5 +171,17 @@ namespace Org.OpenAPITools.Test
             OuterEnumInteger instance = OuterEnumInteger.NUMBER_1;
             Assert.Equal(1, (int)instance);
         }
+
+        /// <summary>
+        /// Test inner enum integer
+        /// </summary>
+        [Fact]
+        public void InnerEnumIntegerInstanceTest()
+        {
+            EnumTest enumTest = new EnumTest();
+            enumTest.EnumIntegerOnly = EnumTest.EnumIntegerOnlyEnum.NUMBER_2;
+            enumTest.EnumInteger = EnumTest.EnumIntegerEnum.NUMBER_MINUS_1;
+            Assert.Equal("{\"enum_integer\":-1,\"enum_integer_only\":2,\"outerEnum\":null}", JsonConvert.SerializeObject(enumTest));
+        }
     }
 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -48,6 +48,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -48,7 +48,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -46,6 +46,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,6 +52,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -76,6 +77,7 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
+
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,7 +52,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -77,8 +76,6 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
-
-
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,6 +52,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -76,6 +77,8 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
+
+
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -89,6 +90,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -111,6 +113,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
@@ -132,6 +135,7 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_2 = -2
 
         }
+
 
         /// <summary>
         /// Gets or Sets EnumIntegerOnly
@@ -158,26 +162,31 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumNumber
         /// </summary>
         [DataMember(Name = "enum_number", EmitDefaultValue = false)]
         public EnumNumberEnum? EnumNumber { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnum
         /// </summary>
         [DataMember(Name = "outerEnum", EmitDefaultValue = true)]
         public OuterEnum? OuterEnum { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumInteger
         /// </summary>
         [DataMember(Name = "outerEnumInteger", EmitDefaultValue = false)]
         public OuterEnumInteger? OuterEnumInteger { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumDefaultValue
         /// </summary>
         [DataMember(Name = "outerEnumDefaultValue", EmitDefaultValue = false)]
         public OuterEnumDefaultValue? OuterEnumDefaultValue { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumIntegerDefaultValue
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,7 +58,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -90,7 +89,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -113,7 +111,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
@@ -135,7 +132,6 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_2 = -2
 
         }
-
 
         /// <summary>
         /// Gets or Sets EnumIntegerOnly
@@ -161,7 +157,6 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_1_DOT_2 = 2
 
         }
-
 
         /// <summary>
         /// Gets or Sets EnumNumber

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -89,6 +90,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -111,6 +113,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
@@ -132,6 +135,7 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_2 = -2
 
         }
+
 
         /// <summary>
         /// Gets or Sets EnumIntegerOnly
@@ -157,6 +161,7 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_1_DOT_2 = 2
 
         }
+
 
         /// <summary>
         /// Gets or Sets EnumNumber

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -117,6 +117,28 @@ namespace Org.OpenAPITools.Model
         [DataMember(Name = "enum_integer", EmitDefaultValue = false)]
         public EnumIntegerEnum? EnumInteger { get; set; }
         /// <summary>
+        /// Defines EnumIntegerOnly
+        /// </summary>
+        public enum EnumIntegerOnlyEnum
+        {
+            /// <summary>
+            /// Enum NUMBER_2 for value: 2
+            /// </summary>
+            NUMBER_2 = 2,
+
+            /// <summary>
+            /// Enum NUMBER_MINUS_2 for value: -2
+            /// </summary>
+            NUMBER_MINUS_2 = -2
+
+        }
+
+        /// <summary>
+        /// Gets or Sets EnumIntegerOnly
+        /// </summary>
+        [DataMember(Name = "enum_integer_only", EmitDefaultValue = false)]
+        public EnumIntegerOnlyEnum? EnumIntegerOnly { get; set; }
+        /// <summary>
         /// Defines EnumNumber
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]
@@ -175,16 +197,18 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumString">enumString.</param>
         /// <param name="enumStringRequired">enumStringRequired (required).</param>
         /// <param name="enumInteger">enumInteger.</param>
+        /// <param name="enumIntegerOnly">enumIntegerOnly.</param>
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
         /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
         /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
+        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? enumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;
             this.EnumInteger = enumInteger;
+            this.EnumIntegerOnly = enumIntegerOnly;
             this.EnumNumber = enumNumber;
             this.OuterEnum = outerEnum;
             this.OuterEnumInteger = outerEnumInteger;
@@ -210,6 +234,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("  EnumString: ").Append(EnumString).Append("\n");
             sb.Append("  EnumStringRequired: ").Append(EnumStringRequired).Append("\n");
             sb.Append("  EnumInteger: ").Append(EnumInteger).Append("\n");
+            sb.Append("  EnumIntegerOnly: ").Append(EnumIntegerOnly).Append("\n");
             sb.Append("  EnumNumber: ").Append(EnumNumber).Append("\n");
             sb.Append("  OuterEnum: ").Append(OuterEnum).Append("\n");
             sb.Append("  OuterEnumInteger: ").Append(OuterEnumInteger).Append("\n");
@@ -261,6 +286,7 @@ namespace Org.OpenAPITools.Model
                 hashCode = hashCode * 59 + this.EnumString.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumStringRequired.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumInteger.GetHashCode();
+                hashCode = hashCode * 59 + this.EnumIntegerOnly.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumNumber.GetHashCode();
                 hashCode = hashCode * 59 + this.OuterEnum.GetHashCode();
                 hashCode = hashCode * 59 + this.OuterEnumInteger.GetHashCode();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,6 +53,7 @@ namespace Org.OpenAPITools.Model
         }
 
 
+
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,6 +53,8 @@ namespace Org.OpenAPITools.Model
         }
 
 
+
+
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,8 +53,6 @@ namespace Org.OpenAPITools.Model
         }
 
 
-
-
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
@@ -59,6 +59,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Order Status
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
@@ -59,7 +59,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Order Status
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
@@ -59,6 +59,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// pet status in the store
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
@@ -59,7 +59,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// pet status in the store
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Zebra.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets Type
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Zebra.cs
@@ -58,7 +58,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets Type
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/EnumTest.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **EnumString** | **string** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
 **EnumInteger** | **int** |  | [optional] 
+**EnumIntegerOnly** | **int** |  | [optional] 
 **EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -48,6 +48,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -48,7 +48,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -46,6 +46,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCatAllOf.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets PetType
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,6 +52,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -76,6 +77,7 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
+
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,7 +52,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -77,8 +76,6 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
-
-
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -52,6 +52,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets JustSymbol
         /// </summary>
@@ -76,6 +77,8 @@ namespace Org.OpenAPITools.Model
             Crab = 2
 
         }
+
+
 
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -89,6 +90,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -111,11 +113,35 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
         [DataMember(Name = "enum_integer", EmitDefaultValue = false)]
         public EnumIntegerEnum? EnumInteger { get; set; }
+        /// <summary>
+        /// Defines EnumIntegerOnly
+        /// </summary>
+        public enum EnumIntegerOnlyEnum
+        {
+            /// <summary>
+            /// Enum NUMBER_2 for value: 2
+            /// </summary>
+            NUMBER_2 = 2,
+
+            /// <summary>
+            /// Enum NUMBER_MINUS_2 for value: -2
+            /// </summary>
+            NUMBER_MINUS_2 = -2
+
+        }
+
+
+        /// <summary>
+        /// Gets or Sets EnumIntegerOnly
+        /// </summary>
+        [DataMember(Name = "enum_integer_only", EmitDefaultValue = false)]
+        public EnumIntegerOnlyEnum? EnumIntegerOnly { get; set; }
         /// <summary>
         /// Defines EnumNumber
         /// </summary>
@@ -135,6 +161,7 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_1_DOT_2 = 2
 
         }
+
 
         /// <summary>
         /// Gets or Sets EnumNumber
@@ -172,16 +199,18 @@ namespace Org.OpenAPITools.Model
         /// <param name="enumString">enumString.</param>
         /// <param name="enumStringRequired">enumStringRequired (required).</param>
         /// <param name="enumInteger">enumInteger.</param>
+        /// <param name="enumIntegerOnly">enumIntegerOnly.</param>
         /// <param name="enumNumber">enumNumber.</param>
         /// <param name="outerEnum">outerEnum.</param>
         /// <param name="outerEnumInteger">outerEnumInteger.</param>
         /// <param name="outerEnumDefaultValue">outerEnumDefaultValue.</param>
         /// <param name="outerEnumIntegerDefaultValue">outerEnumIntegerDefaultValue.</param>
-        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
+        public EnumTest(EnumStringEnum? enumString = default(EnumStringEnum?), EnumStringRequiredEnum enumStringRequired = default(EnumStringRequiredEnum), EnumIntegerEnum? enumInteger = default(EnumIntegerEnum?), EnumIntegerOnlyEnum? enumIntegerOnly = default(EnumIntegerOnlyEnum?), EnumNumberEnum? enumNumber = default(EnumNumberEnum?), OuterEnum? outerEnum = default(OuterEnum?), OuterEnumInteger? outerEnumInteger = default(OuterEnumInteger?), OuterEnumDefaultValue? outerEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumIntegerDefaultValue? outerEnumIntegerDefaultValue = default(OuterEnumIntegerDefaultValue?))
         {
             this.EnumStringRequired = enumStringRequired;
             this.EnumString = enumString;
             this.EnumInteger = enumInteger;
+            this.EnumIntegerOnly = enumIntegerOnly;
             this.EnumNumber = enumNumber;
             this.OuterEnum = outerEnum;
             this.OuterEnumInteger = outerEnumInteger;
@@ -200,6 +229,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("  EnumString: ").Append(EnumString).Append("\n");
             sb.Append("  EnumStringRequired: ").Append(EnumStringRequired).Append("\n");
             sb.Append("  EnumInteger: ").Append(EnumInteger).Append("\n");
+            sb.Append("  EnumIntegerOnly: ").Append(EnumIntegerOnly).Append("\n");
             sb.Append("  EnumNumber: ").Append(EnumNumber).Append("\n");
             sb.Append("  OuterEnum: ").Append(OuterEnum).Append("\n");
             sb.Append("  OuterEnumInteger: ").Append(OuterEnumInteger).Append("\n");
@@ -250,6 +280,7 @@ namespace Org.OpenAPITools.Model
                 hashCode = hashCode * 59 + this.EnumString.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumStringRequired.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumInteger.GetHashCode();
+                hashCode = hashCode * 59 + this.EnumIntegerOnly.GetHashCode();
                 hashCode = hashCode * 59 + this.EnumNumber.GetHashCode();
                 hashCode = hashCode * 59 + this.OuterEnum.GetHashCode();
                 hashCode = hashCode * 59 + this.OuterEnumInteger.GetHashCode();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -89,6 +90,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -111,6 +113,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
@@ -132,6 +135,7 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_2 = -2
 
         }
+
 
         /// <summary>
         /// Gets or Sets EnumIntegerOnly
@@ -158,26 +162,31 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets EnumNumber
         /// </summary>
         [DataMember(Name = "enum_number", EmitDefaultValue = false)]
         public EnumNumberEnum? EnumNumber { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnum
         /// </summary>
         [DataMember(Name = "outerEnum", EmitDefaultValue = true)]
         public OuterEnum? OuterEnum { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumInteger
         /// </summary>
         [DataMember(Name = "outerEnumInteger", EmitDefaultValue = false)]
         public OuterEnumInteger? OuterEnumInteger { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumDefaultValue
         /// </summary>
         [DataMember(Name = "outerEnumDefaultValue", EmitDefaultValue = false)]
         public OuterEnumDefaultValue? OuterEnumDefaultValue { get; set; }
+
         /// <summary>
         /// Gets or Sets OuterEnumIntegerDefaultValue
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -58,7 +58,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumString
         /// </summary>
@@ -90,7 +89,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumStringRequired
         /// </summary>
@@ -113,7 +111,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets EnumInteger
         /// </summary>
@@ -135,7 +132,6 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_2 = -2
 
         }
-
 
         /// <summary>
         /// Gets or Sets EnumIntegerOnly
@@ -161,7 +157,6 @@ namespace Org.OpenAPITools.Model
             NUMBER_MINUS_1_DOT_2 = 2
 
         }
-
 
         /// <summary>
         /// Gets or Sets EnumNumber

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,6 +53,7 @@ namespace Org.OpenAPITools.Model
         }
 
 
+
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,6 +53,8 @@ namespace Org.OpenAPITools.Model
         }
 
 
+
+
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -53,8 +53,6 @@ namespace Org.OpenAPITools.Model
         }
 
 
-
-
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Order.cs
@@ -59,6 +59,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Order Status
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Order.cs
@@ -59,7 +59,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Order Status
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pet.cs
@@ -59,6 +59,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// pet status in the store
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pet.cs
@@ -59,7 +59,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// pet status in the store
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -58,6 +58,7 @@ namespace Org.OpenAPITools.Model
 
         }
 
+
         /// <summary>
         /// Gets or Sets Type
         /// </summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -58,7 +58,6 @@ namespace Org.OpenAPITools.Model
 
         }
 
-
         /// <summary>
         /// Gets or Sets Type
         /// </summary>

--- a/samples/openapi3/client/petstore/java/jersey2-java8/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/api/openapi.yaml
@@ -1689,6 +1689,11 @@ components:
           - -1
           format: int32
           type: integer
+        enum_integer_only:
+          enum:
+          - 2
+          - -2
+          type: integer
         enum_number:
           enum:
           - 1.1

--- a/samples/openapi3/client/petstore/java/jersey2-java8/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/docs/EnumTest.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **enumString** | [**EnumStringEnum**](#EnumStringEnum) |  |  [optional]
 **enumStringRequired** | [**EnumStringRequiredEnum**](#EnumStringRequiredEnum) |  | 
 **enumInteger** | [**EnumIntegerEnum**](#EnumIntegerEnum) |  |  [optional]
+**enumIntegerOnly** | [**EnumIntegerOnlyEnum**](#EnumIntegerOnlyEnum) |  |  [optional]
 **enumNumber** | [**EnumNumberEnum**](#EnumNumberEnum) |  |  [optional]
 **outerEnum** | **OuterEnum** |  |  [optional]
 **outerEnumInteger** | **OuterEnumInteger** |  |  [optional]
@@ -44,6 +45,15 @@ Name | Value
 ---- | -----
 NUMBER_1 | 1
 NUMBER_MINUS_1 | -1
+
+
+
+## Enum: EnumIntegerOnlyEnum
+
+Name | Value
+---- | -----
+NUMBER_2 | 2
+NUMBER_MINUS_2 | -2
 
 
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -42,6 +42,7 @@ import org.openapitools.client.JSON;
   EnumTest.JSON_PROPERTY_ENUM_STRING,
   EnumTest.JSON_PROPERTY_ENUM_STRING_REQUIRED,
   EnumTest.JSON_PROPERTY_ENUM_INTEGER,
+  EnumTest.JSON_PROPERTY_ENUM_INTEGER_ONLY,
   EnumTest.JSON_PROPERTY_ENUM_NUMBER,
   EnumTest.JSON_PROPERTY_OUTER_ENUM,
   EnumTest.JSON_PROPERTY_OUTER_ENUM_INTEGER,
@@ -169,6 +170,44 @@ public class EnumTest {
   private EnumIntegerEnum enumInteger;
 
   /**
+   * Gets or Sets enumIntegerOnly
+   */
+  public enum EnumIntegerOnlyEnum {
+    NUMBER_2(2),
+    
+    NUMBER_MINUS_2(-2);
+
+    private Integer value;
+
+    EnumIntegerOnlyEnum(Integer value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public Integer getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static EnumIntegerOnlyEnum fromValue(Integer value) {
+      for (EnumIntegerOnlyEnum b : EnumIntegerOnlyEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+  }
+
+  public static final String JSON_PROPERTY_ENUM_INTEGER_ONLY = "enum_integer_only";
+  private EnumIntegerOnlyEnum enumIntegerOnly;
+
+  /**
    * Gets or Sets enumNumber
    */
   public enum EnumNumberEnum {
@@ -293,6 +332,32 @@ public class EnumTest {
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
+  }
+
+
+  public EnumTest enumIntegerOnly(EnumIntegerOnlyEnum enumIntegerOnly) {
+    this.enumIntegerOnly = enumIntegerOnly;
+    return this;
+  }
+
+   /**
+   * Get enumIntegerOnly
+   * @return enumIntegerOnly
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER_ONLY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public EnumIntegerOnlyEnum getEnumIntegerOnly() {
+    return enumIntegerOnly;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER_ONLY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setEnumIntegerOnly(EnumIntegerOnlyEnum enumIntegerOnly) {
+    this.enumIntegerOnly = enumIntegerOnly;
   }
 
 
@@ -449,6 +514,7 @@ public class EnumTest {
     return Objects.equals(this.enumString, enumTest.enumString) &&
         Objects.equals(this.enumStringRequired, enumTest.enumStringRequired) &&
         Objects.equals(this.enumInteger, enumTest.enumInteger) &&
+        Objects.equals(this.enumIntegerOnly, enumTest.enumIntegerOnly) &&
         Objects.equals(this.enumNumber, enumTest.enumNumber) &&
         Objects.equals(this.outerEnum, enumTest.outerEnum) &&
         Objects.equals(this.outerEnumInteger, enumTest.outerEnumInteger) &&
@@ -458,7 +524,7 @@ public class EnumTest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(enumString, enumStringRequired, enumInteger, enumNumber, outerEnum, outerEnumInteger, outerEnumDefaultValue, outerEnumIntegerDefaultValue);
+    return Objects.hash(enumString, enumStringRequired, enumInteger, enumIntegerOnly, enumNumber, outerEnum, outerEnumInteger, outerEnumDefaultValue, outerEnumIntegerDefaultValue);
   }
 
   @Override
@@ -468,6 +534,7 @@ public class EnumTest {
     sb.append("    enumString: ").append(toIndentedString(enumString)).append("\n");
     sb.append("    enumStringRequired: ").append(toIndentedString(enumStringRequired)).append("\n");
     sb.append("    enumInteger: ").append(toIndentedString(enumInteger)).append("\n");
+    sb.append("    enumIntegerOnly: ").append(toIndentedString(enumIntegerOnly)).append("\n");
     sb.append("    enumNumber: ").append(toIndentedString(enumNumber)).append("\n");
     sb.append("    outerEnum: ").append(toIndentedString(outerEnum)).append("\n");
     sb.append("    outerEnumInteger: ").append(toIndentedString(outerEnumInteger)).append("\n");

--- a/samples/openapi3/client/petstore/java/native/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/java/native/api/openapi.yaml
@@ -1689,6 +1689,11 @@ components:
           - -1
           format: int32
           type: integer
+        enum_integer_only:
+          enum:
+          - 2
+          - -2
+          type: integer
         enum_number:
           enum:
           - 1.1

--- a/samples/openapi3/client/petstore/java/native/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/java/native/docs/EnumTest.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **enumString** | [**EnumStringEnum**](#EnumStringEnum) |  |  [optional]
 **enumStringRequired** | [**EnumStringRequiredEnum**](#EnumStringRequiredEnum) |  | 
 **enumInteger** | [**EnumIntegerEnum**](#EnumIntegerEnum) |  |  [optional]
+**enumIntegerOnly** | [**EnumIntegerOnlyEnum**](#EnumIntegerOnlyEnum) |  |  [optional]
 **enumNumber** | [**EnumNumberEnum**](#EnumNumberEnum) |  |  [optional]
 **outerEnum** | **OuterEnum** |  |  [optional]
 **outerEnumInteger** | **OuterEnumInteger** |  |  [optional]
@@ -44,6 +45,15 @@ Name | Value
 ---- | -----
 NUMBER_1 | 1
 NUMBER_MINUS_1 | -1
+
+
+
+## Enum: EnumIntegerOnlyEnum
+
+Name | Value
+---- | -----
+NUMBER_2 | 2
+NUMBER_MINUS_2 | -2
 
 
 

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   EnumTest.JSON_PROPERTY_ENUM_STRING,
   EnumTest.JSON_PROPERTY_ENUM_STRING_REQUIRED,
   EnumTest.JSON_PROPERTY_ENUM_INTEGER,
+  EnumTest.JSON_PROPERTY_ENUM_INTEGER_ONLY,
   EnumTest.JSON_PROPERTY_ENUM_NUMBER,
   EnumTest.JSON_PROPERTY_OUTER_ENUM,
   EnumTest.JSON_PROPERTY_OUTER_ENUM_INTEGER,
@@ -168,6 +169,44 @@ public class EnumTest {
   private EnumIntegerEnum enumInteger;
 
   /**
+   * Gets or Sets enumIntegerOnly
+   */
+  public enum EnumIntegerOnlyEnum {
+    NUMBER_2(2),
+    
+    NUMBER_MINUS_2(-2);
+
+    private Integer value;
+
+    EnumIntegerOnlyEnum(Integer value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public Integer getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static EnumIntegerOnlyEnum fromValue(Integer value) {
+      for (EnumIntegerOnlyEnum b : EnumIntegerOnlyEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+  }
+
+  public static final String JSON_PROPERTY_ENUM_INTEGER_ONLY = "enum_integer_only";
+  private EnumIntegerOnlyEnum enumIntegerOnly;
+
+  /**
    * Gets or Sets enumNumber
    */
   public enum EnumNumberEnum {
@@ -292,6 +331,32 @@ public class EnumTest {
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
+  }
+
+
+  public EnumTest enumIntegerOnly(EnumIntegerOnlyEnum enumIntegerOnly) {
+    this.enumIntegerOnly = enumIntegerOnly;
+    return this;
+  }
+
+   /**
+   * Get enumIntegerOnly
+   * @return enumIntegerOnly
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER_ONLY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public EnumIntegerOnlyEnum getEnumIntegerOnly() {
+    return enumIntegerOnly;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER_ONLY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setEnumIntegerOnly(EnumIntegerOnlyEnum enumIntegerOnly) {
+    this.enumIntegerOnly = enumIntegerOnly;
   }
 
 
@@ -448,6 +513,7 @@ public class EnumTest {
     return Objects.equals(this.enumString, enumTest.enumString) &&
         Objects.equals(this.enumStringRequired, enumTest.enumStringRequired) &&
         Objects.equals(this.enumInteger, enumTest.enumInteger) &&
+        Objects.equals(this.enumIntegerOnly, enumTest.enumIntegerOnly) &&
         Objects.equals(this.enumNumber, enumTest.enumNumber) &&
         Objects.equals(this.outerEnum, enumTest.outerEnum) &&
         Objects.equals(this.outerEnumInteger, enumTest.outerEnumInteger) &&
@@ -457,7 +523,7 @@ public class EnumTest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(enumString, enumStringRequired, enumInteger, enumNumber, outerEnum, outerEnumInteger, outerEnumDefaultValue, outerEnumIntegerDefaultValue);
+    return Objects.hash(enumString, enumStringRequired, enumInteger, enumIntegerOnly, enumNumber, outerEnum, outerEnumInteger, outerEnumDefaultValue, outerEnumIntegerDefaultValue);
   }
 
   @Override
@@ -467,6 +533,7 @@ public class EnumTest {
     sb.append("    enumString: ").append(toIndentedString(enumString)).append("\n");
     sb.append("    enumStringRequired: ").append(toIndentedString(enumStringRequired)).append("\n");
     sb.append("    enumInteger: ").append(toIndentedString(enumInteger)).append("\n");
+    sb.append("    enumIntegerOnly: ").append(toIndentedString(enumIntegerOnly)).append("\n");
     sb.append("    enumNumber: ").append(toIndentedString(enumNumber)).append("\n");
     sb.append("    outerEnum: ").append(toIndentedString(outerEnum)).append("\n");
     sb.append("    outerEnumInteger: ").append(toIndentedString(outerEnumInteger)).append("\n");


### PR DESCRIPTION
- Fix enum of type `integer` without format (e.g. int32)
- better code format
- added a test

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02) @Blackclaws (2021/03)

