### PR TITLE
fix(#9328): Gradle Plugin ValidateTask does not work under Gradle 7.0

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
@@ -56,11 +56,11 @@ import org.openapitools.codegen.validations.oas.RuleConfiguration
 open class ValidateTask : DefaultTask() {
     @get:InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
-    var inputSpec = project.objects.property<String>()
+    val inputSpec = project.objects.property<String>()
 
     @Optional
     @Input
-    var recommend = project.objects.property<Boolean?>()
+    val recommend = project.objects.property<Boolean?>()
 
     @Suppress("unused")
     @get:Internal

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
@@ -3,6 +3,8 @@ package org.openapitools.generator.gradle.plugin
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.gradle.util.GradleVersion
+import org.testng.annotations.DataProvider
 import org.testng.annotations.Test
 import java.io.File
 import kotlin.test.assertEquals
@@ -11,8 +13,21 @@ import kotlin.test.assertTrue
 class ValidateTaskDslTest : TestBase() {
     override var temp: File = createTempDir(javaClass.simpleName)
 
-    @Test
-    fun `openApiValidate should fail on non-file spec`() {
+    @DataProvider(name = "gradle_version_provider")
+    fun gradleVersionProvider(): Array<Array<String?>> = arrayOf(arrayOf(null), arrayOf("7.0"))
+
+    private fun getGradleRunner(gradleVersion: String?): GradleRunner {
+        val gradleRunner = GradleRunner.create()
+        return if (gradleVersion.isNullOrBlank()) {
+            //Use the current version of Gradle
+            gradleRunner
+        } else {
+            gradleRunner.withGradleVersion(gradleVersion)
+        }
+    }
+
+    @Test(dataProvider = "gradle_version_provider")
+    fun `openApiValidate should fail on non-file spec`(gradleVersion: String?) {
         // Arrange
         withProject("""
             | plugins {
@@ -25,20 +40,28 @@ class ValidateTaskDslTest : TestBase() {
         """.trimMargin())
 
         // Act
-        val result = GradleRunner.create()
+        val result = getGradleRunner(gradleVersion)
                 .withProjectDir(temp)
                 .withArguments("openApiValidate")
                 .withPluginClasspath()
                 .buildAndFail()
 
         // Assert
-        assertTrue(result.output.contains("some_location' specified for property 'inputSpec' does not exist"), "Unexpected/no message presented to the user for a spec pointing to an invalid URI.")
+        val gradleActualVersion = gradleVersion ?: GradleVersion.current().version
+        val gradleVersionParts = gradleActualVersion.split(".")
+        val isBeforeGradle7 = (gradleVersionParts.isEmpty() || gradleVersionParts[0].toInt() < 7)
+        val expectedMessage = if (isBeforeGradle7) {
+            "some_location' specified for property 'inputSpec' does not exist"
+        } else {
+            "An input file was expected to be present but it doesn't exist."
+        }
+        assertTrue(result.output.contains(expectedMessage), "Unexpected/no message presented to the user for a spec pointing to an invalid URI.")
         assertEquals(FAILED, result.task(":openApiValidate")?.outcome,
                 "Expected a failed run, but found ${result.task(":openApiValidate")?.outcome}")
     }
 
-    @Test
-    fun `openApiValidate should succeed on valid spec`() {
+    @Test(dataProvider = "gradle_version_provider")
+    fun `openApiValidate should succeed on valid spec`(gradleVersion: String?) {
         // Arrange
         val projectFiles = mapOf(
                 "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0.yaml")
@@ -55,7 +78,7 @@ class ValidateTaskDslTest : TestBase() {
         """.trimMargin(), projectFiles)
 
         // Act
-        val result = GradleRunner.create()
+        val result = getGradleRunner(gradleVersion)
                 .withProjectDir(temp)
                 .withArguments("openApiValidate")
                 .withPluginClasspath()
@@ -67,8 +90,8 @@ class ValidateTaskDslTest : TestBase() {
                 "Expected a successful run, but found ${result.task(":openApiValidate")?.outcome}")
     }
 
-    @Test
-    fun `openApiValidate should fail on invalid spec`() {
+    @Test(dataProvider = "gradle_version_provider")
+    fun `openApiValidate should fail on invalid spec`(gradleVersion: String?) {
         // Arrange
         val projectFiles = mapOf(
                 "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0-invalid.yaml")
@@ -84,7 +107,7 @@ class ValidateTaskDslTest : TestBase() {
         """.trimMargin(), projectFiles)
 
         // Act
-        val result = GradleRunner.create()
+        val result = getGradleRunner(gradleVersion)
                 .withProjectDir(temp)
                 .withArguments("openApiValidate")
                 .withPluginClasspath()

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
@@ -14,7 +14,11 @@ class ValidateTaskDslTest : TestBase() {
     override var temp: File = createTempDir(javaClass.simpleName)
 
     @DataProvider(name = "gradle_version_provider")
-    fun gradleVersionProvider(): Array<Array<String?>> = arrayOf(arrayOf(null), arrayOf("7.0"))
+    fun gradleVersionProvider(): Array<Array<String?>> = arrayOf(
+        arrayOf(null), // uses the version of Gradle used to build the plugin itself
+        arrayOf("5.6.4"),
+        arrayOf("6.9"),
+        arrayOf("7.0"))
 
     private fun getGradleRunner(gradleVersion: String?): GradleRunner {
         val gradleRunner = GradleRunner.create()


### PR DESCRIPTION
This fixes #9328, which prevents from using the OpenAPI Generator Gradle Plugin with the latest Gradle 7.0.

As of Gradle 7.0, an error is returned at configuration time if a plugin task declares a property of "mutable" type with a setter.
See https://docs.gradle.org/7.0/userguide/validation_problems.html#mutable_type_with_setter for further details.

This PR fixes this issue by declaring such properties as Kotlin `val` members instead, so they do not have setters.
To validate that the fix works, this PR also adds the capability to run the same set of tests in `ValidateTaskDslTest` using different instances of `GradleRunner`, configured with different versions of Gradle. 

@agilob and @jimschubert I'm mentioning the two of you since you reviewed a similar PR (#9059 ) about `GenerateTask`. 

cc @ilya40umov @wing328

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
