### PR TITLE
[Enhancement] added support for custom type & format mapping

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2043,10 +2043,10 @@ public class DefaultCodegen implements CodegenConfig {
     private String getPrimitiveType(Schema schema) {
         if (schema == null) {
             throw new RuntimeException("schema cannot be null in getPrimitiveType");
-        } else if (typeMapping.containsKey(schema.getType() + "_" + schema.getFormat())) {
+        } else if (typeMapping.containsKey(schema.getType() + "+" + schema.getFormat())) {
             // allows custom type_format mapping.
-            // use {type}_{format}
-            return typeMapping.get(schema.getType() + "_" + schema.getFormat());
+            // use {type}+{format}
+            return typeMapping.get(schema.getType() + "+" + schema.getFormat());
         } else if (ModelUtils.isNullType(schema)) {
             // The 'null' type is allowed in OAS 3.1 and above. It is not supported by OAS 3.0.x,
             // though this tooling supports it.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2043,6 +2043,10 @@ public class DefaultCodegen implements CodegenConfig {
     private String getPrimitiveType(Schema schema) {
         if (schema == null) {
             throw new RuntimeException("schema cannot be null in getPrimitiveType");
+        } else if (typeMapping.containsKey(schema.getType() + "_" + schema.getFormat())) {
+            // allows custom type_format mapping.
+            // use {type}_{format}
+            return typeMapping.get(schema.getType() + "_" + schema.getFormat());
         } else if (ModelUtils.isNullType(schema)) {
             // The 'null' type is allowed in OAS 3.1 and above. It is not supported by OAS 3.0.x,
             // though this tooling supports it.

--- a/modules/openapi-generator/src/test/resources/3_0/type_mapping_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/type_mapping_test.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Sample API to test type mapping
+  description: API description in Markdown.
+  version: 1.0.0
+paths:
+  /animals:
+    get:
+      summary: Returns all animals.
+      description: Optional extended description in Markdown.
+      parameters:
+        - in: query
+          name: parameter_type_mapping
+          schema:
+            type: string 
+            format: special
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Animal'
+components:
+  schemas:
+    Animal:
+      type: object
+      required:
+        - className
+      properties:
+        className:
+          type: string
+        color:
+          type: string
+          default: red
+        mapping_test:
+          type: string
+          format: special


### PR DESCRIPTION
Based on  #4931 (credits: @ShoeBoom) but use `+` as the separator

=========================

Makes it possible to map format.

For example these args can be used to properly map the following:
```
"foo": {
    "enum": [
        "0",
        "1",
        "2"
    ],
    "type": "integer",
    "format": "byte"
}
```

`generate -i openapi.json -o out -g kotlin --type-mappings integer_byte=kotlin.Byte`

By default it would map `foo` to `Int`

this is similar to #2730


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @OpenAPITools/generator-core-team 