### PR TITLE
Update Dart generator dependencies

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
@@ -84,7 +84,7 @@ class ApiClient {
       ? '?${urlEncodedQueryParams.join('&')}'
       : '';
 
-    final url = '$basePath$path$queryString';
+    final url = Uri.parse('$basePath$path$queryString');
 
     if (nullableContentType != null) {
       headerParams['Content-Type'] = nullableContentType;
@@ -96,7 +96,7 @@ class ApiClient {
         body is MultipartFile && (nullableContentType == null ||
         !nullableContentType.toLowerCase().startsWith('multipart/form-data'))
       ) {
-        final request = StreamedRequest(method, Uri.parse(url));
+        final request = StreamedRequest(method, url);
         request.headers.addAll(headerParams);
         request.contentLength = body.length;
         body.finalize().listen(
@@ -110,7 +110,7 @@ class ApiClient {
       }
 
       if (body is MultipartRequest) {
-        final request = MultipartRequest(method, Uri.parse(url));
+        final request = MultipartRequest(method, url);
         request.fields.addAll(body.fields);
         request.files.addAll(body.files);
         request.headers.addAll(body.headers);

--- a/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
@@ -11,13 +11,13 @@ homepage: '{{{pubHomepage}}}'
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dependencies:
-  http: '>=0.12.0 <0.13.0'
-  intl: '^0.16.1'
+  http: '^0.13.0'
+  intl: '^0.17.0'
   meta: '^1.1.8'
 {{#json_serializable}}
   json_annotation: '^3.1.1'{{/json_serializable}}
 dev_dependencies:
-  test: '>=1.3.0 <1.16.0'
+  test: '>=1.3.0 <=1.16.0'
 {{#json_serializable}}
   build_runner: '^1.0.0'
   json_serializable: '^3.5.1'{{/json_serializable}}

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/README.md
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/README.md
@@ -64,94 +64,94 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*AnotherFakeApi* | [**call123testSpecialTags**](doc/AnotherFakeApi.md#call123testspecialtags) | **patch** /another-fake/dummy | To test special tags
-*DefaultApi* | [**fooGet**](doc/DefaultApi.md#fooget) | **get** /foo | 
-*FakeApi* | [**fakeHealthGet**](doc/FakeApi.md#fakehealthget) | **get** /fake/health | Health check endpoint
-*FakeApi* | [**fakeHttpSignatureTest**](doc/FakeApi.md#fakehttpsignaturetest) | **get** /fake/http-signature-test | test http signature authentication
-*FakeApi* | [**fakeOuterBooleanSerialize**](doc/FakeApi.md#fakeouterbooleanserialize) | **post** /fake/outer/boolean | 
-*FakeApi* | [**fakeOuterCompositeSerialize**](doc/FakeApi.md#fakeoutercompositeserialize) | **post** /fake/outer/composite | 
-*FakeApi* | [**fakeOuterNumberSerialize**](doc/FakeApi.md#fakeouternumberserialize) | **post** /fake/outer/number | 
-*FakeApi* | [**fakeOuterStringSerialize**](doc/FakeApi.md#fakeouterstringserialize) | **post** /fake/outer/string | 
-*FakeApi* | [**fakePropertyEnumIntegerSerialize**](doc/FakeApi.md#fakepropertyenumintegerserialize) | **post** /fake/property/enum-int | 
-*FakeApi* | [**testBodyWithFileSchema**](doc/FakeApi.md#testbodywithfileschema) | **put** /fake/body-with-file-schema | 
-*FakeApi* | [**testBodyWithQueryParams**](doc/FakeApi.md#testbodywithqueryparams) | **put** /fake/body-with-query-params | 
-*FakeApi* | [**testClientModel**](doc/FakeApi.md#testclientmodel) | **patch** /fake | To test \&quot;client\&quot; model
-*FakeApi* | [**testEndpointParameters**](doc/FakeApi.md#testendpointparameters) | **post** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-*FakeApi* | [**testEnumParameters**](doc/FakeApi.md#testenumparameters) | **get** /fake | To test enum parameters
-*FakeApi* | [**testGroupParameters**](doc/FakeApi.md#testgroupparameters) | **delete** /fake | Fake endpoint to test group parameters (optional)
-*FakeApi* | [**testInlineAdditionalProperties**](doc/FakeApi.md#testinlineadditionalproperties) | **post** /fake/inline-additionalProperties | test inline additionalProperties
-*FakeApi* | [**testJsonFormData**](doc/FakeApi.md#testjsonformdata) | **get** /fake/jsonFormData | test json serialization of form data
-*FakeApi* | [**testQueryParameterCollectionFormat**](doc/FakeApi.md#testqueryparametercollectionformat) | **put** /fake/test-query-paramters | 
-*FakeClassnameTags123Api* | [**testClassname**](doc/FakeClassnameTags123Api.md#testclassname) | **patch** /fake_classname_test | To test class name in snake case
-*PetApi* | [**addPet**](doc/PetApi.md#addpet) | **post** /pet | Add a new pet to the store
-*PetApi* | [**deletePet**](doc/PetApi.md#deletepet) | **delete** /pet/{petId} | Deletes a pet
-*PetApi* | [**findPetsByStatus**](doc/PetApi.md#findpetsbystatus) | **get** /pet/findByStatus | Finds Pets by status
-*PetApi* | [**findPetsByTags**](doc/PetApi.md#findpetsbytags) | **get** /pet/findByTags | Finds Pets by tags
-*PetApi* | [**getPetById**](doc/PetApi.md#getpetbyid) | **get** /pet/{petId} | Find pet by ID
-*PetApi* | [**updatePet**](doc/PetApi.md#updatepet) | **put** /pet | Update an existing pet
-*PetApi* | [**updatePetWithForm**](doc/PetApi.md#updatepetwithform) | **post** /pet/{petId} | Updates a pet in the store with form data
-*PetApi* | [**uploadFile**](doc/PetApi.md#uploadfile) | **post** /pet/{petId}/uploadImage | uploads an image
-*PetApi* | [**uploadFileWithRequiredFile**](doc/PetApi.md#uploadfilewithrequiredfile) | **post** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
-*StoreApi* | [**deleteOrder**](doc/StoreApi.md#deleteorder) | **delete** /store/order/{order_id} | Delete purchase order by ID
-*StoreApi* | [**getInventory**](doc/StoreApi.md#getinventory) | **get** /store/inventory | Returns pet inventories by status
-*StoreApi* | [**getOrderById**](doc/StoreApi.md#getorderbyid) | **get** /store/order/{order_id} | Find purchase order by ID
-*StoreApi* | [**placeOrder**](doc/StoreApi.md#placeorder) | **post** /store/order | Place an order for a pet
-*UserApi* | [**createUser**](doc/UserApi.md#createuser) | **post** /user | Create user
-*UserApi* | [**createUsersWithArrayInput**](doc/UserApi.md#createuserswitharrayinput) | **post** /user/createWithArray | Creates list of users with given input array
-*UserApi* | [**createUsersWithListInput**](doc/UserApi.md#createuserswithlistinput) | **post** /user/createWithList | Creates list of users with given input array
-*UserApi* | [**deleteUser**](doc/UserApi.md#deleteuser) | **delete** /user/{username} | Delete user
-*UserApi* | [**getUserByName**](doc/UserApi.md#getuserbyname) | **get** /user/{username} | Get user by user name
-*UserApi* | [**loginUser**](doc/UserApi.md#loginuser) | **get** /user/login | Logs user into the system
-*UserApi* | [**logoutUser**](doc/UserApi.md#logoutuser) | **get** /user/logout | Logs out current logged in user session
-*UserApi* | [**updateUser**](doc/UserApi.md#updateuser) | **put** /user/{username} | Updated user
+*AnotherFakeApi* | [**call123testSpecialTags**](doc\AnotherFakeApi.md#call123testspecialtags) | **patch** /another-fake/dummy | To test special tags
+*DefaultApi* | [**fooGet**](doc\DefaultApi.md#fooget) | **get** /foo | 
+*FakeApi* | [**fakeHealthGet**](doc\FakeApi.md#fakehealthget) | **get** /fake/health | Health check endpoint
+*FakeApi* | [**fakeHttpSignatureTest**](doc\FakeApi.md#fakehttpsignaturetest) | **get** /fake/http-signature-test | test http signature authentication
+*FakeApi* | [**fakeOuterBooleanSerialize**](doc\FakeApi.md#fakeouterbooleanserialize) | **post** /fake/outer/boolean | 
+*FakeApi* | [**fakeOuterCompositeSerialize**](doc\FakeApi.md#fakeoutercompositeserialize) | **post** /fake/outer/composite | 
+*FakeApi* | [**fakeOuterNumberSerialize**](doc\FakeApi.md#fakeouternumberserialize) | **post** /fake/outer/number | 
+*FakeApi* | [**fakeOuterStringSerialize**](doc\FakeApi.md#fakeouterstringserialize) | **post** /fake/outer/string | 
+*FakeApi* | [**fakePropertyEnumIntegerSerialize**](doc\FakeApi.md#fakepropertyenumintegerserialize) | **post** /fake/property/enum-int | 
+*FakeApi* | [**testBodyWithFileSchema**](doc\FakeApi.md#testbodywithfileschema) | **put** /fake/body-with-file-schema | 
+*FakeApi* | [**testBodyWithQueryParams**](doc\FakeApi.md#testbodywithqueryparams) | **put** /fake/body-with-query-params | 
+*FakeApi* | [**testClientModel**](doc\FakeApi.md#testclientmodel) | **patch** /fake | To test \&quot;client\&quot; model
+*FakeApi* | [**testEndpointParameters**](doc\FakeApi.md#testendpointparameters) | **post** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+*FakeApi* | [**testEnumParameters**](doc\FakeApi.md#testenumparameters) | **get** /fake | To test enum parameters
+*FakeApi* | [**testGroupParameters**](doc\FakeApi.md#testgroupparameters) | **delete** /fake | Fake endpoint to test group parameters (optional)
+*FakeApi* | [**testInlineAdditionalProperties**](doc\FakeApi.md#testinlineadditionalproperties) | **post** /fake/inline-additionalProperties | test inline additionalProperties
+*FakeApi* | [**testJsonFormData**](doc\FakeApi.md#testjsonformdata) | **get** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**testQueryParameterCollectionFormat**](doc\FakeApi.md#testqueryparametercollectionformat) | **put** /fake/test-query-paramters | 
+*FakeClassnameTags123Api* | [**testClassname**](doc\FakeClassnameTags123Api.md#testclassname) | **patch** /fake_classname_test | To test class name in snake case
+*PetApi* | [**addPet**](doc\PetApi.md#addpet) | **post** /pet | Add a new pet to the store
+*PetApi* | [**deletePet**](doc\PetApi.md#deletepet) | **delete** /pet/{petId} | Deletes a pet
+*PetApi* | [**findPetsByStatus**](doc\PetApi.md#findpetsbystatus) | **get** /pet/findByStatus | Finds Pets by status
+*PetApi* | [**findPetsByTags**](doc\PetApi.md#findpetsbytags) | **get** /pet/findByTags | Finds Pets by tags
+*PetApi* | [**getPetById**](doc\PetApi.md#getpetbyid) | **get** /pet/{petId} | Find pet by ID
+*PetApi* | [**updatePet**](doc\PetApi.md#updatepet) | **put** /pet | Update an existing pet
+*PetApi* | [**updatePetWithForm**](doc\PetApi.md#updatepetwithform) | **post** /pet/{petId} | Updates a pet in the store with form data
+*PetApi* | [**uploadFile**](doc\PetApi.md#uploadfile) | **post** /pet/{petId}/uploadImage | uploads an image
+*PetApi* | [**uploadFileWithRequiredFile**](doc\PetApi.md#uploadfilewithrequiredfile) | **post** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
+*StoreApi* | [**deleteOrder**](doc\StoreApi.md#deleteorder) | **delete** /store/order/{order_id} | Delete purchase order by ID
+*StoreApi* | [**getInventory**](doc\StoreApi.md#getinventory) | **get** /store/inventory | Returns pet inventories by status
+*StoreApi* | [**getOrderById**](doc\StoreApi.md#getorderbyid) | **get** /store/order/{order_id} | Find purchase order by ID
+*StoreApi* | [**placeOrder**](doc\StoreApi.md#placeorder) | **post** /store/order | Place an order for a pet
+*UserApi* | [**createUser**](doc\UserApi.md#createuser) | **post** /user | Create user
+*UserApi* | [**createUsersWithArrayInput**](doc\UserApi.md#createuserswitharrayinput) | **post** /user/createWithArray | Creates list of users with given input array
+*UserApi* | [**createUsersWithListInput**](doc\UserApi.md#createuserswithlistinput) | **post** /user/createWithList | Creates list of users with given input array
+*UserApi* | [**deleteUser**](doc\UserApi.md#deleteuser) | **delete** /user/{username} | Delete user
+*UserApi* | [**getUserByName**](doc\UserApi.md#getuserbyname) | **get** /user/{username} | Get user by user name
+*UserApi* | [**loginUser**](doc\UserApi.md#loginuser) | **get** /user/login | Logs user into the system
+*UserApi* | [**logoutUser**](doc\UserApi.md#logoutuser) | **get** /user/logout | Logs out current logged in user session
+*UserApi* | [**updateUser**](doc\UserApi.md#updateuser) | **put** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [AdditionalPropertiesClass](doc/AdditionalPropertiesClass.md)
- - [Animal](doc/Animal.md)
- - [ApiResponse](doc/ApiResponse.md)
- - [ArrayOfArrayOfNumberOnly](doc/ArrayOfArrayOfNumberOnly.md)
- - [ArrayOfNumberOnly](doc/ArrayOfNumberOnly.md)
- - [ArrayTest](doc/ArrayTest.md)
- - [Capitalization](doc/Capitalization.md)
- - [Cat](doc/Cat.md)
- - [CatAllOf](doc/CatAllOf.md)
- - [Category](doc/Category.md)
- - [ClassModel](doc/ClassModel.md)
- - [Dog](doc/Dog.md)
- - [DogAllOf](doc/DogAllOf.md)
- - [EnumArrays](doc/EnumArrays.md)
- - [EnumTest](doc/EnumTest.md)
- - [FileSchemaTestClass](doc/FileSchemaTestClass.md)
- - [Foo](doc/Foo.md)
- - [FormatTest](doc/FormatTest.md)
- - [HasOnlyReadOnly](doc/HasOnlyReadOnly.md)
- - [HealthCheckResult](doc/HealthCheckResult.md)
- - [InlineResponseDefault](doc/InlineResponseDefault.md)
- - [MapTest](doc/MapTest.md)
- - [MixedPropertiesAndAdditionalPropertiesClass](doc/MixedPropertiesAndAdditionalPropertiesClass.md)
- - [Model200Response](doc/Model200Response.md)
- - [ModelClient](doc/ModelClient.md)
- - [ModelEnumClass](doc/ModelEnumClass.md)
- - [ModelFile](doc/ModelFile.md)
- - [ModelList](doc/ModelList.md)
- - [ModelReturn](doc/ModelReturn.md)
- - [Name](doc/Name.md)
- - [NullableClass](doc/NullableClass.md)
- - [NumberOnly](doc/NumberOnly.md)
- - [Order](doc/Order.md)
- - [OuterComposite](doc/OuterComposite.md)
- - [OuterEnum](doc/OuterEnum.md)
- - [OuterEnumDefaultValue](doc/OuterEnumDefaultValue.md)
- - [OuterEnumInteger](doc/OuterEnumInteger.md)
- - [OuterEnumIntegerDefaultValue](doc/OuterEnumIntegerDefaultValue.md)
- - [OuterObjectWithEnumProperty](doc/OuterObjectWithEnumProperty.md)
- - [Pet](doc/Pet.md)
- - [ReadOnlyFirst](doc/ReadOnlyFirst.md)
- - [SpecialModelName](doc/SpecialModelName.md)
- - [Tag](doc/Tag.md)
- - [User](doc/User.md)
+ - [AdditionalPropertiesClass](doc\AdditionalPropertiesClass.md)
+ - [Animal](doc\Animal.md)
+ - [ApiResponse](doc\ApiResponse.md)
+ - [ArrayOfArrayOfNumberOnly](doc\ArrayOfArrayOfNumberOnly.md)
+ - [ArrayOfNumberOnly](doc\ArrayOfNumberOnly.md)
+ - [ArrayTest](doc\ArrayTest.md)
+ - [Capitalization](doc\Capitalization.md)
+ - [Cat](doc\Cat.md)
+ - [CatAllOf](doc\CatAllOf.md)
+ - [Category](doc\Category.md)
+ - [ClassModel](doc\ClassModel.md)
+ - [Dog](doc\Dog.md)
+ - [DogAllOf](doc\DogAllOf.md)
+ - [EnumArrays](doc\EnumArrays.md)
+ - [EnumTest](doc\EnumTest.md)
+ - [FileSchemaTestClass](doc\FileSchemaTestClass.md)
+ - [Foo](doc\Foo.md)
+ - [FormatTest](doc\FormatTest.md)
+ - [HasOnlyReadOnly](doc\HasOnlyReadOnly.md)
+ - [HealthCheckResult](doc\HealthCheckResult.md)
+ - [InlineResponseDefault](doc\InlineResponseDefault.md)
+ - [MapTest](doc\MapTest.md)
+ - [MixedPropertiesAndAdditionalPropertiesClass](doc\MixedPropertiesAndAdditionalPropertiesClass.md)
+ - [Model200Response](doc\Model200Response.md)
+ - [ModelClient](doc\ModelClient.md)
+ - [ModelEnumClass](doc\ModelEnumClass.md)
+ - [ModelFile](doc\ModelFile.md)
+ - [ModelList](doc\ModelList.md)
+ - [ModelReturn](doc\ModelReturn.md)
+ - [Name](doc\Name.md)
+ - [NullableClass](doc\NullableClass.md)
+ - [NumberOnly](doc\NumberOnly.md)
+ - [Order](doc\Order.md)
+ - [OuterComposite](doc\OuterComposite.md)
+ - [OuterEnum](doc\OuterEnum.md)
+ - [OuterEnumDefaultValue](doc\OuterEnumDefaultValue.md)
+ - [OuterEnumInteger](doc\OuterEnumInteger.md)
+ - [OuterEnumIntegerDefaultValue](doc\OuterEnumIntegerDefaultValue.md)
+ - [OuterObjectWithEnumProperty](doc\OuterObjectWithEnumProperty.md)
+ - [Pet](doc\Pet.md)
+ - [ReadOnlyFirst](doc\ReadOnlyFirst.md)
+ - [SpecialModelName](doc\SpecialModelName.md)
+ - [Tag](doc\Tag.md)
+ - [User](doc\User.md)
 
 
 ## Documentation For Authorization

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/README.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/README.md
@@ -58,36 +58,36 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*PetApi* | [**addPet**](doc/PetApi.md#addpet) | **post** /pet | Add a new pet to the store
-*PetApi* | [**deletePet**](doc/PetApi.md#deletepet) | **delete** /pet/{petId} | Deletes a pet
-*PetApi* | [**findPetsByStatus**](doc/PetApi.md#findpetsbystatus) | **get** /pet/findByStatus | Finds Pets by status
-*PetApi* | [**findPetsByTags**](doc/PetApi.md#findpetsbytags) | **get** /pet/findByTags | Finds Pets by tags
-*PetApi* | [**getPetById**](doc/PetApi.md#getpetbyid) | **get** /pet/{petId} | Find pet by ID
-*PetApi* | [**updatePet**](doc/PetApi.md#updatepet) | **put** /pet | Update an existing pet
-*PetApi* | [**updatePetWithForm**](doc/PetApi.md#updatepetwithform) | **post** /pet/{petId} | Updates a pet in the store with form data
-*PetApi* | [**uploadFile**](doc/PetApi.md#uploadfile) | **post** /pet/{petId}/uploadImage | uploads an image
-*StoreApi* | [**deleteOrder**](doc/StoreApi.md#deleteorder) | **delete** /store/order/{orderId} | Delete purchase order by ID
-*StoreApi* | [**getInventory**](doc/StoreApi.md#getinventory) | **get** /store/inventory | Returns pet inventories by status
-*StoreApi* | [**getOrderById**](doc/StoreApi.md#getorderbyid) | **get** /store/order/{orderId} | Find purchase order by ID
-*StoreApi* | [**placeOrder**](doc/StoreApi.md#placeorder) | **post** /store/order | Place an order for a pet
-*UserApi* | [**createUser**](doc/UserApi.md#createuser) | **post** /user | Create user
-*UserApi* | [**createUsersWithArrayInput**](doc/UserApi.md#createuserswitharrayinput) | **post** /user/createWithArray | Creates list of users with given input array
-*UserApi* | [**createUsersWithListInput**](doc/UserApi.md#createuserswithlistinput) | **post** /user/createWithList | Creates list of users with given input array
-*UserApi* | [**deleteUser**](doc/UserApi.md#deleteuser) | **delete** /user/{username} | Delete user
-*UserApi* | [**getUserByName**](doc/UserApi.md#getuserbyname) | **get** /user/{username} | Get user by user name
-*UserApi* | [**loginUser**](doc/UserApi.md#loginuser) | **get** /user/login | Logs user into the system
-*UserApi* | [**logoutUser**](doc/UserApi.md#logoutuser) | **get** /user/logout | Logs out current logged in user session
-*UserApi* | [**updateUser**](doc/UserApi.md#updateuser) | **put** /user/{username} | Updated user
+*PetApi* | [**addPet**](doc\PetApi.md#addpet) | **post** /pet | Add a new pet to the store
+*PetApi* | [**deletePet**](doc\PetApi.md#deletepet) | **delete** /pet/{petId} | Deletes a pet
+*PetApi* | [**findPetsByStatus**](doc\PetApi.md#findpetsbystatus) | **get** /pet/findByStatus | Finds Pets by status
+*PetApi* | [**findPetsByTags**](doc\PetApi.md#findpetsbytags) | **get** /pet/findByTags | Finds Pets by tags
+*PetApi* | [**getPetById**](doc\PetApi.md#getpetbyid) | **get** /pet/{petId} | Find pet by ID
+*PetApi* | [**updatePet**](doc\PetApi.md#updatepet) | **put** /pet | Update an existing pet
+*PetApi* | [**updatePetWithForm**](doc\PetApi.md#updatepetwithform) | **post** /pet/{petId} | Updates a pet in the store with form data
+*PetApi* | [**uploadFile**](doc\PetApi.md#uploadfile) | **post** /pet/{petId}/uploadImage | uploads an image
+*StoreApi* | [**deleteOrder**](doc\StoreApi.md#deleteorder) | **delete** /store/order/{orderId} | Delete purchase order by ID
+*StoreApi* | [**getInventory**](doc\StoreApi.md#getinventory) | **get** /store/inventory | Returns pet inventories by status
+*StoreApi* | [**getOrderById**](doc\StoreApi.md#getorderbyid) | **get** /store/order/{orderId} | Find purchase order by ID
+*StoreApi* | [**placeOrder**](doc\StoreApi.md#placeorder) | **post** /store/order | Place an order for a pet
+*UserApi* | [**createUser**](doc\UserApi.md#createuser) | **post** /user | Create user
+*UserApi* | [**createUsersWithArrayInput**](doc\UserApi.md#createuserswitharrayinput) | **post** /user/createWithArray | Creates list of users with given input array
+*UserApi* | [**createUsersWithListInput**](doc\UserApi.md#createuserswithlistinput) | **post** /user/createWithList | Creates list of users with given input array
+*UserApi* | [**deleteUser**](doc\UserApi.md#deleteuser) | **delete** /user/{username} | Delete user
+*UserApi* | [**getUserByName**](doc\UserApi.md#getuserbyname) | **get** /user/{username} | Get user by user name
+*UserApi* | [**loginUser**](doc\UserApi.md#loginuser) | **get** /user/login | Logs user into the system
+*UserApi* | [**logoutUser**](doc\UserApi.md#logoutuser) | **get** /user/logout | Logs out current logged in user session
+*UserApi* | [**updateUser**](doc\UserApi.md#updateuser) | **put** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [ApiResponse](doc/ApiResponse.md)
- - [Category](doc/Category.md)
- - [Order](doc/Order.md)
- - [Pet](doc/Pet.md)
- - [Tag](doc/Tag.md)
- - [User](doc/User.md)
+ - [ApiResponse](doc\ApiResponse.md)
+ - [Category](doc\Category.md)
+ - [Order](doc\Order.md)
+ - [Pet](doc\Pet.md)
+ - [Tag](doc\Tag.md)
+ - [User](doc\User.md)
 
 
 ## Documentation For Authorization

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/README.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/README.md
@@ -58,94 +58,94 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*AnotherFakeApi* | [**call123testSpecialTags**](doc/AnotherFakeApi.md#call123testspecialtags) | **patch** /another-fake/dummy | To test special tags
-*DefaultApi* | [**fooGet**](doc/DefaultApi.md#fooget) | **get** /foo | 
-*FakeApi* | [**fakeHealthGet**](doc/FakeApi.md#fakehealthget) | **get** /fake/health | Health check endpoint
-*FakeApi* | [**fakeHttpSignatureTest**](doc/FakeApi.md#fakehttpsignaturetest) | **get** /fake/http-signature-test | test http signature authentication
-*FakeApi* | [**fakeOuterBooleanSerialize**](doc/FakeApi.md#fakeouterbooleanserialize) | **post** /fake/outer/boolean | 
-*FakeApi* | [**fakeOuterCompositeSerialize**](doc/FakeApi.md#fakeoutercompositeserialize) | **post** /fake/outer/composite | 
-*FakeApi* | [**fakeOuterNumberSerialize**](doc/FakeApi.md#fakeouternumberserialize) | **post** /fake/outer/number | 
-*FakeApi* | [**fakeOuterStringSerialize**](doc/FakeApi.md#fakeouterstringserialize) | **post** /fake/outer/string | 
-*FakeApi* | [**fakePropertyEnumIntegerSerialize**](doc/FakeApi.md#fakepropertyenumintegerserialize) | **post** /fake/property/enum-int | 
-*FakeApi* | [**testBodyWithFileSchema**](doc/FakeApi.md#testbodywithfileschema) | **put** /fake/body-with-file-schema | 
-*FakeApi* | [**testBodyWithQueryParams**](doc/FakeApi.md#testbodywithqueryparams) | **put** /fake/body-with-query-params | 
-*FakeApi* | [**testClientModel**](doc/FakeApi.md#testclientmodel) | **patch** /fake | To test \&quot;client\&quot; model
-*FakeApi* | [**testEndpointParameters**](doc/FakeApi.md#testendpointparameters) | **post** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-*FakeApi* | [**testEnumParameters**](doc/FakeApi.md#testenumparameters) | **get** /fake | To test enum parameters
-*FakeApi* | [**testGroupParameters**](doc/FakeApi.md#testgroupparameters) | **delete** /fake | Fake endpoint to test group parameters (optional)
-*FakeApi* | [**testInlineAdditionalProperties**](doc/FakeApi.md#testinlineadditionalproperties) | **post** /fake/inline-additionalProperties | test inline additionalProperties
-*FakeApi* | [**testJsonFormData**](doc/FakeApi.md#testjsonformdata) | **get** /fake/jsonFormData | test json serialization of form data
-*FakeApi* | [**testQueryParameterCollectionFormat**](doc/FakeApi.md#testqueryparametercollectionformat) | **put** /fake/test-query-paramters | 
-*FakeClassnameTags123Api* | [**testClassname**](doc/FakeClassnameTags123Api.md#testclassname) | **patch** /fake_classname_test | To test class name in snake case
-*PetApi* | [**addPet**](doc/PetApi.md#addpet) | **post** /pet | Add a new pet to the store
-*PetApi* | [**deletePet**](doc/PetApi.md#deletepet) | **delete** /pet/{petId} | Deletes a pet
-*PetApi* | [**findPetsByStatus**](doc/PetApi.md#findpetsbystatus) | **get** /pet/findByStatus | Finds Pets by status
-*PetApi* | [**findPetsByTags**](doc/PetApi.md#findpetsbytags) | **get** /pet/findByTags | Finds Pets by tags
-*PetApi* | [**getPetById**](doc/PetApi.md#getpetbyid) | **get** /pet/{petId} | Find pet by ID
-*PetApi* | [**updatePet**](doc/PetApi.md#updatepet) | **put** /pet | Update an existing pet
-*PetApi* | [**updatePetWithForm**](doc/PetApi.md#updatepetwithform) | **post** /pet/{petId} | Updates a pet in the store with form data
-*PetApi* | [**uploadFile**](doc/PetApi.md#uploadfile) | **post** /pet/{petId}/uploadImage | uploads an image
-*PetApi* | [**uploadFileWithRequiredFile**](doc/PetApi.md#uploadfilewithrequiredfile) | **post** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
-*StoreApi* | [**deleteOrder**](doc/StoreApi.md#deleteorder) | **delete** /store/order/{order_id} | Delete purchase order by ID
-*StoreApi* | [**getInventory**](doc/StoreApi.md#getinventory) | **get** /store/inventory | Returns pet inventories by status
-*StoreApi* | [**getOrderById**](doc/StoreApi.md#getorderbyid) | **get** /store/order/{order_id} | Find purchase order by ID
-*StoreApi* | [**placeOrder**](doc/StoreApi.md#placeorder) | **post** /store/order | Place an order for a pet
-*UserApi* | [**createUser**](doc/UserApi.md#createuser) | **post** /user | Create user
-*UserApi* | [**createUsersWithArrayInput**](doc/UserApi.md#createuserswitharrayinput) | **post** /user/createWithArray | Creates list of users with given input array
-*UserApi* | [**createUsersWithListInput**](doc/UserApi.md#createuserswithlistinput) | **post** /user/createWithList | Creates list of users with given input array
-*UserApi* | [**deleteUser**](doc/UserApi.md#deleteuser) | **delete** /user/{username} | Delete user
-*UserApi* | [**getUserByName**](doc/UserApi.md#getuserbyname) | **get** /user/{username} | Get user by user name
-*UserApi* | [**loginUser**](doc/UserApi.md#loginuser) | **get** /user/login | Logs user into the system
-*UserApi* | [**logoutUser**](doc/UserApi.md#logoutuser) | **get** /user/logout | Logs out current logged in user session
-*UserApi* | [**updateUser**](doc/UserApi.md#updateuser) | **put** /user/{username} | Updated user
+*AnotherFakeApi* | [**call123testSpecialTags**](doc\AnotherFakeApi.md#call123testspecialtags) | **patch** /another-fake/dummy | To test special tags
+*DefaultApi* | [**fooGet**](doc\DefaultApi.md#fooget) | **get** /foo | 
+*FakeApi* | [**fakeHealthGet**](doc\FakeApi.md#fakehealthget) | **get** /fake/health | Health check endpoint
+*FakeApi* | [**fakeHttpSignatureTest**](doc\FakeApi.md#fakehttpsignaturetest) | **get** /fake/http-signature-test | test http signature authentication
+*FakeApi* | [**fakeOuterBooleanSerialize**](doc\FakeApi.md#fakeouterbooleanserialize) | **post** /fake/outer/boolean | 
+*FakeApi* | [**fakeOuterCompositeSerialize**](doc\FakeApi.md#fakeoutercompositeserialize) | **post** /fake/outer/composite | 
+*FakeApi* | [**fakeOuterNumberSerialize**](doc\FakeApi.md#fakeouternumberserialize) | **post** /fake/outer/number | 
+*FakeApi* | [**fakeOuterStringSerialize**](doc\FakeApi.md#fakeouterstringserialize) | **post** /fake/outer/string | 
+*FakeApi* | [**fakePropertyEnumIntegerSerialize**](doc\FakeApi.md#fakepropertyenumintegerserialize) | **post** /fake/property/enum-int | 
+*FakeApi* | [**testBodyWithFileSchema**](doc\FakeApi.md#testbodywithfileschema) | **put** /fake/body-with-file-schema | 
+*FakeApi* | [**testBodyWithQueryParams**](doc\FakeApi.md#testbodywithqueryparams) | **put** /fake/body-with-query-params | 
+*FakeApi* | [**testClientModel**](doc\FakeApi.md#testclientmodel) | **patch** /fake | To test \&quot;client\&quot; model
+*FakeApi* | [**testEndpointParameters**](doc\FakeApi.md#testendpointparameters) | **post** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+*FakeApi* | [**testEnumParameters**](doc\FakeApi.md#testenumparameters) | **get** /fake | To test enum parameters
+*FakeApi* | [**testGroupParameters**](doc\FakeApi.md#testgroupparameters) | **delete** /fake | Fake endpoint to test group parameters (optional)
+*FakeApi* | [**testInlineAdditionalProperties**](doc\FakeApi.md#testinlineadditionalproperties) | **post** /fake/inline-additionalProperties | test inline additionalProperties
+*FakeApi* | [**testJsonFormData**](doc\FakeApi.md#testjsonformdata) | **get** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**testQueryParameterCollectionFormat**](doc\FakeApi.md#testqueryparametercollectionformat) | **put** /fake/test-query-paramters | 
+*FakeClassnameTags123Api* | [**testClassname**](doc\FakeClassnameTags123Api.md#testclassname) | **patch** /fake_classname_test | To test class name in snake case
+*PetApi* | [**addPet**](doc\PetApi.md#addpet) | **post** /pet | Add a new pet to the store
+*PetApi* | [**deletePet**](doc\PetApi.md#deletepet) | **delete** /pet/{petId} | Deletes a pet
+*PetApi* | [**findPetsByStatus**](doc\PetApi.md#findpetsbystatus) | **get** /pet/findByStatus | Finds Pets by status
+*PetApi* | [**findPetsByTags**](doc\PetApi.md#findpetsbytags) | **get** /pet/findByTags | Finds Pets by tags
+*PetApi* | [**getPetById**](doc\PetApi.md#getpetbyid) | **get** /pet/{petId} | Find pet by ID
+*PetApi* | [**updatePet**](doc\PetApi.md#updatepet) | **put** /pet | Update an existing pet
+*PetApi* | [**updatePetWithForm**](doc\PetApi.md#updatepetwithform) | **post** /pet/{petId} | Updates a pet in the store with form data
+*PetApi* | [**uploadFile**](doc\PetApi.md#uploadfile) | **post** /pet/{petId}/uploadImage | uploads an image
+*PetApi* | [**uploadFileWithRequiredFile**](doc\PetApi.md#uploadfilewithrequiredfile) | **post** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
+*StoreApi* | [**deleteOrder**](doc\StoreApi.md#deleteorder) | **delete** /store/order/{order_id} | Delete purchase order by ID
+*StoreApi* | [**getInventory**](doc\StoreApi.md#getinventory) | **get** /store/inventory | Returns pet inventories by status
+*StoreApi* | [**getOrderById**](doc\StoreApi.md#getorderbyid) | **get** /store/order/{order_id} | Find purchase order by ID
+*StoreApi* | [**placeOrder**](doc\StoreApi.md#placeorder) | **post** /store/order | Place an order for a pet
+*UserApi* | [**createUser**](doc\UserApi.md#createuser) | **post** /user | Create user
+*UserApi* | [**createUsersWithArrayInput**](doc\UserApi.md#createuserswitharrayinput) | **post** /user/createWithArray | Creates list of users with given input array
+*UserApi* | [**createUsersWithListInput**](doc\UserApi.md#createuserswithlistinput) | **post** /user/createWithList | Creates list of users with given input array
+*UserApi* | [**deleteUser**](doc\UserApi.md#deleteuser) | **delete** /user/{username} | Delete user
+*UserApi* | [**getUserByName**](doc\UserApi.md#getuserbyname) | **get** /user/{username} | Get user by user name
+*UserApi* | [**loginUser**](doc\UserApi.md#loginuser) | **get** /user/login | Logs user into the system
+*UserApi* | [**logoutUser**](doc\UserApi.md#logoutuser) | **get** /user/logout | Logs out current logged in user session
+*UserApi* | [**updateUser**](doc\UserApi.md#updateuser) | **put** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [AdditionalPropertiesClass](doc/AdditionalPropertiesClass.md)
- - [Animal](doc/Animal.md)
- - [ApiResponse](doc/ApiResponse.md)
- - [ArrayOfArrayOfNumberOnly](doc/ArrayOfArrayOfNumberOnly.md)
- - [ArrayOfNumberOnly](doc/ArrayOfNumberOnly.md)
- - [ArrayTest](doc/ArrayTest.md)
- - [Capitalization](doc/Capitalization.md)
- - [Cat](doc/Cat.md)
- - [CatAllOf](doc/CatAllOf.md)
- - [Category](doc/Category.md)
- - [ClassModel](doc/ClassModel.md)
- - [Dog](doc/Dog.md)
- - [DogAllOf](doc/DogAllOf.md)
- - [EnumArrays](doc/EnumArrays.md)
- - [EnumTest](doc/EnumTest.md)
- - [FileSchemaTestClass](doc/FileSchemaTestClass.md)
- - [Foo](doc/Foo.md)
- - [FormatTest](doc/FormatTest.md)
- - [HasOnlyReadOnly](doc/HasOnlyReadOnly.md)
- - [HealthCheckResult](doc/HealthCheckResult.md)
- - [InlineResponseDefault](doc/InlineResponseDefault.md)
- - [MapTest](doc/MapTest.md)
- - [MixedPropertiesAndAdditionalPropertiesClass](doc/MixedPropertiesAndAdditionalPropertiesClass.md)
- - [Model200Response](doc/Model200Response.md)
- - [ModelClient](doc/ModelClient.md)
- - [ModelEnumClass](doc/ModelEnumClass.md)
- - [ModelFile](doc/ModelFile.md)
- - [ModelList](doc/ModelList.md)
- - [ModelReturn](doc/ModelReturn.md)
- - [Name](doc/Name.md)
- - [NullableClass](doc/NullableClass.md)
- - [NumberOnly](doc/NumberOnly.md)
- - [Order](doc/Order.md)
- - [OuterComposite](doc/OuterComposite.md)
- - [OuterEnum](doc/OuterEnum.md)
- - [OuterEnumDefaultValue](doc/OuterEnumDefaultValue.md)
- - [OuterEnumInteger](doc/OuterEnumInteger.md)
- - [OuterEnumIntegerDefaultValue](doc/OuterEnumIntegerDefaultValue.md)
- - [OuterObjectWithEnumProperty](doc/OuterObjectWithEnumProperty.md)
- - [Pet](doc/Pet.md)
- - [ReadOnlyFirst](doc/ReadOnlyFirst.md)
- - [SpecialModelName](doc/SpecialModelName.md)
- - [Tag](doc/Tag.md)
- - [User](doc/User.md)
+ - [AdditionalPropertiesClass](doc\AdditionalPropertiesClass.md)
+ - [Animal](doc\Animal.md)
+ - [ApiResponse](doc\ApiResponse.md)
+ - [ArrayOfArrayOfNumberOnly](doc\ArrayOfArrayOfNumberOnly.md)
+ - [ArrayOfNumberOnly](doc\ArrayOfNumberOnly.md)
+ - [ArrayTest](doc\ArrayTest.md)
+ - [Capitalization](doc\Capitalization.md)
+ - [Cat](doc\Cat.md)
+ - [CatAllOf](doc\CatAllOf.md)
+ - [Category](doc\Category.md)
+ - [ClassModel](doc\ClassModel.md)
+ - [Dog](doc\Dog.md)
+ - [DogAllOf](doc\DogAllOf.md)
+ - [EnumArrays](doc\EnumArrays.md)
+ - [EnumTest](doc\EnumTest.md)
+ - [FileSchemaTestClass](doc\FileSchemaTestClass.md)
+ - [Foo](doc\Foo.md)
+ - [FormatTest](doc\FormatTest.md)
+ - [HasOnlyReadOnly](doc\HasOnlyReadOnly.md)
+ - [HealthCheckResult](doc\HealthCheckResult.md)
+ - [InlineResponseDefault](doc\InlineResponseDefault.md)
+ - [MapTest](doc\MapTest.md)
+ - [MixedPropertiesAndAdditionalPropertiesClass](doc\MixedPropertiesAndAdditionalPropertiesClass.md)
+ - [Model200Response](doc\Model200Response.md)
+ - [ModelClient](doc\ModelClient.md)
+ - [ModelEnumClass](doc\ModelEnumClass.md)
+ - [ModelFile](doc\ModelFile.md)
+ - [ModelList](doc\ModelList.md)
+ - [ModelReturn](doc\ModelReturn.md)
+ - [Name](doc\Name.md)
+ - [NullableClass](doc\NullableClass.md)
+ - [NumberOnly](doc\NumberOnly.md)
+ - [Order](doc\Order.md)
+ - [OuterComposite](doc\OuterComposite.md)
+ - [OuterEnum](doc\OuterEnum.md)
+ - [OuterEnumDefaultValue](doc\OuterEnumDefaultValue.md)
+ - [OuterEnumInteger](doc\OuterEnumInteger.md)
+ - [OuterEnumIntegerDefaultValue](doc\OuterEnumIntegerDefaultValue.md)
+ - [OuterObjectWithEnumProperty](doc\OuterObjectWithEnumProperty.md)
+ - [Pet](doc\Pet.md)
+ - [ReadOnlyFirst](doc\ReadOnlyFirst.md)
+ - [SpecialModelName](doc\SpecialModelName.md)
+ - [Tag](doc\Tag.md)
+ - [User](doc\User.md)
 
 
 ## Documentation For Authorization

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/README.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/README.md
@@ -60,36 +60,36 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*PetApi* | [**addPet**](doc//PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
-*PetApi* | [**deletePet**](doc//PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
-*PetApi* | [**findPetsByStatus**](doc//PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
-*PetApi* | [**findPetsByTags**](doc//PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
-*PetApi* | [**getPetById**](doc//PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
-*PetApi* | [**updatePet**](doc//PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
-*PetApi* | [**updatePetWithForm**](doc//PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
-*PetApi* | [**uploadFile**](doc//PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
-*StoreApi* | [**deleteOrder**](doc//StoreApi.md#deleteorder) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
-*StoreApi* | [**getInventory**](doc//StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
-*StoreApi* | [**getOrderById**](doc//StoreApi.md#getorderbyid) | **GET** /store/order/{orderId} | Find purchase order by ID
-*StoreApi* | [**placeOrder**](doc//StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
-*UserApi* | [**createUser**](doc//UserApi.md#createuser) | **POST** /user | Create user
-*UserApi* | [**createUsersWithArrayInput**](doc//UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
-*UserApi* | [**createUsersWithListInput**](doc//UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
-*UserApi* | [**deleteUser**](doc//UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
-*UserApi* | [**getUserByName**](doc//UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
-*UserApi* | [**loginUser**](doc//UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
-*UserApi* | [**logoutUser**](doc//UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
-*UserApi* | [**updateUser**](doc//UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
+*PetApi* | [**addPet**](doc\/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
+*PetApi* | [**deletePet**](doc\/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
+*PetApi* | [**findPetsByStatus**](doc\/PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
+*PetApi* | [**findPetsByTags**](doc\/PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
+*PetApi* | [**getPetById**](doc\/PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
+*PetApi* | [**updatePet**](doc\/PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
+*PetApi* | [**updatePetWithForm**](doc\/PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
+*PetApi* | [**uploadFile**](doc\/PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
+*StoreApi* | [**deleteOrder**](doc\/StoreApi.md#deleteorder) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
+*StoreApi* | [**getInventory**](doc\/StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
+*StoreApi* | [**getOrderById**](doc\/StoreApi.md#getorderbyid) | **GET** /store/order/{orderId} | Find purchase order by ID
+*StoreApi* | [**placeOrder**](doc\/StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
+*UserApi* | [**createUser**](doc\/UserApi.md#createuser) | **POST** /user | Create user
+*UserApi* | [**createUsersWithArrayInput**](doc\/UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
+*UserApi* | [**createUsersWithListInput**](doc\/UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
+*UserApi* | [**deleteUser**](doc\/UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
+*UserApi* | [**getUserByName**](doc\/UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
+*UserApi* | [**loginUser**](doc\/UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
+*UserApi* | [**logoutUser**](doc\/UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
+*UserApi* | [**updateUser**](doc\/UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [ApiResponse](doc//ApiResponse.md)
- - [Category](doc//Category.md)
- - [Order](doc//Order.md)
- - [Pet](doc//Pet.md)
- - [Tag](doc//Tag.md)
- - [User](doc//User.md)
+ - [ApiResponse](doc\/ApiResponse.md)
+ - [Category](doc\/Category.md)
+ - [Order](doc\/Order.md)
+ - [Pet](doc\/Pet.md)
+ - [Tag](doc\/Tag.md)
+ - [User](doc\/User.md)
 
 
 ## Documentation For Authorization

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
@@ -77,7 +77,7 @@ class ApiClient {
       ? '?${urlEncodedQueryParams.join('&')}'
       : '';
 
-    final url = '$basePath$path$queryString';
+    final url = Uri.parse('$basePath$path$queryString');
 
     if (nullableContentType != null) {
       headerParams['Content-Type'] = nullableContentType;
@@ -89,7 +89,7 @@ class ApiClient {
         body is MultipartFile && (nullableContentType == null ||
         !nullableContentType.toLowerCase().startsWith('multipart/form-data'))
       ) {
-        final request = StreamedRequest(method, Uri.parse(url));
+        final request = StreamedRequest(method, url);
         request.headers.addAll(headerParams);
         request.contentLength = body.length;
         body.finalize().listen(
@@ -103,7 +103,7 @@ class ApiClient {
       }
 
       if (body is MultipartRequest) {
-        final request = MultipartRequest(method, Uri.parse(url));
+        final request = MultipartRequest(method, url);
         request.fields.addAll(body.fields);
         request.files.addAll(body.files);
         request.headers.addAll(body.headers);

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
@@ -11,10 +11,10 @@ homepage: 'homepage'
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dependencies:
-  http: '>=0.12.0 <0.13.0'
-  intl: '^0.16.1'
+  http: '^0.13.0'
+  intl: '^0.17.0'
   meta: '^1.1.8'
 
 dev_dependencies:
-  test: '>=1.3.0 <1.16.0'
+  test: '>=1.3.0 <=1.16.0'
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/README.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/README.md
@@ -58,94 +58,94 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*AnotherFakeApi* | [**call123testSpecialTags**](doc//AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
-*DefaultApi* | [**fooGet**](doc//DefaultApi.md#fooget) | **GET** /foo | 
-*FakeApi* | [**fakeHealthGet**](doc//FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
-*FakeApi* | [**fakeHttpSignatureTest**](doc//FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
-*FakeApi* | [**fakeOuterBooleanSerialize**](doc//FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
-*FakeApi* | [**fakeOuterCompositeSerialize**](doc//FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
-*FakeApi* | [**fakeOuterNumberSerialize**](doc//FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
-*FakeApi* | [**fakeOuterStringSerialize**](doc//FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
-*FakeApi* | [**fakePropertyEnumIntegerSerialize**](doc//FakeApi.md#fakepropertyenumintegerserialize) | **POST** /fake/property/enum-int | 
-*FakeApi* | [**testBodyWithFileSchema**](doc//FakeApi.md#testbodywithfileschema) | **PUT** /fake/body-with-file-schema | 
-*FakeApi* | [**testBodyWithQueryParams**](doc//FakeApi.md#testbodywithqueryparams) | **PUT** /fake/body-with-query-params | 
-*FakeApi* | [**testClientModel**](doc//FakeApi.md#testclientmodel) | **PATCH** /fake | To test \"client\" model
-*FakeApi* | [**testEndpointParameters**](doc//FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-*FakeApi* | [**testEnumParameters**](doc//FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
-*FakeApi* | [**testGroupParameters**](doc//FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
-*FakeApi* | [**testInlineAdditionalProperties**](doc//FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
-*FakeApi* | [**testJsonFormData**](doc//FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
-*FakeApi* | [**testQueryParameterCollectionFormat**](doc//FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-paramters | 
-*FakeClassnameTags123Api* | [**testClassname**](doc//FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
-*PetApi* | [**addPet**](doc//PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
-*PetApi* | [**deletePet**](doc//PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
-*PetApi* | [**findPetsByStatus**](doc//PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
-*PetApi* | [**findPetsByTags**](doc//PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
-*PetApi* | [**getPetById**](doc//PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
-*PetApi* | [**updatePet**](doc//PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
-*PetApi* | [**updatePetWithForm**](doc//PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
-*PetApi* | [**uploadFile**](doc//PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
-*PetApi* | [**uploadFileWithRequiredFile**](doc//PetApi.md#uploadfilewithrequiredfile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
-*StoreApi* | [**deleteOrder**](doc//StoreApi.md#deleteorder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
-*StoreApi* | [**getInventory**](doc//StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
-*StoreApi* | [**getOrderById**](doc//StoreApi.md#getorderbyid) | **GET** /store/order/{order_id} | Find purchase order by ID
-*StoreApi* | [**placeOrder**](doc//StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
-*UserApi* | [**createUser**](doc//UserApi.md#createuser) | **POST** /user | Create user
-*UserApi* | [**createUsersWithArrayInput**](doc//UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
-*UserApi* | [**createUsersWithListInput**](doc//UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
-*UserApi* | [**deleteUser**](doc//UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
-*UserApi* | [**getUserByName**](doc//UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
-*UserApi* | [**loginUser**](doc//UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
-*UserApi* | [**logoutUser**](doc//UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
-*UserApi* | [**updateUser**](doc//UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
+*AnotherFakeApi* | [**call123testSpecialTags**](doc\/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
+*DefaultApi* | [**fooGet**](doc\/DefaultApi.md#fooget) | **GET** /foo | 
+*FakeApi* | [**fakeHealthGet**](doc\/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
+*FakeApi* | [**fakeHttpSignatureTest**](doc\/FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
+*FakeApi* | [**fakeOuterBooleanSerialize**](doc\/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
+*FakeApi* | [**fakeOuterCompositeSerialize**](doc\/FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
+*FakeApi* | [**fakeOuterNumberSerialize**](doc\/FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
+*FakeApi* | [**fakeOuterStringSerialize**](doc\/FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
+*FakeApi* | [**fakePropertyEnumIntegerSerialize**](doc\/FakeApi.md#fakepropertyenumintegerserialize) | **POST** /fake/property/enum-int | 
+*FakeApi* | [**testBodyWithFileSchema**](doc\/FakeApi.md#testbodywithfileschema) | **PUT** /fake/body-with-file-schema | 
+*FakeApi* | [**testBodyWithQueryParams**](doc\/FakeApi.md#testbodywithqueryparams) | **PUT** /fake/body-with-query-params | 
+*FakeApi* | [**testClientModel**](doc\/FakeApi.md#testclientmodel) | **PATCH** /fake | To test \"client\" model
+*FakeApi* | [**testEndpointParameters**](doc\/FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+*FakeApi* | [**testEnumParameters**](doc\/FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
+*FakeApi* | [**testGroupParameters**](doc\/FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
+*FakeApi* | [**testInlineAdditionalProperties**](doc\/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
+*FakeApi* | [**testJsonFormData**](doc\/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**testQueryParameterCollectionFormat**](doc\/FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-paramters | 
+*FakeClassnameTags123Api* | [**testClassname**](doc\/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
+*PetApi* | [**addPet**](doc\/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
+*PetApi* | [**deletePet**](doc\/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
+*PetApi* | [**findPetsByStatus**](doc\/PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
+*PetApi* | [**findPetsByTags**](doc\/PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
+*PetApi* | [**getPetById**](doc\/PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
+*PetApi* | [**updatePet**](doc\/PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
+*PetApi* | [**updatePetWithForm**](doc\/PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
+*PetApi* | [**uploadFile**](doc\/PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
+*PetApi* | [**uploadFileWithRequiredFile**](doc\/PetApi.md#uploadfilewithrequiredfile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
+*StoreApi* | [**deleteOrder**](doc\/StoreApi.md#deleteorder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
+*StoreApi* | [**getInventory**](doc\/StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
+*StoreApi* | [**getOrderById**](doc\/StoreApi.md#getorderbyid) | **GET** /store/order/{order_id} | Find purchase order by ID
+*StoreApi* | [**placeOrder**](doc\/StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
+*UserApi* | [**createUser**](doc\/UserApi.md#createuser) | **POST** /user | Create user
+*UserApi* | [**createUsersWithArrayInput**](doc\/UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
+*UserApi* | [**createUsersWithListInput**](doc\/UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
+*UserApi* | [**deleteUser**](doc\/UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
+*UserApi* | [**getUserByName**](doc\/UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
+*UserApi* | [**loginUser**](doc\/UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
+*UserApi* | [**logoutUser**](doc\/UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
+*UserApi* | [**updateUser**](doc\/UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [AdditionalPropertiesClass](doc//AdditionalPropertiesClass.md)
- - [Animal](doc//Animal.md)
- - [ApiResponse](doc//ApiResponse.md)
- - [ArrayOfArrayOfNumberOnly](doc//ArrayOfArrayOfNumberOnly.md)
- - [ArrayOfNumberOnly](doc//ArrayOfNumberOnly.md)
- - [ArrayTest](doc//ArrayTest.md)
- - [Capitalization](doc//Capitalization.md)
- - [Cat](doc//Cat.md)
- - [CatAllOf](doc//CatAllOf.md)
- - [Category](doc//Category.md)
- - [ClassModel](doc//ClassModel.md)
- - [Dog](doc//Dog.md)
- - [DogAllOf](doc//DogAllOf.md)
- - [EnumArrays](doc//EnumArrays.md)
- - [EnumClass](doc//EnumClass.md)
- - [EnumTest](doc//EnumTest.md)
- - [FileSchemaTestClass](doc//FileSchemaTestClass.md)
- - [Foo](doc//Foo.md)
- - [FormatTest](doc//FormatTest.md)
- - [HasOnlyReadOnly](doc//HasOnlyReadOnly.md)
- - [HealthCheckResult](doc//HealthCheckResult.md)
- - [InlineResponseDefault](doc//InlineResponseDefault.md)
- - [MapTest](doc//MapTest.md)
- - [MixedPropertiesAndAdditionalPropertiesClass](doc//MixedPropertiesAndAdditionalPropertiesClass.md)
- - [Model200Response](doc//Model200Response.md)
- - [ModelClient](doc//ModelClient.md)
- - [ModelFile](doc//ModelFile.md)
- - [ModelList](doc//ModelList.md)
- - [ModelReturn](doc//ModelReturn.md)
- - [Name](doc//Name.md)
- - [NullableClass](doc//NullableClass.md)
- - [NumberOnly](doc//NumberOnly.md)
- - [Order](doc//Order.md)
- - [OuterComposite](doc//OuterComposite.md)
- - [OuterEnum](doc//OuterEnum.md)
- - [OuterEnumDefaultValue](doc//OuterEnumDefaultValue.md)
- - [OuterEnumInteger](doc//OuterEnumInteger.md)
- - [OuterEnumIntegerDefaultValue](doc//OuterEnumIntegerDefaultValue.md)
- - [OuterObjectWithEnumProperty](doc//OuterObjectWithEnumProperty.md)
- - [Pet](doc//Pet.md)
- - [ReadOnlyFirst](doc//ReadOnlyFirst.md)
- - [SpecialModelName](doc//SpecialModelName.md)
- - [Tag](doc//Tag.md)
- - [User](doc//User.md)
+ - [AdditionalPropertiesClass](doc\/AdditionalPropertiesClass.md)
+ - [Animal](doc\/Animal.md)
+ - [ApiResponse](doc\/ApiResponse.md)
+ - [ArrayOfArrayOfNumberOnly](doc\/ArrayOfArrayOfNumberOnly.md)
+ - [ArrayOfNumberOnly](doc\/ArrayOfNumberOnly.md)
+ - [ArrayTest](doc\/ArrayTest.md)
+ - [Capitalization](doc\/Capitalization.md)
+ - [Cat](doc\/Cat.md)
+ - [CatAllOf](doc\/CatAllOf.md)
+ - [Category](doc\/Category.md)
+ - [ClassModel](doc\/ClassModel.md)
+ - [Dog](doc\/Dog.md)
+ - [DogAllOf](doc\/DogAllOf.md)
+ - [EnumArrays](doc\/EnumArrays.md)
+ - [EnumClass](doc\/EnumClass.md)
+ - [EnumTest](doc\/EnumTest.md)
+ - [FileSchemaTestClass](doc\/FileSchemaTestClass.md)
+ - [Foo](doc\/Foo.md)
+ - [FormatTest](doc\/FormatTest.md)
+ - [HasOnlyReadOnly](doc\/HasOnlyReadOnly.md)
+ - [HealthCheckResult](doc\/HealthCheckResult.md)
+ - [InlineResponseDefault](doc\/InlineResponseDefault.md)
+ - [MapTest](doc\/MapTest.md)
+ - [MixedPropertiesAndAdditionalPropertiesClass](doc\/MixedPropertiesAndAdditionalPropertiesClass.md)
+ - [Model200Response](doc\/Model200Response.md)
+ - [ModelClient](doc\/ModelClient.md)
+ - [ModelFile](doc\/ModelFile.md)
+ - [ModelList](doc\/ModelList.md)
+ - [ModelReturn](doc\/ModelReturn.md)
+ - [Name](doc\/Name.md)
+ - [NullableClass](doc\/NullableClass.md)
+ - [NumberOnly](doc\/NumberOnly.md)
+ - [Order](doc\/Order.md)
+ - [OuterComposite](doc\/OuterComposite.md)
+ - [OuterEnum](doc\/OuterEnum.md)
+ - [OuterEnumDefaultValue](doc\/OuterEnumDefaultValue.md)
+ - [OuterEnumInteger](doc\/OuterEnumInteger.md)
+ - [OuterEnumIntegerDefaultValue](doc\/OuterEnumIntegerDefaultValue.md)
+ - [OuterObjectWithEnumProperty](doc\/OuterObjectWithEnumProperty.md)
+ - [Pet](doc\/Pet.md)
+ - [ReadOnlyFirst](doc\/ReadOnlyFirst.md)
+ - [SpecialModelName](doc\/SpecialModelName.md)
+ - [Tag](doc\/Tag.md)
+ - [User](doc\/User.md)
 
 
 ## Documentation For Authorization

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
@@ -80,7 +80,7 @@ class ApiClient {
       ? '?${urlEncodedQueryParams.join('&')}'
       : '';
 
-    final url = '$basePath$path$queryString';
+    final url = Uri.parse('$basePath$path$queryString');
 
     if (nullableContentType != null) {
       headerParams['Content-Type'] = nullableContentType;
@@ -92,7 +92,7 @@ class ApiClient {
         body is MultipartFile && (nullableContentType == null ||
         !nullableContentType.toLowerCase().startsWith('multipart/form-data'))
       ) {
-        final request = StreamedRequest(method, Uri.parse(url));
+        final request = StreamedRequest(method, url);
         request.headers.addAll(headerParams);
         request.contentLength = body.length;
         body.finalize().listen(
@@ -106,7 +106,7 @@ class ApiClient {
       }
 
       if (body is MultipartRequest) {
-        final request = MultipartRequest(method, Uri.parse(url));
+        final request = MultipartRequest(method, url);
         request.fields.addAll(body.fields);
         request.files.addAll(body.files);
         request.headers.addAll(body.headers);

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
@@ -11,10 +11,10 @@ homepage: 'homepage'
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dependencies:
-  http: '>=0.12.0 <0.13.0'
-  intl: '^0.16.1'
+  http: '^0.13.0'
+  intl: '^0.17.0'
   meta: '^1.1.8'
 
 dev_dependencies:
-  test: '>=1.3.0 <1.16.0'
+  test: '>=1.3.0 <=1.16.0'
 

--- a/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/README.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/README.md
@@ -58,94 +58,94 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*AnotherFakeApi* | [**call123testSpecialTags**](doc//AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
-*DefaultApi* | [**fooGet**](doc//DefaultApi.md#fooget) | **GET** /foo | 
-*FakeApi* | [**fakeHealthGet**](doc//FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
-*FakeApi* | [**fakeHttpSignatureTest**](doc//FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
-*FakeApi* | [**fakeOuterBooleanSerialize**](doc//FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
-*FakeApi* | [**fakeOuterCompositeSerialize**](doc//FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
-*FakeApi* | [**fakeOuterNumberSerialize**](doc//FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
-*FakeApi* | [**fakeOuterStringSerialize**](doc//FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
-*FakeApi* | [**fakePropertyEnumIntegerSerialize**](doc//FakeApi.md#fakepropertyenumintegerserialize) | **POST** /fake/property/enum-int | 
-*FakeApi* | [**testBodyWithFileSchema**](doc//FakeApi.md#testbodywithfileschema) | **PUT** /fake/body-with-file-schema | 
-*FakeApi* | [**testBodyWithQueryParams**](doc//FakeApi.md#testbodywithqueryparams) | **PUT** /fake/body-with-query-params | 
-*FakeApi* | [**testClientModel**](doc//FakeApi.md#testclientmodel) | **PATCH** /fake | To test \"client\" model
-*FakeApi* | [**testEndpointParameters**](doc//FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-*FakeApi* | [**testEnumParameters**](doc//FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
-*FakeApi* | [**testGroupParameters**](doc//FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
-*FakeApi* | [**testInlineAdditionalProperties**](doc//FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
-*FakeApi* | [**testJsonFormData**](doc//FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
-*FakeApi* | [**testQueryParameterCollectionFormat**](doc//FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-paramters | 
-*FakeClassnameTags123Api* | [**testClassname**](doc//FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
-*PetApi* | [**addPet**](doc//PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
-*PetApi* | [**deletePet**](doc//PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
-*PetApi* | [**findPetsByStatus**](doc//PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
-*PetApi* | [**findPetsByTags**](doc//PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
-*PetApi* | [**getPetById**](doc//PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
-*PetApi* | [**updatePet**](doc//PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
-*PetApi* | [**updatePetWithForm**](doc//PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
-*PetApi* | [**uploadFile**](doc//PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
-*PetApi* | [**uploadFileWithRequiredFile**](doc//PetApi.md#uploadfilewithrequiredfile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
-*StoreApi* | [**deleteOrder**](doc//StoreApi.md#deleteorder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
-*StoreApi* | [**getInventory**](doc//StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
-*StoreApi* | [**getOrderById**](doc//StoreApi.md#getorderbyid) | **GET** /store/order/{order_id} | Find purchase order by ID
-*StoreApi* | [**placeOrder**](doc//StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
-*UserApi* | [**createUser**](doc//UserApi.md#createuser) | **POST** /user | Create user
-*UserApi* | [**createUsersWithArrayInput**](doc//UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
-*UserApi* | [**createUsersWithListInput**](doc//UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
-*UserApi* | [**deleteUser**](doc//UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
-*UserApi* | [**getUserByName**](doc//UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
-*UserApi* | [**loginUser**](doc//UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
-*UserApi* | [**logoutUser**](doc//UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
-*UserApi* | [**updateUser**](doc//UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
+*AnotherFakeApi* | [**call123testSpecialTags**](doc\/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
+*DefaultApi* | [**fooGet**](doc\/DefaultApi.md#fooget) | **GET** /foo | 
+*FakeApi* | [**fakeHealthGet**](doc\/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
+*FakeApi* | [**fakeHttpSignatureTest**](doc\/FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
+*FakeApi* | [**fakeOuterBooleanSerialize**](doc\/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
+*FakeApi* | [**fakeOuterCompositeSerialize**](doc\/FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
+*FakeApi* | [**fakeOuterNumberSerialize**](doc\/FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
+*FakeApi* | [**fakeOuterStringSerialize**](doc\/FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
+*FakeApi* | [**fakePropertyEnumIntegerSerialize**](doc\/FakeApi.md#fakepropertyenumintegerserialize) | **POST** /fake/property/enum-int | 
+*FakeApi* | [**testBodyWithFileSchema**](doc\/FakeApi.md#testbodywithfileschema) | **PUT** /fake/body-with-file-schema | 
+*FakeApi* | [**testBodyWithQueryParams**](doc\/FakeApi.md#testbodywithqueryparams) | **PUT** /fake/body-with-query-params | 
+*FakeApi* | [**testClientModel**](doc\/FakeApi.md#testclientmodel) | **PATCH** /fake | To test \"client\" model
+*FakeApi* | [**testEndpointParameters**](doc\/FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+*FakeApi* | [**testEnumParameters**](doc\/FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
+*FakeApi* | [**testGroupParameters**](doc\/FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
+*FakeApi* | [**testInlineAdditionalProperties**](doc\/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
+*FakeApi* | [**testJsonFormData**](doc\/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**testQueryParameterCollectionFormat**](doc\/FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-paramters | 
+*FakeClassnameTags123Api* | [**testClassname**](doc\/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
+*PetApi* | [**addPet**](doc\/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
+*PetApi* | [**deletePet**](doc\/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
+*PetApi* | [**findPetsByStatus**](doc\/PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
+*PetApi* | [**findPetsByTags**](doc\/PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
+*PetApi* | [**getPetById**](doc\/PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
+*PetApi* | [**updatePet**](doc\/PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
+*PetApi* | [**updatePetWithForm**](doc\/PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
+*PetApi* | [**uploadFile**](doc\/PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
+*PetApi* | [**uploadFileWithRequiredFile**](doc\/PetApi.md#uploadfilewithrequiredfile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
+*StoreApi* | [**deleteOrder**](doc\/StoreApi.md#deleteorder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
+*StoreApi* | [**getInventory**](doc\/StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
+*StoreApi* | [**getOrderById**](doc\/StoreApi.md#getorderbyid) | **GET** /store/order/{order_id} | Find purchase order by ID
+*StoreApi* | [**placeOrder**](doc\/StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
+*UserApi* | [**createUser**](doc\/UserApi.md#createuser) | **POST** /user | Create user
+*UserApi* | [**createUsersWithArrayInput**](doc\/UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
+*UserApi* | [**createUsersWithListInput**](doc\/UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
+*UserApi* | [**deleteUser**](doc\/UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
+*UserApi* | [**getUserByName**](doc\/UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
+*UserApi* | [**loginUser**](doc\/UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
+*UserApi* | [**logoutUser**](doc\/UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
+*UserApi* | [**updateUser**](doc\/UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [AdditionalPropertiesClass](doc//AdditionalPropertiesClass.md)
- - [Animal](doc//Animal.md)
- - [ApiResponse](doc//ApiResponse.md)
- - [ArrayOfArrayOfNumberOnly](doc//ArrayOfArrayOfNumberOnly.md)
- - [ArrayOfNumberOnly](doc//ArrayOfNumberOnly.md)
- - [ArrayTest](doc//ArrayTest.md)
- - [Capitalization](doc//Capitalization.md)
- - [Cat](doc//Cat.md)
- - [CatAllOf](doc//CatAllOf.md)
- - [Category](doc//Category.md)
- - [ClassModel](doc//ClassModel.md)
- - [Dog](doc//Dog.md)
- - [DogAllOf](doc//DogAllOf.md)
- - [EnumArrays](doc//EnumArrays.md)
- - [EnumClass](doc//EnumClass.md)
- - [EnumTest](doc//EnumTest.md)
- - [FileSchemaTestClass](doc//FileSchemaTestClass.md)
- - [Foo](doc//Foo.md)
- - [FormatTest](doc//FormatTest.md)
- - [HasOnlyReadOnly](doc//HasOnlyReadOnly.md)
- - [HealthCheckResult](doc//HealthCheckResult.md)
- - [InlineResponseDefault](doc//InlineResponseDefault.md)
- - [MapTest](doc//MapTest.md)
- - [MixedPropertiesAndAdditionalPropertiesClass](doc//MixedPropertiesAndAdditionalPropertiesClass.md)
- - [Model200Response](doc//Model200Response.md)
- - [ModelClient](doc//ModelClient.md)
- - [ModelFile](doc//ModelFile.md)
- - [ModelList](doc//ModelList.md)
- - [ModelReturn](doc//ModelReturn.md)
- - [Name](doc//Name.md)
- - [NullableClass](doc//NullableClass.md)
- - [NumberOnly](doc//NumberOnly.md)
- - [Order](doc//Order.md)
- - [OuterComposite](doc//OuterComposite.md)
- - [OuterEnum](doc//OuterEnum.md)
- - [OuterEnumDefaultValue](doc//OuterEnumDefaultValue.md)
- - [OuterEnumInteger](doc//OuterEnumInteger.md)
- - [OuterEnumIntegerDefaultValue](doc//OuterEnumIntegerDefaultValue.md)
- - [OuterObjectWithEnumProperty](doc//OuterObjectWithEnumProperty.md)
- - [Pet](doc//Pet.md)
- - [ReadOnlyFirst](doc//ReadOnlyFirst.md)
- - [SpecialModelName](doc//SpecialModelName.md)
- - [Tag](doc//Tag.md)
- - [User](doc//User.md)
+ - [AdditionalPropertiesClass](doc\/AdditionalPropertiesClass.md)
+ - [Animal](doc\/Animal.md)
+ - [ApiResponse](doc\/ApiResponse.md)
+ - [ArrayOfArrayOfNumberOnly](doc\/ArrayOfArrayOfNumberOnly.md)
+ - [ArrayOfNumberOnly](doc\/ArrayOfNumberOnly.md)
+ - [ArrayTest](doc\/ArrayTest.md)
+ - [Capitalization](doc\/Capitalization.md)
+ - [Cat](doc\/Cat.md)
+ - [CatAllOf](doc\/CatAllOf.md)
+ - [Category](doc\/Category.md)
+ - [ClassModel](doc\/ClassModel.md)
+ - [Dog](doc\/Dog.md)
+ - [DogAllOf](doc\/DogAllOf.md)
+ - [EnumArrays](doc\/EnumArrays.md)
+ - [EnumClass](doc\/EnumClass.md)
+ - [EnumTest](doc\/EnumTest.md)
+ - [FileSchemaTestClass](doc\/FileSchemaTestClass.md)
+ - [Foo](doc\/Foo.md)
+ - [FormatTest](doc\/FormatTest.md)
+ - [HasOnlyReadOnly](doc\/HasOnlyReadOnly.md)
+ - [HealthCheckResult](doc\/HealthCheckResult.md)
+ - [InlineResponseDefault](doc\/InlineResponseDefault.md)
+ - [MapTest](doc\/MapTest.md)
+ - [MixedPropertiesAndAdditionalPropertiesClass](doc\/MixedPropertiesAndAdditionalPropertiesClass.md)
+ - [Model200Response](doc\/Model200Response.md)
+ - [ModelClient](doc\/ModelClient.md)
+ - [ModelFile](doc\/ModelFile.md)
+ - [ModelList](doc\/ModelList.md)
+ - [ModelReturn](doc\/ModelReturn.md)
+ - [Name](doc\/Name.md)
+ - [NullableClass](doc\/NullableClass.md)
+ - [NumberOnly](doc\/NumberOnly.md)
+ - [Order](doc\/Order.md)
+ - [OuterComposite](doc\/OuterComposite.md)
+ - [OuterEnum](doc\/OuterEnum.md)
+ - [OuterEnumDefaultValue](doc\/OuterEnumDefaultValue.md)
+ - [OuterEnumInteger](doc\/OuterEnumInteger.md)
+ - [OuterEnumIntegerDefaultValue](doc\/OuterEnumIntegerDefaultValue.md)
+ - [OuterObjectWithEnumProperty](doc\/OuterObjectWithEnumProperty.md)
+ - [Pet](doc\/Pet.md)
+ - [ReadOnlyFirst](doc\/ReadOnlyFirst.md)
+ - [SpecialModelName](doc\/SpecialModelName.md)
+ - [Tag](doc\/Tag.md)
+ - [User](doc\/User.md)
 
 
 ## Documentation For Authorization

--- a/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/lib/api_client.dart
@@ -80,7 +80,7 @@ class ApiClient {
       ? '?${urlEncodedQueryParams.join('&')}'
       : '';
 
-    final url = '$basePath$path$queryString';
+    final url = Uri.parse('$basePath$path$queryString');
 
     if (nullableContentType != null) {
       headerParams['Content-Type'] = nullableContentType;
@@ -92,7 +92,7 @@ class ApiClient {
         body is MultipartFile && (nullableContentType == null ||
         !nullableContentType.toLowerCase().startsWith('multipart/form-data'))
       ) {
-        final request = StreamedRequest(method, Uri.parse(url));
+        final request = StreamedRequest(method, url);
         request.headers.addAll(headerParams);
         request.contentLength = body.length;
         body.finalize().listen(
@@ -106,7 +106,7 @@ class ApiClient {
       }
 
       if (body is MultipartRequest) {
-        final request = MultipartRequest(method, Uri.parse(url));
+        final request = MultipartRequest(method, url);
         request.fields.addAll(body.fields);
         request.files.addAll(body.files);
         request.headers.addAll(body.headers);

--- a/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/pubspec.yaml
@@ -11,11 +11,11 @@ homepage: 'homepage'
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dependencies:
-  http: '>=0.12.0 <0.13.0'
-  intl: '^0.16.1'
+  http: '^0.13.0'
+  intl: '^0.17.0'
   meta: '^1.1.8'
   json_annotation: '^3.1.1'
 dev_dependencies:
-  test: '>=1.3.0 <1.16.0'
+  test: '>=1.3.0 <=1.16.0'
   build_runner: '^1.0.0'
   json_serializable: '^3.5.1'


### PR DESCRIPTION
**This is updated to target the master branch, and I've attempted to link the commits to my GitHub account**

Currently, the dart generator has outdated dependencies on `http`, `intl`, and `test`. This prevents usage of the generator with newer Flutter applications.

This PR upgrades the dependencies, and also changes the way that the API URI's are handled to comply with a change in the `http` package.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
