### PR TITLE
Swift5 models improvements

### DIFF
--- a/bin/configs/swift5-urlsessionLibrary.yaml
+++ b/bin/configs/swift5-urlsessionLibrary.yaml
@@ -10,3 +10,4 @@ additionalProperties:
   projectName: PetstoreClient
   podHomepage: https://github.com/openapitools/openapi-generator
   useSPMFileStructure: true
+  useClasses: true

--- a/docs/generators/swift5.md
+++ b/docs/generators/swift5.md
@@ -14,7 +14,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C#have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
 |lenientTypeCast|Accept and cast values for simple types (string-&gt;bool, string-&gt;int, int-&gt;string)| |false|
-|library|Library template (sub-template) to use|<dl><dt>**urlsession**</dt><dd>[DEFAULT] HTTP client: URLSession</dd><dt>**alamofire**</dt><dd>HTTP client: Alamofire</dd><dt>**vapor**</dt><dd>HTTP client: Vapor</dd></dl>|urlsession|
+|library|Library template (sub-template) to use|<dl><dt>**urlsession**</dt><dd>[DEFAULT] HTTP client: URLSession</dd><dt>**alamofire**</dt><dd>HTTP client: Alamofire</dd></dl>|urlsession|
 |nonPublicApi|Generates code with reduced access modifiers; allows embedding elsewhere without exposing non-public API calls to consumers.(default: false)| |null|
 |objcCompatible|Add additional properties and methods for Objective-C compatibility (default: false)| |null|
 |podAuthors|Authors used for Podspec| |null|

