### PR TITLE
 [scala-sttp] Compilation failure URI parameter not camelCase, fixes #9345

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
@@ -37,6 +37,8 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
@@ -179,8 +181,17 @@ public class ScalaSttpClientCodegen extends AbstractScalaCodegen implements Code
 
     @Override
     public String encodePath(String input) {
-        String result = super.encodePath(input);
-        return result.replace("{", "${");
+        String path = super.encodePath(input);
+
+        // The parameter names in the URI must be converted to the same case as
+        // the method parameter.
+        StringBuffer buf = new StringBuffer(path.length());
+        Matcher matcher = Pattern.compile("[{](.*?)[}]").matcher(path);
+        while (matcher.find()) {
+            matcher.appendReplacement(buf, "\\${" + toParamName(matcher.group(0)) + "}");
+        }
+        matcher.appendTail(buf);
+        return buf.toString();
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/SttpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/SttpCodegenTest.java
@@ -1,0 +1,20 @@
+package org.openapitools.codegen.scala;
+
+import org.openapitools.codegen.languages.ScalaSttpClientCodegen;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SttpCodegenTest {
+
+    private final ScalaSttpClientCodegen codegen = new ScalaSttpClientCodegen();
+
+    @Test
+    public void encodePath() {
+        Assert.assertEquals(codegen.encodePath("{user_name}"), "${userName}");
+        Assert.assertEquals(codegen.encodePath("{userName}"), "${userName}");
+        Assert.assertEquals(codegen.encodePath("{UserName}"), "${userName}");
+        Assert.assertEquals(codegen.encodePath("user_name"), "user_name");
+        Assert.assertEquals(codegen.encodePath("before/{UserName}/after"), "before/${userName}/after");
+    }
+
+}


### PR DESCRIPTION
scala-sttp generators would not compile when URI parameter names were not camelCase.  Fixed by substituting the names in the URI with values from encodePath.

Test case added.

Fixes #9345

<!-- Please check the completed items below -->
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @clasnake (2017/07), @jimschubert (2017/09) heart, @shijinkui (2018/01), @ramzimaalej (2018/03), @chameleon82 (2020/03), @Bouillie (2020/04)