### PR TITLE
[kotlin][moshi] add polymorphic support with sealed classes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -42,6 +42,8 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
     protected static final String JVM_RETROFIT2 = "jvm-retrofit2";
     protected static final String MULTIPLATFORM = "multiplatform";
 
+    public static final String USE_SEALED_CLASS = "useSealedClass";
+
     public static final String USE_RX_JAVA = "useRxJava";
     public static final String USE_RX_JAVA2 = "useRxJava2";
     public static final String USE_RX_JAVA3 = "useRxJava3";
@@ -173,10 +175,10 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
         collectionType.setDefault(this.collectionType);
         cliOptions.add(collectionType);
 
-        supportedLibraries.put(JVM_OKHTTP4, "[DEFAULT] Platform: Java Virtual Machine. HTTP client: OkHttp 4.2.0 (Android 5.0+ and Java 8+). JSON processing: Moshi 1.8.0.");
-        supportedLibraries.put(JVM_OKHTTP3, "Platform: Java Virtual Machine. HTTP client: OkHttp 3.12.4 (Android 2.3+ and Java 7+). JSON processing: Moshi 1.8.0.");
-        supportedLibraries.put(JVM_RETROFIT2, "Platform: Java Virtual Machine. HTTP client: Retrofit 2.6.2.");
-        supportedLibraries.put(MULTIPLATFORM, "Platform: Kotlin multiplatform. HTTP client: Ktor 1.2.4. JSON processing: Kotlinx Serialization: 0.12.0.");
+        supportedLibraries.put(JVM_OKHTTP4, "[DEFAULT] Platform: Java Virtual Machine. HTTP client: OkHttp 4.9.0 (Android 5.0+ and Java 8+).");
+        supportedLibraries.put(JVM_OKHTTP3, "Platform: Java Virtual Machine. HTTP client: OkHttp 3.12.4 (Android 2.3+ and Java 7+).");
+        supportedLibraries.put(JVM_RETROFIT2, "Platform: Java Virtual Machine. HTTP client: Retrofit 2.7.2.");
+        supportedLibraries.put(MULTIPLATFORM, "Platform: Kotlin multiplatform. HTTP client: Ktor 1.2.4. JSON processing: Kotlinx Serialization: 1.1.0.");
 
         CliOption libraryOption = new CliOption(CodegenConstants.LIBRARY, "Library template (sub-template) to use");
         libraryOption.setEnum(supportedLibraries);
@@ -191,6 +193,8 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
         requestDateConverter.setEnum(requestDateConverterOptions);
         requestDateConverter.setDefault(this.requestDateConverter);
         cliOptions.add(requestDateConverter);
+
+        cliOptions.add(CliOption.newBoolean(USE_SEALED_CLASS, "Use sealed classes instead of interfaces."));
 
         cliOptions.add(CliOption.newBoolean(USE_RX_JAVA, "Whether to use the RxJava adapter with the retrofit2 library."));
         cliOptions.add(CliOption.newBoolean(USE_RX_JAVA2, "Whether to use the RxJava2 adapter with the retrofit2 library."));
@@ -362,7 +366,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
             additionalProperties.put("isList", true);
         }
 
