### PR TITLE
[typescript-angular] Provide return value for all code paths (#9174)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/configuration.mustache
@@ -70,9 +70,9 @@ export class {{configurationClassName}} {
 {{#isBasic}}
     {{#isBasicBasic}}
             this.credentials['{{name}}'] = () => {
-                if (this.username || this.password) {
-                    return btoa(this.username + ':' + this.password);
-                }
+                return (this.username || this.password)
+                    ? btoa(this.username + ':' + this.password)
+                    : undefined;
             };
     {{/isBasicBasic}}
     {{#isBasicBearer}}


### PR DESCRIPTION
In order to avoid a compiler error when using `noImplicitReturns `, we
change the mustache template to use provide a return value for the if-
and else branch.

Fixes #9174.

---- 


### PR checklist
* [x]  Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
* [x]  Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
* [x]  Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ```
  
  
  Commit all changed files.
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
* [x]  File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
* [x]  If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.