### PR TITLE
Could org.openapitools:petstore-resteasy:1.0.0 drop off redundant dependencies to loose weight? 

### DIFF
--- a/samples/client/petstore/java/resteasy/pom.xml
+++ b/samples/client/petstore/java/resteasy/pom.xml
@@ -175,11 +175,43 @@
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
             <version>${resteasy-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jaxrs-services</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.jcip</groupId>
+                    <artifactId>jcip-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-multipart-provider</artifactId>
             <version>${resteasy-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>javax.mail</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- JSON processing: jackson -->
         <dependency>


### PR DESCRIPTION
Hi, I am a user of project **_org.openapitools:petstore-resteasy:1.0.0_**. I found that its pom file introduced **_43_** dependencies. However, among them, **_11_** libraries (**_25%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_org.openapitools:petstore-resteasy:1.0.0_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
javax.xml.bind:jaxb-api:jar:2.2.7:compile
net.jcip:jcip-annotations:jar:1.0:compile
com.sun.mail:javax.mail:jar:1.5.6:compile
com.sun.istack:istack-commons-runtime:jar:2.16:compile
com.sun.xml.bind:jaxb-impl:jar:2.2.7:compile
javax.xml.bind:jsr173_api:jar:1.0:compile
com.sun.xml.fastinfoset:FastInfoset:jar:1.2.12:compile
javax.activation:activation:jar:1.1.1:compile
com.sun.xml.bind:jaxb-core:jar:2.2.7:compile
org.jboss.resteasy:resteasy-jaxrs-services:jar:3.1.3.Final:compile
org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar:1.0.0.Final:compile
</code></pre>

### PR checklist
* [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
* [ ]  Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
* [ ]  Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
   ```
   ./mvnw clean package 
   ./bin/generate-samples.sh
   ./bin/utils/export_docs_generators.sh
   ```
   Commit all changed files.
   This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
   These must match the expectations made by your contribution.
   You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
   For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
 * [ ]  File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
 * [ ]  If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08)