### PR TITLE
[csharp][httpclient] Remove noncompliant post behaviour

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
@@ -315,11 +315,7 @@ namespace {{packageName}}.Client
 
             builder.AddPathParameters(options.PathParameters);
 
-            // In case of POST or PUT pass query parameters in request body
-            if (method != HttpMethod.Post && method != HttpMethod.Put)
-            {
-                builder.AddQueryParameters(options.QueryParameters);
-            }
+            builder.AddQueryParameters(options.QueryParameters);
 
             HttpRequestMessage request = new HttpRequestMessage(method, builder.GetFullUri());
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -314,11 +314,7 @@ namespace Org.OpenAPITools.Client
 
             builder.AddPathParameters(options.PathParameters);
 
-            // In case of POST or PUT pass query parameters in request body
-            if (method != HttpMethod.Post && method != HttpMethod.Put)
-            {
-                builder.AddQueryParameters(options.QueryParameters);
-            }
+            builder.AddQueryParameters(options.QueryParameters);
 
             HttpRequestMessage request = new HttpRequestMessage(method, builder.GetFullUri());
 


### PR DESCRIPTION
Removes noncompliant merging of post query parameters, which makes more sense but is not exactly to spec

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)