### PR TITLE
[python][flask] Fix to failed tests on TravisCI

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-flask/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/requirements.mustache
@@ -22,3 +22,4 @@ typing >= 3.5.2.2
 pyyaml < 5.3; python_version<="2.7"
 {{/supportPython2}}
 setuptools >= 21.0.0
+Flask == 1.1.2

--- a/samples/server/petstore/python-flask/requirements.txt
+++ b/samples/server/petstore/python-flask/requirements.txt
@@ -8,3 +8,4 @@ werkzeug == 0.16.1; python_version=="3.5" or python_version=="3.4"
 swagger-ui-bundle >= 0.0.2
 python_dateutil >= 2.6.0
 setuptools >= 21.0.0
+Flask == 1.1.2


### PR DESCRIPTION
As a result of the release of [Flask 2.0](https://github.com/pallets/flask/releases), the python-flask tests in TravisCI seem to be failing.

[For example](https://travis-ci.org/github/OpenAPITools/openapi-generator/builds/770872412):

```
==================================== ERRORS ====================================
_________ ERROR collecting openapi_server/test/test_pet_controller.py __________
ImportError while importing test module '/home/travis/build/OpenAPITools/openapi-generator/samples/server/petstore/python-flask/openapi_server/test/test_pet_controller.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
openapi_server/test/__init__.py:4: in <module>
    from flask_testing import TestCase
.tox/py3/lib/python3.6/site-packages/flask_testing/__init__.py:13: in <module>
    from .utils import TestCase, LiveServerTestCase
.tox/py3/lib/python3.6/site-packages/flask_testing/utils.py:38: in <module>
    from flask import json_available, templating, template_rendered
E   ImportError: cannot import name 'json_available'

...

!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!
=========================== 3 error in 1.41 seconds ============================
ERROR: InvocationError for command /home/travis/build/OpenAPITools/openapi-generator/samples/server/petstore/python-flask/.tox/py3/bin/pytest --cov=openapi_server (exited with code 2)
```

The cause seems to be that the `flask.json_available` flag was removed in 2.0.0.

> Version 1.1.1
>
> The flask.json_available flag was added back for compatibility with some extensions. It will raise a deprecation warning when used, and will be removed in version 2.0.0. #3288

- https://flask.palletsprojects.com/en/1.1.x/changelog/#version-1-1-1
- https://github.com/pallets/flask/pull/3292
- https://github.com/pallets/flask/issues/3288

In this PR, as a temporary measure, I will fix the Flask version to 1.1.2.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @arun-nalla (2019/11) @spacether (2019/11) 

and @wing328 (Since it appeared that they were investigating this issue)

I hope this is helpful.