### PR TITLE
Unicode arrows in Scala are deprecated (since Scala 2.13.0)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
@@ -37,6 +37,8 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
@@ -179,8 +181,17 @@ public class ScalaSttpClientCodegen extends AbstractScalaCodegen implements Code
 
     @Override
     public String encodePath(String input) {
-        String result = super.encodePath(input);
-        return result.replace("{", "${");
+        String path = super.encodePath(input);
+
+        // The parameter names in the URI must be converted to the same case as
+        // the method parameter.
+        StringBuffer buf = new StringBuffer(path.length());
+        Matcher matcher = Pattern.compile("[{](.*?)[}]").matcher(path);
+        while (matcher.find()) {
+            matcher.appendReplacement(buf, "\\${" + toParamName(matcher.group(0)) + "}");
+        }
+        matcher.appendTail(buf);
+        return buf.toString();
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/apiInvoker.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/apiInvoker.mustache
@@ -86,7 +86,7 @@ class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomC
 
   private val http = Http()
 
-  val CompressionFilter: HttpMessage ⇒ Boolean = (msg: HttpMessage) =>
+  val CompressionFilter: HttpMessage => Boolean = (msg: HttpMessage) =>
     Seq(
       { _: HttpMessage => settings.compressionEnabled },
       Encoder.DefaultFilter,
@@ -214,11 +214,11 @@ class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomC
       .singleRequest(request)
       .map { response =>
         val decoder: Coder with StreamDecoder = response.encoding match {
-          case HttpEncodings.gzip ⇒
+          case HttpEncodings.gzip =>
             Gzip
-          case HttpEncodings.deflate ⇒
+          case HttpEncodings.deflate =>
             Deflate
-          case HttpEncodings.identity ⇒
+          case HttpEncodings.identity =>
             NoCoding
           case HttpEncoding(encoding) =>
             throw new IllegalArgumentException(s"Unsupported encoding: $encoding")
@@ -253,7 +253,7 @@ class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomC
         Unmarshal(response.entity)
           .to[T]
           .recoverWith {
-            case e ⇒ throw ApiError(response.status.intValue, s"Unable to unmarshall content to [$manifest]", Some(response.entity.toString), e)
+            case e => throw ApiError(response.status.intValue, s"Unable to unmarshall content to [$manifest]", Some(response.entity.toString), e)
           }
           .map(value => responseForState(state, value))
       case None | Some(_) =>

--- a/modules/openapi-generator/src/main/resources/scala-sttp/project/build.properties.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/project/build.properties.mustache
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.5.0

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/SttpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/SttpCodegenTest.java
@@ -1,0 +1,20 @@
+package org.openapitools.codegen.scala;
+
+import org.openapitools.codegen.languages.ScalaSttpClientCodegen;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SttpCodegenTest {
+
+    private final ScalaSttpClientCodegen codegen = new ScalaSttpClientCodegen();
+
+    @Test
+    public void encodePath() {
+        Assert.assertEquals(codegen.encodePath("{user_name}"), "${userName}");
+        Assert.assertEquals(codegen.encodePath("{userName}"), "${userName}");
+        Assert.assertEquals(codegen.encodePath("{UserName}"), "${userName}");
+        Assert.assertEquals(codegen.encodePath("user_name"), "user_name");
+        Assert.assertEquals(codegen.encodePath("before/{UserName}/after"), "before/${userName}/after");
+    }
+
+}

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/ApiInvoker.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/core/ApiInvoker.scala
@@ -96,7 +96,7 @@ class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomC
 
   private val http = Http()
 
-  val CompressionFilter: HttpMessage ⇒ Boolean = (msg: HttpMessage) =>
+  val CompressionFilter: HttpMessage => Boolean = (msg: HttpMessage) =>
     Seq(
       { _: HttpMessage => settings.compressionEnabled },
       Encoder.DefaultFilter,
@@ -224,11 +224,11 @@ class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomC
       .singleRequest(request)
       .map { response =>
         val decoder: Coder with StreamDecoder = response.encoding match {
-          case HttpEncodings.gzip ⇒
+          case HttpEncodings.gzip =>
             Gzip
-          case HttpEncodings.deflate ⇒
+          case HttpEncodings.deflate =>
             Deflate
-          case HttpEncodings.identity ⇒
+          case HttpEncodings.identity =>
             NoCoding
           case HttpEncoding(encoding) =>
             throw new IllegalArgumentException(s"Unsupported encoding: $encoding")
@@ -263,7 +263,7 @@ class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomC
         Unmarshal(response.entity)
           .to[T]
           .recoverWith {
-            case e ⇒ throw ApiError(response.status.intValue, s"Unable to unmarshall content to [$manifest]", Some(response.entity.toString), e)
+            case e => throw ApiError(response.status.intValue, s"Unable to unmarshall content to [$manifest]", Some(response.entity.toString), e)
           }
           .map(value => responseForState(state, value))
       case None | Some(_) =>


### PR DESCRIPTION
Unicode arrows in Scala are deprecated (since Scala 2.13.0) so switch them to regular ASCII =>

@clasnake

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
