### PR TITLE
[typescript] Fix uncompilable output when using allOf (#8000)

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/SharedTypeScriptTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/SharedTypeScriptTest.java
@@ -12,6 +12,8 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 public class SharedTypeScriptTest {
     @Test
@@ -68,5 +70,26 @@ public class SharedTypeScriptTest {
         Assert.assertTrue(apiFileContent.contains("import { Tag }"));
 
         FileUtils.deleteDirectory(new File("src/test/resources/oldImportsStillPresentTest/"));
+    }
+
+    /*
+        #8000
+        Test that primatives are not returned by toModelImportMap
+    */
+    @Test
+    public void toModelImportMapTest() {
+        TypeScriptAxiosClientCodegen codegen = new TypeScriptAxiosClientCodegen();
+
+        Map<String, String[]> types = new HashMap<String, String[]>() {{
+            put("Schema & AnotherSchema", new String[]{ "Schema", "AnotherSchema" });
+            put("Schema | AnotherSchema", new String[]{ "Schema", "AnotherSchema" });
+            put("Schema & object", new String[]{ "Schema" });
+            put("Schema | object", new String[]{ "Schema" });
+        }};
+
+        for (Map.Entry<String, String[]> entry : types.entrySet()) {
+            String[] mapped = codegen.toModelImportMap(entry.getKey()).values().toArray(new String[0]);
+            Assert.assertEquals(mapped, entry.getValue());
+        }
     }
 }


### PR DESCRIPTION
Fixes #8000 

# Summary
When using `allOf`, or `oneOf` with an inline schema, a Union/Intersection type is generated with the primitive `object`. This results in an invalid import because the composed type of the schema is ignored.

```js
import { BaseObject &amp; object }
```

# Approach
To fix this I used  `needToImport` to removes the language primitives from being imported. This same check already happens in `addImport`, but not in `toModelImportMap`.

`toModelImportMap` splits union types but not intersection types, so I've combined those cases into `splitComposedType`. For `splitComposedType` I combined `replace(" ","").split("\\|")` and `split("( [|&] )|[<>]")` into `replace(" ","").split("[|&<>]")`. These should be equivilant regex, and I think stripping the whitespace is good here.

I added the warning in `toModelImport` strictly because there was already a warning for the union type and wanted to be consistent.

# Minimal Reproducible Example

```
-g typescript-axios --additional-properties=withSeparateModelsAndApi=true,apiPackage=api,modelPackage=models
```
```yaml
openapi: 3.0.3

info:
  title: Issue 8000
  version: 1.0.0
  description: Issue 8000 Minimal Reproducible Example

paths:
  /resource:
    get:
      operationId: get_resource
      responses:
        200:
          description: resource
          content:
            application/json:
              schema:
                type: object
                allOf:
                  - $ref: '#/components/schemas/BaseObject'
                  - type: object
                    properties:
                      field:
                        type: string

components:
  schemas:
    BaseObject:
      type: object
      properties:
        id:
          type: integer
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
  - No changes
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)
