### PR TITLE
[csharp][aspnetcore] Allow the use of endpoints (single class per operation)

### DIFF
--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -36,6 +36,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useCollection|Deserialize array types to Collection&lt;T&gt; instead of List&lt;T&gt;.| |false|
 |useDateTimeOffset|Use DateTimeOffset to model date-time properties| |false|
 |useDefaultRouting|Use default routing for the ASP.NET Core version.| |true|
+|useEndpoints|Use one class per operation| |false|
 |useFrameworkReference|Use frameworkReference for ASP.NET Core 3.0+ and PackageReference ASP.NET Core 2.2 or earlier.| |false|
 |useNewtonsoft|Uses the Newtonsoft JSON library.| |true|
 |useSwashbuckle|Uses the Swashbuckle.AspNetCore NuGet package for documentation.| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -60,6 +60,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     public static final String USE_NEWTONSOFT = "useNewtonsoft";
     public static final String USE_DEFAULT_ROUTING = "useDefaultRouting";
     public static final String NEWTONSOFT_VERSION = "newtonsoftVersion";
+    public static final String USE_ENDPOINTS = "useEndpoints";
 
     private String packageGuid = "{" + randomUUID().toString().toUpperCase(Locale.ROOT) + "}";
     private String userSecretsGuid = randomUUID().toString();
@@ -81,6 +82,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private boolean operationIsAsync = false;
     private boolean operationResultTask = false;
     private boolean isLibrary = false;
+    private boolean useEndpoints = false;
     private boolean useFrameworkReference = false;
     private boolean useNewtonsoft = true;
     private boolean useDefaultRouting = true;
@@ -123,7 +125,6 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         outputFolder = "generated-code" + File.separator + getName();
 
         modelTemplateFiles.put("model.mustache", ".cs");
-        apiTemplateFiles.put("controller.mustache", ".cs");
 
         embeddedTemplateDir = templateDir = "aspnetcore/3.0";
 
@@ -275,6 +276,8 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         buildTarget.setOptValue(buildTarget.getDefault());
         cliOptions.add(buildTarget);
 
+        addSwitch(USE_ENDPOINTS, "Use one class per operation", useEndpoints);
+
         addSwitch(GENERATE_BODY,
                 "Generates method body.",
                 generateBody);
@@ -343,6 +346,8 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         setUseSwashbuckle();
         setOperationIsAsync();
 
+
+
         // Check for class modifier if not present set the default value.
         additionalProperties.put(PROJECT_SDK, projectSdk);
 
@@ -366,6 +371,14 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         setIsFramework();
         setUseNewtonsoft();
         setUseEndpointRouting();
+        setUseEndpoints();
+
+        if(useEndpoints && Double.parseDouble(aspnetCoreVersion.getOptValue()) >= 3.0) {
+            apiTemplateFiles.put("controllerEndpoints.mustache", ".cs");
+        }
+        else {
+            apiTemplateFiles.put("controller.mustache", ".cs");
+        }
 
         supportingFiles.add(new SupportingFile("build.sh.mustache", "", "build.sh"));
         supportingFiles.add(new SupportingFile("build.bat.mustache", "", "build.bat"));
