### PR TITLE
[DOCS] Updated pom.xml snippet with latest version

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -15,7 +15,9 @@ Add to your `build->plugins` section (default phase is `generate-sources` phase)
 <plugin>
     <groupId>org.openapitools</groupId>
     <artifactId>openapi-generator-maven-plugin</artifactId>
-    <version>5.0.0</version>
+    <!-- RELEASE_VERSION -->
+    <version>5.1.0</version>
+    <!-- /RELEASE_VERSION -->
     <executions>
         <execution>
             <goals>


### PR DESCRIPTION
The snippet for openapi-generator-maven-plugin ist updated with the latest version (5.1.0) und now similar to https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md. 

Since it's a very simple doc-only change, I didn't run tests etc. 🙈