-        if(usesRetrofit2Library()) {
+        if (usesRetrofit2Library()) {
             if (ProcessUtils.hasOAuthMethods(openAPI)) {
                 supportingFiles.add(new SupportingFile("auth/ApiKeyAuth.kt.mustache", authFolder, "ApiKeyAuth.kt"));
                 supportingFiles.add(new SupportingFile("auth/OAuth.kt.mustache", authFolder, "OAuth.kt"));
@@ -370,11 +374,11 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
                 supportingFiles.add(new SupportingFile("auth/OAuthOkHttpClient.kt.mustache", authFolder, "OAuthOkHttpClient.kt"));
             }
 
-            if(ProcessUtils.hasHttpBearerMethods(openAPI)) {
+            if (ProcessUtils.hasHttpBearerMethods(openAPI)) {
                 supportingFiles.add(new SupportingFile("auth/HttpBearerAuth.kt.mustache", authFolder, "HttpBearerAuth.kt"));
             }
 
-            if(ProcessUtils.hasHttpBasicMethods(openAPI)) {
+            if (ProcessUtils.hasHttpBasicMethods(openAPI)) {
                 supportingFiles.add(new SupportingFile("auth/HttpBasicAuth.kt.mustache", authFolder, "HttpBasicAuth.kt"));
             }
         }
@@ -583,6 +587,32 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
         supportingFiles.add(new SupportingFile("gradle-wrapper.jar", "gradle.wrapper".replace(".", File.separator), "gradle-wrapper.jar"));
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public Map<String, Object> postProcessAllModels(Map<String, Object> objs) {
+        Map<String, Object> result = super.postProcessAllModels(objs);
+
+        // We have to remove duplicate classes if we use sealed classes. So do nothing if we don't use sealed classes.
+        boolean useSealedClass = additionalProperties.containsKey(USE_SEALED_CLASS) && (boolean) additionalProperties.get(USE_SEALED_CLASS);
+        if (!useSealedClass) {
+            return result;
+        }
+
+        Map<String, Object> newMap = new HashMap<String, Object>(result);
+        for (Map.Entry<String, Object> entry : result.entrySet()) {
+            Map<String, Object> inner = (Map<String, Object>) entry.getValue();
+            List<Map<String, Object>> models = (List<Map<String, Object>>) inner.get("models");
+            for (Map<String, Object> mo : models) {
+                CodegenModel cm = (CodegenModel) mo.get("model");
+                if (cm.discriminator != null && cm.children != null) {
+                    // Remove the children from the "normal" models. We have to place it into the sealed classes.
+                    cm.children.forEach(child -> newMap.remove(child.getName()));
+                }
+            }
+        }
+        return newMap;
+    }
+
     @Override
     public Map<String, Object> postProcessModels(Map<String, Object> objs) {
         Map<String, Object> objects = super.postProcessModels(objs);
@@ -610,7 +640,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
             }
 
             CodegenDiscriminator discriminator = cm.getDiscriminator();
-            if(discriminator != null) {
+            if (discriminator != null) {
                 cm.vendorExtensions.put(VENDOR_EXTENSION_DISCRIMINATOR_BASE_NAME_LITERAL, discriminator.getPropertyBaseName().replace("$", "\\$"));
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -18,14 +18,7 @@
 package org.openapitools.codegen.languages;
 
 import org.apache.commons.lang3.StringUtils;
-import org.openapitools.codegen.CliOption;
-import org.openapitools.codegen.CodegenConstants;
-import org.openapitools.codegen.CodegenModel;
-import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenParameter;
-import org.openapitools.codegen.CodegenProperty;
-import org.openapitools.codegen.CodegenType;
-import org.openapitools.codegen.SupportingFile;
+import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +53,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
     public static final String COLLECTION_TYPE = "collectionType";
 
     protected static final String VENDOR_EXTENSION_BASE_NAME_LITERAL = "x-base-name-literal";
+    protected static final String VENDOR_EXTENSION_DISCRIMINATOR_BASE_NAME_LITERAL = "x-base-name-discriminator-literal";
 
     protected String dateLibrary = DateLibrary.JAVA8.value;
     protected String requestDateConverter = RequestDateConverter.TO_JSON.value;
@@ -613,6 +607,11 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
 
             for (CodegenProperty var : vars) {
                 var.vendorExtensions.put(VENDOR_EXTENSION_BASE_NAME_LITERAL, var.baseName.replace("$", "\\$"));
+            }
+
+            CodegenDiscriminator discriminator = cm.getDiscriminator();
+            if(discriminator != null) {
+                cm.vendorExtensions.put(VENDOR_EXTENSION_DISCRIMINATOR_BASE_NAME_LITERAL, discriminator.getPropertyBaseName().replace("$", "\\$"));
             }
         }
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -20,6 +20,9 @@ buildscript {
     {{#useRxJava3}}
     ext.rxJava3Version = '3.0.10'
     {{/useRxJava3}}
+    {{#moshi}}
+    ext.moshiVersion = '1.11.0'
+    {{/moshi}}
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -56,12 +59,13 @@ dependencies {
     {{#moshi}}
     {{^moshiCodeGen}}
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.11.0"
+    compile "com.squareup.moshi:moshi-kotlin:$moshiVersion"
     {{/moshiCodeGen}}
     {{#moshiCodeGen}}
-    compile "com.squareup.moshi:moshi:1.11.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.11.0"
+    compile "com.squareup.moshi:moshi:$moshiVersion"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
     {{/moshiCodeGen}}
+    compile "com.squareup.moshi:moshi-adapters:$moshiVersion"
     {{/moshi}}
     {{#gson}}
     compile "com.google.code.gson:gson:2.8.6"

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -1,41 +1,3 @@
-{{^multiplatform}}
-{{#gson}}
-import com.google.gson.annotations.SerializedName
-{{/gson}}
-{{#moshi}}
-import com.squareup.moshi.Json
-{{#moshiCodeGen}}
-import com.squareup.moshi.JsonClass
-{{/moshiCodeGen}}
-{{/moshi}}
-{{#jackson}}
-import com.fasterxml.jackson.annotation.JsonProperty
-{{#discriminator}}
-import com.fasterxml.jackson.annotation.JsonSubTypes
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-{{/discriminator}}
-{{/jackson}}
-{{#kotlinx_serialization}}
-import {{#serializableModel}}kotlinx.serialization.Serializable as KSerializable{{/serializableModel}}{{^serializableModel}}kotlinx.serialization.Serializable{{/serializableModel}}
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Contextual
-{{#hasEnums}}
-{{/hasEnums}}
-{{/kotlinx_serialization}}
-{{#parcelizeModels}}
-import android.os.Parcelable
-import kotlinx.parcelize.Parcelize
-
-{{/parcelizeModels}}
-{{/multiplatform}}
-{{#multiplatform}}
-import kotlinx.serialization.*
-import kotlinx.serialization.internal.CommonEnumSerializer
-{{/multiplatform}}
-{{#serializableModel}}
-import java.io.Serializable
-{{/serializableModel}}
-
 /**
  * {{{description}}}
 {{#allVars}}
@@ -49,20 +11,21 @@ import java.io.Serializable
 {{#isDeprecated}}
 @Deprecated(message = "This schema is deprecated.")
 {{/isDeprecated}}
-{{#nonPublicApi}}internal {{/nonPublicApi}}{{#discriminator}}interface{{/discriminator}}{{^discriminator}}data class{{/discriminator}} {{classname}}{{^discriminator}} (
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{#discriminator}}{{#useSealedClass}}sealed class{{/useSealedClass}}{{^useSealedClass}}interface{{/useSealedClass}}{{/discriminator}}{{^discriminator}}data class{{/discriminator}} {{classname}}{{^discriminator}} (
 {{#allVars}}
 {{#required}}{{>data_class_req_var}}{{/required}}{{^required}}{{>data_class_opt_var}}{{/required}}{{^-last}},{{/-last}}
 {{/allVars}}
-){{/discriminator}}{{#parent}}{{^serializableModel}}{{^parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#parent}}{{#serializableModel}}{{^parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}, Serializable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#parent}}{{^serializableModel}}{{#parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}, Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#parent}}{{#serializableModel}}{{#parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}, Serializable, Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{^parent}}{{#serializableModel}}{{^parcelizeModels}} : Serializable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{^parent}}{{^serializableModel}}{{#parcelizeModels}} : Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{^parent}}{{#serializableModel}}{{#parcelizeModels}} : Serializable, Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#vendorExtensions.x-has-data-class-body}} {
+){{/discriminator}}{{#parent}}{{^serializableModel}}{{^parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}{{#useSealedClass}}(){{/useSealedClass}}{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#parent}}{{#serializableModel}}{{^parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}{{#useSealedClass}}(){{/useSealedClass}}, Serializable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#parent}}{{^serializableModel}}{{#parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}{{#useSealedClass}}(){{/useSealedClass}}, Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#parent}}{{#serializableModel}}{{#parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}{{#useSealedClass}}(){{/useSealedClass}}, Serializable, Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{^parent}}{{#serializableModel}}{{^parcelizeModels}} : Serializable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{^parent}}{{^serializableModel}}{{#parcelizeModels}} : Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{^parent}}{{#serializableModel}}{{#parcelizeModels}} : Serializable, Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#vendorExtensions.x-has-data-class-body}} {
 {{/vendorExtensions.x-has-data-class-body}}
 {{#serializableModel}}
     {{#nonPublicApi}}internal {{/nonPublicApi}}companion object {
         private const val serialVersionUID: Long = 123
     }
 {{/serializableModel}}
-{{#discriminator}}{{#vars}}{{#required}}
+{{#discriminator}}{{#vars}}{{#useSealedClass}}
+{{>sealed_class_var}}{{/useSealedClass}}{{^useSealedClass}}{{#required}}
 {{>interface_req_var}}{{/required}}{{^required}}
-{{>interface_opt_var}}{{/required}}{{/vars}}{{/discriminator}}
+{{>interface_opt_var}}{{/required}}{{/useSealedClass}}{{/vars}}{{/discriminator}}
 {{#hasEnums}}
 {{#vars}}
 {{#isEnum}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -45,7 +45,7 @@ import java.io.Serializable
 {{#parcelizeModels}}
 @Parcelize
 {{/parcelizeModels}}
-{{#multiplatform}}@Serializable{{/multiplatform}}{{#kotlinx_serialization}}{{#serializableModel}}@KSerializable{{/serializableModel}}{{^serializableModel}}@Serializable{{/serializableModel}}{{/kotlinx_serialization}}{{#moshi}}{{#moshiCodeGen}}@JsonClass(generateAdapter = true){{/moshiCodeGen}}{{/moshi}}{{#jackson}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{/jackson}}
+{{#multiplatform}}@Serializable{{/multiplatform}}{{#kotlinx_serialization}}{{#serializableModel}}@KSerializable{{/serializableModel}}{{^serializableModel}}@Serializable{{/serializableModel}}{{/kotlinx_serialization}}{{#moshi}}{{^discriminator}}{{#moshiCodeGen}}@JsonClass(generateAdapter = true){{/moshiCodeGen}}{{/discriminator}}{{/moshi}}{{#jackson}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{/jackson}}
 {{#isDeprecated}}
 @Deprecated(message = "This schema is deprecated.")
 {{/isDeprecated}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class_header.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class_header.mustache
@@ -1,0 +1,37 @@
+{{^multiplatform}}
+{{#gson}}
+import com.google.gson.annotations.SerializedName
+{{/gson}}
+{{#moshi}}
+import com.squareup.moshi.Json
+{{#moshiCodeGen}}
+import com.squareup.moshi.JsonClass
+{{/moshiCodeGen}}
+{{/moshi}}
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonProperty
+{{#discriminator}}
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+{{/discriminator}}
+{{/jackson}}
+{{#kotlinx_serialization}}
+import {{#serializableModel}}kotlinx.serialization.Serializable as KSerializable{{/serializableModel}}{{^serializableModel}}kotlinx.serialization.Serializable{{/serializableModel}}
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Contextual
+{{#hasEnums}}
+{{/hasEnums}}
+{{/kotlinx_serialization}}
+{{#parcelizeModels}}
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+{{/parcelizeModels}}
+{{/multiplatform}}
+{{#multiplatform}}
+import kotlinx.serialization.*
+import kotlinx.serialization.internal.CommonEnumSerializer
+{{/multiplatform}}
+{{#serializableModel}}
+import java.io.Serializable
+{{/serializableModel}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/interface_opt_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/interface_opt_var.mustache
@@ -2,9 +2,7 @@
     /* {{{description}}} */
 {{/description}}
     {{^multiplatform}}
-    {{#moshi}}
-    @Json(name = "{{{vendorExtensions.x-base-name-literal}}}")
-    {{/moshi}}
+    {{#moshi}}{{^discriminator}}@Json(name = "{{{vendorExtensions.x-base-name-literal}}}"){{/discriminator}}{{/moshi}}
     {{#gson}}
     @get:SerializedName("{{{vendorExtensions.x-base-name-literal}}}")
     {{/gson}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
@@ -51,8 +51,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 {{/kotlinx_serialization}}
-
-{{#moshi}}import {{modelPackage}}.*{{/moshi}}
+{{#moshi}}
+import {{modelPackage}}.*
+{{/moshi}}
 
 {{#nonPublicApi}}internal {{/nonPublicApi}}object Serializer {
 {{#moshi}}
@@ -63,11 +64,13 @@ import java.util.concurrent.atomic.AtomicLong
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
-        {{#models}}{{#model}}{{#discriminator}}.add(PolymorphicJsonAdapterFactory.of({{classname}}::class.java, "{{{vendorExtensions.x-base-name-discriminator-literal}}}")
+        {{#models}}{{#model}}{{#discriminator}}
+        .add(PolymorphicJsonAdapterFactory.of({{classname}}::class.java, "{{{vendorExtensions.x-base-name-discriminator-literal}}}")
         {{#mappedModels}}
             .withSubtype({{modelName}}::class.java, "{{mappingName}}")
         {{/mappedModels}}
-        ){{/discriminator}}{{/model}}{{/models}}
+        )
+        {{/discriminator}}{{/model}}{{/models}}
         {{^moshiCodeGen}}
         .add(KotlinJsonAdapterFactory())
         {{/moshiCodeGen}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
@@ -2,6 +2,7 @@ package {{packageName}}.infrastructure
 
 {{#moshi}}
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 {{^moshiCodeGen}}
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 {{/moshiCodeGen}}
@@ -51,6 +52,8 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 {{/kotlinx_serialization}}
 
+{{#moshi}}import {{modelPackage}}.*{{/moshi}}
+
 {{#nonPublicApi}}internal {{/nonPublicApi}}object Serializer {
 {{#moshi}}
     @JvmStatic
@@ -60,6 +63,11 @@ import java.util.concurrent.atomic.AtomicLong
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
+        {{#models}}{{#model}}{{#discriminator}}.add(PolymorphicJsonAdapterFactory.of({{classname}}::class.java, "{{{vendorExtensions.x-base-name-discriminator-literal}}}")
+        {{#mappedModels}}
+            .withSubtype({{modelName}}::class.java, "{{mappingName}}")
+        {{/mappedModels}}
+        ){{/discriminator}}{{/model}}{{/models}}
         {{^moshiCodeGen}}
         .add(KotlinJsonAdapterFactory())
         {{/moshiCodeGen}}
@@ -76,7 +84,7 @@ import java.util.concurrent.atomic.AtomicLong
         .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeAdapter())
         .registerTypeAdapter(LocalDate::class.java, LocalDateAdapter())
         .registerTypeAdapter(ByteArray::class.java, ByteArrayAdapter())
-    
+
     @JvmStatic
     val gson: Gson by lazy {
         gsonBuilder.create()

--- a/modules/openapi-generator/src/main/resources/kotlin-client/model.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/model.mustache
@@ -6,6 +6,9 @@ package {{modelPackage}}
 
 {{#models}}
 {{#model}}
-{{#isEnum}}{{>enum_class}}{{/isEnum}}{{^isEnum}}{{#isAlias}}typealias {{classname}} = {{{dataType}}}{{/isAlias}}{{^isAlias}}{{>data_class}}{{/isAlias}}{{/isEnum}}
+{{#isEnum}}{{>enum_class}}{{/isEnum}}{{^isEnum}}{{#isAlias}}typealias {{classname}} = {{{dataType}}}{{/isAlias}}{{^isAlias}}{{>data_class_header}}
+{{>data_class}}{{/isAlias}}{{/isEnum}}
+{{#useSealedClass}}{{#children}}{{>data_class}}
+{{/children}}{{/useSealedClass}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/model.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/model.mustache
@@ -7,8 +7,8 @@ package {{modelPackage}}
 {{#models}}
 {{#model}}
 {{#isEnum}}{{>enum_class}}{{/isEnum}}{{^isEnum}}{{#isAlias}}typealias {{classname}} = {{{dataType}}}{{/isAlias}}{{^isAlias}}{{>data_class_header}}
-{{>data_class}}{{/isAlias}}{{/isEnum}}
-{{#useSealedClass}}{{#children}}{{>data_class}}
+{{>data_class}}{{/isAlias}}{{/isEnum}}{{#useSealedClass}}
+{{#children}}{{>data_class}}
 {{/children}}{{/useSealedClass}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/sealed_class_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/sealed_class_var.mustache
@@ -1,0 +1,4 @@
+{{#description}}
+    /* {{{description}}} */
+{{/description}}
+    abstract {{>modelMutable}} {{{name}}}: {{#isArray}}{{#isList}}kotlin.collections.List{{/isList}}{{^isList}}kotlin.Array{{/isList}}<{{^items.isEnum}}{{{items.dataType}}}{{/items.isEnum}}{{#items.isEnum}}{{classname}}.{{{nameInCamelCase}}}{{/items.isEnum}}>{{/isArray}}{{^isEnum}}{{^isArray}}{{{dataType}}}{{/isArray}}{{/isEnum}}{{#isEnum}}{{^isArray}}{{classname}}.{{{nameInCamelCase}}}{{/isArray}}{{/isEnum}}{{^required}}?{{/required}}

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -15,7 +15,7 @@ object Serializer {
         .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeAdapter())
         .registerTypeAdapter(LocalDate::class.java, LocalDateAdapter())
         .registerTypeAdapter(ByteArray::class.java, ByteArrayAdapter())
-    
+
     @JvmStatic
     val gson: Gson by lazy {
         gsonBuilder.create()

--- a/samples/client/petstore/kotlin-json-request-string/build.gradle
+++ b/samples/client/petstore/kotlin-json-request-string/build.gradle
@@ -8,6 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.4.30'
+    ext.moshiVersion = '1.11.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -30,7 +31,8 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.11.0"
+    compile "com.squareup.moshi:moshi-kotlin:$moshiVersion"
+    compile "com.squareup.moshi:moshi-adapters:$moshiVersion"
     compile "com.squareup.okhttp3:okhttp:4.9.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,10 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
+import org.openapitools.client.models.*
 
 object Serializer {
     @JvmStatic
@@ -12,6 +14,7 @@ object Serializer {
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
+        
         .add(KotlinJsonAdapterFactory())
 
     @JvmStatic

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -15,7 +15,7 @@ object Serializer {
         .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeAdapter())
         .registerTypeAdapter(LocalDate::class.java, LocalDateAdapter())
         .registerTypeAdapter(ByteArray::class.java, ByteArrayAdapter())
-    
+
     @JvmStatic
     val gson: Gson by lazy {
         gsonBuilder.create()

--- a/samples/client/petstore/kotlin-moshi-codegen/build.gradle
+++ b/samples/client/petstore/kotlin-moshi-codegen/build.gradle
@@ -8,6 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.4.30'
+    ext.moshiVersion = '1.11.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -30,8 +31,9 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "com.squareup.moshi:moshi:1.11.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.11.0"
+    compile "com.squareup.moshi:moshi:$moshiVersion"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion"
+    compile "com.squareup.moshi:moshi-adapters:$moshiVersion"
     compile "com.squareup.okhttp3:okhttp:4.9.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -14,6 +14,7 @@ object Serializer {
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
         
+
     @JvmStatic
     val moshi: Moshi by lazy {
         moshiBuilder.build()

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,7 +1,9 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import java.util.Date
+import org.openapitools.client.models.*
 
 object Serializer {
     @JvmStatic
@@ -11,7 +13,7 @@ object Serializer {
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
-
+        
     @JvmStatic
     val moshi: Moshi by lazy {
         moshiBuilder.build()

--- a/samples/client/petstore/kotlin-nonpublic/build.gradle
+++ b/samples/client/petstore/kotlin-nonpublic/build.gradle
@@ -8,6 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.4.30'
+    ext.moshiVersion = '1.11.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -30,7 +31,8 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.11.0"
+    compile "com.squareup.moshi:moshi-kotlin:$moshiVersion"
+    compile "com.squareup.moshi:moshi-adapters:$moshiVersion"
     compile "com.squareup.okhttp3:okhttp:4.9.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,10 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
+import org.openapitools.client.models.*
 
 internal object Serializer {
     @JvmStatic
@@ -12,6 +14,7 @@ internal object Serializer {
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
+        
         .add(KotlinJsonAdapterFactory())
 
     @JvmStatic

--- a/samples/client/petstore/kotlin-nullable/build.gradle
+++ b/samples/client/petstore/kotlin-nullable/build.gradle
@@ -8,6 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.4.30'
+    ext.moshiVersion = '1.11.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -30,7 +31,8 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.11.0"
+    compile "com.squareup.moshi:moshi-kotlin:$moshiVersion"
+    compile "com.squareup.moshi:moshi-adapters:$moshiVersion"
     compile "com.squareup.okhttp3:okhttp:4.9.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,10 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
+import org.openapitools.client.models.*
 
 object Serializer {
     @JvmStatic
@@ -12,6 +14,7 @@ object Serializer {
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
+        
         .add(KotlinJsonAdapterFactory())
 
     @JvmStatic

--- a/samples/client/petstore/kotlin-okhttp3/build.gradle
+++ b/samples/client/petstore/kotlin-okhttp3/build.gradle
@@ -8,6 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.4.30'
+    ext.moshiVersion = '1.11.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -30,7 +31,8 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.11.0"
+    compile "com.squareup.moshi:moshi-kotlin:$moshiVersion"
+    compile "com.squareup.moshi:moshi-adapters:$moshiVersion"
     compile "com.squareup.okhttp3:okhttp:3.12.13"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,10 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
+import org.openapitools.client.models.*
 
 object Serializer {
     @JvmStatic
@@ -12,6 +14,7 @@ object Serializer {
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
+        
         .add(KotlinJsonAdapterFactory())
 
     @JvmStatic

--- a/samples/client/petstore/kotlin-retrofit2-rx3/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     ext.kotlin_version = '1.4.30'
     ext.retrofitVersion = '2.7.2'
     ext.rxJava3Version = '3.0.10'
+    ext.moshiVersion = '1.11.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -32,7 +33,8 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.11.0"
+    compile "com.squareup.moshi:moshi-kotlin:$moshiVersion"
+    compile "com.squareup.moshi:moshi-adapters:$moshiVersion"
     compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "com.squareup.okhttp3:logging-interceptor:4.9.0"
     compile "io.reactivex.rxjava3:rxjava:$rxJava3Version"

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,10 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
+import org.openapitools.client.models.*
 
 object Serializer {
     @JvmStatic
@@ -12,6 +14,7 @@ object Serializer {
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
+        
         .add(KotlinJsonAdapterFactory())
 
     @JvmStatic

--- a/samples/client/petstore/kotlin-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2/build.gradle
@@ -9,6 +9,7 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.4.30'
     ext.retrofitVersion = '2.7.2'
+    ext.moshiVersion = '1.11.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -31,7 +32,8 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.11.0"
+    compile "com.squareup.moshi:moshi-kotlin:$moshiVersion"
+    compile "com.squareup.moshi:moshi-adapters:$moshiVersion"
     compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "com.squareup.okhttp3:logging-interceptor:4.9.0"
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,10 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
+import org.openapitools.client.models.*
 
 object Serializer {
     @JvmStatic
@@ -12,6 +14,7 @@ object Serializer {
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
+        
         .add(KotlinJsonAdapterFactory())
 
     @JvmStatic

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -8,6 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.4.30'
+    ext.moshiVersion = '1.11.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -30,7 +31,8 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.11.0"
+    compile "com.squareup.moshi:moshi-kotlin:$moshiVersion"
+    compile "com.squareup.moshi:moshi-adapters:$moshiVersion"
     compile "com.squareup.okhttp3:okhttp:4.9.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,10 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
+import org.openapitools.client.models.*
 
 object Serializer {
     @JvmStatic
@@ -12,6 +14,7 @@ object Serializer {
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
+        
         .add(KotlinJsonAdapterFactory())
 
     @JvmStatic

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -8,6 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.4.30'
+    ext.moshiVersion = '1.11.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -30,7 +31,8 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.11.0"
+    compile "com.squareup.moshi:moshi-kotlin:$moshiVersion"
+    compile "com.squareup.moshi:moshi-adapters:$moshiVersion"
     compile "com.squareup.okhttp3:okhttp:4.9.0"
     compile "org.threeten:threetenbp:1.5.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.4.2"

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,10 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
+import org.openapitools.client.models.*
 
 object Serializer {
     @JvmStatic
@@ -12,6 +14,7 @@ object Serializer {
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
+        
         .add(KotlinJsonAdapterFactory())
 
     @JvmStatic

--- a/samples/client/petstore/kotlin-uppercase-enum/build.gradle
+++ b/samples/client/petstore/kotlin-uppercase-enum/build.gradle
@@ -8,6 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.4.30'
+    ext.moshiVersion = '1.11.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -30,7 +31,8 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.11.0"
+    compile "com.squareup.moshi:moshi-kotlin:$moshiVersion"
+    compile "com.squareup.moshi:moshi-adapters:$moshiVersion"
     compile "com.squareup.okhttp3:okhttp:4.9.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,10 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
+import org.openapitools.client.models.*
 
 object Serializer {
     @JvmStatic
@@ -12,6 +14,7 @@ object Serializer {
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
+        
         .add(KotlinJsonAdapterFactory())
 
     @JvmStatic

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -8,6 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.4.30'
+    ext.moshiVersion = '1.11.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -30,7 +31,8 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.11.0"
+    compile "com.squareup.moshi:moshi-kotlin:$moshiVersion"
+    compile "com.squareup.moshi:moshi-adapters:$moshiVersion"
     compile "com.squareup.okhttp3:okhttp:4.9.0"
     testCompile "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,10 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
+import org.openapitools.client.models.*
 
 object Serializer {
     @JvmStatic
@@ -12,6 +14,7 @@ object Serializer {
         .add(LocalDateAdapter())
         .add(UUIDAdapter())
         .add(ByteArrayAdapter())
+        
         .add(KotlinJsonAdapterFactory())
 
     @JvmStatic


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This is almost the same PR as #9159 but it also adds support for sealed classes together with moshi. It will also resolve the issue #8059. I created a separate PR because the changes of my old PR are mostly in the templates (and straight forward). I think this one is a bit more complex, so it make sense to merge the other one first. 

Currently it's not possible to use Kotlin and Moshi with the oneOf-Keyword. I tried to implement the `PolymorphicJsonAdapterFactory` to support this feature. 
The reason why I set the target branch to `master` is because the current strategy will fail during runtime (it's not allowed with moshi to serialize a interface directly). 

I tested it with the following config: 
```
generatorName: kotlin
outputDir: samples/client/3_0/kotlin-retrofit2-moshi-polymorphic
library: jvm-retrofit2
inputSpec: modules/openapi-generator/src/test/resources/3_0/allOf.yaml
templateDir: modules/openapi-generator/src/main/resources/kotlin-client
additionalProperties:
  serializationLibrary: moshi
  artifactId: kotlin-retrofit2-moshi-polymorphic
  moshiCodeGen: true
  useSealedClass: true
```

Saddly in the current petstore samples are no discriminator, that's why I didn't add a sample. 

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

[technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) : @jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m
