### PR TITLE
[Swift 5] Fix missing `parentVars` in Swift 5 generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
@@ -283,8 +283,6 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
         // Get the properties for the parent and child models
         final List<CodegenProperty> parentModelCodegenProperties = parentCodegenModel.vars;
         List<CodegenProperty> codegenProperties = codegenModel.vars;
-        codegenModel.allVars = new ArrayList<CodegenProperty>(codegenProperties);
-        codegenModel.parentVars = parentCodegenModel.allVars;
 
         // Iterate over all of the parent model properties
         boolean removedChildProperty = false;
@@ -763,10 +761,17 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
         if (allDefinitions != null) {
             String parentSchema = codegenModel.parentSchema;
 
+            // Set parentVars once, from parent model
+            if (parentSchema != null) {
+                Schema parentModel = allDefinitions.get(parentSchema);
+                CodegenModel parentCodegenModel = super.fromModel(parentSchema, parentModel);
+                codegenModel.parentVars = parentCodegenModel.allVars;
+            }
+
             // multilevel inheritance: reconcile properties of all the parents
             while (parentSchema != null) {
                 final Schema parentModel = allDefinitions.get(parentSchema);
-                final CodegenModel parentCodegenModel = super.fromModel(codegenModel.parent,
+                final CodegenModel parentCodegenModel = super.fromModel(parentSchema,
                         parentModel);
                 codegenModel = Swift5ClientCodegen.reconcileProperties(codegenModel, parentCodegenModel);
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
@@ -778,6 +778,8 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
                 // get the next parent
                 parentSchema = parentCodegenModel.parentSchema;
             }
+
+            codegenModel.emptyVars = codegenModel.vars.isEmpty();
         }
 
         return codegenModel;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request - @4brunu 
