### PR TITLE
[typescript-rxjs] Update servers.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/servers.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/servers.mustache
@@ -32,9 +32,9 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
         let replacedUrl = this.url;
         for (const key in this.variableConfiguration) {
             if (this.variableConfiguration.hasOwnProperty(key)) {
-				const re = new RegExp("{" + key + "}","g");
-				replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);	
-			}
+                 const re = new RegExp("{" + key + "}","g");
+                 replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);	
+            }
         }
         return replacedUrl
     }

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/servers.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/servers.mustache
@@ -31,8 +31,10 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
     public getUrl(): string {
         let replacedUrl = this.url;
         for (const key in this.variableConfiguration) {
-            var re = new RegExp("{" + key + "}","g");
-            replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
+            if (this.variableConfiguration.hasOwnProperty(key)) {
+				const re = new RegExp("{" + key + "}","g");
+				replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);	
+			}
         }
         return replacedUrl
     }


### PR DESCRIPTION
add hasOwnProperty checking; use const instead of var

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
