### PR TITLE
[BUG] [typescript] Duplicate parameter's names (rename options to _options and config to _config)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -39,8 +39,8 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
         {{#allParams}}
 
         {{#required}}
@@ -57,7 +57,7 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
             .replace('{' + '{{baseName}}' + '}', encodeURIComponent(String({{paramName}}))){{/pathParams}};
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.{{httpMethod}});
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.{{httpMethod}});
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -132,7 +132,7 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
         {{/hasAuthMethods}}
         // Apply auth methods
         {{#authMethods}}
-        authMethod = config.authMethods["{{name}}"]
+        authMethod = _config.authMethods["{{name}}"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }

--- a/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
@@ -62,8 +62,8 @@ export class Observable{{classname}} {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: Configuration): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
-        const requestContextPromise = this.requestFactory.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options);
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+        const requestContextPromise = this.requestFactory.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}_options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);

--- a/modules/openapi-generator/src/main/resources/typescript/types/PromiseAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/PromiseAPI.mustache
@@ -52,8 +52,8 @@ export class Promise{{classname}} {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: Configuration): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
-        const result = this.api.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options);
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+        const result = this.api.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}_options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -19,8 +19,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public async addPet(pet: Pet, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async addPet(pet: Pet, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
@@ -32,7 +32,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -57,7 +57,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -70,8 +70,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public async deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -85,7 +85,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -100,7 +100,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -113,8 +113,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'status' is not null or undefined
         if (status === null || status === undefined) {
@@ -126,7 +126,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByStatus';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -143,7 +143,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -156,8 +156,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public async findPetsByTags(tags: Array<string>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async findPetsByTags(tags: Array<string>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'tags' is not null or undefined
         if (tags === null || tags === undefined) {
@@ -169,7 +169,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByTags';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -186,7 +186,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -199,8 +199,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public async getPetById(petId: number, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getPetById(petId: number, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -213,7 +213,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -227,7 +227,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -239,8 +239,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public async updatePet(pet: Pet, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updatePet(pet: Pet, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
@@ -252,7 +252,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -277,7 +277,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -291,8 +291,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public async updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -307,7 +307,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -331,7 +331,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -345,8 +345,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public async uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -361,7 +361,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -385,7 +385,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -19,8 +19,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public async deleteOrder(orderId: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deleteOrder(orderId: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -33,7 +33,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -54,14 +54,14 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public async getInventory(options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getInventory(_options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // Path Params
         const localVarPath = '/store/inventory';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -75,7 +75,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -88,8 +88,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public async getOrderById(orderId: number, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getOrderById(orderId: number, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -102,7 +102,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -123,8 +123,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public async placeOrder(order: Order, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async placeOrder(order: Order, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'order' is not null or undefined
         if (order === null || order === undefined) {
@@ -136,7 +136,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/order';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -19,8 +19,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Create user
      * @param user Created user object
      */
-    public async createUser(user: User, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUser(user: User, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -32,7 +32,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -55,7 +55,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -67,8 +67,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public async createUsersWithArrayInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -80,7 +80,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithArray';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -103,7 +103,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -115,8 +115,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public async createUsersWithListInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -128,7 +128,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithList';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -151,7 +151,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -164,8 +164,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public async deleteUser(username: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deleteUser(username: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -178,7 +178,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -192,7 +192,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -204,8 +204,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public async getUserByName(username: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getUserByName(username: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -218,7 +218,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -240,8 +240,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public async loginUser(username: string, password: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async loginUser(username: string, password: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -259,7 +259,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/login';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -285,14 +285,14 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Logs out current logged in user session
      */
-    public async logoutUser(options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async logoutUser(_options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // Path Params
         const localVarPath = '/user/logout';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -306,7 +306,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -320,8 +320,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public async updateUser(username: string, user: User, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updateUser(username: string, user: User, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -340,7 +340,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -363,7 +363,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
@@ -30,8 +30,8 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.addPet(pet, options);
+    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -54,8 +54,8 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, options);
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -78,8 +78,8 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Observable<Array<Pet>> {
-        const requestContextPromise = this.requestFactory.findPetsByStatus(status, options);
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+        const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -102,8 +102,8 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, options?: Configuration): Observable<Array<Pet>> {
-        const requestContextPromise = this.requestFactory.findPetsByTags(tags, options);
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+        const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -126,8 +126,8 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.getPetById(petId, options);
+    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -149,8 +149,8 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.updatePet(pet, options);
+    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -174,8 +174,8 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, options);
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -199,8 +199,8 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Observable<ApiResponse> {
-        const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, options);
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+        const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -241,8 +241,8 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deleteOrder(orderId, options);
+    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -264,8 +264,8 @@ export class ObservableStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(options?: Configuration): Observable<{ [key: string]: number; }> {
-        const requestContextPromise = this.requestFactory.getInventory(options);
+    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+        const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -288,8 +288,8 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, options?: Configuration): Observable<Order> {
-        const requestContextPromise = this.requestFactory.getOrderById(orderId, options);
+    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+        const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -311,8 +311,8 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, options?: Configuration): Observable<Order> {
-        const requestContextPromise = this.requestFactory.placeOrder(order, options);
+    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+        const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -353,8 +353,8 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUser(user, options);
+    public createUser(user: User, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -376,8 +376,8 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, options);
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -399,8 +399,8 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUsersWithListInput(user, options);
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -423,8 +423,8 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deleteUser(username, options);
+    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -446,8 +446,8 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, options?: Configuration): Observable<User> {
-        const requestContextPromise = this.requestFactory.getUserByName(username, options);
+    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+        const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -470,8 +470,8 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, options?: Configuration): Observable<string> {
-        const requestContextPromise = this.requestFactory.loginUser(username, password, options);
+    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+        const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -492,8 +492,8 @@ export class ObservableUserApi {
     /**
      * Logs out current logged in user session
      */
-    public logoutUser(options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.logoutUser(options);
+    public logoutUser(_options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -517,8 +517,8 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.updateUser(username, user, options);
+    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/PromiseAPI.ts
@@ -26,8 +26,8 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, options?: Configuration): Promise<Pet> {
-        const result = this.api.addPet(pet, options);
+    public addPet(pet: Pet, _options?: Configuration): Promise<Pet> {
+        const result = this.api.addPet(pet, _options);
         return result.toPromise();
     }
 
@@ -36,8 +36,8 @@ export class PromisePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<void> {
-        const result = this.api.deletePet(petId, apiKey, options);
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deletePet(petId, apiKey, _options);
         return result.toPromise();
     }
 
@@ -46,8 +46,8 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<Array<Pet>> {
-        const result = this.api.findPetsByStatus(status, options);
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<Array<Pet>> {
+        const result = this.api.findPetsByStatus(status, _options);
         return result.toPromise();
     }
 
@@ -56,8 +56,8 @@ export class PromisePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, options?: Configuration): Promise<Array<Pet>> {
-        const result = this.api.findPetsByTags(tags, options);
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Promise<Array<Pet>> {
+        const result = this.api.findPetsByTags(tags, _options);
         return result.toPromise();
     }
 
@@ -66,8 +66,8 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, options?: Configuration): Promise<Pet> {
-        const result = this.api.getPetById(petId, options);
+    public getPetById(petId: number, _options?: Configuration): Promise<Pet> {
+        const result = this.api.getPetById(petId, _options);
         return result.toPromise();
     }
 
@@ -75,8 +75,8 @@ export class PromisePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, options?: Configuration): Promise<Pet> {
-        const result = this.api.updatePet(pet, options);
+    public updatePet(pet: Pet, _options?: Configuration): Promise<Pet> {
+        const result = this.api.updatePet(pet, _options);
         return result.toPromise();
     }
 
@@ -86,8 +86,8 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Promise<void> {
-        const result = this.api.updatePetWithForm(petId, name, status, options);
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.updatePetWithForm(petId, name, status, _options);
         return result.toPromise();
     }
 
@@ -97,8 +97,8 @@ export class PromisePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Promise<ApiResponse> {
-        const result = this.api.uploadFile(petId, additionalMetadata, file, options);
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
+        const result = this.api.uploadFile(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
 
@@ -126,8 +126,8 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, options?: Configuration): Promise<void> {
-        const result = this.api.deleteOrder(orderId, options);
+    public deleteOrder(orderId: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deleteOrder(orderId, _options);
         return result.toPromise();
     }
 
@@ -135,8 +135,8 @@ export class PromiseStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(options?: Configuration): Promise<{ [key: string]: number; }> {
-        const result = this.api.getInventory(options);
+    public getInventory(_options?: Configuration): Promise<{ [key: string]: number; }> {
+        const result = this.api.getInventory(_options);
         return result.toPromise();
     }
 
@@ -145,8 +145,8 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, options?: Configuration): Promise<Order> {
-        const result = this.api.getOrderById(orderId, options);
+    public getOrderById(orderId: number, _options?: Configuration): Promise<Order> {
+        const result = this.api.getOrderById(orderId, _options);
         return result.toPromise();
     }
 
@@ -154,8 +154,8 @@ export class PromiseStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, options?: Configuration): Promise<Order> {
-        const result = this.api.placeOrder(order, options);
+    public placeOrder(order: Order, _options?: Configuration): Promise<Order> {
+        const result = this.api.placeOrder(order, _options);
         return result.toPromise();
     }
 
@@ -183,8 +183,8 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, options?: Configuration): Promise<void> {
-        const result = this.api.createUser(user, options);
+    public createUser(user: User, _options?: Configuration): Promise<void> {
+        const result = this.api.createUser(user, _options);
         return result.toPromise();
     }
 
@@ -192,8 +192,8 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: Configuration): Promise<void> {
-        const result = this.api.createUsersWithArrayInput(user, options);
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Promise<void> {
+        const result = this.api.createUsersWithArrayInput(user, _options);
         return result.toPromise();
     }
 
@@ -201,8 +201,8 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, options?: Configuration): Promise<void> {
-        const result = this.api.createUsersWithListInput(user, options);
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<void> {
+        const result = this.api.createUsersWithListInput(user, _options);
         return result.toPromise();
     }
 
@@ -211,8 +211,8 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, options?: Configuration): Promise<void> {
-        const result = this.api.deleteUser(username, options);
+    public deleteUser(username: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deleteUser(username, _options);
         return result.toPromise();
     }
 
@@ -220,8 +220,8 @@ export class PromiseUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, options?: Configuration): Promise<User> {
-        const result = this.api.getUserByName(username, options);
+    public getUserByName(username: string, _options?: Configuration): Promise<User> {
+        const result = this.api.getUserByName(username, _options);
         return result.toPromise();
     }
 
@@ -230,16 +230,16 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, options?: Configuration): Promise<string> {
-        const result = this.api.loginUser(username, password, options);
+    public loginUser(username: string, password: string, _options?: Configuration): Promise<string> {
+        const result = this.api.loginUser(username, password, _options);
         return result.toPromise();
     }
 
     /**
      * Logs out current logged in user session
      */
-    public logoutUser(options?: Configuration): Promise<void> {
-        const result = this.api.logoutUser(options);
+    public logoutUser(_options?: Configuration): Promise<void> {
+        const result = this.api.logoutUser(_options);
         return result.toPromise();
     }
 
@@ -249,8 +249,8 @@ export class PromiseUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, options?: Configuration): Promise<void> {
-        const result = this.api.updateUser(username, user, options);
+    public updateUser(username: string, user: User, _options?: Configuration): Promise<void> {
+        const result = this.api.updateUser(username, user, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
@@ -18,8 +18,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public async addPet(pet: Pet, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async addPet(pet: Pet, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
@@ -31,7 +31,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -56,7 +56,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -69,8 +69,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public async deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -84,7 +84,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -99,7 +99,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -112,8 +112,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'status' is not null or undefined
         if (status === null || status === undefined) {
@@ -125,7 +125,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByStatus';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -142,7 +142,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -155,8 +155,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public async findPetsByTags(tags: Array<string>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async findPetsByTags(tags: Array<string>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'tags' is not null or undefined
         if (tags === null || tags === undefined) {
@@ -168,7 +168,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByTags';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -185,7 +185,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -198,8 +198,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public async getPetById(petId: number, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getPetById(petId: number, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -212,7 +212,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -226,7 +226,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -238,8 +238,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public async updatePet(pet: Pet, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updatePet(pet: Pet, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
@@ -251,7 +251,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -276,7 +276,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -290,8 +290,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public async updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -306,7 +306,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -330,7 +330,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -344,8 +344,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public async uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -360,7 +360,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -384,7 +384,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
@@ -18,8 +18,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public async deleteOrder(orderId: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deleteOrder(orderId: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -32,7 +32,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -53,14 +53,14 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public async getInventory(options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getInventory(_options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // Path Params
         const localVarPath = '/store/inventory';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -74,7 +74,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -87,8 +87,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public async getOrderById(orderId: number, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getOrderById(orderId: number, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -101,7 +101,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -122,8 +122,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public async placeOrder(order: Order, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async placeOrder(order: Order, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'order' is not null or undefined
         if (order === null || order === undefined) {
@@ -135,7 +135,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/order';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
@@ -18,8 +18,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Create user
      * @param user Created user object
      */
-    public async createUser(user: User, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUser(user: User, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -31,7 +31,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -54,7 +54,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -66,8 +66,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public async createUsersWithArrayInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -79,7 +79,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithArray';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -102,7 +102,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -114,8 +114,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public async createUsersWithListInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -127,7 +127,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithList';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -150,7 +150,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -163,8 +163,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public async deleteUser(username: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deleteUser(username: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -177,7 +177,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -191,7 +191,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -203,8 +203,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public async getUserByName(username: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getUserByName(username: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -217,7 +217,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -239,8 +239,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public async loginUser(username: string, password: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async loginUser(username: string, password: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -258,7 +258,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/login';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -284,14 +284,14 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Logs out current logged in user session
      */
-    public async logoutUser(options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async logoutUser(_options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // Path Params
         const localVarPath = '/user/logout';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -305,7 +305,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -319,8 +319,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public async updateUser(username: string, user: User, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updateUser(username: string, user: User, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -339,7 +339,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -362,7 +362,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/ObservableAPI.ts
@@ -30,8 +30,8 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.addPet(pet, options);
+    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -54,8 +54,8 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, options);
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -78,8 +78,8 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Observable<Array<Pet>> {
-        const requestContextPromise = this.requestFactory.findPetsByStatus(status, options);
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+        const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -102,8 +102,8 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, options?: Configuration): Observable<Array<Pet>> {
-        const requestContextPromise = this.requestFactory.findPetsByTags(tags, options);
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+        const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -126,8 +126,8 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.getPetById(petId, options);
+    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -149,8 +149,8 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.updatePet(pet, options);
+    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -174,8 +174,8 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, options);
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -199,8 +199,8 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Observable<ApiResponse> {
-        const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, options);
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+        const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -241,8 +241,8 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deleteOrder(orderId, options);
+    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -264,8 +264,8 @@ export class ObservableStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(options?: Configuration): Observable<{ [key: string]: number; }> {
-        const requestContextPromise = this.requestFactory.getInventory(options);
+    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+        const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -288,8 +288,8 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, options?: Configuration): Observable<Order> {
-        const requestContextPromise = this.requestFactory.getOrderById(orderId, options);
+    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+        const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -311,8 +311,8 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, options?: Configuration): Observable<Order> {
-        const requestContextPromise = this.requestFactory.placeOrder(order, options);
+    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+        const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -353,8 +353,8 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUser(user, options);
+    public createUser(user: User, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -376,8 +376,8 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, options);
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -399,8 +399,8 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUsersWithListInput(user, options);
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -423,8 +423,8 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deleteUser(username, options);
+    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -446,8 +446,8 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, options?: Configuration): Observable<User> {
-        const requestContextPromise = this.requestFactory.getUserByName(username, options);
+    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+        const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -470,8 +470,8 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, options?: Configuration): Observable<string> {
-        const requestContextPromise = this.requestFactory.loginUser(username, password, options);
+    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+        const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -492,8 +492,8 @@ export class ObservableUserApi {
     /**
      * Logs out current logged in user session
      */
-    public logoutUser(options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.logoutUser(options);
+    public logoutUser(_options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -517,8 +517,8 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.updateUser(username, user, options);
+    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/PromiseAPI.ts
@@ -26,8 +26,8 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, options?: Configuration): Promise<Pet> {
-        const result = this.api.addPet(pet, options);
+    public addPet(pet: Pet, _options?: Configuration): Promise<Pet> {
+        const result = this.api.addPet(pet, _options);
         return result.toPromise();
     }
 
@@ -36,8 +36,8 @@ export class PromisePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<void> {
-        const result = this.api.deletePet(petId, apiKey, options);
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deletePet(petId, apiKey, _options);
         return result.toPromise();
     }
 
@@ -46,8 +46,8 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<Array<Pet>> {
-        const result = this.api.findPetsByStatus(status, options);
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<Array<Pet>> {
+        const result = this.api.findPetsByStatus(status, _options);
         return result.toPromise();
     }
 
@@ -56,8 +56,8 @@ export class PromisePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, options?: Configuration): Promise<Array<Pet>> {
-        const result = this.api.findPetsByTags(tags, options);
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Promise<Array<Pet>> {
+        const result = this.api.findPetsByTags(tags, _options);
         return result.toPromise();
     }
 
@@ -66,8 +66,8 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, options?: Configuration): Promise<Pet> {
-        const result = this.api.getPetById(petId, options);
+    public getPetById(petId: number, _options?: Configuration): Promise<Pet> {
+        const result = this.api.getPetById(petId, _options);
         return result.toPromise();
     }
 
@@ -75,8 +75,8 @@ export class PromisePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, options?: Configuration): Promise<Pet> {
-        const result = this.api.updatePet(pet, options);
+    public updatePet(pet: Pet, _options?: Configuration): Promise<Pet> {
+        const result = this.api.updatePet(pet, _options);
         return result.toPromise();
     }
 
@@ -86,8 +86,8 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Promise<void> {
-        const result = this.api.updatePetWithForm(petId, name, status, options);
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.updatePetWithForm(petId, name, status, _options);
         return result.toPromise();
     }
 
@@ -97,8 +97,8 @@ export class PromisePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Promise<ApiResponse> {
-        const result = this.api.uploadFile(petId, additionalMetadata, file, options);
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
+        const result = this.api.uploadFile(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
 
@@ -126,8 +126,8 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, options?: Configuration): Promise<void> {
-        const result = this.api.deleteOrder(orderId, options);
+    public deleteOrder(orderId: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deleteOrder(orderId, _options);
         return result.toPromise();
     }
 
@@ -135,8 +135,8 @@ export class PromiseStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(options?: Configuration): Promise<{ [key: string]: number; }> {
-        const result = this.api.getInventory(options);
+    public getInventory(_options?: Configuration): Promise<{ [key: string]: number; }> {
+        const result = this.api.getInventory(_options);
         return result.toPromise();
     }
 
@@ -145,8 +145,8 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, options?: Configuration): Promise<Order> {
-        const result = this.api.getOrderById(orderId, options);
+    public getOrderById(orderId: number, _options?: Configuration): Promise<Order> {
+        const result = this.api.getOrderById(orderId, _options);
         return result.toPromise();
     }
 
@@ -154,8 +154,8 @@ export class PromiseStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, options?: Configuration): Promise<Order> {
-        const result = this.api.placeOrder(order, options);
+    public placeOrder(order: Order, _options?: Configuration): Promise<Order> {
+        const result = this.api.placeOrder(order, _options);
         return result.toPromise();
     }
 
@@ -183,8 +183,8 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, options?: Configuration): Promise<void> {
-        const result = this.api.createUser(user, options);
+    public createUser(user: User, _options?: Configuration): Promise<void> {
+        const result = this.api.createUser(user, _options);
         return result.toPromise();
     }
 
@@ -192,8 +192,8 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: Configuration): Promise<void> {
-        const result = this.api.createUsersWithArrayInput(user, options);
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Promise<void> {
+        const result = this.api.createUsersWithArrayInput(user, _options);
         return result.toPromise();
     }
 
@@ -201,8 +201,8 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, options?: Configuration): Promise<void> {
-        const result = this.api.createUsersWithListInput(user, options);
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<void> {
+        const result = this.api.createUsersWithListInput(user, _options);
         return result.toPromise();
     }
 
@@ -211,8 +211,8 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, options?: Configuration): Promise<void> {
-        const result = this.api.deleteUser(username, options);
+    public deleteUser(username: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deleteUser(username, _options);
         return result.toPromise();
     }
 
@@ -220,8 +220,8 @@ export class PromiseUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, options?: Configuration): Promise<User> {
-        const result = this.api.getUserByName(username, options);
+    public getUserByName(username: string, _options?: Configuration): Promise<User> {
+        const result = this.api.getUserByName(username, _options);
         return result.toPromise();
     }
 
@@ -230,16 +230,16 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, options?: Configuration): Promise<string> {
-        const result = this.api.loginUser(username, password, options);
+    public loginUser(username: string, password: string, _options?: Configuration): Promise<string> {
+        const result = this.api.loginUser(username, password, _options);
         return result.toPromise();
     }
 
     /**
      * Logs out current logged in user session
      */
-    public logoutUser(options?: Configuration): Promise<void> {
-        const result = this.api.logoutUser(options);
+    public logoutUser(_options?: Configuration): Promise<void> {
+        const result = this.api.logoutUser(_options);
         return result.toPromise();
     }
 
@@ -249,8 +249,8 @@ export class PromiseUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, options?: Configuration): Promise<void> {
-        const result = this.api.updateUser(username, user, options);
+    public updateUser(username: string, user: User, _options?: Configuration): Promise<void> {
+        const result = this.api.updateUser(username, user, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
@@ -21,8 +21,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public async addPet(pet: Pet, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async addPet(pet: Pet, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
@@ -34,7 +34,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -59,7 +59,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -72,8 +72,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public async deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -87,7 +87,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -102,7 +102,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -115,8 +115,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'status' is not null or undefined
         if (status === null || status === undefined) {
@@ -128,7 +128,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByStatus';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -145,7 +145,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -158,8 +158,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public async findPetsByTags(tags: Array<string>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async findPetsByTags(tags: Array<string>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'tags' is not null or undefined
         if (tags === null || tags === undefined) {
@@ -171,7 +171,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByTags';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -188,7 +188,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -201,8 +201,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public async getPetById(petId: number, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getPetById(petId: number, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -215,7 +215,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -229,7 +229,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -241,8 +241,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public async updatePet(pet: Pet, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updatePet(pet: Pet, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
@@ -254,7 +254,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -279,7 +279,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -293,8 +293,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public async updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -309,7 +309,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -333,7 +333,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -347,8 +347,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public async uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -363,7 +363,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -387,7 +387,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
@@ -21,8 +21,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public async deleteOrder(orderId: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deleteOrder(orderId: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -35,7 +35,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -56,14 +56,14 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public async getInventory(options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getInventory(_options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // Path Params
         const localVarPath = '/store/inventory';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -77,7 +77,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -90,8 +90,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public async getOrderById(orderId: number, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getOrderById(orderId: number, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -104,7 +104,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -125,8 +125,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public async placeOrder(order: Order, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async placeOrder(order: Order, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'order' is not null or undefined
         if (order === null || order === undefined) {
@@ -138,7 +138,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/order';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
@@ -21,8 +21,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Create user
      * @param user Created user object
      */
-    public async createUser(user: User, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUser(user: User, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -34,7 +34,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -57,7 +57,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -69,8 +69,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public async createUsersWithArrayInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -82,7 +82,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithArray';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -105,7 +105,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -117,8 +117,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public async createUsersWithListInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -130,7 +130,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithList';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -153,7 +153,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -166,8 +166,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public async deleteUser(username: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deleteUser(username: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -180,7 +180,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -194,7 +194,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -206,8 +206,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public async getUserByName(username: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getUserByName(username: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -220,7 +220,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -242,8 +242,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public async loginUser(username: string, password: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async loginUser(username: string, password: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -261,7 +261,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/login';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -287,14 +287,14 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Logs out current logged in user session
      */
-    public async logoutUser(options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async logoutUser(_options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // Path Params
         const localVarPath = '/user/logout';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -308,7 +308,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -322,8 +322,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public async updateUser(username: string, user: User, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updateUser(username: string, user: User, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -342,7 +342,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -365,7 +365,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
@@ -35,8 +35,8 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.addPet(pet, options);
+    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -59,8 +59,8 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, options);
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -83,8 +83,8 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Observable<Array<Pet>> {
-        const requestContextPromise = this.requestFactory.findPetsByStatus(status, options);
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+        const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -107,8 +107,8 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, options?: Configuration): Observable<Array<Pet>> {
-        const requestContextPromise = this.requestFactory.findPetsByTags(tags, options);
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+        const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -131,8 +131,8 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.getPetById(petId, options);
+    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -154,8 +154,8 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.updatePet(pet, options);
+    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -179,8 +179,8 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, options);
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -204,8 +204,8 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Observable<ApiResponse> {
-        const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, options);
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+        const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -249,8 +249,8 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deleteOrder(orderId, options);
+    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -272,8 +272,8 @@ export class ObservableStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(options?: Configuration): Observable<{ [key: string]: number; }> {
-        const requestContextPromise = this.requestFactory.getInventory(options);
+    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+        const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -296,8 +296,8 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, options?: Configuration): Observable<Order> {
-        const requestContextPromise = this.requestFactory.getOrderById(orderId, options);
+    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+        const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -319,8 +319,8 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, options?: Configuration): Observable<Order> {
-        const requestContextPromise = this.requestFactory.placeOrder(order, options);
+    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+        const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -364,8 +364,8 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUser(user, options);
+    public createUser(user: User, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -387,8 +387,8 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, options);
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -410,8 +410,8 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUsersWithListInput(user, options);
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -434,8 +434,8 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deleteUser(username, options);
+    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -457,8 +457,8 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, options?: Configuration): Observable<User> {
-        const requestContextPromise = this.requestFactory.getUserByName(username, options);
+    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+        const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -481,8 +481,8 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, options?: Configuration): Observable<string> {
-        const requestContextPromise = this.requestFactory.loginUser(username, password, options);
+    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+        const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -503,8 +503,8 @@ export class ObservableUserApi {
     /**
      * Logs out current logged in user session
      */
-    public logoutUser(options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.logoutUser(options);
+    public logoutUser(_options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -528,8 +528,8 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.updateUser(username, user, options);
+    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/PromiseAPI.ts
@@ -31,8 +31,8 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, options?: Configuration): Promise<Pet> {
-        const result = this.api.addPet(pet, options);
+    public addPet(pet: Pet, _options?: Configuration): Promise<Pet> {
+        const result = this.api.addPet(pet, _options);
         return result.toPromise();
     }
 
@@ -41,8 +41,8 @@ export class PromisePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<void> {
-        const result = this.api.deletePet(petId, apiKey, options);
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deletePet(petId, apiKey, _options);
         return result.toPromise();
     }
 
@@ -51,8 +51,8 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<Array<Pet>> {
-        const result = this.api.findPetsByStatus(status, options);
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<Array<Pet>> {
+        const result = this.api.findPetsByStatus(status, _options);
         return result.toPromise();
     }
 
@@ -61,8 +61,8 @@ export class PromisePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, options?: Configuration): Promise<Array<Pet>> {
-        const result = this.api.findPetsByTags(tags, options);
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Promise<Array<Pet>> {
+        const result = this.api.findPetsByTags(tags, _options);
         return result.toPromise();
     }
 
@@ -71,8 +71,8 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, options?: Configuration): Promise<Pet> {
-        const result = this.api.getPetById(petId, options);
+    public getPetById(petId: number, _options?: Configuration): Promise<Pet> {
+        const result = this.api.getPetById(petId, _options);
         return result.toPromise();
     }
 
@@ -80,8 +80,8 @@ export class PromisePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, options?: Configuration): Promise<Pet> {
-        const result = this.api.updatePet(pet, options);
+    public updatePet(pet: Pet, _options?: Configuration): Promise<Pet> {
+        const result = this.api.updatePet(pet, _options);
         return result.toPromise();
     }
 
@@ -91,8 +91,8 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Promise<void> {
-        const result = this.api.updatePetWithForm(petId, name, status, options);
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.updatePetWithForm(petId, name, status, _options);
         return result.toPromise();
     }
 
@@ -102,8 +102,8 @@ export class PromisePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Promise<ApiResponse> {
-        const result = this.api.uploadFile(petId, additionalMetadata, file, options);
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
+        const result = this.api.uploadFile(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
 
@@ -134,8 +134,8 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, options?: Configuration): Promise<void> {
-        const result = this.api.deleteOrder(orderId, options);
+    public deleteOrder(orderId: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deleteOrder(orderId, _options);
         return result.toPromise();
     }
 
@@ -143,8 +143,8 @@ export class PromiseStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(options?: Configuration): Promise<{ [key: string]: number; }> {
-        const result = this.api.getInventory(options);
+    public getInventory(_options?: Configuration): Promise<{ [key: string]: number; }> {
+        const result = this.api.getInventory(_options);
         return result.toPromise();
     }
 
@@ -153,8 +153,8 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, options?: Configuration): Promise<Order> {
-        const result = this.api.getOrderById(orderId, options);
+    public getOrderById(orderId: number, _options?: Configuration): Promise<Order> {
+        const result = this.api.getOrderById(orderId, _options);
         return result.toPromise();
     }
 
@@ -162,8 +162,8 @@ export class PromiseStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, options?: Configuration): Promise<Order> {
-        const result = this.api.placeOrder(order, options);
+    public placeOrder(order: Order, _options?: Configuration): Promise<Order> {
+        const result = this.api.placeOrder(order, _options);
         return result.toPromise();
     }
 
@@ -194,8 +194,8 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, options?: Configuration): Promise<void> {
-        const result = this.api.createUser(user, options);
+    public createUser(user: User, _options?: Configuration): Promise<void> {
+        const result = this.api.createUser(user, _options);
         return result.toPromise();
     }
 
@@ -203,8 +203,8 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: Configuration): Promise<void> {
-        const result = this.api.createUsersWithArrayInput(user, options);
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Promise<void> {
+        const result = this.api.createUsersWithArrayInput(user, _options);
         return result.toPromise();
     }
 
@@ -212,8 +212,8 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, options?: Configuration): Promise<void> {
-        const result = this.api.createUsersWithListInput(user, options);
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<void> {
+        const result = this.api.createUsersWithListInput(user, _options);
         return result.toPromise();
     }
 
@@ -222,8 +222,8 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, options?: Configuration): Promise<void> {
-        const result = this.api.deleteUser(username, options);
+    public deleteUser(username: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deleteUser(username, _options);
         return result.toPromise();
     }
 
@@ -231,8 +231,8 @@ export class PromiseUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, options?: Configuration): Promise<User> {
-        const result = this.api.getUserByName(username, options);
+    public getUserByName(username: string, _options?: Configuration): Promise<User> {
+        const result = this.api.getUserByName(username, _options);
         return result.toPromise();
     }
 
@@ -241,16 +241,16 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, options?: Configuration): Promise<string> {
-        const result = this.api.loginUser(username, password, options);
+    public loginUser(username: string, password: string, _options?: Configuration): Promise<string> {
+        const result = this.api.loginUser(username, password, _options);
         return result.toPromise();
     }
 
     /**
      * Logs out current logged in user session
      */
-    public logoutUser(options?: Configuration): Promise<void> {
-        const result = this.api.logoutUser(options);
+    public logoutUser(_options?: Configuration): Promise<void> {
+        const result = this.api.logoutUser(_options);
         return result.toPromise();
     }
 
@@ -260,8 +260,8 @@ export class PromiseUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, options?: Configuration): Promise<void> {
-        const result = this.api.updateUser(username, user, options);
+    public updateUser(username: string, user: User, _options?: Configuration): Promise<void> {
+        const result = this.api.updateUser(username, user, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -18,8 +18,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public async addPet(pet: Pet, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async addPet(pet: Pet, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
@@ -31,7 +31,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -56,7 +56,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -69,8 +69,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public async deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -84,7 +84,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -99,7 +99,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -112,8 +112,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'status' is not null or undefined
         if (status === null || status === undefined) {
@@ -125,7 +125,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByStatus';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -142,7 +142,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -155,8 +155,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public async findPetsByTags(tags: Array<string>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async findPetsByTags(tags: Array<string>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'tags' is not null or undefined
         if (tags === null || tags === undefined) {
@@ -168,7 +168,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByTags';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -185,7 +185,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -198,8 +198,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public async getPetById(petId: number, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getPetById(petId: number, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -212,7 +212,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -226,7 +226,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -238,8 +238,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public async updatePet(pet: Pet, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updatePet(pet: Pet, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
@@ -251,7 +251,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -276,7 +276,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -290,8 +290,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public async updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -306,7 +306,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -330,7 +330,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -344,8 +344,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public async uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -360,7 +360,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -384,7 +384,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -18,8 +18,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public async deleteOrder(orderId: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deleteOrder(orderId: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -32,7 +32,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -53,14 +53,14 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public async getInventory(options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getInventory(_options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // Path Params
         const localVarPath = '/store/inventory';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -74,7 +74,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -87,8 +87,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public async getOrderById(orderId: number, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getOrderById(orderId: number, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -101,7 +101,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -122,8 +122,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public async placeOrder(order: Order, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async placeOrder(order: Order, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'order' is not null or undefined
         if (order === null || order === undefined) {
@@ -135,7 +135,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/order';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -18,8 +18,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Create user
      * @param user Created user object
      */
-    public async createUser(user: User, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUser(user: User, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -31,7 +31,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -54,7 +54,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -66,8 +66,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public async createUsersWithArrayInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -79,7 +79,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithArray';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -102,7 +102,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -114,8 +114,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public async createUsersWithListInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -127,7 +127,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithList';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -150,7 +150,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -163,8 +163,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public async deleteUser(username: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deleteUser(username: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -177,7 +177,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -191,7 +191,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -203,8 +203,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public async getUserByName(username: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getUserByName(username: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -217,7 +217,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -239,8 +239,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public async loginUser(username: string, password: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async loginUser(username: string, password: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -258,7 +258,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/login';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -284,14 +284,14 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Logs out current logged in user session
      */
-    public async logoutUser(options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async logoutUser(_options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // Path Params
         const localVarPath = '/user/logout';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -305,7 +305,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -319,8 +319,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public async updateUser(username: string, user: User, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updateUser(username: string, user: User, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -339,7 +339,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -362,7 +362,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
@@ -30,8 +30,8 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.addPet(pet, options);
+    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -54,8 +54,8 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, options);
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -78,8 +78,8 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Observable<Array<Pet>> {
-        const requestContextPromise = this.requestFactory.findPetsByStatus(status, options);
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+        const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -102,8 +102,8 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, options?: Configuration): Observable<Array<Pet>> {
-        const requestContextPromise = this.requestFactory.findPetsByTags(tags, options);
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+        const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -126,8 +126,8 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.getPetById(petId, options);
+    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -149,8 +149,8 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.updatePet(pet, options);
+    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -174,8 +174,8 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, options);
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -199,8 +199,8 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Observable<ApiResponse> {
-        const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, options);
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+        const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -241,8 +241,8 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deleteOrder(orderId, options);
+    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -264,8 +264,8 @@ export class ObservableStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(options?: Configuration): Observable<{ [key: string]: number; }> {
-        const requestContextPromise = this.requestFactory.getInventory(options);
+    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+        const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -288,8 +288,8 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, options?: Configuration): Observable<Order> {
-        const requestContextPromise = this.requestFactory.getOrderById(orderId, options);
+    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+        const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -311,8 +311,8 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, options?: Configuration): Observable<Order> {
-        const requestContextPromise = this.requestFactory.placeOrder(order, options);
+    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+        const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -353,8 +353,8 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUser(user, options);
+    public createUser(user: User, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -376,8 +376,8 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, options);
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -399,8 +399,8 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUsersWithListInput(user, options);
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -423,8 +423,8 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deleteUser(username, options);
+    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -446,8 +446,8 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, options?: Configuration): Observable<User> {
-        const requestContextPromise = this.requestFactory.getUserByName(username, options);
+    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+        const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -470,8 +470,8 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, options?: Configuration): Observable<string> {
-        const requestContextPromise = this.requestFactory.loginUser(username, password, options);
+    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+        const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -492,8 +492,8 @@ export class ObservableUserApi {
     /**
      * Logs out current logged in user session
      */
-    public logoutUser(options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.logoutUser(options);
+    public logoutUser(_options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -517,8 +517,8 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.updateUser(username, user, options);
+    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/PromiseAPI.ts
@@ -26,8 +26,8 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, options?: Configuration): Promise<Pet> {
-        const result = this.api.addPet(pet, options);
+    public addPet(pet: Pet, _options?: Configuration): Promise<Pet> {
+        const result = this.api.addPet(pet, _options);
         return result.toPromise();
     }
 
@@ -36,8 +36,8 @@ export class PromisePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<void> {
-        const result = this.api.deletePet(petId, apiKey, options);
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deletePet(petId, apiKey, _options);
         return result.toPromise();
     }
 
@@ -46,8 +46,8 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<Array<Pet>> {
-        const result = this.api.findPetsByStatus(status, options);
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<Array<Pet>> {
+        const result = this.api.findPetsByStatus(status, _options);
         return result.toPromise();
     }
 
@@ -56,8 +56,8 @@ export class PromisePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, options?: Configuration): Promise<Array<Pet>> {
-        const result = this.api.findPetsByTags(tags, options);
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Promise<Array<Pet>> {
+        const result = this.api.findPetsByTags(tags, _options);
         return result.toPromise();
     }
 
@@ -66,8 +66,8 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, options?: Configuration): Promise<Pet> {
-        const result = this.api.getPetById(petId, options);
+    public getPetById(petId: number, _options?: Configuration): Promise<Pet> {
+        const result = this.api.getPetById(petId, _options);
         return result.toPromise();
     }
 
@@ -75,8 +75,8 @@ export class PromisePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, options?: Configuration): Promise<Pet> {
-        const result = this.api.updatePet(pet, options);
+    public updatePet(pet: Pet, _options?: Configuration): Promise<Pet> {
+        const result = this.api.updatePet(pet, _options);
         return result.toPromise();
     }
 
@@ -86,8 +86,8 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Promise<void> {
-        const result = this.api.updatePetWithForm(petId, name, status, options);
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.updatePetWithForm(petId, name, status, _options);
         return result.toPromise();
     }
 
@@ -97,8 +97,8 @@ export class PromisePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Promise<ApiResponse> {
-        const result = this.api.uploadFile(petId, additionalMetadata, file, options);
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
+        const result = this.api.uploadFile(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
 
@@ -126,8 +126,8 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, options?: Configuration): Promise<void> {
-        const result = this.api.deleteOrder(orderId, options);
+    public deleteOrder(orderId: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deleteOrder(orderId, _options);
         return result.toPromise();
     }
 
@@ -135,8 +135,8 @@ export class PromiseStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(options?: Configuration): Promise<{ [key: string]: number; }> {
-        const result = this.api.getInventory(options);
+    public getInventory(_options?: Configuration): Promise<{ [key: string]: number; }> {
+        const result = this.api.getInventory(_options);
         return result.toPromise();
     }
 
@@ -145,8 +145,8 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, options?: Configuration): Promise<Order> {
-        const result = this.api.getOrderById(orderId, options);
+    public getOrderById(orderId: number, _options?: Configuration): Promise<Order> {
+        const result = this.api.getOrderById(orderId, _options);
         return result.toPromise();
     }
 
@@ -154,8 +154,8 @@ export class PromiseStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, options?: Configuration): Promise<Order> {
-        const result = this.api.placeOrder(order, options);
+    public placeOrder(order: Order, _options?: Configuration): Promise<Order> {
+        const result = this.api.placeOrder(order, _options);
         return result.toPromise();
     }
 
@@ -183,8 +183,8 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, options?: Configuration): Promise<void> {
-        const result = this.api.createUser(user, options);
+    public createUser(user: User, _options?: Configuration): Promise<void> {
+        const result = this.api.createUser(user, _options);
         return result.toPromise();
     }
 
@@ -192,8 +192,8 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: Configuration): Promise<void> {
-        const result = this.api.createUsersWithArrayInput(user, options);
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Promise<void> {
+        const result = this.api.createUsersWithArrayInput(user, _options);
         return result.toPromise();
     }
 
@@ -201,8 +201,8 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, options?: Configuration): Promise<void> {
-        const result = this.api.createUsersWithListInput(user, options);
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<void> {
+        const result = this.api.createUsersWithListInput(user, _options);
         return result.toPromise();
     }
 
@@ -211,8 +211,8 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, options?: Configuration): Promise<void> {
-        const result = this.api.deleteUser(username, options);
+    public deleteUser(username: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deleteUser(username, _options);
         return result.toPromise();
     }
 
@@ -220,8 +220,8 @@ export class PromiseUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, options?: Configuration): Promise<User> {
-        const result = this.api.getUserByName(username, options);
+    public getUserByName(username: string, _options?: Configuration): Promise<User> {
+        const result = this.api.getUserByName(username, _options);
         return result.toPromise();
     }
 
@@ -230,16 +230,16 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, options?: Configuration): Promise<string> {
-        const result = this.api.loginUser(username, password, options);
+    public loginUser(username: string, password: string, _options?: Configuration): Promise<string> {
+        const result = this.api.loginUser(username, password, _options);
         return result.toPromise();
     }
 
     /**
      * Logs out current logged in user session
      */
-    public logoutUser(options?: Configuration): Promise<void> {
-        const result = this.api.logoutUser(options);
+    public logoutUser(_options?: Configuration): Promise<void> {
+        const result = this.api.logoutUser(_options);
         return result.toPromise();
     }
 
@@ -249,8 +249,8 @@ export class PromiseUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, options?: Configuration): Promise<void> {
-        const result = this.api.updateUser(username, user, options);
+    public updateUser(username: string, user: User, _options?: Configuration): Promise<void> {
+        const result = this.api.updateUser(username, user, _options);
         return result.toPromise();
     }
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
@@ -19,8 +19,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public async addPet(pet: Pet, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async addPet(pet: Pet, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
@@ -32,7 +32,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -57,7 +57,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -70,8 +70,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public async deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -85,7 +85,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -100,7 +100,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -113,8 +113,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'status' is not null or undefined
         if (status === null || status === undefined) {
@@ -126,7 +126,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByStatus';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -143,7 +143,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -156,8 +156,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public async findPetsByTags(tags: Array<string>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async findPetsByTags(tags: Array<string>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'tags' is not null or undefined
         if (tags === null || tags === undefined) {
@@ -169,7 +169,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet/findByTags';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -186,7 +186,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -199,8 +199,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public async getPetById(petId: number, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getPetById(petId: number, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -213,7 +213,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -227,7 +227,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -239,8 +239,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public async updatePet(pet: Pet, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updatePet(pet: Pet, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
@@ -252,7 +252,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/pet';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -277,7 +277,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -291,8 +291,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public async updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -307,7 +307,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -331,7 +331,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -345,8 +345,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public async uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
@@ -361,7 +361,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -385,7 +385,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["petstore_auth"]
+        authMethod = _config.authMethods["petstore_auth"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
@@ -19,8 +19,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public async deleteOrder(orderId: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deleteOrder(orderId: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -33,7 +33,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -54,14 +54,14 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public async getInventory(options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getInventory(_options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // Path Params
         const localVarPath = '/store/inventory';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -75,7 +75,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -88,8 +88,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public async getOrderById(orderId: number, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getOrderById(orderId: number, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
@@ -102,7 +102,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -123,8 +123,8 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public async placeOrder(order: Order, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async placeOrder(order: Order, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'order' is not null or undefined
         if (order === null || order === undefined) {
@@ -136,7 +136,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/store/order';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
@@ -19,8 +19,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Create user
      * @param user Created user object
      */
-    public async createUser(user: User, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUser(user: User, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -32,7 +32,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -55,7 +55,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -67,8 +67,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public async createUsersWithArrayInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -80,7 +80,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithArray';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -103,7 +103,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -115,8 +115,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public async createUsersWithListInput(user: Array<User>, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
@@ -128,7 +128,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/createWithList';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -151,7 +151,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -164,8 +164,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public async deleteUser(username: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async deleteUser(username: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -178,7 +178,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.DELETE);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -192,7 +192,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -204,8 +204,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public async getUserByName(username: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async getUserByName(username: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -218,7 +218,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -240,8 +240,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public async loginUser(username: string, password: string, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async loginUser(username: string, password: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -259,7 +259,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
         const localVarPath = '/user/login';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -285,14 +285,14 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Logs out current logged in user session
      */
-    public async logoutUser(options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async logoutUser(_options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // Path Params
         const localVarPath = '/user/logout';
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -306,7 +306,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }
@@ -320,8 +320,8 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public async updateUser(username: string, user: User, options?: Configuration): Promise<RequestContext> {
-        let config = options || this.configuration;
+    public async updateUser(username: string, user: User, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
@@ -340,7 +340,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
 
         // Make Request Context
-        const requestContext = config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.PUT);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Query Params
@@ -363,7 +363,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         let authMethod = null;
         // Apply auth methods
-        authMethod = config.authMethods["api_key"]
+        authMethod = _config.authMethods["api_key"]
         if (authMethod) {
             await authMethod.applySecurityAuthentication(requestContext);
         }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObservableAPI.ts
@@ -30,8 +30,8 @@ export class ObservablePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.addPet(pet, options);
+    public addPet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.addPet(pet, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -54,8 +54,8 @@ export class ObservablePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, options);
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -78,8 +78,8 @@ export class ObservablePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Observable<Array<Pet>> {
-        const requestContextPromise = this.requestFactory.findPetsByStatus(status, options);
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<Array<Pet>> {
+        const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -102,8 +102,8 @@ export class ObservablePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, options?: Configuration): Observable<Array<Pet>> {
-        const requestContextPromise = this.requestFactory.findPetsByTags(tags, options);
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Observable<Array<Pet>> {
+        const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -126,8 +126,8 @@ export class ObservablePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.getPetById(petId, options);
+    public getPetById(petId: number, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.getPetById(petId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -149,8 +149,8 @@ export class ObservablePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, options?: Configuration): Observable<Pet> {
-        const requestContextPromise = this.requestFactory.updatePet(pet, options);
+    public updatePet(pet: Pet, _options?: Configuration): Observable<Pet> {
+        const requestContextPromise = this.requestFactory.updatePet(pet, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -174,8 +174,8 @@ export class ObservablePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, options);
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -199,8 +199,8 @@ export class ObservablePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Observable<ApiResponse> {
-        const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, options);
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<ApiResponse> {
+        const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -241,8 +241,8 @@ export class ObservableStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deleteOrder(orderId, options);
+    public deleteOrder(orderId: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -264,8 +264,8 @@ export class ObservableStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(options?: Configuration): Observable<{ [key: string]: number; }> {
-        const requestContextPromise = this.requestFactory.getInventory(options);
+    public getInventory(_options?: Configuration): Observable<{ [key: string]: number; }> {
+        const requestContextPromise = this.requestFactory.getInventory(_options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -288,8 +288,8 @@ export class ObservableStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, options?: Configuration): Observable<Order> {
-        const requestContextPromise = this.requestFactory.getOrderById(orderId, options);
+    public getOrderById(orderId: number, _options?: Configuration): Observable<Order> {
+        const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -311,8 +311,8 @@ export class ObservableStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, options?: Configuration): Observable<Order> {
-        const requestContextPromise = this.requestFactory.placeOrder(order, options);
+    public placeOrder(order: Order, _options?: Configuration): Observable<Order> {
+        const requestContextPromise = this.requestFactory.placeOrder(order, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -353,8 +353,8 @@ export class ObservableUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUser(user, options);
+    public createUser(user: User, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUser(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -376,8 +376,8 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, options);
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -399,8 +399,8 @@ export class ObservableUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.createUsersWithListInput(user, options);
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -423,8 +423,8 @@ export class ObservableUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.deleteUser(username, options);
+    public deleteUser(username: string, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.deleteUser(username, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -446,8 +446,8 @@ export class ObservableUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, options?: Configuration): Observable<User> {
-        const requestContextPromise = this.requestFactory.getUserByName(username, options);
+    public getUserByName(username: string, _options?: Configuration): Observable<User> {
+        const requestContextPromise = this.requestFactory.getUserByName(username, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -470,8 +470,8 @@ export class ObservableUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, options?: Configuration): Observable<string> {
-        const requestContextPromise = this.requestFactory.loginUser(username, password, options);
+    public loginUser(username: string, password: string, _options?: Configuration): Observable<string> {
+        const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -492,8 +492,8 @@ export class ObservableUserApi {
     /**
      * Logs out current logged in user session
      */
-    public logoutUser(options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.logoutUser(options);
+    public logoutUser(_options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.logoutUser(_options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
@@ -517,8 +517,8 @@ export class ObservableUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, options?: Configuration): Observable<void> {
-        const requestContextPromise = this.requestFactory.updateUser(username, user, options);
+    public updateUser(username: string, user: User, _options?: Configuration): Observable<void> {
+        const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
 
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/PromiseAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/PromiseAPI.ts
@@ -26,8 +26,8 @@ export class PromisePetApi {
      * Add a new pet to the store
      * @param pet Pet object that needs to be added to the store
      */
-    public addPet(pet: Pet, options?: Configuration): Promise<Pet> {
-        const result = this.api.addPet(pet, options);
+    public addPet(pet: Pet, _options?: Configuration): Promise<Pet> {
+        const result = this.api.addPet(pet, _options);
         return result.toPromise();
     }
 
@@ -36,8 +36,8 @@ export class PromisePetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet(petId: number, apiKey?: string, options?: Configuration): Promise<void> {
-        const result = this.api.deletePet(petId, apiKey, options);
+    public deletePet(petId: number, apiKey?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deletePet(petId, apiKey, _options);
         return result.toPromise();
     }
 
@@ -46,8 +46,8 @@ export class PromisePetApi {
      * Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, options?: Configuration): Promise<Array<Pet>> {
-        const result = this.api.findPetsByStatus(status, options);
+    public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<Array<Pet>> {
+        const result = this.api.findPetsByStatus(status, _options);
         return result.toPromise();
     }
 
@@ -56,8 +56,8 @@ export class PromisePetApi {
      * Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags(tags: Array<string>, options?: Configuration): Promise<Array<Pet>> {
-        const result = this.api.findPetsByTags(tags, options);
+    public findPetsByTags(tags: Array<string>, _options?: Configuration): Promise<Array<Pet>> {
+        const result = this.api.findPetsByTags(tags, _options);
         return result.toPromise();
     }
 
@@ -66,8 +66,8 @@ export class PromisePetApi {
      * Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById(petId: number, options?: Configuration): Promise<Pet> {
-        const result = this.api.getPetById(petId, options);
+    public getPetById(petId: number, _options?: Configuration): Promise<Pet> {
+        const result = this.api.getPetById(petId, _options);
         return result.toPromise();
     }
 
@@ -75,8 +75,8 @@ export class PromisePetApi {
      * Update an existing pet
      * @param pet Pet object that needs to be added to the store
      */
-    public updatePet(pet: Pet, options?: Configuration): Promise<Pet> {
-        const result = this.api.updatePet(pet, options);
+    public updatePet(pet: Pet, _options?: Configuration): Promise<Pet> {
+        const result = this.api.updatePet(pet, _options);
         return result.toPromise();
     }
 
@@ -86,8 +86,8 @@ export class PromisePetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm(petId: number, name?: string, status?: string, options?: Configuration): Promise<void> {
-        const result = this.api.updatePetWithForm(petId, name, status, options);
+    public updatePetWithForm(petId: number, name?: string, status?: string, _options?: Configuration): Promise<void> {
+        const result = this.api.updatePetWithForm(petId, name, status, _options);
         return result.toPromise();
     }
 
@@ -97,8 +97,8 @@ export class PromisePetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, options?: Configuration): Promise<ApiResponse> {
-        const result = this.api.uploadFile(petId, additionalMetadata, file, options);
+    public uploadFile(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Promise<ApiResponse> {
+        const result = this.api.uploadFile(petId, additionalMetadata, file, _options);
         return result.toPromise();
     }
 
@@ -126,8 +126,8 @@ export class PromiseStoreApi {
      * Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder(orderId: string, options?: Configuration): Promise<void> {
-        const result = this.api.deleteOrder(orderId, options);
+    public deleteOrder(orderId: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deleteOrder(orderId, _options);
         return result.toPromise();
     }
 
@@ -135,8 +135,8 @@ export class PromiseStoreApi {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    public getInventory(options?: Configuration): Promise<{ [key: string]: number; }> {
-        const result = this.api.getInventory(options);
+    public getInventory(_options?: Configuration): Promise<{ [key: string]: number; }> {
+        const result = this.api.getInventory(_options);
         return result.toPromise();
     }
 
@@ -145,8 +145,8 @@ export class PromiseStoreApi {
      * Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById(orderId: number, options?: Configuration): Promise<Order> {
-        const result = this.api.getOrderById(orderId, options);
+    public getOrderById(orderId: number, _options?: Configuration): Promise<Order> {
+        const result = this.api.getOrderById(orderId, _options);
         return result.toPromise();
     }
 
@@ -154,8 +154,8 @@ export class PromiseStoreApi {
      * Place an order for a pet
      * @param order order placed for purchasing the pet
      */
-    public placeOrder(order: Order, options?: Configuration): Promise<Order> {
-        const result = this.api.placeOrder(order, options);
+    public placeOrder(order: Order, _options?: Configuration): Promise<Order> {
+        const result = this.api.placeOrder(order, _options);
         return result.toPromise();
     }
 
@@ -183,8 +183,8 @@ export class PromiseUserApi {
      * Create user
      * @param user Created user object
      */
-    public createUser(user: User, options?: Configuration): Promise<void> {
-        const result = this.api.createUser(user, options);
+    public createUser(user: User, _options?: Configuration): Promise<void> {
+        const result = this.api.createUser(user, _options);
         return result.toPromise();
     }
 
@@ -192,8 +192,8 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithArrayInput(user: Array<User>, options?: Configuration): Promise<void> {
-        const result = this.api.createUsersWithArrayInput(user, options);
+    public createUsersWithArrayInput(user: Array<User>, _options?: Configuration): Promise<void> {
+        const result = this.api.createUsersWithArrayInput(user, _options);
         return result.toPromise();
     }
 
@@ -201,8 +201,8 @@ export class PromiseUserApi {
      * Creates list of users with given input array
      * @param user List of user object
      */
-    public createUsersWithListInput(user: Array<User>, options?: Configuration): Promise<void> {
-        const result = this.api.createUsersWithListInput(user, options);
+    public createUsersWithListInput(user: Array<User>, _options?: Configuration): Promise<void> {
+        const result = this.api.createUsersWithListInput(user, _options);
         return result.toPromise();
     }
 
@@ -211,8 +211,8 @@ export class PromiseUserApi {
      * Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser(username: string, options?: Configuration): Promise<void> {
-        const result = this.api.deleteUser(username, options);
+    public deleteUser(username: string, _options?: Configuration): Promise<void> {
+        const result = this.api.deleteUser(username, _options);
         return result.toPromise();
     }
 
@@ -220,8 +220,8 @@ export class PromiseUserApi {
      * Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName(username: string, options?: Configuration): Promise<User> {
-        const result = this.api.getUserByName(username, options);
+    public getUserByName(username: string, _options?: Configuration): Promise<User> {
+        const result = this.api.getUserByName(username, _options);
         return result.toPromise();
     }
 
@@ -230,16 +230,16 @@ export class PromiseUserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser(username: string, password: string, options?: Configuration): Promise<string> {
-        const result = this.api.loginUser(username, password, options);
+    public loginUser(username: string, password: string, _options?: Configuration): Promise<string> {
+        const result = this.api.loginUser(username, password, _options);
         return result.toPromise();
     }
 
     /**
      * Logs out current logged in user session
      */
-    public logoutUser(options?: Configuration): Promise<void> {
-        const result = this.api.logoutUser(options);
+    public logoutUser(_options?: Configuration): Promise<void> {
+        const result = this.api.logoutUser(_options);
         return result.toPromise();
     }
 
@@ -249,8 +249,8 @@ export class PromiseUserApi {
      * @param username name that need to be deleted
      * @param user Updated user object
      */
-    public updateUser(username: string, user: User, options?: Configuration): Promise<void> {
-        const result = this.api.updateUser(username, user, options);
+    public updateUser(username: string, user: User, _options?: Configuration): Promise<void> {
+        const result = this.api.updateUser(username, user, _options);
         return result.toPromise();
     }
 


### PR DESCRIPTION
fixes https://github.com/OpenAPITools/openapi-generator/issues/9425

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
