### PR TITLE
[Bash] Fix matching of header parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/bash/client.mustache
+++ b/modules/openapi-generator/src/main/resources/bash/client.mustache
@@ -979,7 +979,7 @@ case $key in
         body_parameters[${body_key}]=${body_value}
     fi
     ;;
-    +\([^=]\):*)
+    +([^=]):*)
     # Parse header arguments and convert them into curl
     # only after the operation argument
     if [[ "$operation" ]]; then

--- a/samples/client/petstore/bash/petstore-cli
+++ b/samples/client/petstore/bash/petstore-cli
@@ -3820,7 +3820,7 @@ case $key in
         body_parameters[${body_key}]=${body_value}
     fi
     ;;
-    +\([^=]\):*)
+    +([^=]):*)
     # Parse header arguments and convert them into curl
     # only after the operation argument
     if [[ "$operation" ]]; then


### PR DESCRIPTION
Currently a generated bash client will not append headers as documented:

```
bash samples/client/petstore/bash/petstore-cli --dry-run --host localhost getPetById a:b
curl  -sS --tlsv1.2   -X GET "localhost/v2/pet/"
```

This PR fixes the generated client to match `Header-Name: Header-Value` parameters and add them to the request:
```
bash samples/client/petstore/bash/petstore-cli --dry-run --host localhost getPetById a:b
curl  -sS --tlsv1.2 -H "a: b"   -X GET "localhost/v2/pet/"
```

@frol @bkryza @kenjones-cisco