### PR TITLE
Allow to specify response headers (needed for redirecting clients)

### DIFF
--- a/bin/configs/go-server-go-api-server.yaml
+++ b/bin/configs/go-server-go-api-server.yaml
@@ -5,3 +5,4 @@ templateDir: modules/openapi-generator/src/main/resources/go-server
 additionalProperties:
   hideGenerationTimestamp: "true"
   packageName: petstoreserver
+  addResponseHeaders: true

--- a/docs/generators/go-server.md
+++ b/docs/generators/go-server.md
@@ -7,6 +7,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 
 | Option | Description | Values | Default |
 | ------ | ----------- | ------ | ------- |
+|addResponseHeaders|To include response headers in ImplResponse| |false|
 |enumClassPrefix|Prefix enum with class name| |false|
 |featureCORS|Enable Cross-Origin Resource Sharing middleware| |false|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
@@ -37,6 +37,7 @@ public class GoServerCodegen extends AbstractGoCodegen {
     protected String projectName = "openapi-server";
     protected String sourceFolder = "go";
     protected Boolean corsFeatureEnabled = false;
+    protected Boolean addResponseHeaders = false;
 
 
     public GoServerCodegen() {
@@ -79,6 +80,12 @@ public class GoServerCodegen extends AbstractGoCodegen {
         cliOptions.add(optFeatureCORS);
 
         cliOptions.add(CliOption.newBoolean(CodegenConstants.ENUM_CLASS_PREFIX, CodegenConstants.ENUM_CLASS_PREFIX_DESC));
+
+        // option to include headers in the response
+        CliOption optAddResponseHeaders = new CliOption("addResponseHeaders", "To include response headers in ImplResponse");
+        optAddResponseHeaders.setType("bool");
+        optAddResponseHeaders.defaultValue(addResponseHeaders.toString());
+        cliOptions.add(optAddResponseHeaders);
 
         /*
          * Models.  You can write model files using the modelTemplateFiles map.
@@ -172,10 +179,17 @@ public class GoServerCodegen extends AbstractGoCodegen {
         } else {
             additionalProperties.put("serverPort", serverPort);
         }
+
         if (additionalProperties.containsKey("featureCORS")) {
             this.setFeatureCORS(convertPropertyToBooleanAndWriteBack("featureCORS"));
         } else {
             additionalProperties.put("featureCORS", corsFeatureEnabled);
+        }
+
+        if (additionalProperties.containsKey("addResponseHeaders")) {
+            this.setAddResponseHeaders(convertPropertyToBooleanAndWriteBack("addResponseHeaders"));
+        } else {
+            additionalProperties.put("addResponseHeaders", addResponseHeaders);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.ENUM_CLASS_PREFIX)) {
@@ -313,5 +327,9 @@ public class GoServerCodegen extends AbstractGoCodegen {
 
     public void setFeatureCORS(Boolean featureCORS) {
         this.corsFeatureEnabled = featureCORS;
+    }
+
+    public void setAddResponseHeaders(Boolean addResponseHeaders) {
+        this.addResponseHeaders = addResponseHeaders;
     }
 }

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -95,10 +95,10 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	result, err := c.service.{{nickname}}(r.Context(){{#allParams}}, {{#isBodyParam}}*{{/isBodyParam}}{{paramName}}{{/allParams}})
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code,{{#addResponseHeaders}} result.Headers,{{/addResponseHeaders}} w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code,{{#addResponseHeaders}} result.Headers,{{/addResponseHeaders}} w)
 	
 }{{/operation}}{{/operations}}

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -95,10 +95,10 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	result, err := c.service.{{nickname}}(r.Context(){{#allParams}}, {{#isBodyParam}}*{{/isBodyParam}}{{paramName}}{{/allParams}})
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }{{/operation}}{{/operations}}

--- a/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
@@ -8,7 +8,7 @@ func Response(code int, body interface{}) ImplResponse {
 		{{#addResponseHeaders}}
 		Headers: nil,
 		{{/addResponseHeaders}}
-		Body: body
+		Body: body,
 	}
 }
 {{#addResponseHeaders}}
@@ -18,7 +18,7 @@ func ResponseWithHeaders(code int, headers map[string][]string, body interface{}
 	return ImplResponse {
 		Code: code,
 		Headers: headers,
-		Body: body
+		Body: body,
 	}
 }
 {{/addResponseHeaders}}

--- a/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
@@ -3,6 +3,18 @@ package {{packageName}}
 
 //Response return a ImplResponse struct filled
 func Response(code int, body interface{}) ImplResponse {
-	return ImplResponse{Code: code, Body: body}
+	return ImplResponse {
+		Code: code,
+		Headers: nil,
+		Body: body,
+	}
 }
 
+//ResponseWithHeaders return a ImplResponse struct filled, including headers
+func ResponseWithHeaders(code int, headers map[string][]string, body interface{}) ImplResponse {
+	return ImplResponse {
+		Code: code,
+		Headers: headers,
+		Body: body,
+	}
+}

--- a/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
@@ -5,10 +5,13 @@ package {{packageName}}
 func Response(code int, body interface{}) ImplResponse {
 	return ImplResponse {
 		Code: code,
+		{{#addResponseHeaders}}
 		Headers: nil,
+		{{/addResponseHeaders}}
 		Body: body,
 	}
 }
+{{#addResponseHeaders}}
 
 //ResponseWithHeaders return a ImplResponse struct filled, including headers
 func ResponseWithHeaders(code int, headers map[string][]string, body interface{}) ImplResponse {
@@ -18,3 +21,4 @@ func ResponseWithHeaders(code int, headers map[string][]string, body interface{}
 		Body: body,
 	}
 }
+{{/addResponseHeaders}}

--- a/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
@@ -8,7 +8,7 @@ func Response(code int, body interface{}) ImplResponse {
 		{{#addResponseHeaders}}
 		Headers: nil,
 		{{/addResponseHeaders}}
-		Body: body,
+		Body: body
 	}
 }
 {{#addResponseHeaders}}
@@ -18,7 +18,7 @@ func ResponseWithHeaders(code int, headers map[string][]string, body interface{}
 	return ImplResponse {
 		Code: code,
 		Headers: headers,
-		Body: body,
+		Body: body
 	}
 }
 {{/addResponseHeaders}}

--- a/modules/openapi-generator/src/main/resources/go-server/impl.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/impl.mustache
@@ -4,5 +4,6 @@ package {{packageName}}
 //Implementation response defines an error code with the associated body
 type ImplResponse struct {
 	Code int
+	Headers map[string][]string
 	Body interface{}
 }

--- a/modules/openapi-generator/src/main/resources/go-server/impl.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/impl.mustache
@@ -4,6 +4,8 @@ package {{packageName}}
 //Implementation response defines an error code with the associated body
 type ImplResponse struct {
 	Code int
+	{{#addResponseHeaders}}
 	Headers map[string][]string
+	{{/addResponseHeaders}}
 	Body interface{}
 }

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -54,7 +54,8 @@ func NewRouter(routers ...Router) *mux.Router {
 }
 
 // EncodeJSONResponse uses the json encoder to write an interface to the http response with an optional status code
-func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string, w http.ResponseWriter) error {
+func EncodeJSONResponse(i interface{}, status *int,{{#addResponseHeaders}} headers map[string][]string,{{/addResponseHeaders}} w http.ResponseWriter) error {
+	{{#addResponseHeader}}
 	wHeader := w.Header()
 	if headers != nil {
 		for key, values := range headers {
@@ -64,6 +65,10 @@ func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string,
 		}
 	}
 	wHeader.Set("Content-Type", "application/json; charset=UTF-8")
+	{{/addResponseHeader}}
+	{{^addResponseHeader}}
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	{{/addResponseHeader}}
 	if status != nil {
 		w.WriteHeader(*status)
 	} else {

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -54,8 +54,16 @@ func NewRouter(routers ...Router) *mux.Router {
 }
 
 // EncodeJSONResponse uses the json encoder to write an interface to the http response with an optional status code
-func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string, w http.ResponseWriter) error {
+	wHeader := w.Header()
+	if headers != nil {
+		for key, values := range headers {
+			for _, value := range values {
+				wHeader.Add(key, value)
+			}
+		}
+	}
+	wHeader.Set("Content-Type", "application/json; charset=UTF-8")
 	if status != nil {
 		w.WriteHeader(*status)
 	} else {

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -92,11 +92,11 @@ func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.AddPet(r.Context(), *pet)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -112,11 +112,11 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.DeletePet(r.Context(), petId, apiKey)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -127,11 +127,11 @@ func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 	result, err := c.service.FindPetsByStatus(r.Context(), status)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -142,11 +142,11 @@ func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 	result, err := c.service.FindPetsByTags(r.Context(), tags)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -161,11 +161,11 @@ func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.GetPetById(r.Context(), petId)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -180,11 +180,11 @@ func (c *PetApiController) UpdatePet(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.UpdatePet(r.Context(), *pet)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -207,11 +207,11 @@ func (c *PetApiController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	result, err := c.service.UpdatePetWithForm(r.Context(), petId, name, status)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -239,10 +239,10 @@ func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.UploadFile(r.Context(), petId, additionalMetadata, file)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -92,11 +92,11 @@ func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.AddPet(r.Context(), *pet)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -112,11 +112,11 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.DeletePet(r.Context(), petId, apiKey)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -127,11 +127,11 @@ func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 	result, err := c.service.FindPetsByStatus(r.Context(), status)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -142,11 +142,11 @@ func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 	result, err := c.service.FindPetsByTags(r.Context(), tags)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -161,11 +161,11 @@ func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.GetPetById(r.Context(), petId)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -180,11 +180,11 @@ func (c *PetApiController) UpdatePet(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.UpdatePet(r.Context(), *pet)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -207,11 +207,11 @@ func (c *PetApiController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 	result, err := c.service.UpdatePetWithForm(r.Context(), petId, name, status)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -239,10 +239,10 @@ func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.UploadFile(r.Context(), petId, additionalMetadata, file)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -64,11 +64,11 @@ func (c *StoreApiController) DeleteOrder(w http.ResponseWriter, r *http.Request)
 	result, err := c.service.DeleteOrder(r.Context(), orderId)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -77,11 +77,11 @@ func (c *StoreApiController) GetInventory(w http.ResponseWriter, r *http.Request
 	result, err := c.service.GetInventory(r.Context())
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -96,11 +96,11 @@ func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request
 	result, err := c.service.GetOrderById(r.Context(), orderId)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -115,10 +115,10 @@ func (c *StoreApiController) PlaceOrder(w http.ResponseWriter, r *http.Request) 
 	result, err := c.service.PlaceOrder(r.Context(), *order)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -64,11 +64,11 @@ func (c *StoreApiController) DeleteOrder(w http.ResponseWriter, r *http.Request)
 	result, err := c.service.DeleteOrder(r.Context(), orderId)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -77,11 +77,11 @@ func (c *StoreApiController) GetInventory(w http.ResponseWriter, r *http.Request
 	result, err := c.service.GetInventory(r.Context())
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -96,11 +96,11 @@ func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request
 	result, err := c.service.GetOrderById(r.Context(), orderId)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -115,10 +115,10 @@ func (c *StoreApiController) PlaceOrder(w http.ResponseWriter, r *http.Request) 
 	result, err := c.service.PlaceOrder(r.Context(), *order)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -92,11 +92,11 @@ func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.CreateUser(r.Context(), *user)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -111,11 +111,11 @@ func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 	result, err := c.service.CreateUsersWithArrayInput(r.Context(), *user)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -130,11 +130,11 @@ func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 	result, err := c.service.CreateUsersWithListInput(r.Context(), *user)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -145,11 +145,11 @@ func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.DeleteUser(r.Context(), username)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -160,11 +160,11 @@ func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request
 	result, err := c.service.GetUserByName(r.Context(), username)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -176,11 +176,11 @@ func (c *UserApiController) LoginUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.LoginUser(r.Context(), username, password)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -189,11 +189,11 @@ func (c *UserApiController) LogoutUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.LogoutUser(r.Context())
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }
 
@@ -210,10 +210,10 @@ func (c *UserApiController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.UpdateUser(r.Context(), username, *user)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, w)
+		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, w)
+	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
 	
 }

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -92,11 +92,11 @@ func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.CreateUser(r.Context(), *user)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -111,11 +111,11 @@ func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 	result, err := c.service.CreateUsersWithArrayInput(r.Context(), *user)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -130,11 +130,11 @@ func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 	result, err := c.service.CreateUsersWithListInput(r.Context(), *user)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -145,11 +145,11 @@ func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.DeleteUser(r.Context(), username)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -160,11 +160,11 @@ func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request
 	result, err := c.service.GetUserByName(r.Context(), username)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -176,11 +176,11 @@ func (c *UserApiController) LoginUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.LoginUser(r.Context(), username, password)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -189,11 +189,11 @@ func (c *UserApiController) LogoutUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.LogoutUser(r.Context())
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }
 
@@ -210,10 +210,10 @@ func (c *UserApiController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	result, err := c.service.UpdateUser(r.Context(), username, *user)
 	//If an error occured, encode the error with the status code
 	if err != nil {
-		EncodeJSONResponse(err.Error(), &result.Code, result.Headers, w)
+		EncodeJSONResponse(err.Error(), &result.Code, w)
 		return
 	}
 	//If no error, encode the body and the result code
-	EncodeJSONResponse(result.Body, &result.Code, result.Headers, w)
+	EncodeJSONResponse(result.Body, &result.Code, w)
 	
 }

--- a/samples/server/petstore/go-api-server/go/helpers.go
+++ b/samples/server/petstore/go-api-server/go/helpers.go
@@ -11,6 +11,18 @@ package petstoreserver
 
 //Response return a ImplResponse struct filled
 func Response(code int, body interface{}) ImplResponse {
-	return ImplResponse{Code: code, Body: body}
+	return ImplResponse {
+		Code: code,
+		Headers: nil,
+		Body: body,
+	}
 }
 
+//ResponseWithHeaders return a ImplResponse struct filled, including headers
+func ResponseWithHeaders(code int, headers map[string][]string, body interface{}) ImplResponse {
+	return ImplResponse {
+		Code: code,
+		Headers: headers,
+		Body: body,
+	}
+}

--- a/samples/server/petstore/go-api-server/go/helpers.go
+++ b/samples/server/petstore/go-api-server/go/helpers.go
@@ -13,16 +13,6 @@ package petstoreserver
 func Response(code int, body interface{}) ImplResponse {
 	return ImplResponse {
 		Code: code,
-		Headers: nil,
-		Body: body,
-	}
-}
-
-//ResponseWithHeaders return a ImplResponse struct filled, including headers
-func ResponseWithHeaders(code int, headers map[string][]string, body interface{}) ImplResponse {
-	return ImplResponse {
-		Code: code,
-		Headers: headers,
 		Body: body,
 	}
 }

--- a/samples/server/petstore/go-api-server/go/helpers.go
+++ b/samples/server/petstore/go-api-server/go/helpers.go
@@ -14,7 +14,7 @@ func Response(code int, body interface{}) ImplResponse {
 	return ImplResponse {
 		Code: code,
 		Headers: nil,
-		Body: body
+		Body: body,
 	}
 }
 
@@ -23,6 +23,6 @@ func ResponseWithHeaders(code int, headers map[string][]string, body interface{}
 	return ImplResponse {
 		Code: code,
 		Headers: headers,
-		Body: body
+		Body: body,
 	}
 }

--- a/samples/server/petstore/go-api-server/go/helpers.go
+++ b/samples/server/petstore/go-api-server/go/helpers.go
@@ -13,6 +13,16 @@ package petstoreserver
 func Response(code int, body interface{}) ImplResponse {
 	return ImplResponse {
 		Code: code,
-		Body: body,
+		Headers: nil,
+		Body: body
+	}
+}
+
+//ResponseWithHeaders return a ImplResponse struct filled, including headers
+func ResponseWithHeaders(code int, headers map[string][]string, body interface{}) ImplResponse {
+	return ImplResponse {
+		Code: code,
+		Headers: headers,
+		Body: body
 	}
 }

--- a/samples/server/petstore/go-api-server/go/impl.go
+++ b/samples/server/petstore/go-api-server/go/impl.go
@@ -12,5 +12,6 @@ package petstoreserver
 //Implementation response defines an error code with the associated body
 type ImplResponse struct {
 	Code int
+	Headers map[string][]string
 	Body interface{}
 }

--- a/samples/server/petstore/go-api-server/go/impl.go
+++ b/samples/server/petstore/go-api-server/go/impl.go
@@ -12,6 +12,5 @@ package petstoreserver
 //Implementation response defines an error code with the associated body
 type ImplResponse struct {
 	Code int
-	Headers map[string][]string
 	Body interface{}
 }

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -56,7 +56,7 @@ func NewRouter(routers ...Router) *mux.Router {
 }
 
 // EncodeJSONResponse uses the json encoder to write an interface to the http response with an optional status code
-func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error {
+func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string, w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	if status != nil {
 		w.WriteHeader(*status)

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -56,16 +56,8 @@ func NewRouter(routers ...Router) *mux.Router {
 }
 
 // EncodeJSONResponse uses the json encoder to write an interface to the http response with an optional status code
-func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string, w http.ResponseWriter) error {
-	wHeader := w.Header()
-	if headers != nil {
-		for key, values := range headers {
-			for _, value := range values {
-				wHeader.Add(key, value)
-			}
-		}
-	}
-	wHeader.Set("Content-Type", "application/json; charset=UTF-8")
+func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	if status != nil {
 		w.WriteHeader(*status)
 	} else {

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -56,8 +56,16 @@ func NewRouter(routers ...Router) *mux.Router {
 }
 
 // EncodeJSONResponse uses the json encoder to write an interface to the http response with an optional status code
-func EncodeJSONResponse(i interface{}, status *int, w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+func EncodeJSONResponse(i interface{}, status *int, headers map[string][]string, w http.ResponseWriter) error {
+	wHeader := w.Header()
+	if headers != nil {
+		for key, values := range headers {
+			for _, value := range values {
+				wHeader.Add(key, value)
+			}
+		}
+	}
+	wHeader.Set("Content-Type", "application/json; charset=UTF-8")
 	if status != nil {
 		w.WriteHeader(*status)
 	} else {


### PR DESCRIPTION
This pull request is intended to provide the capability to specify headers to include in the response.

This is needed, for example, to allow a REST API to redirect the client to a new URL (using the Location header).

This pull request includes also the changes in the pull request #8144

credits: @randomswdev 

Also added an option "addResponseHeaders" to make this change backward-compatible.

Tests also passed without the option enabled: https://app.circleci.com/pipelines/github/OpenAPITools/openapi-generator/10088/workflows/40c945db-9fbc-47e3-a330-e0cfae82cc2f/jobs/23700

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01)


