### PR TITLE
[typescript-angular] Allow generating discriminator based type visitor

### DIFF
--- a/docs/generators/typescript-angular.md
+++ b/docs/generators/typescript-angular.md
@@ -34,6 +34,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |stringEnums|Generate string enums instead of objects for enum values.| |false|
+|subtypeVisitor|Use discriminators to create a subtype visitor (doesn't work with tagged unions).| |false|
 |supportsES6|Generate code that conforms to ES6.| |false|
 |taggedUnions|Use discriminators to create tagged unions instead of extending interfaces.| |false|
 |useSingleRequestParameter|Setting this property to true will generate functions with a single argument containing all API endpoint parameters instead of one argument per parameter.| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -49,6 +49,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     public static final String WITH_INTERFACES = "withInterfaces";
     public static final String USE_SINGLE_REQUEST_PARAMETER = "useSingleRequestParameter";
     public static final String TAGGED_UNIONS = "taggedUnions";
+    public static final String SUBTYPE_VISITOR = "subtypeVisitor";
     public static final String NG_VERSION = "ngVersion";
     public static final String PROVIDED_IN_ROOT = "providedInRoot";
     public static final String PROVIDED_IN = "providedIn";
@@ -77,6 +78,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     protected PROVIDED_IN_LEVEL providedIn = PROVIDED_IN_LEVEL.root;
 
     private boolean taggedUnions = false;
+    private boolean subtypeVisitor = false;
 
     public TypeScriptAngularClientCodegen() {
         super();
@@ -106,6 +108,9 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         this.cliOptions.add(CliOption.newBoolean(TAGGED_UNIONS,
                 "Use discriminators to create tagged unions instead of extending interfaces.",
                 this.taggedUnions));
+        this.cliOptions.add(CliOption.newBoolean(SUBTYPE_VISITOR,
+                "Use discriminators to create a subtype visitor (doesn't work with tagged unions).",
+                this.subtypeVisitor));
         this.cliOptions.add(CliOption.newBoolean(PROVIDED_IN_ROOT,
                 "Use this property to provide Injectables in root (it is only valid in angular version greater or equal to 6.0.0). IMPORTANT: Deprecated for angular version greater or equal to 9.0.0, use **providedIn** instead.",
                 false));
@@ -198,6 +203,10 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
         if (additionalProperties.containsKey(TAGGED_UNIONS)) {
             taggedUnions = Boolean.parseBoolean(additionalProperties.get(TAGGED_UNIONS).toString());
+        }
+
+        if (additionalProperties.containsKey(SUBTYPE_VISITOR)) {
+            subtypeVisitor = Boolean.parseBoolean(additionalProperties.get(SUBTYPE_VISITOR).toString());
         }
 
         if (ngVersion.atLeast("9.0.0") && additionalProperties.containsKey(PROVIDED_IN)) {
@@ -514,11 +523,17 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
                 CodegenModel cm = (CodegenModel) mo.get("model");
                 if (taggedUnions) {
                     mo.put(TAGGED_UNIONS, true);
+                } else if (subtypeVisitor) {
+                    mo.put(SUBTYPE_VISITOR, true);
+                }
+                if (taggedUnions || subtypeVisitor) {
                     if (cm.discriminator != null && cm.children != null) {
                         for (CodegenModel child : cm.children) {
                             cm.imports.add(child.classname);
                         }
                     }
+                }
+                if (taggedUnions) {
                     if (cm.parent != null) {
                         cm.imports.remove(cm.parent);
                     }

--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelGeneric.mustache
@@ -7,4 +7,4 @@ export interface {{classname}}{{#allParents}}{{#-first}} extends {{/-first}}{{{.
     {{/description}}
     {{#isReadOnly}}readonly {{/isReadOnly}}{{{name}}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}} | null{{/isNullable}};
 {{/vars}}
-}{{>modelGenericEnums}}
+}{{>modelGenericEnums}}{{>modelGenericVisitor}}

--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelGenericVisitor.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelGenericVisitor.mustache
@@ -1,0 +1,22 @@
+{{#subtypeVisitor}}
+    {{#discriminator}}
+
+
+export interface {{classname}}Visitor<R> {
+        {{#discriminator.mappedModels}}
+    visit{{modelName}}(value: {{modelName}}): R;
+        {{/discriminator.mappedModels}}
+}
+
+export function visit{{classname}}<R>(value: {{classname}}, visitor: {{classname}}Visitor<R>): R {
+    switch (value.{{discriminator.propertyName}}) {
+        {{#discriminator.mappedModels}}
+        case '{{mappingName}}':
+            return visitor.visit{{modelName}}(<{{modelName}}>value);
+        {{/discriminator.mappedModels}}
+        default:
+            throw new Error("Unknown model discriminator '" + value.{{discriminator.propertyName}} + "'");
+    }
+}
+    {{/discriminator}}
+{{/subtypeVisitor}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAngularClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAngularClientOptionsProvider.java
@@ -75,6 +75,7 @@ public class TypeScriptAngularClientOptionsProvider implements OptionsProvider {
                 .put(TypeScriptAngularClientCodegen.PROVIDED_IN_ROOT, Boolean.FALSE.toString())
                 .put(TypeScriptAngularClientCodegen.PROVIDED_IN, PROVIDED_IN_LEVEL)
                 .put(TypeScriptAngularClientCodegen.TAGGED_UNIONS, Boolean.FALSE.toString())
+                .put(TypeScriptAngularClientCodegen.SUBTYPE_VISITOR, Boolean.FALSE.toString())
                 .put(TypeScriptAngularClientCodegen.NPM_REPOSITORY, NPM_REPOSITORY)
                 .put(TypeScriptAngularClientCodegen.NG_VERSION, NG_VERSION)
                 .put(TypeScriptAngularClientCodegen.API_MODULE_PREFIX, API_MODULE_PREFIX)


### PR DESCRIPTION
When types which extend a common type and are distinguished based on a
discriminator are consumed they are often cast to their specific type
which results in error prone boilerplate code.

By generating a visitor for those kind of types the various subtypes can
be consumed in a type safe manner.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)
