### PR TITLE
[Java][Spring] Fix for #8659 Different in-parameter types generated for api and delegate for binary (application/octet-stream)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -336,8 +336,8 @@ public class SpringCodegen extends AbstractJavaCodegen
         }
         additionalProperties.put(UNHANDLED_EXCEPTION_HANDLING, this.isUnhandledException());
 
-        typeMapping.put("file", "org.springframework.core.io.Resource");
-        importMapping.put("org.springframework.core.io.Resource", "org.springframework.core.io.Resource");
+        typeMapping.put("file", "org.springframework.web.multipart.MultipartFile");
+        importMapping.put("org.springframework.web.multipart.MultipartFile", "org.springframework.web.multipart.MultipartFile");
 
         if (useOptional) {
             writePropertyBack(USE_OPTIONAL, useOptional);

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api.mustache
@@ -71,7 +71,7 @@ public class {{classname}} {
     {{#isDeprecated}}
     @Deprecated
     {{/isDeprecated}}
-    public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.core.io.Resource>{{/collectionFormat}}{{^collectionFormat}}org.springframework.core.io.Resource{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{dataType}}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws RestClientException {
+    public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.web.multipart.MultipartFile>{{/collectionFormat}}{{^collectionFormat}}org.springframework.web.multipart.MultipartFile{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{dataType}}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws RestClientException {
         {{#returnType}}
         return {{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}).getBody();
         {{/returnType}}
@@ -99,7 +99,7 @@ public class {{classname}} {
     {{#isDeprecated}}
     @Deprecated
     {{/isDeprecated}}
-    public ResponseEntity<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.core.io.Resource>{{/collectionFormat}}{{^collectionFormat}}org.springframework.core.io.Resource{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{dataType}}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws RestClientException {
+    public ResponseEntity<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.web.multipart.MultipartFile>{{/collectionFormat}}{{^collectionFormat}}org.springframework.web.multipart.MultipartFile{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{dataType}}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws RestClientException {
         Object postBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
         {{#allParams}}{{#required}}
         // verify the required parameter '{{paramName}}' is set

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api_test.mustache
@@ -34,7 +34,7 @@ public class {{classname}}Test {
     @Test
     public void {{operationId}}Test() {
         {{#allParams}}
-        {{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.core.io.Resource>{{/collectionFormat}}{{^collectionFormat}}org.springframework.core.io.Resource{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{dataType}}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} {{paramName}} = null;
+        {{#isFile}}{{#useAbstractionForFiles}}{{#collectionFormat}}java.util.Collection<org.springframework.web.multipart.MultipartFile>{{/collectionFormat}}{{^collectionFormat}}org.springframework.web.multipart.MultipartFile{{/collectionFormat}}{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{dataType}}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} {{paramName}} = null;
         {{/allParams}}
         {{#returnType}}{{{returnType}}} response = {{/returnType}}api.{{operationId}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
 

--- a/modules/openapi-generator/src/main/resources/JavaSpring/homeController.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/homeController.mustache
@@ -4,7 +4,7 @@ package {{configPackage}};
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
 {{/useSpringfox}}
 import org.springframework.stereotype.Controller;
 {{^useSpringfox}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -1028,18 +1028,18 @@ public class JavaClientCodegenTest {
         Path defaultApi = Paths.get(output + "/src/main/java/xyz/abcdef/api/MultipartApi.java");
         TestUtils.assertFileContains(defaultApi,
                 //multiple files
-                "multipartArray(java.util.Collection<org.springframework.core.io.Resource> files)",
-                "multipartArrayWithHttpInfo(java.util.Collection<org.springframework.core.io.Resource> files)",
+                "multipartArray(java.util.Collection<org.springframework.web.multipart.MultipartFile> files)",
+                "multipartArrayWithHttpInfo(java.util.Collection<org.springframework.web.multipart.MultipartFile> files)",
                 "formParams.addAll(\"files\", files.stream().collect(Collectors.toList()));",
 
                 //mixed
-                "multipartMixed(org.springframework.core.io.Resource file, MultipartMixedMarker marker)",
-                "multipartMixedWithHttpInfo(org.springframework.core.io.Resource file, MultipartMixedMarker marker)",
+                "multipartMixed(org.springframework.web.multipart.MultipartFile file, MultipartMixedMarker marker)",
+                "multipartMixedWithHttpInfo(org.springframework.web.multipart.MultipartFile file, MultipartMixedMarker marker)",
                 "formParams.add(\"file\", file);",
 
                 //single file
-                "multipartSingle(org.springframework.core.io.Resource file)",
-                "multipartSingleWithHttpInfo(org.springframework.core.io.Resource file)",
+                "multipartSingle(org.springframework.web.multipart.MultipartFile file)",
+                "multipartSingleWithHttpInfo(org.springframework.web.multipart.MultipartFile file)",
                 "formParams.add(\"file\", file);"
         );
     }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/spring-mvc-no-nullable/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc-no-nullable/src/main/java/org/openapitools/model/FormatTest.java
@@ -43,7 +43,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -235,7 +235,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -248,11 +248,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/spring-mvc-spring-pageable/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc-spring-pageable/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/FormatTest.java
@@ -46,7 +46,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -238,7 +238,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -251,11 +251,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/FormatTest.java
@@ -43,7 +43,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -235,7 +235,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -248,11 +248,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/configuration/HomeController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/configuration/HomeController.java
@@ -3,7 +3,7 @@ package org.openapitools.configuration;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FormatTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,7 @@ public class FormatTest   {
   private byte[] _byte;
 
   @JsonProperty("binary")
-  private org.springframework.core.io.Resource binary;
+  private org.springframework.web.multipart.MultipartFile binary;
 
   @JsonProperty("date")
   @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE)
@@ -236,7 +236,7 @@ public class FormatTest   {
     this._byte = _byte;
   }
 
-  public FormatTest binary(org.springframework.core.io.Resource binary) {
+  public FormatTest binary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
     return this;
   }
@@ -249,11 +249,11 @@ public class FormatTest   {
 
   @Valid
 
-  public org.springframework.core.io.Resource getBinary() {
+  public org.springframework.web.multipart.MultipartFile getBinary() {
     return binary;
   }
 
-  public void setBinary(org.springframework.core.io.Resource binary) {
+  public void setBinary(org.springframework.web.multipart.MultipartFile binary) {
     this.binary = binary;
   }
 


### PR DESCRIPTION
Related to #8659 

Actual api endpoint is using `org.springframework.core.io.Resource` but delegatee is using `org.springframework.web.multipart.MultipartFile`
Now both are using the second one, which is recommended by Spring (according to my latest knowledge)
Tests are passing and also generation of the following endpoint works (it does not work on plain 5.1.0)
```
post:
  operationId: setClientFile
  tags:
    - clients
  parameters:
    - $ref: '#/components/parameters/clientId'
  requestBody:
    required: true
    content:
      application/octet-stream:
        schema:
          type: string
          format: binary
  responses:
    204:
      description: No records found
    415:
      description: Invalid image type
    200:
      description: Upload successful
```

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @nmuesch


- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