@@ -646,6 +659,16 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
             useSwashbuckle = convertPropertyToBooleanAndWriteBack(USE_SWASHBUCKLE);
         } else {
             additionalProperties.put(USE_SWASHBUCKLE, useSwashbuckle);
+        }
+    }
+
+    private void setUseEndpoints() {
+        if (useEndpoints) {
+            additionalProperties.put(USE_ENDPOINTS, useEndpoints);
+        } else if (additionalProperties.containsKey(USE_ENDPOINTS)) {
+            useEndpoints = convertPropertyToBooleanAndWriteBack(USE_ENDPOINTS);
+        } else {
+            additionalProperties.put(USE_ENDPOINTS, useEndpoints);
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Startup.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Startup.mustache
@@ -114,6 +114,7 @@ namespace {{packageName}}
                     // Include DataAnnotation attributes on Controller Action parameters as OpenAPI validation rules (e.g required, pattern, ..)
                     // Use [ValidateModelState] on Actions to actually validate it in C# as well!
                     c.OperationFilter<GeneratePathParamsValidationFilter>();
+                    c.EnableAnnotations();
                 });
 {{#useNewtonsoft}}
                 services

--- a/modules/openapi-generator/src/main/resources/aspnetcore/3.0/controllerEndpoints.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/3.0/controllerEndpoints.mustache
@@ -55,7 +55,7 @@ namespace {{apiPackage}}.Endpoints
         ]{{#responses}}{{#dataType}}
         [SwaggerResponse(statusCode: {{code}}, type: typeof({{&dataType}}), description: "{{message}}")]{{/dataType}}{{^dataType}}{{/dataType}}{{/responses}}{{/useSwashbuckle}}{{^useSwashbuckle}}{{#responses}}{{#dataType}}
         [ProducesResponseType(statusCode: {{code}}, type: typeof({{&dataType}}))]{{/dataType}}{{^dataType}}{{/dataType}}{{/responses}}{{/useSwashbuckle}}
-    public {{operationModifier}} {{#operationResultTask}}{{#operationIsAsync}}async {{/operationIsAsync}}Task<{{/operationResultTask}}IActionResult{{#operationResultTask}}>{{/operationResultTask}} Handle{{#operationResultTask}}Async{{/operationResultTask}}({{#allParams}}{{>pathParam}}{{>queryParam}}{{>bodyParam}}{{>formParam}}{{>headerParam}}{{^-last}}{{^isCookieParam}}, {{/isCookieParam}}{{/-last}}{{/allParams}}){{^generateBody}};{{/generateBody}}
+        public {{operationModifier}} {{#operationResultTask}}{{#operationIsAsync}}async {{/operationIsAsync}}Task<{{/operationResultTask}}IActionResult{{#operationResultTask}}>{{/operationResultTask}} Handle{{#operationResultTask}}Async{{/operationResultTask}}({{#allParams}}{{>pathParam}}{{>queryParam}}{{>bodyParam}}{{>formParam}}{{>headerParam}}{{^-last}}{{^isCookieParam}}, {{/isCookieParam}}{{/-last}}{{/allParams}}){{^generateBody}};{{/generateBody}}
         {{#generateBody}}
         { 
             {{#cookieParams}}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/3.0/controllerEndpoints.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/3.0/controllerEndpoints.mustache
@@ -1,0 +1,90 @@
+{{>partial_header}}
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+{{#operationResultTask}}
+using System.Threading.Tasks;
+{{/operationResultTask}}
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+{{#useSwashbuckle}}
+using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.SwaggerGen;
+{{/useSwashbuckle}}
+{{^isLibrary}}
+using Newtonsoft.Json;
+{{/isLibrary}}
+using {{packageName}}.Attributes;
+using {{modelPackage}};
+
+namespace {{apiPackage}}.Endpoints
+{ {{#operations}}
+    {{#operation}}
+    /// <summary>
+    /// {{description}}
+    /// </summary>{{#description}}
+    [Description("{{description}}")]{{/description}}
+    [ApiController]
+    public {{#classModifier}}{{classModifier}} {{/classModifier}}class {{operationId}} : ControllerBase
+    {
+        /// <summary>
+        /// {{#summary}}{{summary}}{{/summary}}
+        /// </summary>{{#notes}}
+        /// <remarks>{{notes}}</remarks>{{/notes}}{{#allParams}}
+        /// <param name="{{paramName}}">{{description}}</param>{{/allParams}}{{#responses}}
+        /// <response code="{{code}}">{{message}}</response>{{/responses}}
+        [{{httpMethod}}]
+        [Route("{{{basePathWithoutHost}}}{{{path}}}")]
+{{#authMethods}}
+{{#isApiKey}}
+        [Authorize(Policy = "{{name}}")]
+{{/isApiKey}}
+{{#isBasicBearer}}
+        [Authorize{{#scopes}}{{#-first}}(Roles = "{{/-first}}{{scope}}{{^-last}},{{/-last}}{{#-last}}"){{/-last}}{{/scopes}}]
+{{/isBasicBearer}}
+{{/authMethods}}
+        {{#vendorExtensions.x-aspnetcore-consumes}}
+        [Consumes({{&vendorExtensions.x-aspnetcore-consumes}})]
+        {{/vendorExtensions.x-aspnetcore-consumes}}
+        [ValidateModelState]{{#useSwashbuckle}}
+        [SwaggerOperation(
+            Summary = "{{summary}}",
+            OperationId = "{{operationId}}",
+            Tags = new[] { {{#tags}}"{{name}}"{{/tags}}, })
+        ]{{#responses}}{{#dataType}}
+        [SwaggerResponse(statusCode: {{code}}, type: typeof({{&dataType}}), description: "{{message}}")]{{/dataType}}{{^dataType}}{{/dataType}}{{/responses}}{{/useSwashbuckle}}{{^useSwashbuckle}}{{#responses}}{{#dataType}}
+        [ProducesResponseType(statusCode: {{code}}, type: typeof({{&dataType}}))]{{/dataType}}{{^dataType}}{{/dataType}}{{/responses}}{{/useSwashbuckle}}
+    public {{operationModifier}} {{#operationResultTask}}{{#operationIsAsync}}async {{/operationIsAsync}}Task<{{/operationResultTask}}IActionResult{{#operationResultTask}}>{{/operationResultTask}} Handle{{#operationResultTask}}Async{{/operationResultTask}}({{#allParams}}{{>pathParam}}{{>queryParam}}{{>bodyParam}}{{>formParam}}{{>headerParam}}{{^-last}}{{^isCookieParam}}, {{/isCookieParam}}{{/-last}}{{/allParams}}){{^generateBody}};{{/generateBody}}
+        {{#generateBody}}
+        { 
+            {{#cookieParams}}
+            var {{paramName}} = Request.Cookies["{{paramName}}"];
+            {{/cookieParams}}
+
+{{#responses}}
+{{#dataType}}
+            //TODO: Uncomment the next line to return response {{code}} or use other options such as return this.NotFound(), return this.BadRequest(..), ...
+            // return StatusCode({{code}}, default({{&dataType}}));
+{{/dataType}}
+{{^dataType}}
+            //TODO: Uncomment the next line to return response {{code}} or use other options such as return this.NotFound(), return this.BadRequest(..), ...
+            // return StatusCode({{code}});
+{{/dataType}}
+{{/responses}}
+{{#returnType}}
+            string exampleJson = null;
+            {{#examples}}
+            exampleJson = "{{{example}}}";
+            {{/examples}}
+            {{#isListCollection}}{{>listReturn}}{{/isListCollection}}{{^isListCollection}}{{#isMap}}{{>mapReturn}}{{/isMap}}{{^isMap}}{{>objectReturn}}{{/isMap}}{{/isListCollection}}
+            {{!TODO: defaultResponse, examples, auth, consumes, produces, nickname, externalDocs, imports, security}}
+            //TODO: Change the data returned
+            return {{#operationResultTask}}Task.FromResult<IActionResult>({{/operationResultTask}}new ObjectResult(example){{#operationResultTask}}){{/operationResultTask}};{{/returnType}}{{^returnType}}
+            throw new NotImplementedException();{{/returnType}}
+        }
+        {{/generateBody}}
+    }
+    {{/operation}}
+{{/operations}}
+}

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Startup.cs
@@ -106,6 +106,7 @@ namespace Org.OpenAPITools
                     // Include DataAnnotation attributes on Controller Action parameters as OpenAPI validation rules (e.g required, pattern, ..)
                     // Use [ValidateModelState] on Actions to actually validate it in C# as well!
                     c.OperationFilter<GeneratePathParamsValidationFilter>();
+                    c.EnableAnnotations();
                 });
                 services
                     .AddSwaggerGenNewtonsoftSupport();

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Startup.cs
@@ -106,6 +106,7 @@ namespace Org.OpenAPITools
                     // Include DataAnnotation attributes on Controller Action parameters as OpenAPI validation rules (e.g required, pattern, ..)
                     // Use [ValidateModelState] on Actions to actually validate it in C# as well!
                     c.OperationFilter<GeneratePathParamsValidationFilter>();
+                    c.EnableAnnotations();
                 });
                 services
                     .AddSwaggerGenNewtonsoftSupport();

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Startup.cs
@@ -106,6 +106,7 @@ namespace Org.OpenAPITools
                     // Include DataAnnotation attributes on Controller Action parameters as OpenAPI validation rules (e.g required, pattern, ..)
                     // Use [ValidateModelState] on Actions to actually validate it in C# as well!
                     c.OperationFilter<GeneratePathParamsValidationFilter>();
+                    c.EnableAnnotations();
                 });
                 services
                     .AddSwaggerGenNewtonsoftSupport();


### PR DESCRIPTION
This adds support for endpoints, i.e. a single class per operation to the generator. Unfortunately the way the generator currently works they are still all part of the same file. We can discuss whether we want to put them under an even further nested namespace. 
As a side effect enabled actual usage of annotations. Might want to expand the annotations of the normal controllers later on as well.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@mandrean (2017/08) @frankyjuang (2019/09) @shibayan (2020/02)