### PR TITLE
Support UUID types in scala-akka-client

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-akka-client/requests.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/requests.mustache
@@ -3,6 +3,7 @@ package {{invokerPackage}}
 
 import java.io.File
 import java.net.URLEncoder
+import java.util.UUID
 import java.time.OffsetDateTime
 
 import scala.util.Try
@@ -181,6 +182,7 @@ object ParametersMap {
       case Some(opt) => formattedParams(name, opt)
       case s: Seq[Any] => formattedParams(name, ArrayValues(s))
       case v: String => Seq((name, urlEncode(v)))
+      case v: UUID => formattedParams(name, v.toString)
       case NumericValue(v) => Seq((name, urlEncode(v)))
       case f: File => Seq((name, f))
       case m: ApiModel => Seq((name, m))

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/serializers.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/serializers.mustache
@@ -9,6 +9,7 @@ import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{LocalDate, DateTime}
 {{/joda}}
 import org.json4s.{Serializer, CustomSerializer, JNull}
+import org.json4s.ext.JavaTypesSerializers
 import org.json4s.JsonAST.JString
 
 import scala.util.Try
@@ -47,6 +48,6 @@ object Serializers {
   }))
 {{/joda}}
 
- def all: Seq[Serializer[_]] = Seq[Serializer[_]]() :+ DateTimeSerializer :+ LocalDateSerializer
+ def all: Seq[Serializer[_]] = JavaTypesSerializers.all :+ DateTimeSerializer :+ LocalDateSerializer
 
 }

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/Serializers.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/Serializers.scala
@@ -3,6 +3,7 @@ package org.openapitools.client.core
 import java.time.{LocalDate, LocalDateTime, OffsetDateTime, ZoneId}
 import java.time.format.DateTimeFormatter
 import org.json4s.{Serializer, CustomSerializer, JNull}
+import org.json4s.ext.JavaTypesSerializers
 import org.json4s.JsonAST.JString
 
 import scala.util.Try
@@ -25,6 +26,6 @@ object Serializers {
       JString(d.format(DateTimeFormatter.ISO_LOCAL_DATE))
   }))
 
- def all: Seq[Serializer[_]] = Seq[Serializer[_]]() :+ DateTimeSerializer :+ LocalDateSerializer
+ def all: Seq[Serializer[_]] = JavaTypesSerializers.all :+ DateTimeSerializer :+ LocalDateSerializer
 
 }

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/requests.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/requests.scala
@@ -13,6 +13,7 @@ package org.openapitools.client.core
 
 import java.io.File
 import java.net.URLEncoder
+import java.util.UUID
 import java.time.OffsetDateTime
 
 import scala.util.Try
@@ -191,6 +192,7 @@ object ParametersMap {
       case Some(opt) => formattedParams(name, opt)
       case s: Seq[Any] => formattedParams(name, ArrayValues(s))
       case v: String => Seq((name, urlEncode(v)))
+      case v: UUID => formattedParams(name, v.toString)
       case NumericValue(v) => Seq((name, urlEncode(v)))
       case f: File => Seq((name, f))
       case m: ApiModel => Seq((name, m))


### PR DESCRIPTION
Add support for the `java.util.UUID` type in parameter serialization and response deserialization.

This additionally adds support for `java.net.URI`, `java.net.URL` for response deserialization.

The UUID types are already generated, when using a schema using uuid formatted strings in the openapi schema.

@cchafer


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
