### PR TITLE
[nim] camelize names

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NimClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NimClientCodegen.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 
+import static org.openapitools.codegen.utils.StringUtils.camelize;
+
 public class NimClientCodegen extends DefaultCodegen implements CodegenConfig {
      final Logger LOGGER = LoggerFactory.getLogger(NimClientCodegen.class);
 
@@ -297,12 +299,30 @@ public class NimClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toVarName(String name) {
-        if (isReservedWord(name)) {
-            name = escapeReservedWord(name);
+        // sanitize name
+        name = sanitizeName(name, "\\W-[\\$]"); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
+
+        if ("_".equals(name)) {
+            name = "_u";
         }
 
+        // numbers are not allowed at the beginning
         if (name.matches("^\\d.*")) {
             name = "`" + name + "`";
+        }
+
+        // if it's all uppper case, do nothing
+        if (name.matches("^[A-Z0-9_]*$")) {
+            return name;
+        }
+
+        // camelize (lower first character) the variable name
+        // pet_id => petId
+        name = camelize(name, true);
+
+        // for reserved word or word starting with number, append _
+        if (isReservedWord(name)) {
+            name = escapeReservedWord(name);
         }
 
         return name;

--- a/samples/client/petstore/nim/petstore/apis/api_pet.nim
+++ b/samples/client/petstore/nim/petstore/apis/api_pet.nim
@@ -45,9 +45,9 @@ proc addPet*(httpClient: HttpClient, body: Pet): Response =
   httpClient.post(basepath & "/pet", $(%body))
 
 
-proc deletePet*(httpClient: HttpClient, petId: int64, api_key: string): Response =
+proc deletePet*(httpClient: HttpClient, petId: int64, apiKey: string): Response =
   ## Deletes a pet
-  httpClient.headers["api_key"] = api_key
+  httpClient.headers["api_key"] = apiKey
   httpClient.delete(basepath & fmt"/pet/{petId}")
 
 


### PR DESCRIPTION
camelize names (e.g. api_key => apiKey)

To fix https://github.com/OpenAPITools/openapi-generator/issues/9250

Ref: https://nim-lang.org/docs/nep1.html

cc @hokamoto

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