--- a/modules/openapi-generator/src/main/resources/swift5/modelObject.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/modelObject.mustache
@@ -1,4 +1,4 @@
-{{^objcCompatible}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} struct {{classname}}: Codable, Hashable {
+{{^objcCompatible}}{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#useClasses}}final class{{/useClasses}}{{^useClasses}}struct{{/useClasses}} {{classname}}: Codable, Hashable {
 {{/objcCompatible}}{{#objcCompatible}}@objc {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} class {{classname}}: NSObject, Codable {
 {{/objcCompatible}}
 

--- a/modules/openapi-generator/src/main/resources/swift5/modelObject.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/modelObject.mustache
@@ -56,19 +56,22 @@
             additionalProperties[key] = newValue
         }
     }
+{{/additionalPropertiesType}}
 
     // Encodable protocol methods
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
+        var container = encoder.container(keyedBy: CodingKeys.self)
         {{#allVars}}
-        try container.encode{{#required}}{{#isNullable}}IfPresent{{/isNullable}}{{/required}}{{^required}}IfPresent{{/required}}({{{name}}}, forKey: "{{{baseName}}}")
+        try container.encode{{^required}}IfPresent{{/required}}({{{name}}}, forKey: .{{{name}}})
         {{/allVars}}
-        try container.encodeMap(additionalProperties)
+        {{#additionalPropertiesType}}
+        var additionalPropertiesContainer = encoder.container(keyedBy: String.self)
+        try additionalPropertiesContainer.encodeMap(additionalProperties)
+        {{/additionalPropertiesType}}
     }
 
+{{#additionalPropertiesType}}
     // Decodable protocol methods
 
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}}{{#objcCompatible}} required{{/objcCompatible}} init(from decoder: Decoder) throws {

--- a/modules/openapi-generator/src/main/resources/swift5/modelObject.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/modelObject.mustache
@@ -84,4 +84,20 @@
         additionalProperties = try container.decodeMap({{{additionalPropertiesType}}}.self, excludedKeys: nonAdditionalPropertyKeys)
     }
 {{/additionalPropertiesType}}
+
+{{^objcCompatible}}{{#useClasses}}
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func == (lhs: {{classname}}, rhs: {{classname}}) -> Bool {
+        {{#allVars}}
+        lhs.{{{name}}} == rhs.{{{name}}}{{^-last}} &&{{/-last}}
+        {{/allVars}}
+        {{#additionalPropertiesType}}{{#hasVars}}&& {{/hasVars}}lhs.additionalProperties == rhs.additionalProperties{{/additionalPropertiesType}}
+    }
+
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func hash(into hasher: inout Hasher) {
+        {{#allVars}}
+        hasher.combine({{{name}}}{{^required}}?{{/required}}.hashValue)
+        {{/allVars}}
+        {{#additionalPropertiesType}}hasher.combine(additionalProperties.hashValue){{/additionalPropertiesType}}
+    }
+{{/useClasses}}{{/objcCompatible}}
 }

--- a/modules/openapi-generator/src/main/resources/swift5/modelObject.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/modelObject.mustache
@@ -36,6 +36,11 @@
         {{/allVars}}
     }
 {{/hasVars}}
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum CodingKeys: {{#hasVars}}String, {{/hasVars}}CodingKey, CaseIterable {
+        {{#allVars}}
+        case {{{name}}}{{#vendorExtensions.x-codegen-escaped-property-name}} = "{{{baseName}}}"{{/vendorExtensions.x-codegen-escaped-property-name}}
+        {{/allVars}}
+    }
 {{#additionalPropertiesType}}
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} {{#readonlyProperties}}private(set) {{/readonlyProperties}}var additionalProperties: [String: {{{additionalPropertiesType}}}] = [:]
 
@@ -79,11 +84,4 @@
         additionalProperties = try container.decodeMap({{{additionalPropertiesType}}}.self, excludedKeys: nonAdditionalPropertyKeys)
     }
 {{/additionalPropertiesType}}
-{{^additionalPropertiesType}}{{#vendorExtensions.x-codegen-has-escaped-property-names}}
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum CodingKeys: String, CodingKey, CaseIterable {
-        {{#allVars}}
-        case {{{name}}}{{#vendorExtensions.x-codegen-escaped-property-name}} = "{{{baseName}}}"{{/vendorExtensions.x-codegen-escaped-property-name}}
-        {{/allVars}}
-    }
-{{/vendorExtensions.x-codegen-has-escaped-property-names}}{{/additionalPropertiesType}}
 }

--- a/modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1096,6 +1096,7 @@ definitions:
       name:
         type: string
         default: default-name
+        x-nullable: true
     xml:
       name: Category
   User:

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -16,10 +16,19 @@ public struct AdditionalPropertiesClass: Codable, Hashable {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapString = "map_string"
         case mapMapString = "map_map_string"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapString, forKey: .mapString)
+        try container.encodeIfPresent(mapMapString, forKey: .mapMapString)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -16,5 +16,19 @@ public struct Animal: Codable, Hashable {
         self.className = className
         self.color = color
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -18,5 +18,21 @@ public struct ApiResponse: Codable, Hashable {
         self.type = type
         self.message = message
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case code
+        case type
+        case message
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
     public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayArrayNumber = "ArrayArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayArrayNumber, forKey: .arrayArrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfNumberOnly: Codable, Hashable {
     public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayNumber = "ArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayNumber, forKey: .arrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -18,11 +18,21 @@ public struct ArrayTest: Codable, Hashable {
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayOfString = "array_of_string"
         case arrayArrayOfInteger = "array_array_of_integer"
         case arrayArrayOfModel = "array_array_of_model"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayOfString, forKey: .arrayOfString)
+        try container.encodeIfPresent(arrayArrayOfInteger, forKey: .arrayArrayOfInteger)
+        try container.encodeIfPresent(arrayArrayOfModel, forKey: .arrayArrayOfModel)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -25,7 +25,6 @@ public struct Capitalization: Codable, Hashable {
         self.sCAETHFlowPoints = sCAETHFlowPoints
         self.ATT_NAME = ATT_NAME
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case smallCamel
         case capitalCamel = "CapitalCamel"
@@ -34,5 +33,19 @@ public struct Capitalization: Codable, Hashable {
         case sCAETHFlowPoints = "SCA_ETH_Flow_Points"
         case ATT_NAME
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(smallCamel, forKey: .smallCamel)
+        try container.encodeIfPresent(capitalCamel, forKey: .capitalCamel)
+        try container.encodeIfPresent(smallSnake, forKey: .smallSnake)
+        try container.encodeIfPresent(capitalSnake, forKey: .capitalSnake)
+        try container.encodeIfPresent(sCAETHFlowPoints, forKey: .sCAETHFlowPoints)
+        try container.encodeIfPresent(ATT_NAME, forKey: .ATT_NAME)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -18,5 +18,21 @@ public struct Cat: Codable, Hashable {
         self.color = color
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -14,5 +14,17 @@ public struct CatAllOf: Codable, Hashable {
     public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -10,11 +10,25 @@ import Foundation
 public struct Category: Codable, Hashable {
 
     public var id: Int64?
-    public var name: String = "default-name"
+    public var name: String? = "default-name"
 
-    public init(id: Int64? = nil, name: String = "default-name") {
+    public init(id: Int64? = nil, name: String? = "default-name") {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -15,5 +15,17 @@ public struct ClassModel: Codable, Hashable {
     public init(_class: String? = nil) {
         self._class = _class
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case _class
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -14,5 +14,17 @@ public struct Client: Codable, Hashable {
     public init(client: String? = nil) {
         self.client = client
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case client
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(client, forKey: .client)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -18,5 +18,21 @@ public struct Dog: Codable, Hashable {
         self.color = color
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -14,5 +14,17 @@ public struct DogAllOf: Codable, Hashable {
     public init(breed: String? = nil) {
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -24,10 +24,19 @@ public struct EnumArrays: Codable, Hashable {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justSymbol = "just_symbol"
         case arrayEnum = "array_enum"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justSymbol, forKey: .justSymbol)
+        try container.encodeIfPresent(arrayEnum, forKey: .arrayEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -40,7 +40,6 @@ public struct EnumTest: Codable, Hashable {
         self.enumNumber = enumNumber
         self.outerEnum = outerEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case enumString = "enum_string"
         case enumStringRequired = "enum_string_required"
@@ -48,5 +47,18 @@ public struct EnumTest: Codable, Hashable {
         case enumNumber = "enum_number"
         case outerEnum
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(enumString, forKey: .enumString)
+        try container.encode(enumStringRequired, forKey: .enumStringRequired)
+        try container.encodeIfPresent(enumInteger, forKey: .enumInteger)
+        try container.encodeIfPresent(enumNumber, forKey: .enumNumber)
+        try container.encodeIfPresent(outerEnum, forKey: .outerEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -16,5 +16,17 @@ public struct File: Codable, Hashable {
     public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case sourceURI
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(sourceURI, forKey: .sourceURI)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -16,5 +16,19 @@ public struct FileSchemaTestClass: Codable, Hashable {
         self.file = file
         self.files = files
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case file
+        case files
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(file, forKey: .file)
+        try container.encodeIfPresent(files, forKey: .files)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -38,5 +38,41 @@ public struct FormatTest: Codable, Hashable {
         self.uuid = uuid
         self.password = password
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case integer
+        case int32
+        case int64
+        case number
+        case float
+        case double
+        case string
+        case byte
+        case binary
+        case date
+        case dateTime
+        case uuid
+        case password
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(integer, forKey: .integer)
+        try container.encodeIfPresent(int32, forKey: .int32)
+        try container.encodeIfPresent(int64, forKey: .int64)
+        try container.encode(number, forKey: .number)
+        try container.encodeIfPresent(float, forKey: .float)
+        try container.encodeIfPresent(double, forKey: .double)
+        try container.encodeIfPresent(string, forKey: .string)
+        try container.encode(byte, forKey: .byte)
+        try container.encodeIfPresent(binary, forKey: .binary)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(password, forKey: .password)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -16,5 +16,19 @@ public struct HasOnlyReadOnly: Codable, Hashable {
         self.bar = bar
         self.foo = foo
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case foo
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(foo, forKey: .foo)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -14,9 +14,17 @@ public struct List: Codable, Hashable {
     public init(_123list: String? = nil) {
         self._123list = _123list
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _123list = "123-list"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_123list, forKey: ._123list)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -24,12 +24,23 @@ public struct MapTest: Codable, Hashable {
         self.directMap = directMap
         self.indirectMap = indirectMap
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapMapOfString = "map_map_of_string"
         case mapOfEnumString = "map_of_enum_string"
         case directMap = "direct_map"
         case indirectMap = "indirect_map"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapMapOfString, forKey: .mapMapOfString)
+        try container.encodeIfPresent(mapOfEnumString, forKey: .mapOfEnumString)
+        try container.encodeIfPresent(directMap, forKey: .directMap)
+        try container.encodeIfPresent(indirectMap, forKey: .indirectMap)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -18,5 +18,21 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
         self.dateTime = dateTime
         self.map = map
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case uuid
+        case dateTime
+        case map
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(map, forKey: .map)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -17,10 +17,19 @@ public struct Model200Response: Codable, Hashable {
         self.name = name
         self._class = _class
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case _class = "class"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -21,12 +21,23 @@ public struct Name: Codable, Hashable {
         self.property = property
         self._123number = _123number
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case snakeCase = "snake_case"
         case property
         case _123number = "123Number"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(snakeCase, forKey: .snakeCase)
+        try container.encodeIfPresent(property, forKey: .property)
+        try container.encodeIfPresent(_123number, forKey: ._123number)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -14,9 +14,17 @@ public struct NumberOnly: Codable, Hashable {
     public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justNumber = "JustNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justNumber, forKey: .justNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -30,5 +30,27 @@ public struct Order: Codable, Hashable {
         self.status = status
         self.complete = complete
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case petId
+        case quantity
+        case shipDate
+        case status
+        case complete
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(petId, forKey: .petId)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
+        try container.encodeIfPresent(shipDate, forKey: .shipDate)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(complete, forKey: .complete)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -18,11 +18,21 @@ public struct OuterComposite: Codable, Hashable {
         self.myString = myString
         self.myBoolean = myBoolean
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case myNumber = "my_number"
         case myString = "my_string"
         case myBoolean = "my_boolean"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(myNumber, forKey: .myNumber)
+        try container.encodeIfPresent(myString, forKey: .myString)
+        try container.encodeIfPresent(myBoolean, forKey: .myBoolean)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -30,5 +30,27 @@ public struct Pet: Codable, Hashable {
         self.tags = tags
         self.status = status
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case category
+        case name
+        case photoUrls
+        case tags
+        case status
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(photoUrls, forKey: .photoUrls)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -16,5 +16,19 @@ public struct ReadOnlyFirst: Codable, Hashable {
         self.bar = bar
         self.baz = baz
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case baz
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(baz, forKey: .baz)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -15,9 +15,17 @@ public struct Return: Codable, Hashable {
     public init(_return: Int? = nil) {
         self._return = _return
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _return = "return"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_return, forKey: ._return)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -14,9 +14,17 @@ public struct SpecialModelName: Codable, Hashable {
     public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case specialPropertyName = "$special[property.name]"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(specialPropertyName, forKey: .specialPropertyName)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public struct StringBooleanMap: Codable, Hashable {
 
+    public enum CodingKeys: CodingKey, CaseIterable {
+    }
     public var additionalProperties: [String: Bool] = [:]
 
     public subscript(key: String) -> Bool? {
@@ -27,10 +29,9 @@ public struct StringBooleanMap: Codable, Hashable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
-        try container.encodeMap(additionalProperties)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var additionalPropertiesContainer = encoder.container(keyedBy: String.self)
+        try additionalPropertiesContainer.encodeMap(additionalProperties)
     }
 
     // Decodable protocol methods
@@ -41,5 +42,6 @@ public struct StringBooleanMap: Codable, Hashable {
         var nonAdditionalPropertyKeys = Set<String>()
         additionalProperties = try container.decodeMap(Bool.self, excludedKeys: nonAdditionalPropertyKeys)
     }
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -16,5 +16,19 @@ public struct Tag: Codable, Hashable {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -22,7 +22,6 @@ public struct TypeHolderDefault: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderDefault: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -22,7 +22,6 @@ public struct TypeHolderExample: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderExample: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -29,5 +29,31 @@ public struct User: Codable, Hashable {
         self.phone = phone
         self.userStatus = userStatus
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case firstName
+        case lastName
+        case email
+        case password
+        case phone
+        case userStatus
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(username, forKey: .username)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(password, forKey: .password)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(userStatus, forKey: .userStatus)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -16,10 +16,19 @@ public struct AdditionalPropertiesClass: Codable, Hashable {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapString = "map_string"
         case mapMapString = "map_map_string"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapString, forKey: .mapString)
+        try container.encodeIfPresent(mapMapString, forKey: .mapMapString)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -16,5 +16,19 @@ public struct Animal: Codable, Hashable {
         self.className = className
         self.color = color
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -18,5 +18,21 @@ public struct ApiResponse: Codable, Hashable {
         self.type = type
         self.message = message
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case code
+        case type
+        case message
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
     public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayArrayNumber = "ArrayArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayArrayNumber, forKey: .arrayArrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfNumberOnly: Codable, Hashable {
     public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayNumber = "ArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayNumber, forKey: .arrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -18,11 +18,21 @@ public struct ArrayTest: Codable, Hashable {
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayOfString = "array_of_string"
         case arrayArrayOfInteger = "array_array_of_integer"
         case arrayArrayOfModel = "array_array_of_model"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayOfString, forKey: .arrayOfString)
+        try container.encodeIfPresent(arrayArrayOfInteger, forKey: .arrayArrayOfInteger)
+        try container.encodeIfPresent(arrayArrayOfModel, forKey: .arrayArrayOfModel)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -25,7 +25,6 @@ public struct Capitalization: Codable, Hashable {
         self.sCAETHFlowPoints = sCAETHFlowPoints
         self.ATT_NAME = ATT_NAME
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case smallCamel
         case capitalCamel = "CapitalCamel"
@@ -34,5 +33,19 @@ public struct Capitalization: Codable, Hashable {
         case sCAETHFlowPoints = "SCA_ETH_Flow_Points"
         case ATT_NAME
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(smallCamel, forKey: .smallCamel)
+        try container.encodeIfPresent(capitalCamel, forKey: .capitalCamel)
+        try container.encodeIfPresent(smallSnake, forKey: .smallSnake)
+        try container.encodeIfPresent(capitalSnake, forKey: .capitalSnake)
+        try container.encodeIfPresent(sCAETHFlowPoints, forKey: .sCAETHFlowPoints)
+        try container.encodeIfPresent(ATT_NAME, forKey: .ATT_NAME)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -18,5 +18,21 @@ public struct Cat: Codable, Hashable {
         self.color = color
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -14,5 +14,17 @@ public struct CatAllOf: Codable, Hashable {
     public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -10,11 +10,25 @@ import Foundation
 public struct Category: Codable, Hashable {
 
     public var id: Int64?
-    public var name: String = "default-name"
+    public var name: String? = "default-name"
 
-    public init(id: Int64? = nil, name: String = "default-name") {
+    public init(id: Int64? = nil, name: String? = "default-name") {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -15,5 +15,17 @@ public struct ClassModel: Codable, Hashable {
     public init(_class: String? = nil) {
         self._class = _class
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case _class
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -14,5 +14,17 @@ public struct Client: Codable, Hashable {
     public init(client: String? = nil) {
         self.client = client
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case client
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(client, forKey: .client)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -18,5 +18,21 @@ public struct Dog: Codable, Hashable {
         self.color = color
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -14,5 +14,17 @@ public struct DogAllOf: Codable, Hashable {
     public init(breed: String? = nil) {
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -24,10 +24,19 @@ public struct EnumArrays: Codable, Hashable {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justSymbol = "just_symbol"
         case arrayEnum = "array_enum"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justSymbol, forKey: .justSymbol)
+        try container.encodeIfPresent(arrayEnum, forKey: .arrayEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -40,7 +40,6 @@ public struct EnumTest: Codable, Hashable {
         self.enumNumber = enumNumber
         self.outerEnum = outerEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case enumString = "enum_string"
         case enumStringRequired = "enum_string_required"
@@ -48,5 +47,18 @@ public struct EnumTest: Codable, Hashable {
         case enumNumber = "enum_number"
         case outerEnum
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(enumString, forKey: .enumString)
+        try container.encode(enumStringRequired, forKey: .enumStringRequired)
+        try container.encodeIfPresent(enumInteger, forKey: .enumInteger)
+        try container.encodeIfPresent(enumNumber, forKey: .enumNumber)
+        try container.encodeIfPresent(outerEnum, forKey: .outerEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -16,5 +16,17 @@ public struct File: Codable, Hashable {
     public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case sourceURI
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(sourceURI, forKey: .sourceURI)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -16,5 +16,19 @@ public struct FileSchemaTestClass: Codable, Hashable {
         self.file = file
         self.files = files
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case file
+        case files
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(file, forKey: .file)
+        try container.encodeIfPresent(files, forKey: .files)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -38,5 +38,41 @@ public struct FormatTest: Codable, Hashable {
         self.uuid = uuid
         self.password = password
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case integer
+        case int32
+        case int64
+        case number
+        case float
+        case double
+        case string
+        case byte
+        case binary
+        case date
+        case dateTime
+        case uuid
+        case password
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(integer, forKey: .integer)
+        try container.encodeIfPresent(int32, forKey: .int32)
+        try container.encodeIfPresent(int64, forKey: .int64)
+        try container.encode(number, forKey: .number)
+        try container.encodeIfPresent(float, forKey: .float)
+        try container.encodeIfPresent(double, forKey: .double)
+        try container.encodeIfPresent(string, forKey: .string)
+        try container.encode(byte, forKey: .byte)
+        try container.encodeIfPresent(binary, forKey: .binary)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(password, forKey: .password)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -16,5 +16,19 @@ public struct HasOnlyReadOnly: Codable, Hashable {
         self.bar = bar
         self.foo = foo
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case foo
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(foo, forKey: .foo)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -14,9 +14,17 @@ public struct List: Codable, Hashable {
     public init(_123list: String? = nil) {
         self._123list = _123list
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _123list = "123-list"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_123list, forKey: ._123list)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -24,12 +24,23 @@ public struct MapTest: Codable, Hashable {
         self.directMap = directMap
         self.indirectMap = indirectMap
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapMapOfString = "map_map_of_string"
         case mapOfEnumString = "map_of_enum_string"
         case directMap = "direct_map"
         case indirectMap = "indirect_map"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapMapOfString, forKey: .mapMapOfString)
+        try container.encodeIfPresent(mapOfEnumString, forKey: .mapOfEnumString)
+        try container.encodeIfPresent(directMap, forKey: .directMap)
+        try container.encodeIfPresent(indirectMap, forKey: .indirectMap)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -18,5 +18,21 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
         self.dateTime = dateTime
         self.map = map
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case uuid
+        case dateTime
+        case map
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(map, forKey: .map)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -17,10 +17,19 @@ public struct Model200Response: Codable, Hashable {
         self.name = name
         self._class = _class
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case _class = "class"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -21,12 +21,23 @@ public struct Name: Codable, Hashable {
         self.property = property
         self._123number = _123number
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case snakeCase = "snake_case"
         case property
         case _123number = "123Number"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(snakeCase, forKey: .snakeCase)
+        try container.encodeIfPresent(property, forKey: .property)
+        try container.encodeIfPresent(_123number, forKey: ._123number)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -14,9 +14,17 @@ public struct NumberOnly: Codable, Hashable {
     public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justNumber = "JustNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justNumber, forKey: .justNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -30,5 +30,27 @@ public struct Order: Codable, Hashable {
         self.status = status
         self.complete = complete
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case petId
+        case quantity
+        case shipDate
+        case status
+        case complete
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(petId, forKey: .petId)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
+        try container.encodeIfPresent(shipDate, forKey: .shipDate)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(complete, forKey: .complete)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -18,11 +18,21 @@ public struct OuterComposite: Codable, Hashable {
         self.myString = myString
         self.myBoolean = myBoolean
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case myNumber = "my_number"
         case myString = "my_string"
         case myBoolean = "my_boolean"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(myNumber, forKey: .myNumber)
+        try container.encodeIfPresent(myString, forKey: .myString)
+        try container.encodeIfPresent(myBoolean, forKey: .myBoolean)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -30,5 +30,27 @@ public struct Pet: Codable, Hashable {
         self.tags = tags
         self.status = status
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case category
+        case name
+        case photoUrls
+        case tags
+        case status
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(photoUrls, forKey: .photoUrls)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -16,5 +16,19 @@ public struct ReadOnlyFirst: Codable, Hashable {
         self.bar = bar
         self.baz = baz
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case baz
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(baz, forKey: .baz)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -15,9 +15,17 @@ public struct Return: Codable, Hashable {
     public init(_return: Int? = nil) {
         self._return = _return
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _return = "return"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_return, forKey: ._return)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -14,9 +14,17 @@ public struct SpecialModelName: Codable, Hashable {
     public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case specialPropertyName = "$special[property.name]"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(specialPropertyName, forKey: .specialPropertyName)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public struct StringBooleanMap: Codable, Hashable {
 
+    public enum CodingKeys: CodingKey, CaseIterable {
+    }
     public var additionalProperties: [String: Bool] = [:]
 
     public subscript(key: String) -> Bool? {
@@ -27,10 +29,9 @@ public struct StringBooleanMap: Codable, Hashable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
-        try container.encodeMap(additionalProperties)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var additionalPropertiesContainer = encoder.container(keyedBy: String.self)
+        try additionalPropertiesContainer.encodeMap(additionalProperties)
     }
 
     // Decodable protocol methods
@@ -41,5 +42,6 @@ public struct StringBooleanMap: Codable, Hashable {
         var nonAdditionalPropertyKeys = Set<String>()
         additionalProperties = try container.decodeMap(Bool.self, excludedKeys: nonAdditionalPropertyKeys)
     }
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -16,5 +16,19 @@ public struct Tag: Codable, Hashable {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -22,7 +22,6 @@ public struct TypeHolderDefault: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderDefault: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -22,7 +22,6 @@ public struct TypeHolderExample: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderExample: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -29,5 +29,31 @@ public struct User: Codable, Hashable {
         self.phone = phone
         self.userStatus = userStatus
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case firstName
+        case lastName
+        case email
+        case password
+        case phone
+        case userStatus
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(username, forKey: .username)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(password, forKey: .password)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(userStatus, forKey: .userStatus)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -16,10 +16,19 @@ public struct AdditionalPropertiesClass: Codable, Hashable {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapString = "map_string"
         case mapMapString = "map_map_string"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapString, forKey: .mapString)
+        try container.encodeIfPresent(mapMapString, forKey: .mapMapString)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -16,5 +16,19 @@ public struct Animal: Codable, Hashable {
         self.className = className
         self.color = color
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -18,5 +18,21 @@ public struct ApiResponse: Codable, Hashable {
         self.type = type
         self.message = message
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case code
+        case type
+        case message
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
     public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayArrayNumber = "ArrayArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayArrayNumber, forKey: .arrayArrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfNumberOnly: Codable, Hashable {
     public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayNumber = "ArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayNumber, forKey: .arrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -18,11 +18,21 @@ public struct ArrayTest: Codable, Hashable {
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayOfString = "array_of_string"
         case arrayArrayOfInteger = "array_array_of_integer"
         case arrayArrayOfModel = "array_array_of_model"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayOfString, forKey: .arrayOfString)
+        try container.encodeIfPresent(arrayArrayOfInteger, forKey: .arrayArrayOfInteger)
+        try container.encodeIfPresent(arrayArrayOfModel, forKey: .arrayArrayOfModel)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -25,7 +25,6 @@ public struct Capitalization: Codable, Hashable {
         self.sCAETHFlowPoints = sCAETHFlowPoints
         self.ATT_NAME = ATT_NAME
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case smallCamel
         case capitalCamel = "CapitalCamel"
@@ -34,5 +33,19 @@ public struct Capitalization: Codable, Hashable {
         case sCAETHFlowPoints = "SCA_ETH_Flow_Points"
         case ATT_NAME
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(smallCamel, forKey: .smallCamel)
+        try container.encodeIfPresent(capitalCamel, forKey: .capitalCamel)
+        try container.encodeIfPresent(smallSnake, forKey: .smallSnake)
+        try container.encodeIfPresent(capitalSnake, forKey: .capitalSnake)
+        try container.encodeIfPresent(sCAETHFlowPoints, forKey: .sCAETHFlowPoints)
+        try container.encodeIfPresent(ATT_NAME, forKey: .ATT_NAME)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -18,5 +18,21 @@ public struct Cat: Codable, Hashable {
         self.color = color
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -14,5 +14,17 @@ public struct CatAllOf: Codable, Hashable {
     public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -10,11 +10,25 @@ import Foundation
 public struct Category: Codable, Hashable {
 
     public var id: Int64?
-    public var name: String = "default-name"
+    public var name: String? = "default-name"
 
-    public init(id: Int64? = nil, name: String = "default-name") {
+    public init(id: Int64? = nil, name: String? = "default-name") {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -15,5 +15,17 @@ public struct ClassModel: Codable, Hashable {
     public init(_class: String? = nil) {
         self._class = _class
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case _class
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -14,5 +14,17 @@ public struct Client: Codable, Hashable {
     public init(client: String? = nil) {
         self.client = client
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case client
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(client, forKey: .client)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -18,5 +18,21 @@ public struct Dog: Codable, Hashable {
         self.color = color
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -14,5 +14,17 @@ public struct DogAllOf: Codable, Hashable {
     public init(breed: String? = nil) {
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -24,10 +24,19 @@ public struct EnumArrays: Codable, Hashable {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justSymbol = "just_symbol"
         case arrayEnum = "array_enum"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justSymbol, forKey: .justSymbol)
+        try container.encodeIfPresent(arrayEnum, forKey: .arrayEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -40,7 +40,6 @@ public struct EnumTest: Codable, Hashable {
         self.enumNumber = enumNumber
         self.outerEnum = outerEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case enumString = "enum_string"
         case enumStringRequired = "enum_string_required"
@@ -48,5 +47,18 @@ public struct EnumTest: Codable, Hashable {
         case enumNumber = "enum_number"
         case outerEnum
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(enumString, forKey: .enumString)
+        try container.encode(enumStringRequired, forKey: .enumStringRequired)
+        try container.encodeIfPresent(enumInteger, forKey: .enumInteger)
+        try container.encodeIfPresent(enumNumber, forKey: .enumNumber)
+        try container.encodeIfPresent(outerEnum, forKey: .outerEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -16,5 +16,17 @@ public struct File: Codable, Hashable {
     public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case sourceURI
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(sourceURI, forKey: .sourceURI)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -16,5 +16,19 @@ public struct FileSchemaTestClass: Codable, Hashable {
         self.file = file
         self.files = files
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case file
+        case files
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(file, forKey: .file)
+        try container.encodeIfPresent(files, forKey: .files)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -38,5 +38,41 @@ public struct FormatTest: Codable, Hashable {
         self.uuid = uuid
         self.password = password
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case integer
+        case int32
+        case int64
+        case number
+        case float
+        case double
+        case string
+        case byte
+        case binary
+        case date
+        case dateTime
+        case uuid
+        case password
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(integer, forKey: .integer)
+        try container.encodeIfPresent(int32, forKey: .int32)
+        try container.encodeIfPresent(int64, forKey: .int64)
+        try container.encode(number, forKey: .number)
+        try container.encodeIfPresent(float, forKey: .float)
+        try container.encodeIfPresent(double, forKey: .double)
+        try container.encodeIfPresent(string, forKey: .string)
+        try container.encode(byte, forKey: .byte)
+        try container.encodeIfPresent(binary, forKey: .binary)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(password, forKey: .password)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -16,5 +16,19 @@ public struct HasOnlyReadOnly: Codable, Hashable {
         self.bar = bar
         self.foo = foo
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case foo
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(foo, forKey: .foo)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -14,9 +14,17 @@ public struct List: Codable, Hashable {
     public init(_123list: String? = nil) {
         self._123list = _123list
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _123list = "123-list"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_123list, forKey: ._123list)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -24,12 +24,23 @@ public struct MapTest: Codable, Hashable {
         self.directMap = directMap
         self.indirectMap = indirectMap
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapMapOfString = "map_map_of_string"
         case mapOfEnumString = "map_of_enum_string"
         case directMap = "direct_map"
         case indirectMap = "indirect_map"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapMapOfString, forKey: .mapMapOfString)
+        try container.encodeIfPresent(mapOfEnumString, forKey: .mapOfEnumString)
+        try container.encodeIfPresent(directMap, forKey: .directMap)
+        try container.encodeIfPresent(indirectMap, forKey: .indirectMap)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -18,5 +18,21 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
         self.dateTime = dateTime
         self.map = map
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case uuid
+        case dateTime
+        case map
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(map, forKey: .map)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -17,10 +17,19 @@ public struct Model200Response: Codable, Hashable {
         self.name = name
         self._class = _class
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case _class = "class"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -21,12 +21,23 @@ public struct Name: Codable, Hashable {
         self.property = property
         self._123number = _123number
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case snakeCase = "snake_case"
         case property
         case _123number = "123Number"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(snakeCase, forKey: .snakeCase)
+        try container.encodeIfPresent(property, forKey: .property)
+        try container.encodeIfPresent(_123number, forKey: ._123number)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -14,9 +14,17 @@ public struct NumberOnly: Codable, Hashable {
     public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justNumber = "JustNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justNumber, forKey: .justNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -30,5 +30,27 @@ public struct Order: Codable, Hashable {
         self.status = status
         self.complete = complete
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case petId
+        case quantity
+        case shipDate
+        case status
+        case complete
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(petId, forKey: .petId)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
+        try container.encodeIfPresent(shipDate, forKey: .shipDate)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(complete, forKey: .complete)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -18,11 +18,21 @@ public struct OuterComposite: Codable, Hashable {
         self.myString = myString
         self.myBoolean = myBoolean
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case myNumber = "my_number"
         case myString = "my_string"
         case myBoolean = "my_boolean"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(myNumber, forKey: .myNumber)
+        try container.encodeIfPresent(myString, forKey: .myString)
+        try container.encodeIfPresent(myBoolean, forKey: .myBoolean)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -30,5 +30,27 @@ public struct Pet: Codable, Hashable {
         self.tags = tags
         self.status = status
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case category
+        case name
+        case photoUrls
+        case tags
+        case status
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(photoUrls, forKey: .photoUrls)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -16,5 +16,19 @@ public struct ReadOnlyFirst: Codable, Hashable {
         self.bar = bar
         self.baz = baz
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case baz
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(baz, forKey: .baz)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -15,9 +15,17 @@ public struct Return: Codable, Hashable {
     public init(_return: Int? = nil) {
         self._return = _return
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _return = "return"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_return, forKey: ._return)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -14,9 +14,17 @@ public struct SpecialModelName: Codable, Hashable {
     public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case specialPropertyName = "$special[property.name]"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(specialPropertyName, forKey: .specialPropertyName)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public struct StringBooleanMap: Codable, Hashable {
 
+    public enum CodingKeys: CodingKey, CaseIterable {
+    }
     public var additionalProperties: [String: Bool] = [:]
 
     public subscript(key: String) -> Bool? {
@@ -27,10 +29,9 @@ public struct StringBooleanMap: Codable, Hashable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
-        try container.encodeMap(additionalProperties)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var additionalPropertiesContainer = encoder.container(keyedBy: String.self)
+        try additionalPropertiesContainer.encodeMap(additionalProperties)
     }
 
     // Decodable protocol methods
@@ -41,5 +42,6 @@ public struct StringBooleanMap: Codable, Hashable {
         var nonAdditionalPropertyKeys = Set<String>()
         additionalProperties = try container.decodeMap(Bool.self, excludedKeys: nonAdditionalPropertyKeys)
     }
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -16,5 +16,19 @@ public struct Tag: Codable, Hashable {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -22,7 +22,6 @@ public struct TypeHolderDefault: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderDefault: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -22,7 +22,6 @@ public struct TypeHolderExample: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderExample: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -29,5 +29,31 @@ public struct User: Codable, Hashable {
         self.phone = phone
         self.userStatus = userStatus
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case firstName
+        case lastName
+        case email
+        case password
+        case phone
+        case userStatus
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(username, forKey: .username)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(password, forKey: .password)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(userStatus, forKey: .userStatus)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -19,5 +19,21 @@ public struct ApiResponse: Codable, Hashable {
         self.type = type
         self.message = message
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case code
+        case type
+        case message
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -17,5 +17,19 @@ public struct Category: Codable, Hashable {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -32,5 +32,27 @@ public struct Order: Codable, Hashable {
         self.status = status
         self.complete = complete
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case petId
+        case quantity
+        case shipDate
+        case status
+        case complete
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(petId, forKey: .petId)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
+        try container.encodeIfPresent(shipDate, forKey: .shipDate)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(complete, forKey: .complete)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -32,5 +32,27 @@ public struct Pet: Codable, Hashable {
         self.tags = tags
         self.status = status
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case category
+        case name
+        case photoUrls
+        case tags
+        case status
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(photoUrls, forKey: .photoUrls)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -17,5 +17,19 @@ public struct Tag: Codable, Hashable {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -30,5 +30,31 @@ public struct User: Codable, Hashable {
         self.phone = phone
         self.userStatus = userStatus
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case firstName
+        case lastName
+        case email
+        case password
+        case phone
+        case userStatus
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(username, forKey: .username)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(password, forKey: .password)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(userStatus, forKey: .userStatus)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -16,10 +16,19 @@ internal struct AdditionalPropertiesClass: Codable, Hashable {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case mapString = "map_string"
         case mapMapString = "map_map_string"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapString, forKey: .mapString)
+        try container.encodeIfPresent(mapMapString, forKey: .mapMapString)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -16,5 +16,19 @@ internal struct Animal: Codable, Hashable {
         self.className = className
         self.color = color
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -18,5 +18,21 @@ internal struct ApiResponse: Codable, Hashable {
         self.type = type
         self.message = message
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case code
+        case type
+        case message
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ internal struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
     internal init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayArrayNumber = "ArrayArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayArrayNumber, forKey: .arrayArrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ internal struct ArrayOfNumberOnly: Codable, Hashable {
     internal init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayNumber = "ArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayNumber, forKey: .arrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -18,11 +18,21 @@ internal struct ArrayTest: Codable, Hashable {
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayOfString = "array_of_string"
         case arrayArrayOfInteger = "array_array_of_integer"
         case arrayArrayOfModel = "array_array_of_model"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayOfString, forKey: .arrayOfString)
+        try container.encodeIfPresent(arrayArrayOfInteger, forKey: .arrayArrayOfInteger)
+        try container.encodeIfPresent(arrayArrayOfModel, forKey: .arrayArrayOfModel)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -25,7 +25,6 @@ internal struct Capitalization: Codable, Hashable {
         self.sCAETHFlowPoints = sCAETHFlowPoints
         self.ATT_NAME = ATT_NAME
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case smallCamel
         case capitalCamel = "CapitalCamel"
@@ -34,5 +33,19 @@ internal struct Capitalization: Codable, Hashable {
         case sCAETHFlowPoints = "SCA_ETH_Flow_Points"
         case ATT_NAME
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(smallCamel, forKey: .smallCamel)
+        try container.encodeIfPresent(capitalCamel, forKey: .capitalCamel)
+        try container.encodeIfPresent(smallSnake, forKey: .smallSnake)
+        try container.encodeIfPresent(capitalSnake, forKey: .capitalSnake)
+        try container.encodeIfPresent(sCAETHFlowPoints, forKey: .sCAETHFlowPoints)
+        try container.encodeIfPresent(ATT_NAME, forKey: .ATT_NAME)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -18,5 +18,21 @@ internal struct Cat: Codable, Hashable {
         self.color = color
         self.declawed = declawed
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -14,5 +14,17 @@ internal struct CatAllOf: Codable, Hashable {
     internal init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -10,11 +10,25 @@ import Foundation
 internal struct Category: Codable, Hashable {
 
     internal var id: Int64?
-    internal var name: String = "default-name"
+    internal var name: String? = "default-name"
 
-    internal init(id: Int64? = nil, name: String = "default-name") {
+    internal init(id: Int64? = nil, name: String? = "default-name") {
         self.id = id
         self.name = name
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -15,5 +15,17 @@ internal struct ClassModel: Codable, Hashable {
     internal init(_class: String? = nil) {
         self._class = _class
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case _class
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -14,5 +14,17 @@ internal struct Client: Codable, Hashable {
     internal init(client: String? = nil) {
         self.client = client
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case client
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(client, forKey: .client)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -18,5 +18,21 @@ internal struct Dog: Codable, Hashable {
         self.color = color
         self.breed = breed
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -14,5 +14,17 @@ internal struct DogAllOf: Codable, Hashable {
     internal init(breed: String? = nil) {
         self.breed = breed
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -24,10 +24,19 @@ internal struct EnumArrays: Codable, Hashable {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case justSymbol = "just_symbol"
         case arrayEnum = "array_enum"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justSymbol, forKey: .justSymbol)
+        try container.encodeIfPresent(arrayEnum, forKey: .arrayEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -40,7 +40,6 @@ internal struct EnumTest: Codable, Hashable {
         self.enumNumber = enumNumber
         self.outerEnum = outerEnum
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case enumString = "enum_string"
         case enumStringRequired = "enum_string_required"
@@ -48,5 +47,18 @@ internal struct EnumTest: Codable, Hashable {
         case enumNumber = "enum_number"
         case outerEnum
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(enumString, forKey: .enumString)
+        try container.encode(enumStringRequired, forKey: .enumStringRequired)
+        try container.encodeIfPresent(enumInteger, forKey: .enumInteger)
+        try container.encodeIfPresent(enumNumber, forKey: .enumNumber)
+        try container.encodeIfPresent(outerEnum, forKey: .outerEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -16,5 +16,17 @@ internal struct File: Codable, Hashable {
     internal init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case sourceURI
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(sourceURI, forKey: .sourceURI)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -16,5 +16,19 @@ internal struct FileSchemaTestClass: Codable, Hashable {
         self.file = file
         self.files = files
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case file
+        case files
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(file, forKey: .file)
+        try container.encodeIfPresent(files, forKey: .files)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -38,5 +38,41 @@ internal struct FormatTest: Codable, Hashable {
         self.uuid = uuid
         self.password = password
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case integer
+        case int32
+        case int64
+        case number
+        case float
+        case double
+        case string
+        case byte
+        case binary
+        case date
+        case dateTime
+        case uuid
+        case password
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(integer, forKey: .integer)
+        try container.encodeIfPresent(int32, forKey: .int32)
+        try container.encodeIfPresent(int64, forKey: .int64)
+        try container.encode(number, forKey: .number)
+        try container.encodeIfPresent(float, forKey: .float)
+        try container.encodeIfPresent(double, forKey: .double)
+        try container.encodeIfPresent(string, forKey: .string)
+        try container.encode(byte, forKey: .byte)
+        try container.encodeIfPresent(binary, forKey: .binary)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(password, forKey: .password)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -16,5 +16,19 @@ internal struct HasOnlyReadOnly: Codable, Hashable {
         self.bar = bar
         self.foo = foo
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case foo
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(foo, forKey: .foo)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -14,9 +14,17 @@ internal struct List: Codable, Hashable {
     internal init(_123list: String? = nil) {
         self._123list = _123list
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case _123list = "123-list"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_123list, forKey: ._123list)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -24,12 +24,23 @@ internal struct MapTest: Codable, Hashable {
         self.directMap = directMap
         self.indirectMap = indirectMap
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case mapMapOfString = "map_map_of_string"
         case mapOfEnumString = "map_of_enum_string"
         case directMap = "direct_map"
         case indirectMap = "indirect_map"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapMapOfString, forKey: .mapMapOfString)
+        try container.encodeIfPresent(mapOfEnumString, forKey: .mapOfEnumString)
+        try container.encodeIfPresent(directMap, forKey: .directMap)
+        try container.encodeIfPresent(indirectMap, forKey: .indirectMap)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -18,5 +18,21 @@ internal struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
         self.dateTime = dateTime
         self.map = map
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case uuid
+        case dateTime
+        case map
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(map, forKey: .map)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -17,10 +17,19 @@ internal struct Model200Response: Codable, Hashable {
         self.name = name
         self._class = _class
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case _class = "class"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -21,12 +21,23 @@ internal struct Name: Codable, Hashable {
         self.property = property
         self._123number = _123number
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case snakeCase = "snake_case"
         case property
         case _123number = "123Number"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(snakeCase, forKey: .snakeCase)
+        try container.encodeIfPresent(property, forKey: .property)
+        try container.encodeIfPresent(_123number, forKey: ._123number)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -14,9 +14,17 @@ internal struct NumberOnly: Codable, Hashable {
     internal init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case justNumber = "JustNumber"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justNumber, forKey: .justNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -30,5 +30,27 @@ internal struct Order: Codable, Hashable {
         self.status = status
         self.complete = complete
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case petId
+        case quantity
+        case shipDate
+        case status
+        case complete
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(petId, forKey: .petId)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
+        try container.encodeIfPresent(shipDate, forKey: .shipDate)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(complete, forKey: .complete)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -18,11 +18,21 @@ internal struct OuterComposite: Codable, Hashable {
         self.myString = myString
         self.myBoolean = myBoolean
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case myNumber = "my_number"
         case myString = "my_string"
         case myBoolean = "my_boolean"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(myNumber, forKey: .myNumber)
+        try container.encodeIfPresent(myString, forKey: .myString)
+        try container.encodeIfPresent(myBoolean, forKey: .myBoolean)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -30,5 +30,27 @@ internal struct Pet: Codable, Hashable {
         self.tags = tags
         self.status = status
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case category
+        case name
+        case photoUrls
+        case tags
+        case status
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(photoUrls, forKey: .photoUrls)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -16,5 +16,19 @@ internal struct ReadOnlyFirst: Codable, Hashable {
         self.bar = bar
         self.baz = baz
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case baz
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(baz, forKey: .baz)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -15,9 +15,17 @@ internal struct Return: Codable, Hashable {
     internal init(_return: Int? = nil) {
         self._return = _return
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case _return = "return"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_return, forKey: ._return)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -14,9 +14,17 @@ internal struct SpecialModelName: Codable, Hashable {
     internal init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case specialPropertyName = "$special[property.name]"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(specialPropertyName, forKey: .specialPropertyName)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -9,6 +9,8 @@ import Foundation
 
 internal struct StringBooleanMap: Codable, Hashable {
 
+    internal enum CodingKeys: CodingKey, CaseIterable {
+    }
     internal var additionalProperties: [String: Bool] = [:]
 
     internal subscript(key: String) -> Bool? {
@@ -27,10 +29,9 @@ internal struct StringBooleanMap: Codable, Hashable {
     // Encodable protocol methods
 
     internal func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
-        try container.encodeMap(additionalProperties)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var additionalPropertiesContainer = encoder.container(keyedBy: String.self)
+        try additionalPropertiesContainer.encodeMap(additionalProperties)
     }
 
     // Decodable protocol methods
@@ -41,5 +42,6 @@ internal struct StringBooleanMap: Codable, Hashable {
         var nonAdditionalPropertyKeys = Set<String>()
         additionalProperties = try container.decodeMap(Bool.self, excludedKeys: nonAdditionalPropertyKeys)
     }
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -16,5 +16,19 @@ internal struct Tag: Codable, Hashable {
         self.id = id
         self.name = name
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -22,7 +22,6 @@ internal struct TypeHolderDefault: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ internal struct TypeHolderDefault: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -22,7 +22,6 @@ internal struct TypeHolderExample: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     internal enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ internal struct TypeHolderExample: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -29,5 +29,31 @@ internal struct User: Codable, Hashable {
         self.phone = phone
         self.userStatus = userStatus
     }
+    internal enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case firstName
+        case lastName
+        case email
+        case password
+        case phone
+        case userStatus
+    }
+
+    // Encodable protocol methods
+
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(username, forKey: .username)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(password, forKey: .password)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(userStatus, forKey: .userStatus)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -16,10 +16,19 @@ import Foundation
         self.mapString = mapString
         self.mapMapString = mapMapString
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapString = "map_string"
         case mapMapString = "map_map_string"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapString, forKey: .mapString)
+        try container.encodeIfPresent(mapMapString, forKey: .mapMapString)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -16,10 +16,19 @@ import Foundation
         self._className = _className
         self.color = color
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _className = "className"
         case color
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(_className, forKey: ._className)
+        try container.encodeIfPresent(color, forKey: .color)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -23,5 +23,21 @@ import Foundation
         self.type = type
         self.message = message
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case code
+        case type
+        case message
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ import Foundation
     public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayArrayNumber = "ArrayArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayArrayNumber, forKey: .arrayArrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ import Foundation
     public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayNumber = "ArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayNumber, forKey: .arrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -18,11 +18,21 @@ import Foundation
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayOfString = "array_of_string"
         case arrayArrayOfInteger = "array_array_of_integer"
         case arrayArrayOfModel = "array_array_of_model"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayOfString, forKey: .arrayOfString)
+        try container.encodeIfPresent(arrayArrayOfInteger, forKey: .arrayArrayOfInteger)
+        try container.encodeIfPresent(arrayArrayOfModel, forKey: .arrayArrayOfModel)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -25,7 +25,6 @@ import Foundation
         self.sCAETHFlowPoints = sCAETHFlowPoints
         self.ATT_NAME = ATT_NAME
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case smallCamel
         case capitalCamel = "CapitalCamel"
@@ -34,5 +33,19 @@ import Foundation
         case sCAETHFlowPoints = "SCA_ETH_Flow_Points"
         case ATT_NAME
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(smallCamel, forKey: .smallCamel)
+        try container.encodeIfPresent(capitalCamel, forKey: .capitalCamel)
+        try container.encodeIfPresent(smallSnake, forKey: .smallSnake)
+        try container.encodeIfPresent(capitalSnake, forKey: .capitalSnake)
+        try container.encodeIfPresent(sCAETHFlowPoints, forKey: .sCAETHFlowPoints)
+        try container.encodeIfPresent(ATT_NAME, forKey: .ATT_NAME)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -23,11 +23,21 @@ import Foundation
         self.color = color
         self.declawed = declawed
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _className = "className"
         case color
         case declawed
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(_className, forKey: ._className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -19,5 +19,17 @@ import Foundation
     public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -15,16 +15,25 @@ import Foundation
             return _id as NSNumber?
         }
     }
-    public var name: String = "default-name"
+    public var name: String? = "default-name"
 
-    public init(_id: Int64? = nil, name: String = "default-name") {
+    public init(_id: Int64? = nil, name: String? = "default-name") {
         self._id = _id
         self.name = name
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _id = "id"
         case name
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_id, forKey: ._id)
+        try container.encode(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -15,5 +15,17 @@ import Foundation
     public init(_class: String? = nil) {
         self._class = _class
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case _class
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -14,5 +14,17 @@ import Foundation
     public init(client: String? = nil) {
         self.client = client
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case client
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(client, forKey: .client)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -18,11 +18,21 @@ import Foundation
         self.color = color
         self.breed = breed
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _className = "className"
         case color
         case breed
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(_className, forKey: ._className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -14,5 +14,17 @@ import Foundation
     public init(breed: String? = nil) {
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -24,10 +24,19 @@ import Foundation
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justSymbol = "just_symbol"
         case arrayEnum = "array_enum"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justSymbol, forKey: .justSymbol)
+        try container.encodeIfPresent(arrayEnum, forKey: .arrayEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -40,7 +40,6 @@ import Foundation
         self.enumNumber = enumNumber
         self.outerEnum = outerEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case enumString = "enum_string"
         case enumStringRequired = "enum_string_required"
@@ -48,5 +47,18 @@ import Foundation
         case enumNumber = "enum_number"
         case outerEnum
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(enumString, forKey: .enumString)
+        try container.encode(enumStringRequired, forKey: .enumStringRequired)
+        try container.encodeIfPresent(enumInteger, forKey: .enumInteger)
+        try container.encodeIfPresent(enumNumber, forKey: .enumNumber)
+        try container.encodeIfPresent(outerEnum, forKey: .outerEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -16,5 +16,17 @@ import Foundation
     public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case sourceURI
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(sourceURI, forKey: .sourceURI)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -16,5 +16,19 @@ import Foundation
         self.file = file
         self.files = files
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case file
+        case files
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(file, forKey: .file)
+        try container.encodeIfPresent(files, forKey: .files)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -63,5 +63,41 @@ import Foundation
         self.uuid = uuid
         self.password = password
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case integer
+        case int32
+        case int64
+        case number
+        case float
+        case double
+        case string
+        case byte
+        case binary
+        case date
+        case dateTime
+        case uuid
+        case password
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(integer, forKey: .integer)
+        try container.encodeIfPresent(int32, forKey: .int32)
+        try container.encodeIfPresent(int64, forKey: .int64)
+        try container.encode(number, forKey: .number)
+        try container.encodeIfPresent(float, forKey: .float)
+        try container.encodeIfPresent(double, forKey: .double)
+        try container.encodeIfPresent(string, forKey: .string)
+        try container.encode(byte, forKey: .byte)
+        try container.encodeIfPresent(binary, forKey: .binary)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(password, forKey: .password)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -16,5 +16,19 @@ import Foundation
         self.bar = bar
         self.foo = foo
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case foo
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(foo, forKey: .foo)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -14,9 +14,17 @@ import Foundation
     public init(_123list: String? = nil) {
         self._123list = _123list
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _123list = "123-list"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_123list, forKey: ._123list)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -24,12 +24,23 @@ import Foundation
         self.directMap = directMap
         self.indirectMap = indirectMap
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapMapOfString = "map_map_of_string"
         case mapOfEnumString = "map_of_enum_string"
         case directMap = "direct_map"
         case indirectMap = "indirect_map"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapMapOfString, forKey: .mapMapOfString)
+        try container.encodeIfPresent(mapOfEnumString, forKey: .mapOfEnumString)
+        try container.encodeIfPresent(directMap, forKey: .directMap)
+        try container.encodeIfPresent(indirectMap, forKey: .indirectMap)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -18,5 +18,21 @@ import Foundation
         self.dateTime = dateTime
         self.map = map
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case uuid
+        case dateTime
+        case map
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(map, forKey: .map)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -22,10 +22,19 @@ import Foundation
         self.name = name
         self._class = _class
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case _class = "class"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -31,12 +31,23 @@ import Foundation
         self.property = property
         self._123number = _123number
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case snakeCase = "snake_case"
         case property
         case _123number = "123Number"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(snakeCase, forKey: .snakeCase)
+        try container.encodeIfPresent(property, forKey: .property)
+        try container.encodeIfPresent(_123number, forKey: ._123number)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -14,9 +14,17 @@ import Foundation
     public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justNumber = "JustNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justNumber, forKey: .justNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -50,7 +50,6 @@ import Foundation
         self.status = status
         self.complete = complete
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _id = "id"
         case petId
@@ -59,5 +58,19 @@ import Foundation
         case status
         case complete
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_id, forKey: ._id)
+        try container.encodeIfPresent(petId, forKey: .petId)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
+        try container.encodeIfPresent(shipDate, forKey: .shipDate)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(complete, forKey: .complete)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -23,11 +23,21 @@ import Foundation
         self.myString = myString
         self.myBoolean = myBoolean
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case myNumber = "my_number"
         case myString = "my_string"
         case myBoolean = "my_boolean"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(myNumber, forKey: .myNumber)
+        try container.encodeIfPresent(myString, forKey: .myString)
+        try container.encodeIfPresent(myBoolean, forKey: .myBoolean)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -35,7 +35,6 @@ import Foundation
         self.tags = tags
         self.status = status
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _id = "id"
         case category
@@ -44,5 +43,19 @@ import Foundation
         case tags
         case status
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_id, forKey: ._id)
+        try container.encodeIfPresent(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(photoUrls, forKey: .photoUrls)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -16,5 +16,19 @@ import Foundation
         self.bar = bar
         self.baz = baz
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case baz
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(baz, forKey: .baz)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -20,9 +20,17 @@ import Foundation
     public init(_return: Int? = nil) {
         self._return = _return
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _return = "return"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_return, forKey: ._return)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -19,9 +19,17 @@ import Foundation
     public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case specialPropertyName = "$special[property.name]"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(specialPropertyName, forKey: .specialPropertyName)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -9,6 +9,8 @@ import Foundation
 
 @objc public class StringBooleanMap: NSObject, Codable {
 
+    public enum CodingKeys: CodingKey, CaseIterable {
+    }
     public var additionalProperties: [String: Bool] = [:]
 
     public subscript(key: String) -> Bool? {
@@ -27,10 +29,9 @@ import Foundation
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
-        try container.encodeMap(additionalProperties)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var additionalPropertiesContainer = encoder.container(keyedBy: String.self)
+        try additionalPropertiesContainer.encodeMap(additionalProperties)
     }
 
     // Decodable protocol methods
@@ -41,5 +42,6 @@ import Foundation
         var nonAdditionalPropertyKeys = Set<String>()
         additionalProperties = try container.decodeMap(Bool.self, excludedKeys: nonAdditionalPropertyKeys)
     }
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -21,10 +21,19 @@ import Foundation
         self._id = _id
         self.name = name
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _id = "id"
         case name
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_id, forKey: ._id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -22,7 +22,6 @@ import Foundation
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ import Foundation
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -22,7 +22,6 @@ import Foundation
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ import Foundation
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -39,7 +39,6 @@ import Foundation
         self.phone = phone
         self.userStatus = userStatus
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _id = "id"
         case username
@@ -50,5 +49,21 @@ import Foundation
         case phone
         case userStatus
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_id, forKey: ._id)
+        try container.encodeIfPresent(username, forKey: .username)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(password, forKey: .password)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(userStatus, forKey: .userStatus)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -16,10 +16,19 @@ public struct AdditionalPropertiesClass: Codable, Hashable {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapString = "map_string"
         case mapMapString = "map_map_string"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapString, forKey: .mapString)
+        try container.encodeIfPresent(mapMapString, forKey: .mapMapString)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -16,5 +16,19 @@ public struct Animal: Codable, Hashable {
         self.className = className
         self.color = color
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -18,5 +18,21 @@ public struct ApiResponse: Codable, Hashable {
         self.type = type
         self.message = message
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case code
+        case type
+        case message
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
     public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayArrayNumber = "ArrayArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayArrayNumber, forKey: .arrayArrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfNumberOnly: Codable, Hashable {
     public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayNumber = "ArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayNumber, forKey: .arrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -18,11 +18,21 @@ public struct ArrayTest: Codable, Hashable {
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayOfString = "array_of_string"
         case arrayArrayOfInteger = "array_array_of_integer"
         case arrayArrayOfModel = "array_array_of_model"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayOfString, forKey: .arrayOfString)
+        try container.encodeIfPresent(arrayArrayOfInteger, forKey: .arrayArrayOfInteger)
+        try container.encodeIfPresent(arrayArrayOfModel, forKey: .arrayArrayOfModel)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -25,7 +25,6 @@ public struct Capitalization: Codable, Hashable {
         self.sCAETHFlowPoints = sCAETHFlowPoints
         self.ATT_NAME = ATT_NAME
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case smallCamel
         case capitalCamel = "CapitalCamel"
@@ -34,5 +33,19 @@ public struct Capitalization: Codable, Hashable {
         case sCAETHFlowPoints = "SCA_ETH_Flow_Points"
         case ATT_NAME
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(smallCamel, forKey: .smallCamel)
+        try container.encodeIfPresent(capitalCamel, forKey: .capitalCamel)
+        try container.encodeIfPresent(smallSnake, forKey: .smallSnake)
+        try container.encodeIfPresent(capitalSnake, forKey: .capitalSnake)
+        try container.encodeIfPresent(sCAETHFlowPoints, forKey: .sCAETHFlowPoints)
+        try container.encodeIfPresent(ATT_NAME, forKey: .ATT_NAME)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -18,5 +18,21 @@ public struct Cat: Codable, Hashable {
         self.color = color
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -14,5 +14,17 @@ public struct CatAllOf: Codable, Hashable {
     public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -10,11 +10,25 @@ import Foundation
 public struct Category: Codable, Hashable {
 
     public var id: Int64?
-    public var name: String = "default-name"
+    public var name: String? = "default-name"
 
-    public init(id: Int64? = nil, name: String = "default-name") {
+    public init(id: Int64? = nil, name: String? = "default-name") {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -15,5 +15,17 @@ public struct ClassModel: Codable, Hashable {
     public init(_class: String? = nil) {
         self._class = _class
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case _class
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -14,5 +14,17 @@ public struct Client: Codable, Hashable {
     public init(client: String? = nil) {
         self.client = client
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case client
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(client, forKey: .client)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -18,5 +18,21 @@ public struct Dog: Codable, Hashable {
         self.color = color
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -14,5 +14,17 @@ public struct DogAllOf: Codable, Hashable {
     public init(breed: String? = nil) {
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -24,10 +24,19 @@ public struct EnumArrays: Codable, Hashable {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justSymbol = "just_symbol"
         case arrayEnum = "array_enum"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justSymbol, forKey: .justSymbol)
+        try container.encodeIfPresent(arrayEnum, forKey: .arrayEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -40,7 +40,6 @@ public struct EnumTest: Codable, Hashable {
         self.enumNumber = enumNumber
         self.outerEnum = outerEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case enumString = "enum_string"
         case enumStringRequired = "enum_string_required"
@@ -48,5 +47,18 @@ public struct EnumTest: Codable, Hashable {
         case enumNumber = "enum_number"
         case outerEnum
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(enumString, forKey: .enumString)
+        try container.encode(enumStringRequired, forKey: .enumStringRequired)
+        try container.encodeIfPresent(enumInteger, forKey: .enumInteger)
+        try container.encodeIfPresent(enumNumber, forKey: .enumNumber)
+        try container.encodeIfPresent(outerEnum, forKey: .outerEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -16,5 +16,17 @@ public struct File: Codable, Hashable {
     public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case sourceURI
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(sourceURI, forKey: .sourceURI)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -16,5 +16,19 @@ public struct FileSchemaTestClass: Codable, Hashable {
         self.file = file
         self.files = files
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case file
+        case files
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(file, forKey: .file)
+        try container.encodeIfPresent(files, forKey: .files)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -38,5 +38,41 @@ public struct FormatTest: Codable, Hashable {
         self.uuid = uuid
         self.password = password
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case integer
+        case int32
+        case int64
+        case number
+        case float
+        case double
+        case string
+        case byte
+        case binary
+        case date
+        case dateTime
+        case uuid
+        case password
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(integer, forKey: .integer)
+        try container.encodeIfPresent(int32, forKey: .int32)
+        try container.encodeIfPresent(int64, forKey: .int64)
+        try container.encode(number, forKey: .number)
+        try container.encodeIfPresent(float, forKey: .float)
+        try container.encodeIfPresent(double, forKey: .double)
+        try container.encodeIfPresent(string, forKey: .string)
+        try container.encode(byte, forKey: .byte)
+        try container.encodeIfPresent(binary, forKey: .binary)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(password, forKey: .password)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -16,5 +16,19 @@ public struct HasOnlyReadOnly: Codable, Hashable {
         self.bar = bar
         self.foo = foo
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case foo
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(foo, forKey: .foo)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -14,9 +14,17 @@ public struct List: Codable, Hashable {
     public init(_123list: String? = nil) {
         self._123list = _123list
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _123list = "123-list"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_123list, forKey: ._123list)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -24,12 +24,23 @@ public struct MapTest: Codable, Hashable {
         self.directMap = directMap
         self.indirectMap = indirectMap
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapMapOfString = "map_map_of_string"
         case mapOfEnumString = "map_of_enum_string"
         case directMap = "direct_map"
         case indirectMap = "indirect_map"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapMapOfString, forKey: .mapMapOfString)
+        try container.encodeIfPresent(mapOfEnumString, forKey: .mapOfEnumString)
+        try container.encodeIfPresent(directMap, forKey: .directMap)
+        try container.encodeIfPresent(indirectMap, forKey: .indirectMap)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -18,5 +18,21 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
         self.dateTime = dateTime
         self.map = map
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case uuid
+        case dateTime
+        case map
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(map, forKey: .map)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -17,10 +17,19 @@ public struct Model200Response: Codable, Hashable {
         self.name = name
         self._class = _class
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case _class = "class"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -21,12 +21,23 @@ public struct Name: Codable, Hashable {
         self.property = property
         self._123number = _123number
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case snakeCase = "snake_case"
         case property
         case _123number = "123Number"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(snakeCase, forKey: .snakeCase)
+        try container.encodeIfPresent(property, forKey: .property)
+        try container.encodeIfPresent(_123number, forKey: ._123number)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -14,9 +14,17 @@ public struct NumberOnly: Codable, Hashable {
     public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justNumber = "JustNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justNumber, forKey: .justNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -30,5 +30,27 @@ public struct Order: Codable, Hashable {
         self.status = status
         self.complete = complete
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case petId
+        case quantity
+        case shipDate
+        case status
+        case complete
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(petId, forKey: .petId)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
+        try container.encodeIfPresent(shipDate, forKey: .shipDate)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(complete, forKey: .complete)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -18,11 +18,21 @@ public struct OuterComposite: Codable, Hashable {
         self.myString = myString
         self.myBoolean = myBoolean
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case myNumber = "my_number"
         case myString = "my_string"
         case myBoolean = "my_boolean"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(myNumber, forKey: .myNumber)
+        try container.encodeIfPresent(myString, forKey: .myString)
+        try container.encodeIfPresent(myBoolean, forKey: .myBoolean)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -30,5 +30,27 @@ public struct Pet: Codable, Hashable {
         self.tags = tags
         self.status = status
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case category
+        case name
+        case photoUrls
+        case tags
+        case status
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(photoUrls, forKey: .photoUrls)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -16,5 +16,19 @@ public struct ReadOnlyFirst: Codable, Hashable {
         self.bar = bar
         self.baz = baz
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case baz
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(baz, forKey: .baz)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -15,9 +15,17 @@ public struct Return: Codable, Hashable {
     public init(_return: Int? = nil) {
         self._return = _return
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _return = "return"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_return, forKey: ._return)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -14,9 +14,17 @@ public struct SpecialModelName: Codable, Hashable {
     public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case specialPropertyName = "$special[property.name]"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(specialPropertyName, forKey: .specialPropertyName)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public struct StringBooleanMap: Codable, Hashable {
 
+    public enum CodingKeys: CodingKey, CaseIterable {
+    }
     public var additionalProperties: [String: Bool] = [:]
 
     public subscript(key: String) -> Bool? {
@@ -27,10 +29,9 @@ public struct StringBooleanMap: Codable, Hashable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
-        try container.encodeMap(additionalProperties)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var additionalPropertiesContainer = encoder.container(keyedBy: String.self)
+        try additionalPropertiesContainer.encodeMap(additionalProperties)
     }
 
     // Decodable protocol methods
@@ -41,5 +42,6 @@ public struct StringBooleanMap: Codable, Hashable {
         var nonAdditionalPropertyKeys = Set<String>()
         additionalProperties = try container.decodeMap(Bool.self, excludedKeys: nonAdditionalPropertyKeys)
     }
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -16,5 +16,19 @@ public struct Tag: Codable, Hashable {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -22,7 +22,6 @@ public struct TypeHolderDefault: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderDefault: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -22,7 +22,6 @@ public struct TypeHolderExample: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderExample: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -29,5 +29,31 @@ public struct User: Codable, Hashable {
         self.phone = phone
         self.userStatus = userStatus
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case firstName
+        case lastName
+        case email
+        case password
+        case phone
+        case userStatus
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(username, forKey: .username)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(password, forKey: .password)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(userStatus, forKey: .userStatus)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -16,10 +16,19 @@ public struct AdditionalPropertiesClass: Codable, Hashable {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapString = "map_string"
         case mapMapString = "map_map_string"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapString, forKey: .mapString)
+        try container.encodeIfPresent(mapMapString, forKey: .mapMapString)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -16,5 +16,19 @@ public struct Animal: Codable, Hashable {
         self.className = className
         self.color = color
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -18,5 +18,21 @@ public struct ApiResponse: Codable, Hashable {
         self.type = type
         self.message = message
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case code
+        case type
+        case message
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
     public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayArrayNumber = "ArrayArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayArrayNumber, forKey: .arrayArrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfNumberOnly: Codable, Hashable {
     public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayNumber = "ArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayNumber, forKey: .arrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -18,11 +18,21 @@ public struct ArrayTest: Codable, Hashable {
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayOfString = "array_of_string"
         case arrayArrayOfInteger = "array_array_of_integer"
         case arrayArrayOfModel = "array_array_of_model"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayOfString, forKey: .arrayOfString)
+        try container.encodeIfPresent(arrayArrayOfInteger, forKey: .arrayArrayOfInteger)
+        try container.encodeIfPresent(arrayArrayOfModel, forKey: .arrayArrayOfModel)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -25,7 +25,6 @@ public struct Capitalization: Codable, Hashable {
         self.sCAETHFlowPoints = sCAETHFlowPoints
         self.ATT_NAME = ATT_NAME
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case smallCamel
         case capitalCamel = "CapitalCamel"
@@ -34,5 +33,19 @@ public struct Capitalization: Codable, Hashable {
         case sCAETHFlowPoints = "SCA_ETH_Flow_Points"
         case ATT_NAME
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(smallCamel, forKey: .smallCamel)
+        try container.encodeIfPresent(capitalCamel, forKey: .capitalCamel)
+        try container.encodeIfPresent(smallSnake, forKey: .smallSnake)
+        try container.encodeIfPresent(capitalSnake, forKey: .capitalSnake)
+        try container.encodeIfPresent(sCAETHFlowPoints, forKey: .sCAETHFlowPoints)
+        try container.encodeIfPresent(ATT_NAME, forKey: .ATT_NAME)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -18,5 +18,21 @@ public struct Cat: Codable, Hashable {
         self.color = color
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -14,5 +14,17 @@ public struct CatAllOf: Codable, Hashable {
     public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -10,11 +10,25 @@ import Foundation
 public struct Category: Codable, Hashable {
 
     public private(set) var id: Int64?
-    public private(set) var name: String = "default-name"
+    public private(set) var name: String? = "default-name"
 
-    public init(id: Int64? = nil, name: String = "default-name") {
+    public init(id: Int64? = nil, name: String? = "default-name") {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -15,5 +15,17 @@ public struct ClassModel: Codable, Hashable {
     public init(_class: String? = nil) {
         self._class = _class
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case _class
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -14,5 +14,17 @@ public struct Client: Codable, Hashable {
     public init(client: String? = nil) {
         self.client = client
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case client
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(client, forKey: .client)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -18,5 +18,21 @@ public struct Dog: Codable, Hashable {
         self.color = color
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -14,5 +14,17 @@ public struct DogAllOf: Codable, Hashable {
     public init(breed: String? = nil) {
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -24,10 +24,19 @@ public struct EnumArrays: Codable, Hashable {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justSymbol = "just_symbol"
         case arrayEnum = "array_enum"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justSymbol, forKey: .justSymbol)
+        try container.encodeIfPresent(arrayEnum, forKey: .arrayEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -40,7 +40,6 @@ public struct EnumTest: Codable, Hashable {
         self.enumNumber = enumNumber
         self.outerEnum = outerEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case enumString = "enum_string"
         case enumStringRequired = "enum_string_required"
@@ -48,5 +47,18 @@ public struct EnumTest: Codable, Hashable {
         case enumNumber = "enum_number"
         case outerEnum
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(enumString, forKey: .enumString)
+        try container.encode(enumStringRequired, forKey: .enumStringRequired)
+        try container.encodeIfPresent(enumInteger, forKey: .enumInteger)
+        try container.encodeIfPresent(enumNumber, forKey: .enumNumber)
+        try container.encodeIfPresent(outerEnum, forKey: .outerEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -16,5 +16,17 @@ public struct File: Codable, Hashable {
     public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case sourceURI
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(sourceURI, forKey: .sourceURI)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -16,5 +16,19 @@ public struct FileSchemaTestClass: Codable, Hashable {
         self.file = file
         self.files = files
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case file
+        case files
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(file, forKey: .file)
+        try container.encodeIfPresent(files, forKey: .files)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -38,5 +38,41 @@ public struct FormatTest: Codable, Hashable {
         self.uuid = uuid
         self.password = password
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case integer
+        case int32
+        case int64
+        case number
+        case float
+        case double
+        case string
+        case byte
+        case binary
+        case date
+        case dateTime
+        case uuid
+        case password
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(integer, forKey: .integer)
+        try container.encodeIfPresent(int32, forKey: .int32)
+        try container.encodeIfPresent(int64, forKey: .int64)
+        try container.encode(number, forKey: .number)
+        try container.encodeIfPresent(float, forKey: .float)
+        try container.encodeIfPresent(double, forKey: .double)
+        try container.encodeIfPresent(string, forKey: .string)
+        try container.encode(byte, forKey: .byte)
+        try container.encodeIfPresent(binary, forKey: .binary)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(password, forKey: .password)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -16,5 +16,19 @@ public struct HasOnlyReadOnly: Codable, Hashable {
         self.bar = bar
         self.foo = foo
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case foo
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(foo, forKey: .foo)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -14,9 +14,17 @@ public struct List: Codable, Hashable {
     public init(_123list: String? = nil) {
         self._123list = _123list
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _123list = "123-list"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_123list, forKey: ._123list)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -24,12 +24,23 @@ public struct MapTest: Codable, Hashable {
         self.directMap = directMap
         self.indirectMap = indirectMap
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapMapOfString = "map_map_of_string"
         case mapOfEnumString = "map_of_enum_string"
         case directMap = "direct_map"
         case indirectMap = "indirect_map"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapMapOfString, forKey: .mapMapOfString)
+        try container.encodeIfPresent(mapOfEnumString, forKey: .mapOfEnumString)
+        try container.encodeIfPresent(directMap, forKey: .directMap)
+        try container.encodeIfPresent(indirectMap, forKey: .indirectMap)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -18,5 +18,21 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
         self.dateTime = dateTime
         self.map = map
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case uuid
+        case dateTime
+        case map
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(map, forKey: .map)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -17,10 +17,19 @@ public struct Model200Response: Codable, Hashable {
         self.name = name
         self._class = _class
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case _class = "class"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -21,12 +21,23 @@ public struct Name: Codable, Hashable {
         self.property = property
         self._123number = _123number
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case snakeCase = "snake_case"
         case property
         case _123number = "123Number"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(snakeCase, forKey: .snakeCase)
+        try container.encodeIfPresent(property, forKey: .property)
+        try container.encodeIfPresent(_123number, forKey: ._123number)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -14,9 +14,17 @@ public struct NumberOnly: Codable, Hashable {
     public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justNumber = "JustNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justNumber, forKey: .justNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -30,5 +30,27 @@ public struct Order: Codable, Hashable {
         self.status = status
         self.complete = complete
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case petId
+        case quantity
+        case shipDate
+        case status
+        case complete
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(petId, forKey: .petId)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
+        try container.encodeIfPresent(shipDate, forKey: .shipDate)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(complete, forKey: .complete)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -18,11 +18,21 @@ public struct OuterComposite: Codable, Hashable {
         self.myString = myString
         self.myBoolean = myBoolean
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case myNumber = "my_number"
         case myString = "my_string"
         case myBoolean = "my_boolean"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(myNumber, forKey: .myNumber)
+        try container.encodeIfPresent(myString, forKey: .myString)
+        try container.encodeIfPresent(myBoolean, forKey: .myBoolean)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -30,5 +30,27 @@ public struct Pet: Codable, Hashable {
         self.tags = tags
         self.status = status
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case category
+        case name
+        case photoUrls
+        case tags
+        case status
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(photoUrls, forKey: .photoUrls)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -16,5 +16,19 @@ public struct ReadOnlyFirst: Codable, Hashable {
         self.bar = bar
         self.baz = baz
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case baz
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(baz, forKey: .baz)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -15,9 +15,17 @@ public struct Return: Codable, Hashable {
     public init(_return: Int? = nil) {
         self._return = _return
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _return = "return"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_return, forKey: ._return)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -14,9 +14,17 @@ public struct SpecialModelName: Codable, Hashable {
     public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case specialPropertyName = "$special[property.name]"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(specialPropertyName, forKey: .specialPropertyName)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public struct StringBooleanMap: Codable, Hashable {
 
+    public enum CodingKeys: CodingKey, CaseIterable {
+    }
     public private(set) var additionalProperties: [String: Bool] = [:]
 
     public subscript(key: String) -> Bool? {
@@ -27,10 +29,9 @@ public struct StringBooleanMap: Codable, Hashable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
-        try container.encodeMap(additionalProperties)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var additionalPropertiesContainer = encoder.container(keyedBy: String.self)
+        try additionalPropertiesContainer.encodeMap(additionalProperties)
     }
 
     // Decodable protocol methods
@@ -41,5 +42,6 @@ public struct StringBooleanMap: Codable, Hashable {
         var nonAdditionalPropertyKeys = Set<String>()
         additionalProperties = try container.decodeMap(Bool.self, excludedKeys: nonAdditionalPropertyKeys)
     }
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -16,5 +16,19 @@ public struct Tag: Codable, Hashable {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -22,7 +22,6 @@ public struct TypeHolderDefault: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderDefault: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -22,7 +22,6 @@ public struct TypeHolderExample: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderExample: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -29,5 +29,31 @@ public struct User: Codable, Hashable {
         self.phone = phone
         self.userStatus = userStatus
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case firstName
+        case lastName
+        case email
+        case password
+        case phone
+        case userStatus
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(username, forKey: .username)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(password, forKey: .password)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(userStatus, forKey: .userStatus)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -16,10 +16,19 @@ public struct AdditionalPropertiesClass: Codable, Hashable {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapString = "map_string"
         case mapMapString = "map_map_string"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapString, forKey: .mapString)
+        try container.encodeIfPresent(mapMapString, forKey: .mapMapString)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -16,5 +16,19 @@ public struct Animal: Codable, Hashable {
         self.className = className
         self.color = color
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -18,5 +18,21 @@ public struct ApiResponse: Codable, Hashable {
         self.type = type
         self.message = message
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case code
+        case type
+        case message
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
     public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayArrayNumber = "ArrayArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayArrayNumber, forKey: .arrayArrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfNumberOnly: Codable, Hashable {
     public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayNumber = "ArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayNumber, forKey: .arrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -18,11 +18,21 @@ public struct ArrayTest: Codable, Hashable {
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayOfString = "array_of_string"
         case arrayArrayOfInteger = "array_array_of_integer"
         case arrayArrayOfModel = "array_array_of_model"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayOfString, forKey: .arrayOfString)
+        try container.encodeIfPresent(arrayArrayOfInteger, forKey: .arrayArrayOfInteger)
+        try container.encodeIfPresent(arrayArrayOfModel, forKey: .arrayArrayOfModel)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -25,7 +25,6 @@ public struct Capitalization: Codable, Hashable {
         self.sCAETHFlowPoints = sCAETHFlowPoints
         self.ATT_NAME = ATT_NAME
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case smallCamel
         case capitalCamel = "CapitalCamel"
@@ -34,5 +33,19 @@ public struct Capitalization: Codable, Hashable {
         case sCAETHFlowPoints = "SCA_ETH_Flow_Points"
         case ATT_NAME
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(smallCamel, forKey: .smallCamel)
+        try container.encodeIfPresent(capitalCamel, forKey: .capitalCamel)
+        try container.encodeIfPresent(smallSnake, forKey: .smallSnake)
+        try container.encodeIfPresent(capitalSnake, forKey: .capitalSnake)
+        try container.encodeIfPresent(sCAETHFlowPoints, forKey: .sCAETHFlowPoints)
+        try container.encodeIfPresent(ATT_NAME, forKey: .ATT_NAME)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -18,5 +18,21 @@ public struct Cat: Codable, Hashable {
         self.color = color
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -14,5 +14,17 @@ public struct CatAllOf: Codable, Hashable {
     public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -10,11 +10,25 @@ import Foundation
 public struct Category: Codable, Hashable {
 
     public var id: Int64?
-    public var name: String = "default-name"
+    public var name: String? = "default-name"
 
-    public init(id: Int64? = nil, name: String = "default-name") {
+    public init(id: Int64? = nil, name: String? = "default-name") {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -15,5 +15,17 @@ public struct ClassModel: Codable, Hashable {
     public init(_class: String? = nil) {
         self._class = _class
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case _class
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -14,5 +14,17 @@ public struct Client: Codable, Hashable {
     public init(client: String? = nil) {
         self.client = client
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case client
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(client, forKey: .client)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -18,5 +18,21 @@ public struct Dog: Codable, Hashable {
         self.color = color
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -14,5 +14,17 @@ public struct DogAllOf: Codable, Hashable {
     public init(breed: String? = nil) {
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -24,10 +24,19 @@ public struct EnumArrays: Codable, Hashable {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justSymbol = "just_symbol"
         case arrayEnum = "array_enum"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justSymbol, forKey: .justSymbol)
+        try container.encodeIfPresent(arrayEnum, forKey: .arrayEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -40,7 +40,6 @@ public struct EnumTest: Codable, Hashable {
         self.enumNumber = enumNumber
         self.outerEnum = outerEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case enumString = "enum_string"
         case enumStringRequired = "enum_string_required"
@@ -48,5 +47,18 @@ public struct EnumTest: Codable, Hashable {
         case enumNumber = "enum_number"
         case outerEnum
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(enumString, forKey: .enumString)
+        try container.encode(enumStringRequired, forKey: .enumStringRequired)
+        try container.encodeIfPresent(enumInteger, forKey: .enumInteger)
+        try container.encodeIfPresent(enumNumber, forKey: .enumNumber)
+        try container.encodeIfPresent(outerEnum, forKey: .outerEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -16,5 +16,17 @@ public struct File: Codable, Hashable {
     public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case sourceURI
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(sourceURI, forKey: .sourceURI)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -16,5 +16,19 @@ public struct FileSchemaTestClass: Codable, Hashable {
         self.file = file
         self.files = files
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case file
+        case files
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(file, forKey: .file)
+        try container.encodeIfPresent(files, forKey: .files)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -38,5 +38,41 @@ public struct FormatTest: Codable, Hashable {
         self.uuid = uuid
         self.password = password
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case integer
+        case int32
+        case int64
+        case number
+        case float
+        case double
+        case string
+        case byte
+        case binary
+        case date
+        case dateTime
+        case uuid
+        case password
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(integer, forKey: .integer)
+        try container.encodeIfPresent(int32, forKey: .int32)
+        try container.encodeIfPresent(int64, forKey: .int64)
+        try container.encode(number, forKey: .number)
+        try container.encodeIfPresent(float, forKey: .float)
+        try container.encodeIfPresent(double, forKey: .double)
+        try container.encodeIfPresent(string, forKey: .string)
+        try container.encode(byte, forKey: .byte)
+        try container.encodeIfPresent(binary, forKey: .binary)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(password, forKey: .password)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -16,5 +16,19 @@ public struct HasOnlyReadOnly: Codable, Hashable {
         self.bar = bar
         self.foo = foo
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case foo
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(foo, forKey: .foo)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -14,9 +14,17 @@ public struct List: Codable, Hashable {
     public init(_123list: String? = nil) {
         self._123list = _123list
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _123list = "123-list"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_123list, forKey: ._123list)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -24,12 +24,23 @@ public struct MapTest: Codable, Hashable {
         self.directMap = directMap
         self.indirectMap = indirectMap
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapMapOfString = "map_map_of_string"
         case mapOfEnumString = "map_of_enum_string"
         case directMap = "direct_map"
         case indirectMap = "indirect_map"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapMapOfString, forKey: .mapMapOfString)
+        try container.encodeIfPresent(mapOfEnumString, forKey: .mapOfEnumString)
+        try container.encodeIfPresent(directMap, forKey: .directMap)
+        try container.encodeIfPresent(indirectMap, forKey: .indirectMap)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -18,5 +18,21 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
         self.dateTime = dateTime
         self.map = map
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case uuid
+        case dateTime
+        case map
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(map, forKey: .map)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -17,10 +17,19 @@ public struct Model200Response: Codable, Hashable {
         self.name = name
         self._class = _class
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case _class = "class"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -21,12 +21,23 @@ public struct Name: Codable, Hashable {
         self.property = property
         self._123number = _123number
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case snakeCase = "snake_case"
         case property
         case _123number = "123Number"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(snakeCase, forKey: .snakeCase)
+        try container.encodeIfPresent(property, forKey: .property)
+        try container.encodeIfPresent(_123number, forKey: ._123number)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -14,9 +14,17 @@ public struct NumberOnly: Codable, Hashable {
     public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justNumber = "JustNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justNumber, forKey: .justNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -30,5 +30,27 @@ public struct Order: Codable, Hashable {
         self.status = status
         self.complete = complete
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case petId
+        case quantity
+        case shipDate
+        case status
+        case complete
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(petId, forKey: .petId)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
+        try container.encodeIfPresent(shipDate, forKey: .shipDate)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(complete, forKey: .complete)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -18,11 +18,21 @@ public struct OuterComposite: Codable, Hashable {
         self.myString = myString
         self.myBoolean = myBoolean
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case myNumber = "my_number"
         case myString = "my_string"
         case myBoolean = "my_boolean"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(myNumber, forKey: .myNumber)
+        try container.encodeIfPresent(myString, forKey: .myString)
+        try container.encodeIfPresent(myBoolean, forKey: .myBoolean)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -30,5 +30,27 @@ public struct Pet: Codable, Hashable {
         self.tags = tags
         self.status = status
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case category
+        case name
+        case photoUrls
+        case tags
+        case status
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(photoUrls, forKey: .photoUrls)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -16,5 +16,19 @@ public struct ReadOnlyFirst: Codable, Hashable {
         self.bar = bar
         self.baz = baz
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case baz
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(baz, forKey: .baz)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -15,9 +15,17 @@ public struct Return: Codable, Hashable {
     public init(_return: Int? = nil) {
         self._return = _return
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _return = "return"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_return, forKey: ._return)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -14,9 +14,17 @@ public struct SpecialModelName: Codable, Hashable {
     public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case specialPropertyName = "$special[property.name]"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(specialPropertyName, forKey: .specialPropertyName)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public struct StringBooleanMap: Codable, Hashable {
 
+    public enum CodingKeys: CodingKey, CaseIterable {
+    }
     public var additionalProperties: [String: Bool] = [:]
 
     public subscript(key: String) -> Bool? {
@@ -27,10 +29,9 @@ public struct StringBooleanMap: Codable, Hashable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
-        try container.encodeMap(additionalProperties)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var additionalPropertiesContainer = encoder.container(keyedBy: String.self)
+        try additionalPropertiesContainer.encodeMap(additionalProperties)
     }
 
     // Decodable protocol methods
@@ -41,5 +42,6 @@ public struct StringBooleanMap: Codable, Hashable {
         var nonAdditionalPropertyKeys = Set<String>()
         additionalProperties = try container.decodeMap(Bool.self, excludedKeys: nonAdditionalPropertyKeys)
     }
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -16,5 +16,19 @@ public struct Tag: Codable, Hashable {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -22,7 +22,6 @@ public struct TypeHolderDefault: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderDefault: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -22,7 +22,6 @@ public struct TypeHolderExample: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderExample: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -29,5 +29,31 @@ public struct User: Codable, Hashable {
         self.phone = phone
         self.userStatus = userStatus
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case firstName
+        case lastName
+        case email
+        case password
+        case phone
+        case userStatus
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(username, forKey: .username)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(password, forKey: .password)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(userStatus, forKey: .userStatus)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -16,10 +16,19 @@ public struct AdditionalPropertiesClass: Codable, Hashable {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapString = "map_string"
         case mapMapString = "map_map_string"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapString, forKey: .mapString)
+        try container.encodeIfPresent(mapMapString, forKey: .mapMapString)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -16,5 +16,19 @@ public struct Animal: Codable, Hashable {
         self.className = className
         self.color = color
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -18,5 +18,21 @@ public struct ApiResponse: Codable, Hashable {
         self.type = type
         self.message = message
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case code
+        case type
+        case message
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
     public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayArrayNumber = "ArrayArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayArrayNumber, forKey: .arrayArrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -14,9 +14,17 @@ public struct ArrayOfNumberOnly: Codable, Hashable {
     public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayNumber = "ArrayNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayNumber, forKey: .arrayNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -18,11 +18,21 @@ public struct ArrayTest: Codable, Hashable {
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayOfString = "array_of_string"
         case arrayArrayOfInteger = "array_array_of_integer"
         case arrayArrayOfModel = "array_array_of_model"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayOfString, forKey: .arrayOfString)
+        try container.encodeIfPresent(arrayArrayOfInteger, forKey: .arrayArrayOfInteger)
+        try container.encodeIfPresent(arrayArrayOfModel, forKey: .arrayArrayOfModel)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -25,7 +25,6 @@ public struct Capitalization: Codable, Hashable {
         self.sCAETHFlowPoints = sCAETHFlowPoints
         self.ATT_NAME = ATT_NAME
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case smallCamel
         case capitalCamel = "CapitalCamel"
@@ -34,5 +33,19 @@ public struct Capitalization: Codable, Hashable {
         case sCAETHFlowPoints = "SCA_ETH_Flow_Points"
         case ATT_NAME
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(smallCamel, forKey: .smallCamel)
+        try container.encodeIfPresent(capitalCamel, forKey: .capitalCamel)
+        try container.encodeIfPresent(smallSnake, forKey: .smallSnake)
+        try container.encodeIfPresent(capitalSnake, forKey: .capitalSnake)
+        try container.encodeIfPresent(sCAETHFlowPoints, forKey: .sCAETHFlowPoints)
+        try container.encodeIfPresent(ATT_NAME, forKey: .ATT_NAME)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -18,5 +18,21 @@ public struct Cat: Codable, Hashable {
         self.color = color
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -14,5 +14,17 @@ public struct CatAllOf: Codable, Hashable {
     public init(declawed: Bool? = nil) {
         self.declawed = declawed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -10,11 +10,25 @@ import Foundation
 public struct Category: Codable, Hashable {
 
     public var id: Int64?
-    public var name: String = "default-name"
+    public var name: String? = "default-name"
 
-    public init(id: Int64? = nil, name: String = "default-name") {
+    public init(id: Int64? = nil, name: String? = "default-name") {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -15,9 +15,17 @@ public struct ClassModel: Codable, Hashable {
     public init(`class`: String? = nil) {
         self.`class` = `class`
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case `class` = "_class"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(`class`, forKey: .`class`)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -14,5 +14,17 @@ public struct Client: Codable, Hashable {
     public init(client: String? = nil) {
         self.client = client
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case client
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(client, forKey: .client)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -18,5 +18,21 @@ public struct Dog: Codable, Hashable {
         self.color = color
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -14,5 +14,17 @@ public struct DogAllOf: Codable, Hashable {
     public init(breed: String? = nil) {
         self.breed = breed
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -24,10 +24,19 @@ public struct EnumArrays: Codable, Hashable {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justSymbol = "just_symbol"
         case arrayEnum = "array_enum"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justSymbol, forKey: .justSymbol)
+        try container.encodeIfPresent(arrayEnum, forKey: .arrayEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -40,7 +40,6 @@ public struct EnumTest: Codable, Hashable {
         self.enumNumber = enumNumber
         self.outerEnum = outerEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case enumString = "enum_string"
         case enumStringRequired = "enum_string_required"
@@ -48,5 +47,18 @@ public struct EnumTest: Codable, Hashable {
         case enumNumber = "enum_number"
         case outerEnum
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(enumString, forKey: .enumString)
+        try container.encode(enumStringRequired, forKey: .enumStringRequired)
+        try container.encodeIfPresent(enumInteger, forKey: .enumInteger)
+        try container.encodeIfPresent(enumNumber, forKey: .enumNumber)
+        try container.encodeIfPresent(outerEnum, forKey: .outerEnum)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -16,5 +16,17 @@ public struct File: Codable, Hashable {
     public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case sourceURI
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(sourceURI, forKey: .sourceURI)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -16,5 +16,19 @@ public struct FileSchemaTestClass: Codable, Hashable {
         self.file = file
         self.files = files
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case file
+        case files
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(file, forKey: .file)
+        try container.encodeIfPresent(files, forKey: .files)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -38,5 +38,41 @@ public struct FormatTest: Codable, Hashable {
         self.uuid = uuid
         self.password = password
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case integer
+        case int32
+        case int64
+        case number
+        case float
+        case double
+        case string
+        case byte
+        case binary
+        case date
+        case dateTime
+        case uuid
+        case password
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(integer, forKey: .integer)
+        try container.encodeIfPresent(int32, forKey: .int32)
+        try container.encodeIfPresent(int64, forKey: .int64)
+        try container.encode(number, forKey: .number)
+        try container.encodeIfPresent(float, forKey: .float)
+        try container.encodeIfPresent(double, forKey: .double)
+        try container.encodeIfPresent(string, forKey: .string)
+        try container.encode(byte, forKey: .byte)
+        try container.encodeIfPresent(binary, forKey: .binary)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(password, forKey: .password)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -16,5 +16,19 @@ public struct HasOnlyReadOnly: Codable, Hashable {
         self.bar = bar
         self.foo = foo
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case foo
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(foo, forKey: .foo)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -14,9 +14,17 @@ public struct List: Codable, Hashable {
     public init(_123list: String? = nil) {
         self._123list = _123list
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _123list = "123-list"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_123list, forKey: ._123list)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -24,12 +24,23 @@ public struct MapTest: Codable, Hashable {
         self.directMap = directMap
         self.indirectMap = indirectMap
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapMapOfString = "map_map_of_string"
         case mapOfEnumString = "map_of_enum_string"
         case directMap = "direct_map"
         case indirectMap = "indirect_map"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapMapOfString, forKey: .mapMapOfString)
+        try container.encodeIfPresent(mapOfEnumString, forKey: .mapOfEnumString)
+        try container.encodeIfPresent(directMap, forKey: .directMap)
+        try container.encodeIfPresent(indirectMap, forKey: .indirectMap)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -18,5 +18,21 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
         self.dateTime = dateTime
         self.map = map
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case uuid
+        case dateTime
+        case map
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(map, forKey: .map)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -17,10 +17,19 @@ public struct Model200Response: Codable, Hashable {
         self.name = name
         self.`class` = `class`
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case `class` = "class"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(`class`, forKey: .`class`)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -21,12 +21,23 @@ public struct Name: Codable, Hashable {
         self.property = property
         self._123number = _123number
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case snakeCase = "snake_case"
         case property
         case _123number = "123Number"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(snakeCase, forKey: .snakeCase)
+        try container.encodeIfPresent(property, forKey: .property)
+        try container.encodeIfPresent(_123number, forKey: ._123number)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -14,9 +14,17 @@ public struct NumberOnly: Codable, Hashable {
     public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justNumber = "JustNumber"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justNumber, forKey: .justNumber)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -30,5 +30,27 @@ public struct Order: Codable, Hashable {
         self.status = status
         self.complete = complete
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case petId
+        case quantity
+        case shipDate
+        case status
+        case complete
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(petId, forKey: .petId)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
+        try container.encodeIfPresent(shipDate, forKey: .shipDate)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(complete, forKey: .complete)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -18,11 +18,21 @@ public struct OuterComposite: Codable, Hashable {
         self.myString = myString
         self.myBoolean = myBoolean
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case myNumber = "my_number"
         case myString = "my_string"
         case myBoolean = "my_boolean"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(myNumber, forKey: .myNumber)
+        try container.encodeIfPresent(myString, forKey: .myString)
+        try container.encodeIfPresent(myBoolean, forKey: .myBoolean)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -30,5 +30,27 @@ public struct Pet: Codable, Hashable {
         self.tags = tags
         self.status = status
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case category
+        case name
+        case photoUrls
+        case tags
+        case status
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(photoUrls, forKey: .photoUrls)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -16,5 +16,19 @@ public struct ReadOnlyFirst: Codable, Hashable {
         self.bar = bar
         self.baz = baz
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case baz
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(baz, forKey: .baz)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -15,9 +15,17 @@ public struct Return: Codable, Hashable {
     public init(`return`: Int? = nil) {
         self.`return` = `return`
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case `return` = "return"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(`return`, forKey: .`return`)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -14,9 +14,17 @@ public struct SpecialModelName: Codable, Hashable {
     public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case specialPropertyName = "$special[property.name]"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(specialPropertyName, forKey: .specialPropertyName)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public struct StringBooleanMap: Codable, Hashable {
 
+    public enum CodingKeys: CodingKey, CaseIterable {
+    }
     public var additionalProperties: [String: Bool] = [:]
 
     public subscript(key: String) -> Bool? {
@@ -27,10 +29,9 @@ public struct StringBooleanMap: Codable, Hashable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
-        try container.encodeMap(additionalProperties)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var additionalPropertiesContainer = encoder.container(keyedBy: String.self)
+        try additionalPropertiesContainer.encodeMap(additionalProperties)
     }
 
     // Decodable protocol methods
@@ -41,5 +42,6 @@ public struct StringBooleanMap: Codable, Hashable {
         var nonAdditionalPropertyKeys = Set<String>()
         additionalProperties = try container.decodeMap(Bool.self, excludedKeys: nonAdditionalPropertyKeys)
     }
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -16,5 +16,19 @@ public struct Tag: Codable, Hashable {
         self.id = id
         self.name = name
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -22,7 +22,6 @@ public struct TypeHolderDefault: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderDefault: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -22,7 +22,6 @@ public struct TypeHolderExample: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
@@ -30,5 +29,18 @@ public struct TypeHolderExample: Codable, Hashable {
         case boolItem = "bool_item"
         case arrayItem = "array_item"
     }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -29,5 +29,31 @@ public struct User: Codable, Hashable {
         self.phone = phone
         self.userStatus = userStatus
     }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case firstName
+        case lastName
+        case email
+        case password
+        case phone
+        case userStatus
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(username, forKey: .username)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(password, forKey: .password)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(userStatus, forKey: .userStatus)
+    }
+
+
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/AdditionalPropertiesClass.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct AdditionalPropertiesClass: Codable, Hashable {
+public final class AdditionalPropertiesClass: Codable, Hashable {
 
     public var mapString: [String: String]?
     public var mapMapString: [String: [String: String]]?
@@ -16,10 +16,31 @@ public struct AdditionalPropertiesClass: Codable, Hashable {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapString = "map_string"
         case mapMapString = "map_map_string"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapString, forKey: .mapString)
+        try container.encodeIfPresent(mapMapString, forKey: .mapMapString)
+    }
+
+
+
+    public static func == (lhs: AdditionalPropertiesClass, rhs: AdditionalPropertiesClass) -> Bool {
+        lhs.mapString == rhs.mapString &&
+        lhs.mapMapString == rhs.mapMapString
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(mapString?.hashValue)
+        hasher.combine(mapMapString?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Animal.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Animal.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Animal: Codable, Hashable {
+public final class Animal: Codable, Hashable {
 
     public var className: String
     public var color: String? = "red"
@@ -15,6 +15,32 @@ public struct Animal: Codable, Hashable {
     public init(className: String, color: String? = "red") {
         self.className = className
         self.color = color
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+    }
+
+
+
+    public static func == (lhs: Animal, rhs: Animal) -> Bool {
+        lhs.className == rhs.className &&
+        lhs.color == rhs.color
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(className.hashValue)
+        hasher.combine(color?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/ApiResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ApiResponse: Codable, Hashable {
+public final class ApiResponse: Codable, Hashable {
 
     public var code: Int?
     public var type: String?
@@ -17,6 +17,36 @@ public struct ApiResponse: Codable, Hashable {
         self.code = code
         self.type = type
         self.message = message
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case code
+        case type
+        case message
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+
+
+    public static func == (lhs: ApiResponse, rhs: ApiResponse) -> Bool {
+        lhs.code == rhs.code &&
+        lhs.type == rhs.type &&
+        lhs.message == rhs.message
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(code?.hashValue)
+        hasher.combine(type?.hashValue)
+        hasher.combine(message?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/ArrayOfArrayOfNumberOnly.swift
@@ -7,16 +7,34 @@
 
 import Foundation
 
-public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
+public final class ArrayOfArrayOfNumberOnly: Codable, Hashable {
 
     public var arrayArrayNumber: [[Double]]?
 
     public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayArrayNumber = "ArrayArrayNumber"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayArrayNumber, forKey: .arrayArrayNumber)
+    }
+
+
+
+    public static func == (lhs: ArrayOfArrayOfNumberOnly, rhs: ArrayOfArrayOfNumberOnly) -> Bool {
+        lhs.arrayArrayNumber == rhs.arrayArrayNumber
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(arrayArrayNumber?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/ArrayOfNumberOnly.swift
@@ -7,16 +7,34 @@
 
 import Foundation
 
-public struct ArrayOfNumberOnly: Codable, Hashable {
+public final class ArrayOfNumberOnly: Codable, Hashable {
 
     public var arrayNumber: [Double]?
 
     public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayNumber = "ArrayNumber"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayNumber, forKey: .arrayNumber)
+    }
+
+
+
+    public static func == (lhs: ArrayOfNumberOnly, rhs: ArrayOfNumberOnly) -> Bool {
+        lhs.arrayNumber == rhs.arrayNumber
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(arrayNumber?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/ArrayTest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ArrayTest: Codable, Hashable {
+public final class ArrayTest: Codable, Hashable {
 
     public var arrayOfString: [String]?
     public var arrayArrayOfInteger: [[Int64]]?
@@ -18,11 +18,35 @@ public struct ArrayTest: Codable, Hashable {
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayOfString = "array_of_string"
         case arrayArrayOfInteger = "array_array_of_integer"
         case arrayArrayOfModel = "array_array_of_model"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayOfString, forKey: .arrayOfString)
+        try container.encodeIfPresent(arrayArrayOfInteger, forKey: .arrayArrayOfInteger)
+        try container.encodeIfPresent(arrayArrayOfModel, forKey: .arrayArrayOfModel)
+    }
+
+
+
+    public static func == (lhs: ArrayTest, rhs: ArrayTest) -> Bool {
+        lhs.arrayOfString == rhs.arrayOfString &&
+        lhs.arrayArrayOfInteger == rhs.arrayArrayOfInteger &&
+        lhs.arrayArrayOfModel == rhs.arrayArrayOfModel
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(arrayOfString?.hashValue)
+        hasher.combine(arrayArrayOfInteger?.hashValue)
+        hasher.combine(arrayArrayOfModel?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Capitalization.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Capitalization: Codable, Hashable {
+public final class Capitalization: Codable, Hashable {
 
     public var smallCamel: String?
     public var capitalCamel: String?
@@ -25,7 +25,6 @@ public struct Capitalization: Codable, Hashable {
         self.sCAETHFlowPoints = sCAETHFlowPoints
         self.ATT_NAME = ATT_NAME
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case smallCamel
         case capitalCamel = "CapitalCamel"
@@ -33,6 +32,40 @@ public struct Capitalization: Codable, Hashable {
         case capitalSnake = "Capital_Snake"
         case sCAETHFlowPoints = "SCA_ETH_Flow_Points"
         case ATT_NAME
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(smallCamel, forKey: .smallCamel)
+        try container.encodeIfPresent(capitalCamel, forKey: .capitalCamel)
+        try container.encodeIfPresent(smallSnake, forKey: .smallSnake)
+        try container.encodeIfPresent(capitalSnake, forKey: .capitalSnake)
+        try container.encodeIfPresent(sCAETHFlowPoints, forKey: .sCAETHFlowPoints)
+        try container.encodeIfPresent(ATT_NAME, forKey: .ATT_NAME)
+    }
+
+
+
+    public static func == (lhs: Capitalization, rhs: Capitalization) -> Bool {
+        lhs.smallCamel == rhs.smallCamel &&
+        lhs.capitalCamel == rhs.capitalCamel &&
+        lhs.smallSnake == rhs.smallSnake &&
+        lhs.capitalSnake == rhs.capitalSnake &&
+        lhs.sCAETHFlowPoints == rhs.sCAETHFlowPoints &&
+        lhs.ATT_NAME == rhs.ATT_NAME
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(smallCamel?.hashValue)
+        hasher.combine(capitalCamel?.hashValue)
+        hasher.combine(smallSnake?.hashValue)
+        hasher.combine(capitalSnake?.hashValue)
+        hasher.combine(sCAETHFlowPoints?.hashValue)
+        hasher.combine(ATT_NAME?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Cat.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Cat.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Cat: Codable, Hashable {
+public final class Cat: Codable, Hashable {
 
     public var className: String
     public var color: String? = "red"
@@ -17,6 +17,36 @@ public struct Cat: Codable, Hashable {
         self.className = className
         self.color = color
         self.declawed = declawed
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
+
+    public static func == (lhs: Cat, rhs: Cat) -> Bool {
+        lhs.className == rhs.className &&
+        lhs.color == rhs.color &&
+        lhs.declawed == rhs.declawed
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(className.hashValue)
+        hasher.combine(color?.hashValue)
+        hasher.combine(declawed?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/CatAllOf.swift
@@ -7,12 +7,34 @@
 
 import Foundation
 
-public struct CatAllOf: Codable, Hashable {
+public final class CatAllOf: Codable, Hashable {
 
     public var declawed: Bool?
 
     public init(declawed: Bool? = nil) {
         self.declawed = declawed
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
+
+    public static func == (lhs: CatAllOf, rhs: CatAllOf) -> Bool {
+        lhs.declawed == rhs.declawed
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(declawed?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Category.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Category.swift
@@ -7,14 +7,40 @@
 
 import Foundation
 
-public struct Category: Codable, Hashable {
+public final class Category: Codable, Hashable {
 
     public var id: Int64?
-    public var name: String = "default-name"
+    public var name: String? = "default-name"
 
-    public init(id: Int64? = nil, name: String = "default-name") {
+    public init(id: Int64? = nil, name: String? = "default-name") {
         self.id = id
         self.name = name
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+    }
+
+
+
+    public static func == (lhs: Category, rhs: Category) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.name == rhs.name
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id?.hashValue)
+        hasher.combine(name.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Client.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Client.swift
@@ -7,12 +7,34 @@
 
 import Foundation
 
-public struct Client: Codable, Hashable {
+public final class Client: Codable, Hashable {
 
     public var client: String?
 
     public init(client: String? = nil) {
         self.client = client
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case client
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(client, forKey: .client)
+    }
+
+
+
+    public static func == (lhs: Client, rhs: Client) -> Bool {
+        lhs.client == rhs.client
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(client?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Dog.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Dog.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Dog: Codable, Hashable {
+public final class Dog: Codable, Hashable {
 
     public var className: String
     public var color: String? = "red"
@@ -17,6 +17,36 @@ public struct Dog: Codable, Hashable {
         self.className = className
         self.color = color
         self.breed = breed
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
+
+    public static func == (lhs: Dog, rhs: Dog) -> Bool {
+        lhs.className == rhs.className &&
+        lhs.color == rhs.color &&
+        lhs.breed == rhs.breed
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(className.hashValue)
+        hasher.combine(color?.hashValue)
+        hasher.combine(breed?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/DogAllOf.swift
@@ -7,12 +7,34 @@
 
 import Foundation
 
-public struct DogAllOf: Codable, Hashable {
+public final class DogAllOf: Codable, Hashable {
 
     public var breed: String?
 
     public init(breed: String? = nil) {
         self.breed = breed
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
+
+    public static func == (lhs: DogAllOf, rhs: DogAllOf) -> Bool {
+        lhs.breed == rhs.breed
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(breed?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/EnumArrays.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct EnumArrays: Codable, Hashable {
+public final class EnumArrays: Codable, Hashable {
 
     public enum JustSymbol: String, Codable, CaseIterable {
         case greaterThanOrEqualTo = ">="
@@ -24,10 +24,31 @@ public struct EnumArrays: Codable, Hashable {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justSymbol = "just_symbol"
         case arrayEnum = "array_enum"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justSymbol, forKey: .justSymbol)
+        try container.encodeIfPresent(arrayEnum, forKey: .arrayEnum)
+    }
+
+
+
+    public static func == (lhs: EnumArrays, rhs: EnumArrays) -> Bool {
+        lhs.justSymbol == rhs.justSymbol &&
+        lhs.arrayEnum == rhs.arrayEnum
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(justSymbol?.hashValue)
+        hasher.combine(arrayEnum?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/EnumTest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct EnumTest: Codable, Hashable {
+public final class EnumTest: Codable, Hashable {
 
     public enum EnumString: String, Codable, CaseIterable {
         case upper = "UPPER"
@@ -40,13 +40,43 @@ public struct EnumTest: Codable, Hashable {
         self.enumNumber = enumNumber
         self.outerEnum = outerEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case enumString = "enum_string"
         case enumStringRequired = "enum_string_required"
         case enumInteger = "enum_integer"
         case enumNumber = "enum_number"
         case outerEnum
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(enumString, forKey: .enumString)
+        try container.encode(enumStringRequired, forKey: .enumStringRequired)
+        try container.encodeIfPresent(enumInteger, forKey: .enumInteger)
+        try container.encodeIfPresent(enumNumber, forKey: .enumNumber)
+        try container.encodeIfPresent(outerEnum, forKey: .outerEnum)
+    }
+
+
+
+    public static func == (lhs: EnumTest, rhs: EnumTest) -> Bool {
+        lhs.enumString == rhs.enumString &&
+        lhs.enumStringRequired == rhs.enumStringRequired &&
+        lhs.enumInteger == rhs.enumInteger &&
+        lhs.enumNumber == rhs.enumNumber &&
+        lhs.outerEnum == rhs.outerEnum
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(enumString?.hashValue)
+        hasher.combine(enumStringRequired.hashValue)
+        hasher.combine(enumInteger?.hashValue)
+        hasher.combine(enumNumber?.hashValue)
+        hasher.combine(outerEnum?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/File.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/File.swift
@@ -8,13 +8,35 @@
 import Foundation
 
 /** Must be named &#x60;File&#x60; for test. */
-public struct File: Codable, Hashable {
+public final class File: Codable, Hashable {
 
     /** Test capitalization */
     public var sourceURI: String?
 
     public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case sourceURI
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(sourceURI, forKey: .sourceURI)
+    }
+
+
+
+    public static func == (lhs: File, rhs: File) -> Bool {
+        lhs.sourceURI == rhs.sourceURI
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(sourceURI?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/FileSchemaTestClass.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct FileSchemaTestClass: Codable, Hashable {
+public final class FileSchemaTestClass: Codable, Hashable {
 
     public var file: File?
     public var files: [File]?
@@ -15,6 +15,32 @@ public struct FileSchemaTestClass: Codable, Hashable {
     public init(file: File? = nil, files: [File]? = nil) {
         self.file = file
         self.files = files
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case file
+        case files
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(file, forKey: .file)
+        try container.encodeIfPresent(files, forKey: .files)
+    }
+
+
+
+    public static func == (lhs: FileSchemaTestClass, rhs: FileSchemaTestClass) -> Bool {
+        lhs.file == rhs.file &&
+        lhs.files == rhs.files
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(file?.hashValue)
+        hasher.combine(files?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/FormatTest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct FormatTest: Codable, Hashable {
+public final class FormatTest: Codable, Hashable {
 
     public var integer: Int?
     public var int32: Int?
@@ -37,6 +37,76 @@ public struct FormatTest: Codable, Hashable {
         self.dateTime = dateTime
         self.uuid = uuid
         self.password = password
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case integer
+        case int32
+        case int64
+        case number
+        case float
+        case double
+        case string
+        case byte
+        case binary
+        case date
+        case dateTime
+        case uuid
+        case password
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(integer, forKey: .integer)
+        try container.encodeIfPresent(int32, forKey: .int32)
+        try container.encodeIfPresent(int64, forKey: .int64)
+        try container.encode(number, forKey: .number)
+        try container.encodeIfPresent(float, forKey: .float)
+        try container.encodeIfPresent(double, forKey: .double)
+        try container.encodeIfPresent(string, forKey: .string)
+        try container.encode(byte, forKey: .byte)
+        try container.encodeIfPresent(binary, forKey: .binary)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(password, forKey: .password)
+    }
+
+
+
+    public static func == (lhs: FormatTest, rhs: FormatTest) -> Bool {
+        lhs.integer == rhs.integer &&
+        lhs.int32 == rhs.int32 &&
+        lhs.int64 == rhs.int64 &&
+        lhs.number == rhs.number &&
+        lhs.float == rhs.float &&
+        lhs.double == rhs.double &&
+        lhs.string == rhs.string &&
+        lhs.byte == rhs.byte &&
+        lhs.binary == rhs.binary &&
+        lhs.date == rhs.date &&
+        lhs.dateTime == rhs.dateTime &&
+        lhs.uuid == rhs.uuid &&
+        lhs.password == rhs.password
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(integer?.hashValue)
+        hasher.combine(int32?.hashValue)
+        hasher.combine(int64?.hashValue)
+        hasher.combine(number.hashValue)
+        hasher.combine(float?.hashValue)
+        hasher.combine(double?.hashValue)
+        hasher.combine(string?.hashValue)
+        hasher.combine(byte.hashValue)
+        hasher.combine(binary?.hashValue)
+        hasher.combine(date.hashValue)
+        hasher.combine(dateTime?.hashValue)
+        hasher.combine(uuid?.hashValue)
+        hasher.combine(password.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/HasOnlyReadOnly.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct HasOnlyReadOnly: Codable, Hashable {
+public final class HasOnlyReadOnly: Codable, Hashable {
 
     public var bar: String?
     public var foo: String?
@@ -15,6 +15,32 @@ public struct HasOnlyReadOnly: Codable, Hashable {
     public init(bar: String? = nil, foo: String? = nil) {
         self.bar = bar
         self.foo = foo
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case foo
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(foo, forKey: .foo)
+    }
+
+
+
+    public static func == (lhs: HasOnlyReadOnly, rhs: HasOnlyReadOnly) -> Bool {
+        lhs.bar == rhs.bar &&
+        lhs.foo == rhs.foo
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(bar?.hashValue)
+        hasher.combine(foo?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/List.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/List.swift
@@ -7,16 +7,34 @@
 
 import Foundation
 
-public struct List: Codable, Hashable {
+public final class List: Codable, Hashable {
 
     public var _123list: String?
 
     public init(_123list: String? = nil) {
         self._123list = _123list
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _123list = "123-list"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_123list, forKey: ._123list)
+    }
+
+
+
+    public static func == (lhs: List, rhs: List) -> Bool {
+        lhs._123list == rhs._123list
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_123list?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/MapTest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct MapTest: Codable, Hashable {
+public final class MapTest: Codable, Hashable {
 
     public enum MapOfEnumString: String, Codable, CaseIterable {
         case upper = "UPPER"
@@ -24,12 +24,39 @@ public struct MapTest: Codable, Hashable {
         self.directMap = directMap
         self.indirectMap = indirectMap
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapMapOfString = "map_map_of_string"
         case mapOfEnumString = "map_of_enum_string"
         case directMap = "direct_map"
         case indirectMap = "indirect_map"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapMapOfString, forKey: .mapMapOfString)
+        try container.encodeIfPresent(mapOfEnumString, forKey: .mapOfEnumString)
+        try container.encodeIfPresent(directMap, forKey: .directMap)
+        try container.encodeIfPresent(indirectMap, forKey: .indirectMap)
+    }
+
+
+
+    public static func == (lhs: MapTest, rhs: MapTest) -> Bool {
+        lhs.mapMapOfString == rhs.mapMapOfString &&
+        lhs.mapOfEnumString == rhs.mapOfEnumString &&
+        lhs.directMap == rhs.directMap &&
+        lhs.indirectMap == rhs.indirectMap
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(mapMapOfString?.hashValue)
+        hasher.combine(mapOfEnumString?.hashValue)
+        hasher.combine(directMap?.hashValue)
+        hasher.combine(indirectMap?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
+public final class MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
 
     public var uuid: UUID?
     public var dateTime: Date?
@@ -17,6 +17,36 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case uuid
+        case dateTime
+        case map
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(map, forKey: .map)
+    }
+
+
+
+    public static func == (lhs: MixedPropertiesAndAdditionalPropertiesClass, rhs: MixedPropertiesAndAdditionalPropertiesClass) -> Bool {
+        lhs.uuid == rhs.uuid &&
+        lhs.dateTime == rhs.dateTime &&
+        lhs.map == rhs.map
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(uuid?.hashValue)
+        hasher.combine(dateTime?.hashValue)
+        hasher.combine(map?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Name.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Name.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /** Model for testing model name same as property name */
-public struct Name: Codable, Hashable {
+public final class Name: Codable, Hashable {
 
     public var name: Int
     public var snakeCase: Int?
@@ -21,12 +21,39 @@ public struct Name: Codable, Hashable {
         self.property = property
         self._123number = _123number
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case snakeCase = "snake_case"
         case property
         case _123number = "123Number"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(snakeCase, forKey: .snakeCase)
+        try container.encodeIfPresent(property, forKey: .property)
+        try container.encodeIfPresent(_123number, forKey: ._123number)
+    }
+
+
+
+    public static func == (lhs: Name, rhs: Name) -> Bool {
+        lhs.name == rhs.name &&
+        lhs.snakeCase == rhs.snakeCase &&
+        lhs.property == rhs.property &&
+        lhs._123number == rhs._123number
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name.hashValue)
+        hasher.combine(snakeCase?.hashValue)
+        hasher.combine(property?.hashValue)
+        hasher.combine(_123number?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/NumberOnly.swift
@@ -7,16 +7,34 @@
 
 import Foundation
 
-public struct NumberOnly: Codable, Hashable {
+public final class NumberOnly: Codable, Hashable {
 
     public var justNumber: Double?
 
     public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justNumber = "JustNumber"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justNumber, forKey: .justNumber)
+    }
+
+
+
+    public static func == (lhs: NumberOnly, rhs: NumberOnly) -> Bool {
+        lhs.justNumber == rhs.justNumber
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(justNumber?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Order.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Order.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Order: Codable, Hashable {
+public final class Order: Codable, Hashable {
 
     public enum Status: String, Codable, CaseIterable {
         case placed = "placed"
@@ -29,6 +29,48 @@ public struct Order: Codable, Hashable {
         self.shipDate = shipDate
         self.status = status
         self.complete = complete
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case petId
+        case quantity
+        case shipDate
+        case status
+        case complete
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(petId, forKey: .petId)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
+        try container.encodeIfPresent(shipDate, forKey: .shipDate)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(complete, forKey: .complete)
+    }
+
+
+
+    public static func == (lhs: Order, rhs: Order) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.petId == rhs.petId &&
+        lhs.quantity == rhs.quantity &&
+        lhs.shipDate == rhs.shipDate &&
+        lhs.status == rhs.status &&
+        lhs.complete == rhs.complete
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id?.hashValue)
+        hasher.combine(petId?.hashValue)
+        hasher.combine(quantity?.hashValue)
+        hasher.combine(shipDate?.hashValue)
+        hasher.combine(status?.hashValue)
+        hasher.combine(complete?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/OuterComposite.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct OuterComposite: Codable, Hashable {
+public final class OuterComposite: Codable, Hashable {
 
     public var myNumber: Double?
     public var myString: String?
@@ -18,11 +18,35 @@ public struct OuterComposite: Codable, Hashable {
         self.myString = myString
         self.myBoolean = myBoolean
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case myNumber = "my_number"
         case myString = "my_string"
         case myBoolean = "my_boolean"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(myNumber, forKey: .myNumber)
+        try container.encodeIfPresent(myString, forKey: .myString)
+        try container.encodeIfPresent(myBoolean, forKey: .myBoolean)
+    }
+
+
+
+    public static func == (lhs: OuterComposite, rhs: OuterComposite) -> Bool {
+        lhs.myNumber == rhs.myNumber &&
+        lhs.myString == rhs.myString &&
+        lhs.myBoolean == rhs.myBoolean
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(myNumber?.hashValue)
+        hasher.combine(myString?.hashValue)
+        hasher.combine(myBoolean?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Pet.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Pet.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Pet: Codable, Hashable {
+public final class Pet: Codable, Hashable {
 
     public enum Status: String, Codable, CaseIterable {
         case available = "available"
@@ -29,6 +29,48 @@ public struct Pet: Codable, Hashable {
         self.photoUrls = photoUrls
         self.tags = tags
         self.status = status
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case category
+        case name
+        case photoUrls
+        case tags
+        case status
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(photoUrls, forKey: .photoUrls)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+
+
+
+    public static func == (lhs: Pet, rhs: Pet) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.category == rhs.category &&
+        lhs.name == rhs.name &&
+        lhs.photoUrls == rhs.photoUrls &&
+        lhs.tags == rhs.tags &&
+        lhs.status == rhs.status
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id?.hashValue)
+        hasher.combine(category?.hashValue)
+        hasher.combine(name.hashValue)
+        hasher.combine(photoUrls.hashValue)
+        hasher.combine(tags?.hashValue)
+        hasher.combine(status?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/ReadOnlyFirst.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ReadOnlyFirst: Codable, Hashable {
+public final class ReadOnlyFirst: Codable, Hashable {
 
     public var bar: String?
     public var baz: String?
@@ -15,6 +15,32 @@ public struct ReadOnlyFirst: Codable, Hashable {
     public init(bar: String? = nil, baz: String? = nil) {
         self.bar = bar
         self.baz = baz
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case baz
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(baz, forKey: .baz)
+    }
+
+
+
+    public static func == (lhs: ReadOnlyFirst, rhs: ReadOnlyFirst) -> Bool {
+        lhs.bar == rhs.bar &&
+        lhs.baz == rhs.baz
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(bar?.hashValue)
+        hasher.combine(baz?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/SpecialModelName.swift
@@ -7,16 +7,34 @@
 
 import Foundation
 
-public struct SpecialModelName: Codable, Hashable {
+public final class SpecialModelName: Codable, Hashable {
 
     public var specialPropertyName: Int64?
 
     public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case specialPropertyName = "$special[property.name]"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(specialPropertyName, forKey: .specialPropertyName)
+    }
+
+
+
+    public static func == (lhs: SpecialModelName, rhs: SpecialModelName) -> Bool {
+        lhs.specialPropertyName == rhs.specialPropertyName
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(specialPropertyName?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/StringBooleanMap.swift
@@ -7,8 +7,10 @@
 
 import Foundation
 
-public struct StringBooleanMap: Codable, Hashable {
+public final class StringBooleanMap: Codable, Hashable {
 
+    public enum CodingKeys: CodingKey, CaseIterable {
+    }
     public var additionalProperties: [String: Bool] = [:]
 
     public subscript(key: String) -> Bool? {
@@ -27,10 +29,9 @@ public struct StringBooleanMap: Codable, Hashable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
-        try container.encodeMap(additionalProperties)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var additionalPropertiesContainer = encoder.container(keyedBy: String.self)
+        try additionalPropertiesContainer.encodeMap(additionalProperties)
     }
 
     // Decodable protocol methods
@@ -40,6 +41,15 @@ public struct StringBooleanMap: Codable, Hashable {
 
         var nonAdditionalPropertyKeys = Set<String>()
         additionalProperties = try container.decodeMap(Bool.self, excludedKeys: nonAdditionalPropertyKeys)
+    }
+
+
+    public static func == (lhs: StringBooleanMap, rhs: StringBooleanMap) -> Bool {
+        lhs.additionalProperties == rhs.additionalProperties
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(additionalProperties.hashValue)
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Tag.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/Tag.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Tag: Codable, Hashable {
+public final class Tag: Codable, Hashable {
 
     public var id: Int64?
     public var name: String?
@@ -15,6 +15,32 @@ public struct Tag: Codable, Hashable {
     public init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
+
+    public static func == (lhs: Tag, rhs: Tag) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.name == rhs.name
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id?.hashValue)
+        hasher.combine(name?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/TypeHolderDefault.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct TypeHolderDefault: Codable, Hashable {
+public final class TypeHolderDefault: Codable, Hashable {
 
     public var stringItem: String = "what"
     public var numberItem: Double
@@ -22,13 +22,43 @@ public struct TypeHolderDefault: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
         case integerItem = "integer_item"
         case boolItem = "bool_item"
         case arrayItem = "array_item"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
+
+    public static func == (lhs: TypeHolderDefault, rhs: TypeHolderDefault) -> Bool {
+        lhs.stringItem == rhs.stringItem &&
+        lhs.numberItem == rhs.numberItem &&
+        lhs.integerItem == rhs.integerItem &&
+        lhs.boolItem == rhs.boolItem &&
+        lhs.arrayItem == rhs.arrayItem
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(stringItem.hashValue)
+        hasher.combine(numberItem.hashValue)
+        hasher.combine(integerItem.hashValue)
+        hasher.combine(boolItem.hashValue)
+        hasher.combine(arrayItem.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/TypeHolderExample.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct TypeHolderExample: Codable, Hashable {
+public final class TypeHolderExample: Codable, Hashable {
 
     public var stringItem: String
     public var numberItem: Double
@@ -22,13 +22,43 @@ public struct TypeHolderExample: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
         case integerItem = "integer_item"
         case boolItem = "bool_item"
         case arrayItem = "array_item"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
+
+    public static func == (lhs: TypeHolderExample, rhs: TypeHolderExample) -> Bool {
+        lhs.stringItem == rhs.stringItem &&
+        lhs.numberItem == rhs.numberItem &&
+        lhs.integerItem == rhs.integerItem &&
+        lhs.boolItem == rhs.boolItem &&
+        lhs.arrayItem == rhs.arrayItem
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(stringItem.hashValue)
+        hasher.combine(numberItem.hashValue)
+        hasher.combine(integerItem.hashValue)
+        hasher.combine(boolItem.hashValue)
+        hasher.combine(arrayItem.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/User.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/Models/User.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct User: Codable, Hashable {
+public final class User: Codable, Hashable {
 
     public var id: Int64?
     public var username: String?
@@ -28,6 +28,56 @@ public struct User: Codable, Hashable {
         self.password = password
         self.phone = phone
         self.userStatus = userStatus
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case firstName
+        case lastName
+        case email
+        case password
+        case phone
+        case userStatus
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(username, forKey: .username)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(password, forKey: .password)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(userStatus, forKey: .userStatus)
+    }
+
+
+
+    public static func == (lhs: User, rhs: User) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.username == rhs.username &&
+        lhs.firstName == rhs.firstName &&
+        lhs.lastName == rhs.lastName &&
+        lhs.email == rhs.email &&
+        lhs.password == rhs.password &&
+        lhs.phone == rhs.phone &&
+        lhs.userStatus == rhs.userStatus
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id?.hashValue)
+        hasher.combine(username?.hashValue)
+        hasher.combine(firstName?.hashValue)
+        hasher.combine(lastName?.hashValue)
+        hasher.combine(email?.hashValue)
+        hasher.combine(password?.hashValue)
+        hasher.combine(phone?.hashValue)
+        hasher.combine(userStatus?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/AdditionalPropertiesClass.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct AdditionalPropertiesClass: Codable, Hashable {
+public final class AdditionalPropertiesClass: Codable, Hashable {
 
     public var mapString: [String: String]?
     public var mapMapString: [String: [String: String]]?
@@ -16,10 +16,31 @@ public struct AdditionalPropertiesClass: Codable, Hashable {
         self.mapString = mapString
         self.mapMapString = mapMapString
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapString = "map_string"
         case mapMapString = "map_map_string"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapString, forKey: .mapString)
+        try container.encodeIfPresent(mapMapString, forKey: .mapMapString)
+    }
+
+
+
+    public static func == (lhs: AdditionalPropertiesClass, rhs: AdditionalPropertiesClass) -> Bool {
+        lhs.mapString == rhs.mapString &&
+        lhs.mapMapString == rhs.mapMapString
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(mapString?.hashValue)
+        hasher.combine(mapMapString?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Animal.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Animal.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Animal: Codable, Hashable {
+public final class Animal: Codable, Hashable {
 
     public var className: String
     public var color: String? = "red"
@@ -15,6 +15,32 @@ public struct Animal: Codable, Hashable {
     public init(className: String, color: String? = "red") {
         self.className = className
         self.color = color
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+    }
+
+
+
+    public static func == (lhs: Animal, rhs: Animal) -> Bool {
+        lhs.className == rhs.className &&
+        lhs.color == rhs.color
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(className.hashValue)
+        hasher.combine(color?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ApiResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ApiResponse: Codable, Hashable {
+public final class ApiResponse: Codable, Hashable {
 
     public var code: Int?
     public var type: String?
@@ -17,6 +17,36 @@ public struct ApiResponse: Codable, Hashable {
         self.code = code
         self.type = type
         self.message = message
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case code
+        case type
+        case message
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(code, forKey: .code)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(message, forKey: .message)
+    }
+
+
+
+    public static func == (lhs: ApiResponse, rhs: ApiResponse) -> Bool {
+        lhs.code == rhs.code &&
+        lhs.type == rhs.type &&
+        lhs.message == rhs.message
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(code?.hashValue)
+        hasher.combine(type?.hashValue)
+        hasher.combine(message?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ArrayOfArrayOfNumberOnly.swift
@@ -7,16 +7,34 @@
 
 import Foundation
 
-public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
+public final class ArrayOfArrayOfNumberOnly: Codable, Hashable {
 
     public var arrayArrayNumber: [[Double]]?
 
     public init(arrayArrayNumber: [[Double]]? = nil) {
         self.arrayArrayNumber = arrayArrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayArrayNumber = "ArrayArrayNumber"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayArrayNumber, forKey: .arrayArrayNumber)
+    }
+
+
+
+    public static func == (lhs: ArrayOfArrayOfNumberOnly, rhs: ArrayOfArrayOfNumberOnly) -> Bool {
+        lhs.arrayArrayNumber == rhs.arrayArrayNumber
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(arrayArrayNumber?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ArrayOfNumberOnly.swift
@@ -7,16 +7,34 @@
 
 import Foundation
 
-public struct ArrayOfNumberOnly: Codable, Hashable {
+public final class ArrayOfNumberOnly: Codable, Hashable {
 
     public var arrayNumber: [Double]?
 
     public init(arrayNumber: [Double]? = nil) {
         self.arrayNumber = arrayNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayNumber = "ArrayNumber"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayNumber, forKey: .arrayNumber)
+    }
+
+
+
+    public static func == (lhs: ArrayOfNumberOnly, rhs: ArrayOfNumberOnly) -> Bool {
+        lhs.arrayNumber == rhs.arrayNumber
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(arrayNumber?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ArrayTest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ArrayTest: Codable, Hashable {
+public final class ArrayTest: Codable, Hashable {
 
     public var arrayOfString: [String]?
     public var arrayArrayOfInteger: [[Int64]]?
@@ -18,11 +18,35 @@ public struct ArrayTest: Codable, Hashable {
         self.arrayArrayOfInteger = arrayArrayOfInteger
         self.arrayArrayOfModel = arrayArrayOfModel
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case arrayOfString = "array_of_string"
         case arrayArrayOfInteger = "array_array_of_integer"
         case arrayArrayOfModel = "array_array_of_model"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(arrayOfString, forKey: .arrayOfString)
+        try container.encodeIfPresent(arrayArrayOfInteger, forKey: .arrayArrayOfInteger)
+        try container.encodeIfPresent(arrayArrayOfModel, forKey: .arrayArrayOfModel)
+    }
+
+
+
+    public static func == (lhs: ArrayTest, rhs: ArrayTest) -> Bool {
+        lhs.arrayOfString == rhs.arrayOfString &&
+        lhs.arrayArrayOfInteger == rhs.arrayArrayOfInteger &&
+        lhs.arrayArrayOfModel == rhs.arrayArrayOfModel
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(arrayOfString?.hashValue)
+        hasher.combine(arrayArrayOfInteger?.hashValue)
+        hasher.combine(arrayArrayOfModel?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Capitalization.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Capitalization: Codable, Hashable {
+public final class Capitalization: Codable, Hashable {
 
     public var smallCamel: String?
     public var capitalCamel: String?
@@ -25,7 +25,6 @@ public struct Capitalization: Codable, Hashable {
         self.sCAETHFlowPoints = sCAETHFlowPoints
         self.ATT_NAME = ATT_NAME
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case smallCamel
         case capitalCamel = "CapitalCamel"
@@ -33,6 +32,40 @@ public struct Capitalization: Codable, Hashable {
         case capitalSnake = "Capital_Snake"
         case sCAETHFlowPoints = "SCA_ETH_Flow_Points"
         case ATT_NAME
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(smallCamel, forKey: .smallCamel)
+        try container.encodeIfPresent(capitalCamel, forKey: .capitalCamel)
+        try container.encodeIfPresent(smallSnake, forKey: .smallSnake)
+        try container.encodeIfPresent(capitalSnake, forKey: .capitalSnake)
+        try container.encodeIfPresent(sCAETHFlowPoints, forKey: .sCAETHFlowPoints)
+        try container.encodeIfPresent(ATT_NAME, forKey: .ATT_NAME)
+    }
+
+
+
+    public static func == (lhs: Capitalization, rhs: Capitalization) -> Bool {
+        lhs.smallCamel == rhs.smallCamel &&
+        lhs.capitalCamel == rhs.capitalCamel &&
+        lhs.smallSnake == rhs.smallSnake &&
+        lhs.capitalSnake == rhs.capitalSnake &&
+        lhs.sCAETHFlowPoints == rhs.sCAETHFlowPoints &&
+        lhs.ATT_NAME == rhs.ATT_NAME
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(smallCamel?.hashValue)
+        hasher.combine(capitalCamel?.hashValue)
+        hasher.combine(smallSnake?.hashValue)
+        hasher.combine(capitalSnake?.hashValue)
+        hasher.combine(sCAETHFlowPoints?.hashValue)
+        hasher.combine(ATT_NAME?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Cat.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Cat.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Cat: Codable, Hashable {
+public final class Cat: Codable, Hashable {
 
     public var className: String
     public var color: String? = "red"
@@ -17,6 +17,36 @@ public struct Cat: Codable, Hashable {
         self.className = className
         self.color = color
         self.declawed = declawed
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
+
+    public static func == (lhs: Cat, rhs: Cat) -> Bool {
+        lhs.className == rhs.className &&
+        lhs.color == rhs.color &&
+        lhs.declawed == rhs.declawed
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(className.hashValue)
+        hasher.combine(color?.hashValue)
+        hasher.combine(declawed?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/CatAllOf.swift
@@ -7,12 +7,34 @@
 
 import Foundation
 
-public struct CatAllOf: Codable, Hashable {
+public final class CatAllOf: Codable, Hashable {
 
     public var declawed: Bool?
 
     public init(declawed: Bool? = nil) {
         self.declawed = declawed
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case declawed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(declawed, forKey: .declawed)
+    }
+
+
+
+    public static func == (lhs: CatAllOf, rhs: CatAllOf) -> Bool {
+        lhs.declawed == rhs.declawed
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(declawed?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Category.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Category.swift
@@ -7,14 +7,40 @@
 
 import Foundation
 
-public struct Category: Codable, Hashable {
+public final class Category: Codable, Hashable {
 
     public var id: Int64?
-    public var name: String = "default-name"
+    public var name: String? = "default-name"
 
-    public init(id: Int64? = nil, name: String = "default-name") {
+    public init(id: Int64? = nil, name: String? = "default-name") {
         self.id = id
         self.name = name
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+    }
+
+
+
+    public static func == (lhs: Category, rhs: Category) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.name == rhs.name
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id?.hashValue)
+        hasher.combine(name.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ClassModel.swift
@@ -8,12 +8,34 @@
 import Foundation
 
 /** Model for testing model with \&quot;_class\&quot; property */
-public struct ClassModel: Codable, Hashable {
+public final class ClassModel: Codable, Hashable {
 
     public var _class: String?
 
     public init(_class: String? = nil) {
         self._class = _class
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case _class
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
+
+    public static func == (lhs: ClassModel, rhs: ClassModel) -> Bool {
+        lhs._class == rhs._class
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_class?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Client.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Client.swift
@@ -7,12 +7,34 @@
 
 import Foundation
 
-public struct Client: Codable, Hashable {
+public final class Client: Codable, Hashable {
 
     public var client: String?
 
     public init(client: String? = nil) {
         self.client = client
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case client
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(client, forKey: .client)
+    }
+
+
+
+    public static func == (lhs: Client, rhs: Client) -> Bool {
+        lhs.client == rhs.client
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(client?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Dog.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Dog.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Dog: Codable, Hashable {
+public final class Dog: Codable, Hashable {
 
     public var className: String
     public var color: String? = "red"
@@ -17,6 +17,36 @@ public struct Dog: Codable, Hashable {
         self.className = className
         self.color = color
         self.breed = breed
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case className
+        case color
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(className, forKey: .className)
+        try container.encodeIfPresent(color, forKey: .color)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
+
+    public static func == (lhs: Dog, rhs: Dog) -> Bool {
+        lhs.className == rhs.className &&
+        lhs.color == rhs.color &&
+        lhs.breed == rhs.breed
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(className.hashValue)
+        hasher.combine(color?.hashValue)
+        hasher.combine(breed?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/DogAllOf.swift
@@ -7,12 +7,34 @@
 
 import Foundation
 
-public struct DogAllOf: Codable, Hashable {
+public final class DogAllOf: Codable, Hashable {
 
     public var breed: String?
 
     public init(breed: String? = nil) {
         self.breed = breed
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case breed
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(breed, forKey: .breed)
+    }
+
+
+
+    public static func == (lhs: DogAllOf, rhs: DogAllOf) -> Bool {
+        lhs.breed == rhs.breed
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(breed?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/EnumArrays.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct EnumArrays: Codable, Hashable {
+public final class EnumArrays: Codable, Hashable {
 
     public enum JustSymbol: String, Codable, CaseIterable {
         case greaterThanOrEqualTo = ">="
@@ -24,10 +24,31 @@ public struct EnumArrays: Codable, Hashable {
         self.justSymbol = justSymbol
         self.arrayEnum = arrayEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justSymbol = "just_symbol"
         case arrayEnum = "array_enum"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justSymbol, forKey: .justSymbol)
+        try container.encodeIfPresent(arrayEnum, forKey: .arrayEnum)
+    }
+
+
+
+    public static func == (lhs: EnumArrays, rhs: EnumArrays) -> Bool {
+        lhs.justSymbol == rhs.justSymbol &&
+        lhs.arrayEnum == rhs.arrayEnum
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(justSymbol?.hashValue)
+        hasher.combine(arrayEnum?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/EnumTest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct EnumTest: Codable, Hashable {
+public final class EnumTest: Codable, Hashable {
 
     public enum EnumString: String, Codable, CaseIterable {
         case upper = "UPPER"
@@ -40,13 +40,43 @@ public struct EnumTest: Codable, Hashable {
         self.enumNumber = enumNumber
         self.outerEnum = outerEnum
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case enumString = "enum_string"
         case enumStringRequired = "enum_string_required"
         case enumInteger = "enum_integer"
         case enumNumber = "enum_number"
         case outerEnum
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(enumString, forKey: .enumString)
+        try container.encode(enumStringRequired, forKey: .enumStringRequired)
+        try container.encodeIfPresent(enumInteger, forKey: .enumInteger)
+        try container.encodeIfPresent(enumNumber, forKey: .enumNumber)
+        try container.encodeIfPresent(outerEnum, forKey: .outerEnum)
+    }
+
+
+
+    public static func == (lhs: EnumTest, rhs: EnumTest) -> Bool {
+        lhs.enumString == rhs.enumString &&
+        lhs.enumStringRequired == rhs.enumStringRequired &&
+        lhs.enumInteger == rhs.enumInteger &&
+        lhs.enumNumber == rhs.enumNumber &&
+        lhs.outerEnum == rhs.outerEnum
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(enumString?.hashValue)
+        hasher.combine(enumStringRequired.hashValue)
+        hasher.combine(enumInteger?.hashValue)
+        hasher.combine(enumNumber?.hashValue)
+        hasher.combine(outerEnum?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/File.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/File.swift
@@ -8,13 +8,35 @@
 import Foundation
 
 /** Must be named &#x60;File&#x60; for test. */
-public struct File: Codable, Hashable {
+public final class File: Codable, Hashable {
 
     /** Test capitalization */
     public var sourceURI: String?
 
     public init(sourceURI: String? = nil) {
         self.sourceURI = sourceURI
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case sourceURI
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(sourceURI, forKey: .sourceURI)
+    }
+
+
+
+    public static func == (lhs: File, rhs: File) -> Bool {
+        lhs.sourceURI == rhs.sourceURI
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(sourceURI?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/FileSchemaTestClass.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct FileSchemaTestClass: Codable, Hashable {
+public final class FileSchemaTestClass: Codable, Hashable {
 
     public var file: File?
     public var files: [File]?
@@ -15,6 +15,32 @@ public struct FileSchemaTestClass: Codable, Hashable {
     public init(file: File? = nil, files: [File]? = nil) {
         self.file = file
         self.files = files
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case file
+        case files
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(file, forKey: .file)
+        try container.encodeIfPresent(files, forKey: .files)
+    }
+
+
+
+    public static func == (lhs: FileSchemaTestClass, rhs: FileSchemaTestClass) -> Bool {
+        lhs.file == rhs.file &&
+        lhs.files == rhs.files
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(file?.hashValue)
+        hasher.combine(files?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/FormatTest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct FormatTest: Codable, Hashable {
+public final class FormatTest: Codable, Hashable {
 
     public var integer: Int?
     public var int32: Int?
@@ -37,6 +37,76 @@ public struct FormatTest: Codable, Hashable {
         self.dateTime = dateTime
         self.uuid = uuid
         self.password = password
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case integer
+        case int32
+        case int64
+        case number
+        case float
+        case double
+        case string
+        case byte
+        case binary
+        case date
+        case dateTime
+        case uuid
+        case password
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(integer, forKey: .integer)
+        try container.encodeIfPresent(int32, forKey: .int32)
+        try container.encodeIfPresent(int64, forKey: .int64)
+        try container.encode(number, forKey: .number)
+        try container.encodeIfPresent(float, forKey: .float)
+        try container.encodeIfPresent(double, forKey: .double)
+        try container.encodeIfPresent(string, forKey: .string)
+        try container.encode(byte, forKey: .byte)
+        try container.encodeIfPresent(binary, forKey: .binary)
+        try container.encode(date, forKey: .date)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(password, forKey: .password)
+    }
+
+
+
+    public static func == (lhs: FormatTest, rhs: FormatTest) -> Bool {
+        lhs.integer == rhs.integer &&
+        lhs.int32 == rhs.int32 &&
+        lhs.int64 == rhs.int64 &&
+        lhs.number == rhs.number &&
+        lhs.float == rhs.float &&
+        lhs.double == rhs.double &&
+        lhs.string == rhs.string &&
+        lhs.byte == rhs.byte &&
+        lhs.binary == rhs.binary &&
+        lhs.date == rhs.date &&
+        lhs.dateTime == rhs.dateTime &&
+        lhs.uuid == rhs.uuid &&
+        lhs.password == rhs.password
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(integer?.hashValue)
+        hasher.combine(int32?.hashValue)
+        hasher.combine(int64?.hashValue)
+        hasher.combine(number.hashValue)
+        hasher.combine(float?.hashValue)
+        hasher.combine(double?.hashValue)
+        hasher.combine(string?.hashValue)
+        hasher.combine(byte.hashValue)
+        hasher.combine(binary?.hashValue)
+        hasher.combine(date.hashValue)
+        hasher.combine(dateTime?.hashValue)
+        hasher.combine(uuid?.hashValue)
+        hasher.combine(password.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/HasOnlyReadOnly.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct HasOnlyReadOnly: Codable, Hashable {
+public final class HasOnlyReadOnly: Codable, Hashable {
 
     public var bar: String?
     public var foo: String?
@@ -15,6 +15,32 @@ public struct HasOnlyReadOnly: Codable, Hashable {
     public init(bar: String? = nil, foo: String? = nil) {
         self.bar = bar
         self.foo = foo
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case foo
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(foo, forKey: .foo)
+    }
+
+
+
+    public static func == (lhs: HasOnlyReadOnly, rhs: HasOnlyReadOnly) -> Bool {
+        lhs.bar == rhs.bar &&
+        lhs.foo == rhs.foo
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(bar?.hashValue)
+        hasher.combine(foo?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/List.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/List.swift
@@ -7,16 +7,34 @@
 
 import Foundation
 
-public struct List: Codable, Hashable {
+public final class List: Codable, Hashable {
 
     public var _123list: String?
 
     public init(_123list: String? = nil) {
         self._123list = _123list
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _123list = "123-list"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_123list, forKey: ._123list)
+    }
+
+
+
+    public static func == (lhs: List, rhs: List) -> Bool {
+        lhs._123list == rhs._123list
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_123list?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/MapTest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct MapTest: Codable, Hashable {
+public final class MapTest: Codable, Hashable {
 
     public enum MapOfEnumString: String, Codable, CaseIterable {
         case upper = "UPPER"
@@ -24,12 +24,39 @@ public struct MapTest: Codable, Hashable {
         self.directMap = directMap
         self.indirectMap = indirectMap
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case mapMapOfString = "map_map_of_string"
         case mapOfEnumString = "map_of_enum_string"
         case directMap = "direct_map"
         case indirectMap = "indirect_map"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(mapMapOfString, forKey: .mapMapOfString)
+        try container.encodeIfPresent(mapOfEnumString, forKey: .mapOfEnumString)
+        try container.encodeIfPresent(directMap, forKey: .directMap)
+        try container.encodeIfPresent(indirectMap, forKey: .indirectMap)
+    }
+
+
+
+    public static func == (lhs: MapTest, rhs: MapTest) -> Bool {
+        lhs.mapMapOfString == rhs.mapMapOfString &&
+        lhs.mapOfEnumString == rhs.mapOfEnumString &&
+        lhs.directMap == rhs.directMap &&
+        lhs.indirectMap == rhs.indirectMap
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(mapMapOfString?.hashValue)
+        hasher.combine(mapOfEnumString?.hashValue)
+        hasher.combine(directMap?.hashValue)
+        hasher.combine(indirectMap?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
+public final class MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
 
     public var uuid: UUID?
     public var dateTime: Date?
@@ -17,6 +17,36 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case uuid
+        case dateTime
+        case map
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encodeIfPresent(dateTime, forKey: .dateTime)
+        try container.encodeIfPresent(map, forKey: .map)
+    }
+
+
+
+    public static func == (lhs: MixedPropertiesAndAdditionalPropertiesClass, rhs: MixedPropertiesAndAdditionalPropertiesClass) -> Bool {
+        lhs.uuid == rhs.uuid &&
+        lhs.dateTime == rhs.dateTime &&
+        lhs.map == rhs.map
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(uuid?.hashValue)
+        hasher.combine(dateTime?.hashValue)
+        hasher.combine(map?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Model200Response.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /** Model for testing model name starting with number */
-public struct Model200Response: Codable, Hashable {
+public final class Model200Response: Codable, Hashable {
 
     public var name: Int?
     public var _class: String?
@@ -17,10 +17,31 @@ public struct Model200Response: Codable, Hashable {
         self.name = name
         self._class = _class
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case _class = "class"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(_class, forKey: ._class)
+    }
+
+
+
+    public static func == (lhs: Model200Response, rhs: Model200Response) -> Bool {
+        lhs.name == rhs.name &&
+        lhs._class == rhs._class
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name?.hashValue)
+        hasher.combine(_class?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Name.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Name.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /** Model for testing model name same as property name */
-public struct Name: Codable, Hashable {
+public final class Name: Codable, Hashable {
 
     public var name: Int
     public var snakeCase: Int?
@@ -21,12 +21,39 @@ public struct Name: Codable, Hashable {
         self.property = property
         self._123number = _123number
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case name
         case snakeCase = "snake_case"
         case property
         case _123number = "123Number"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(snakeCase, forKey: .snakeCase)
+        try container.encodeIfPresent(property, forKey: .property)
+        try container.encodeIfPresent(_123number, forKey: ._123number)
+    }
+
+
+
+    public static func == (lhs: Name, rhs: Name) -> Bool {
+        lhs.name == rhs.name &&
+        lhs.snakeCase == rhs.snakeCase &&
+        lhs.property == rhs.property &&
+        lhs._123number == rhs._123number
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name.hashValue)
+        hasher.combine(snakeCase?.hashValue)
+        hasher.combine(property?.hashValue)
+        hasher.combine(_123number?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/NumberOnly.swift
@@ -7,16 +7,34 @@
 
 import Foundation
 
-public struct NumberOnly: Codable, Hashable {
+public final class NumberOnly: Codable, Hashable {
 
     public var justNumber: Double?
 
     public init(justNumber: Double? = nil) {
         self.justNumber = justNumber
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case justNumber = "JustNumber"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(justNumber, forKey: .justNumber)
+    }
+
+
+
+    public static func == (lhs: NumberOnly, rhs: NumberOnly) -> Bool {
+        lhs.justNumber == rhs.justNumber
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(justNumber?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Order.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Order.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Order: Codable, Hashable {
+public final class Order: Codable, Hashable {
 
     public enum Status: String, Codable, CaseIterable {
         case placed = "placed"
@@ -29,6 +29,48 @@ public struct Order: Codable, Hashable {
         self.shipDate = shipDate
         self.status = status
         self.complete = complete
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case petId
+        case quantity
+        case shipDate
+        case status
+        case complete
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(petId, forKey: .petId)
+        try container.encodeIfPresent(quantity, forKey: .quantity)
+        try container.encodeIfPresent(shipDate, forKey: .shipDate)
+        try container.encodeIfPresent(status, forKey: .status)
+        try container.encodeIfPresent(complete, forKey: .complete)
+    }
+
+
+
+    public static func == (lhs: Order, rhs: Order) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.petId == rhs.petId &&
+        lhs.quantity == rhs.quantity &&
+        lhs.shipDate == rhs.shipDate &&
+        lhs.status == rhs.status &&
+        lhs.complete == rhs.complete
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id?.hashValue)
+        hasher.combine(petId?.hashValue)
+        hasher.combine(quantity?.hashValue)
+        hasher.combine(shipDate?.hashValue)
+        hasher.combine(status?.hashValue)
+        hasher.combine(complete?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/OuterComposite.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct OuterComposite: Codable, Hashable {
+public final class OuterComposite: Codable, Hashable {
 
     public var myNumber: Double?
     public var myString: String?
@@ -18,11 +18,35 @@ public struct OuterComposite: Codable, Hashable {
         self.myString = myString
         self.myBoolean = myBoolean
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case myNumber = "my_number"
         case myString = "my_string"
         case myBoolean = "my_boolean"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(myNumber, forKey: .myNumber)
+        try container.encodeIfPresent(myString, forKey: .myString)
+        try container.encodeIfPresent(myBoolean, forKey: .myBoolean)
+    }
+
+
+
+    public static func == (lhs: OuterComposite, rhs: OuterComposite) -> Bool {
+        lhs.myNumber == rhs.myNumber &&
+        lhs.myString == rhs.myString &&
+        lhs.myBoolean == rhs.myBoolean
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(myNumber?.hashValue)
+        hasher.combine(myString?.hashValue)
+        hasher.combine(myBoolean?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Pet.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Pet.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Pet: Codable, Hashable {
+public final class Pet: Codable, Hashable {
 
     public enum Status: String, Codable, CaseIterable {
         case available = "available"
@@ -29,6 +29,48 @@ public struct Pet: Codable, Hashable {
         self.photoUrls = photoUrls
         self.tags = tags
         self.status = status
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case category
+        case name
+        case photoUrls
+        case tags
+        case status
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(category, forKey: .category)
+        try container.encode(name, forKey: .name)
+        try container.encode(photoUrls, forKey: .photoUrls)
+        try container.encodeIfPresent(tags, forKey: .tags)
+        try container.encodeIfPresent(status, forKey: .status)
+    }
+
+
+
+    public static func == (lhs: Pet, rhs: Pet) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.category == rhs.category &&
+        lhs.name == rhs.name &&
+        lhs.photoUrls == rhs.photoUrls &&
+        lhs.tags == rhs.tags &&
+        lhs.status == rhs.status
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id?.hashValue)
+        hasher.combine(category?.hashValue)
+        hasher.combine(name.hashValue)
+        hasher.combine(photoUrls.hashValue)
+        hasher.combine(tags?.hashValue)
+        hasher.combine(status?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ReadOnlyFirst.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct ReadOnlyFirst: Codable, Hashable {
+public final class ReadOnlyFirst: Codable, Hashable {
 
     public var bar: String?
     public var baz: String?
@@ -15,6 +15,32 @@ public struct ReadOnlyFirst: Codable, Hashable {
     public init(bar: String? = nil, baz: String? = nil) {
         self.bar = bar
         self.baz = baz
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case bar
+        case baz
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(bar, forKey: .bar)
+        try container.encodeIfPresent(baz, forKey: .baz)
+    }
+
+
+
+    public static func == (lhs: ReadOnlyFirst, rhs: ReadOnlyFirst) -> Bool {
+        lhs.bar == rhs.bar &&
+        lhs.baz == rhs.baz
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(bar?.hashValue)
+        hasher.combine(baz?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Return.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Return.swift
@@ -8,16 +8,34 @@
 import Foundation
 
 /** Model for testing reserved words */
-public struct Return: Codable, Hashable {
+public final class Return: Codable, Hashable {
 
     public var _return: Int?
 
     public init(_return: Int? = nil) {
         self._return = _return
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case _return = "return"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(_return, forKey: ._return)
+    }
+
+
+
+    public static func == (lhs: Return, rhs: Return) -> Bool {
+        lhs._return == rhs._return
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(_return?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/SpecialModelName.swift
@@ -7,16 +7,34 @@
 
 import Foundation
 
-public struct SpecialModelName: Codable, Hashable {
+public final class SpecialModelName: Codable, Hashable {
 
     public var specialPropertyName: Int64?
 
     public init(specialPropertyName: Int64? = nil) {
         self.specialPropertyName = specialPropertyName
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case specialPropertyName = "$special[property.name]"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(specialPropertyName, forKey: .specialPropertyName)
+    }
+
+
+
+    public static func == (lhs: SpecialModelName, rhs: SpecialModelName) -> Bool {
+        lhs.specialPropertyName == rhs.specialPropertyName
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(specialPropertyName?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/StringBooleanMap.swift
@@ -7,8 +7,10 @@
 
 import Foundation
 
-public struct StringBooleanMap: Codable, Hashable {
+public final class StringBooleanMap: Codable, Hashable {
 
+    public enum CodingKeys: CodingKey, CaseIterable {
+    }
     public var additionalProperties: [String: Bool] = [:]
 
     public subscript(key: String) -> Bool? {
@@ -27,10 +29,9 @@ public struct StringBooleanMap: Codable, Hashable {
     // Encodable protocol methods
 
     public func encode(to encoder: Encoder) throws {
-
-        var container = encoder.container(keyedBy: String.self)
-
-        try container.encodeMap(additionalProperties)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var additionalPropertiesContainer = encoder.container(keyedBy: String.self)
+        try additionalPropertiesContainer.encodeMap(additionalProperties)
     }
 
     // Decodable protocol methods
@@ -40,6 +41,15 @@ public struct StringBooleanMap: Codable, Hashable {
 
         var nonAdditionalPropertyKeys = Set<String>()
         additionalProperties = try container.decodeMap(Bool.self, excludedKeys: nonAdditionalPropertyKeys)
+    }
+
+
+    public static func == (lhs: StringBooleanMap, rhs: StringBooleanMap) -> Bool {
+        lhs.additionalProperties == rhs.additionalProperties
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(additionalProperties.hashValue)
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Tag.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Tag.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Tag: Codable, Hashable {
+public final class Tag: Codable, Hashable {
 
     public var id: Int64?
     public var name: String?
@@ -15,6 +15,32 @@ public struct Tag: Codable, Hashable {
     public init(id: Int64? = nil, name: String? = nil) {
         self.id = id
         self.name = name
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case name
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+    }
+
+
+
+    public static func == (lhs: Tag, rhs: Tag) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.name == rhs.name
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id?.hashValue)
+        hasher.combine(name?.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/TypeHolderDefault.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct TypeHolderDefault: Codable, Hashable {
+public final class TypeHolderDefault: Codable, Hashable {
 
     public var stringItem: String = "what"
     public var numberItem: Double
@@ -22,13 +22,43 @@ public struct TypeHolderDefault: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
         case integerItem = "integer_item"
         case boolItem = "bool_item"
         case arrayItem = "array_item"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
+
+    public static func == (lhs: TypeHolderDefault, rhs: TypeHolderDefault) -> Bool {
+        lhs.stringItem == rhs.stringItem &&
+        lhs.numberItem == rhs.numberItem &&
+        lhs.integerItem == rhs.integerItem &&
+        lhs.boolItem == rhs.boolItem &&
+        lhs.arrayItem == rhs.arrayItem
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(stringItem.hashValue)
+        hasher.combine(numberItem.hashValue)
+        hasher.combine(integerItem.hashValue)
+        hasher.combine(boolItem.hashValue)
+        hasher.combine(arrayItem.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/TypeHolderExample.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct TypeHolderExample: Codable, Hashable {
+public final class TypeHolderExample: Codable, Hashable {
 
     public var stringItem: String
     public var numberItem: Double
@@ -22,13 +22,43 @@ public struct TypeHolderExample: Codable, Hashable {
         self.boolItem = boolItem
         self.arrayItem = arrayItem
     }
-
     public enum CodingKeys: String, CodingKey, CaseIterable {
         case stringItem = "string_item"
         case numberItem = "number_item"
         case integerItem = "integer_item"
         case boolItem = "bool_item"
         case arrayItem = "array_item"
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stringItem, forKey: .stringItem)
+        try container.encode(numberItem, forKey: .numberItem)
+        try container.encode(integerItem, forKey: .integerItem)
+        try container.encode(boolItem, forKey: .boolItem)
+        try container.encode(arrayItem, forKey: .arrayItem)
+    }
+
+
+
+    public static func == (lhs: TypeHolderExample, rhs: TypeHolderExample) -> Bool {
+        lhs.stringItem == rhs.stringItem &&
+        lhs.numberItem == rhs.numberItem &&
+        lhs.integerItem == rhs.integerItem &&
+        lhs.boolItem == rhs.boolItem &&
+        lhs.arrayItem == rhs.arrayItem
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(stringItem.hashValue)
+        hasher.combine(numberItem.hashValue)
+        hasher.combine(integerItem.hashValue)
+        hasher.combine(boolItem.hashValue)
+        hasher.combine(arrayItem.hashValue)
+        
     }
 
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/User.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/User.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct User: Codable, Hashable {
+public final class User: Codable, Hashable {
 
     public var id: Int64?
     public var username: String?
@@ -28,6 +28,56 @@ public struct User: Codable, Hashable {
         self.password = password
         self.phone = phone
         self.userStatus = userStatus
+    }
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case username
+        case firstName
+        case lastName
+        case email
+        case password
+        case phone
+        case userStatus
+    }
+
+    // Encodable protocol methods
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(id, forKey: .id)
+        try container.encodeIfPresent(username, forKey: .username)
+        try container.encodeIfPresent(firstName, forKey: .firstName)
+        try container.encodeIfPresent(lastName, forKey: .lastName)
+        try container.encodeIfPresent(email, forKey: .email)
+        try container.encodeIfPresent(password, forKey: .password)
+        try container.encodeIfPresent(phone, forKey: .phone)
+        try container.encodeIfPresent(userStatus, forKey: .userStatus)
+    }
+
+
+
+    public static func == (lhs: User, rhs: User) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.username == rhs.username &&
+        lhs.firstName == rhs.firstName &&
+        lhs.lastName == rhs.lastName &&
+        lhs.email == rhs.email &&
+        lhs.password == rhs.password &&
+        lhs.phone == rhs.phone &&
+        lhs.userStatus == rhs.userStatus
+        
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id?.hashValue)
+        hasher.combine(username?.hashValue)
+        hasher.combine(firstName?.hashValue)
+        hasher.combine(lastName?.hashValue)
+        hasher.combine(email?.hashValue)
+        hasher.combine(password?.hashValue)
+        hasher.combine(phone?.hashValue)
+        hasher.combine(userStatus?.hashValue)
+        
     }
 
 }


### PR DESCRIPTION
- Add the option to use `final class` instead of `struct`
- Always include `CodingKeys`
- Implement equals and `hash` funcs
- Encode `null` values
- Add `useClasses` to urlsessionLibrary config
- Add a required nullable test case to 2_0/swift/petstore*.yaml

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
