### PR TITLE
[DART] Add homepage option to pubspec.yaml

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/README.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/README.mustache
@@ -21,7 +21,9 @@ For more information, please visit [{{{infoUrl}}}]({{{infoUrl}}})
 
 * Dart 2.12.0 or later OR Flutter 1.26.0 or later
 * Dio 4.0.0+
+{{#useDateLibTimeMachine}}
 * timemachine option currently **DOES NOT** support sound null-safety and may not work
+{{/useDateLibTimeMachine}}
 
 ## Installation & Usage
 
@@ -43,6 +45,13 @@ To use the package in your local drive, please include the following in pubspec.
 dependencies:
   {{pubName}}:
     path: /path/to/{{pubName}}
+```
+
+### pub.dev
+To use the package in your local drive, please include the following in pubspec.yaml
+```yaml
+dependencies:
+  {{pubName}}: {{pubVersion}}
 ```
 
 ## Getting Started

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/pubspec.mustache
@@ -1,6 +1,7 @@
 name: {{pubName}}
 version: {{pubVersion}}
 description: {{pubDescription}}
+homepage: {{pubHomepage}}
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/pubspec.mustache
@@ -2,6 +2,8 @@ name: {{pubName}}
 version: {{pubVersion}}
 description: {{pubDescription}}
 homepage: {{pubHomepage}}
+authors:
+  - '{{{pubAuthor}}} <{{{pubAuthorEmail}}}>'
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
package validation fails when trying to publish to pub.dev. A homepage/repository field is required to be set in pubspec.yaml.

See: https://dart.dev/tools/pub/pubspec
Blocking https://github.com/bigpanther/trober/pull/108 via https://github.com/bigpanther/trober/pull/108/checks?check_run_id=2275335010. (using a hack at the moment to set the homepage url out of band)

cc: @kuhnroyal

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
