### PR TITLE
UE4 - Support FGuid with in/out Helpers

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
@@ -105,6 +105,11 @@ inline FStringFormatArg ToStringFormatArg(const FDateTime& Value)
 	return FStringFormatArg(Value.ToIso8601());
 }
 
+inline FStringFormatArg ToStringFormatArg(const FGuid& Value)
+{
+	return FStringFormatArg(Value.ToString(EGuidFormats::DigitsWithHyphens));
+}
+
 inline FStringFormatArg ToStringFormatArg(const TArray<uint8>& Value)
 {
 	return FStringFormatArg(Base64UrlEncode(Value));
@@ -220,6 +225,11 @@ inline void WriteJsonValue(JsonWriter& Writer, const FDateTime& Value)
 	Writer->WriteValue(Value.ToIso8601());
 }
 
+inline void WriteJsonValue(JsonWriter& Writer, const FGuid& Value)
+{
+	Writer->WriteValue(Value.ToString(EGuidFormats::DigitsWithHyphens));
+}
+
 inline void WriteJsonValue(JsonWriter& Writer, const Model& Value)
 {
 	Value.WriteJson(Writer);
@@ -276,6 +286,17 @@ inline bool TryGetJsonValue(const TSharedPtr<FJsonValue>& JsonValue, FDateTime& 
 	if (JsonValue->TryGetString(TmpValue))
 	{
 		return ParseDateTime(TmpValue, Value);
+	}
+	else
+		return false;
+}
+
+inline bool TryGetJsonValue(const TSharedPtr<FJsonValue>& JsonValue, FGuid& Value)
+{
+	FString TmpValue;
+	if (JsonValue->TryGetString(TmpValue))
+	{
+		return FGuid::Parse(TmpValue, Value);
 	}
 	else
 		return false;


### PR DESCRIPTION
If the API we're generating for uses UUID, which is appropriately mapped to FGuid for UE4, we get compiler errors because the default templated c++ methods get called with FGuid, which doesn't support those standard operations.

Here I've added FGuid specializations akin to how FDateTime is handled, which resolves the compiler errors and adds FGuid support.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@Kahncode