### PR TITLE
[Kotlin] Fix (de)serialization of enum classes (kotlinx serialization)

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -114,3 +114,11 @@ dependencies {
     {{/jvm-retrofit2}}
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }
+{{#kotlinx_serialization}}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        freeCompilerArgs += "-Xopt-in=kotlinx.serialization.ExperimentalSerializationApi"
+    }
+}
+{{/kotlinx_serialization}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -70,6 +70,9 @@ import java.io.Serializable
      * {{{description}}}
      * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
      */
+    {{#kotlinx_serialization}}
+    @KSerializable
+    {{/kotlinx_serialization}}
     {{#nonPublicApi}}internal {{/nonPublicApi}}enum class {{{nameInCamelCase}}}(val value: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}kotlin.String{{/isContainer}}) {
     {{#allowableValues}}
     {{#enumVars}}

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/build.gradle
@@ -40,3 +40,9 @@ dependencies {
     compile "com.squareup.retrofit2:converter-scalars:$retrofitVersion"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        freeCompilerArgs += "-Xopt-in=kotlinx.serialization.ExperimentalSerializationApi"
+    }
+}

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -50,6 +50,7 @@ data class Order (
      * Order Status
      * Values: PLACED,APPROVED,DELIVERED
      */
+    @KSerializable
     enum class Status(val value: kotlin.String) {
         @SerialName(value = "placed") PLACED("placed"),
         @SerialName(value = "approved") APPROVED("approved"),

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -52,6 +52,7 @@ data class Pet (
      * pet status in the store
      * Values: AVAILABLE,PENDING,SOLD
      */
+    @KSerializable
     enum class Status(val value: kotlin.String) {
         @SerialName(value = "available") AVAILABLE("available"),
         @SerialName(value = "pending") PENDING("pending"),


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Enum class which are inside the dataClass.mustache file are missing the `Serializable` annotation. This leads to a wrong behavior of the serializer where the names instead of the the SerialName values are used. 

You can reproduce this issue if you run the `kotlin-retrofit2-kotlinx_serialization` sample project. A warning like `Explicit @Serializable annotation on enum class is required when @SerialName or @SerialInfo annotations are used on its members.` will be thrown. 

The changeset also adds the Xopt-in compiler flags for the `ExperimentalSerializationApi` which also leads to compiler warnings.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m