### PR TITLE
[swift5][client] make AnyCodable optional

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/Extensions.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Extensions.mustache
@@ -5,7 +5,9 @@
 //
 
 import Foundation
-import AnyCodable{{#usePromiseKit}}
+#if canImport(AnyCodable)
+import AnyCodable
+#endif{{#usePromiseKit}}
 import PromiseKit{{/usePromiseKit}}
 
 extension Bool: JSONEncodable {
@@ -201,6 +203,7 @@ extension RequestBuilder {
     }
 }{{/usePromiseKit}}
 
+#if canImport(AnyCodable)
 extension AnyCodable: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch value {
@@ -241,3 +244,4 @@ extension AnyCodable: Hashable {
         }
     }
 }
+#endif

--- a/modules/openapi-generator/src/main/resources/swift5/XcodeGen.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/XcodeGen.mustache
@@ -11,8 +11,8 @@ targets:
     settings:
       APPLICATION_EXTENSION_API_ONLY: true
     scheme: {}
-    {{#useAlamofire}}dependencies:{{/useAlamofire}}{{^useAlamofire}}{{#useRxSwift}}dependencies:{{/useRxSwift}}{{/useAlamofire}}{{^useAlamofire}}{{^useRxSwift}}{{#usePromiseKit}}dependencies:{{/usePromiseKit}}{{/useRxSwift}}{{/useAlamofire}}{{#useAlamofire}}
+    dependencies:
+    - carthage: AnyCodable{{#useAlamofire}}
     - carthage: Alamofire{{/useAlamofire}}{{#useRxSwift}}
     - carthage: RxSwift{{/useRxSwift}}{{#usePromiseKit}}
     - carthage: PromiseKit{{/usePromiseKit}}
-    - carthage: AnyCodable

--- a/modules/openapi-generator/src/main/resources/swift5/model.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/model.mustache
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 {{#description}}
 
 /** {{description}} */{{/description}}{{#isDeprecated}}

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -5,7 +5,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 extension Bool: JSONEncodable {
     func encodeToJSON() -> Any { return self as Any }
@@ -185,6 +187,7 @@ extension HTTPURLResponse {
     }
 }
 
+#if canImport(AnyCodable)
 extension AnyCodable: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch value {
@@ -225,3 +228,4 @@ extension AnyCodable: Hashable {
         }
     }
 }
+#endif

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Animal: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ApiResponse: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Capitalization: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Cat: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct CatAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Category: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model with \&quot;_class\&quot; property */
 public struct ClassModel: Codable, Hashable {

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Client: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Dog: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct DogAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumArrays: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum EnumClass: String, Codable, CaseIterable {
     case abc = "_abc"

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Must be named &#x60;File&#x60; for test. */
 public struct File: Codable, Hashable {

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FileSchemaTestClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FormatTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct HasOnlyReadOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct List: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MapTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name starting with number */
 public struct Model200Response: Codable, Hashable {

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name same as property name */
 public struct Name: Codable, Hashable {

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct NumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Order: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct OuterComposite: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
     case placed = "placed"

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Pet: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ReadOnlyFirst: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing reserved words */
 public struct Return: Codable, Hashable {

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct SpecialModelName: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct StringBooleanMap: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Tag: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderDefault: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderExample: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct User: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/alamofireLibrary/project.yml
+++ b/samples/client/petstore/swift5/alamofireLibrary/project.yml
@@ -12,5 +12,5 @@ targets:
       APPLICATION_EXTENSION_API_ONLY: true
     scheme: {}
     dependencies:
-    - carthage: Alamofire
     - carthage: AnyCodable
+    - carthage: Alamofire

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -5,7 +5,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 extension Bool: JSONEncodable {
     func encodeToJSON() -> Any { return self as Any }
@@ -185,6 +187,7 @@ extension HTTPURLResponse {
     }
 }
 
+#if canImport(AnyCodable)
 extension AnyCodable: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch value {
@@ -225,3 +228,4 @@ extension AnyCodable: Hashable {
         }
     }
 }
+#endif

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Animal: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ApiResponse: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Capitalization: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Cat: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct CatAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Category: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model with \&quot;_class\&quot; property */
 public struct ClassModel: Codable, Hashable {

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Client: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Dog: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct DogAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumArrays: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum EnumClass: String, Codable, CaseIterable {
     case abc = "_abc"

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Must be named &#x60;File&#x60; for test. */
 public struct File: Codable, Hashable {

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FileSchemaTestClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FormatTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct HasOnlyReadOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct List: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MapTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name starting with number */
 public struct Model200Response: Codable, Hashable {

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name same as property name */
 public struct Name: Codable, Hashable {

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct NumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Order: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct OuterComposite: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
     case placed = "placed"

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Pet: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ReadOnlyFirst: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing reserved words */
 public struct Return: Codable, Hashable {

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct SpecialModelName: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct StringBooleanMap: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Tag: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderDefault: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderExample: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct User: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/combineLibrary/project.yml
+++ b/samples/client/petstore/swift5/combineLibrary/project.yml
@@ -11,5 +11,5 @@ targets:
     settings:
       APPLICATION_EXTENSION_API_ONLY: true
     scheme: {}
-    
+    dependencies:
     - carthage: AnyCodable

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -5,7 +5,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 extension Bool: JSONEncodable {
     func encodeToJSON() -> Any { return self as Any }
@@ -185,6 +187,7 @@ extension HTTPURLResponse {
     }
 }
 
+#if canImport(AnyCodable)
 extension AnyCodable: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch value {
@@ -225,3 +228,4 @@ extension AnyCodable: Hashable {
         }
     }
 }
+#endif

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesAnyType.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesAnyType.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesAnyType: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesArray.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesArray.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesArray: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesBoolean.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesBoolean.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesBoolean: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesInteger.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesInteger.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesInteger: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesNumber.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesNumber.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesNumber: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesObject.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesObject.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesObject: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesString.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesString.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesString: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Animal: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ApiResponse: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/BigCat.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/BigCat.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct BigCat: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/BigCatAllOf.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/BigCatAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct BigCatAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Capitalization: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Cat: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct CatAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Category: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model with \&quot;_class\&quot; property */
 public struct ClassModel: Codable, Hashable {

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Client: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Dog: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct DogAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumArrays: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum EnumClass: String, Codable, CaseIterable {
     case abc = "_abc"

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Must be named &#x60;File&#x60; for test. */
 public struct File: Codable, Hashable {

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FileSchemaTestClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FormatTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct HasOnlyReadOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct List: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MapTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name starting with number */
 public struct Model200Response: Codable, Hashable {

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name same as property name */
 public struct Name: Codable, Hashable {

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct NumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Order: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct OuterComposite: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
     case placed = "placed"

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Pet: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ReadOnlyFirst: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing reserved words */
 public struct Return: Codable, Hashable {

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct SpecialModelName: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct StringBooleanMap: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Tag: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderDefault: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderExample: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct User: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/XmlItem.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models/XmlItem.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct XmlItem: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/default/project.yml
+++ b/samples/client/petstore/swift5/default/project.yml
@@ -11,5 +11,5 @@ targets:
     settings:
       APPLICATION_EXTENSION_API_ONLY: true
     scheme: {}
-    
+    dependencies:
     - carthage: AnyCodable

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -5,7 +5,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 extension Bool: JSONEncodable {
     func encodeToJSON() -> Any { return self as Any }
@@ -185,6 +187,7 @@ extension HTTPURLResponse {
     }
 }
 
+#if canImport(AnyCodable)
 extension AnyCodable: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch value {
@@ -225,3 +228,4 @@ extension AnyCodable: Hashable {
         }
     }
 }
+#endif

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Describes the result of uploading an image resource */
 public struct ApiResponse: Codable, Hashable {

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** A category for a pet */
 public struct Category: Codable, Hashable {

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** An order for a pets from the pet store */
 @available(*, deprecated, message: "This schema is deprecated.")

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** A pet for sale in the pet store */
 public struct Pet: Codable, Hashable {

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** A tag for a pet */
 public struct Tag: Codable, Hashable {

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** A User who is purchasing from the pet store */
 public struct User: Codable, Hashable {

--- a/samples/client/petstore/swift5/deprecated/project.yml
+++ b/samples/client/petstore/swift5/deprecated/project.yml
@@ -11,5 +11,5 @@ targets:
     settings:
       APPLICATION_EXTENSION_API_ONLY: true
     scheme: {}
-    
+    dependencies:
     - carthage: AnyCodable

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -5,7 +5,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 extension Bool: JSONEncodable {
     func encodeToJSON() -> Any { return self as Any }
@@ -185,6 +187,7 @@ extension HTTPURLResponse {
     }
 }
 
+#if canImport(AnyCodable)
 extension AnyCodable: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch value {
@@ -225,3 +228,4 @@ extension AnyCodable: Hashable {
         }
     }
 }
+#endif

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct AdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct Animal: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct ApiResponse: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct ArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct ArrayTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct Capitalization: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct Cat: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct CatAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct Category: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model with \&quot;_class\&quot; property */
 internal struct ClassModel: Codable, Hashable {

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct Client: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct Dog: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct DogAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct EnumArrays: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal enum EnumClass: String, Codable, CaseIterable {
     case abc = "_abc"

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct EnumTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Must be named &#x60;File&#x60; for test. */
 internal struct File: Codable, Hashable {

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct FileSchemaTestClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct FormatTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct HasOnlyReadOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct List: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct MapTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name starting with number */
 internal struct Model200Response: Codable, Hashable {

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name same as property name */
 internal struct Name: Codable, Hashable {

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct NumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct Order: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct OuterComposite: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal enum OuterEnum: String, Codable, CaseIterable {
     case placed = "placed"

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct Pet: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct ReadOnlyFirst: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing reserved words */
 internal struct Return: Codable, Hashable {

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct SpecialModelName: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct StringBooleanMap: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct Tag: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct TypeHolderDefault: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct TypeHolderExample: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 internal struct User: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/nonPublicApi/project.yml
+++ b/samples/client/petstore/swift5/nonPublicApi/project.yml
@@ -11,5 +11,5 @@ targets:
     settings:
       APPLICATION_EXTENSION_API_ONLY: true
     scheme: {}
-    
+    dependencies:
     - carthage: AnyCodable

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -5,7 +5,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 extension Bool: JSONEncodable {
     func encodeToJSON() -> Any { return self as Any }
@@ -185,6 +187,7 @@ extension HTTPURLResponse {
     }
 }
 
+#if canImport(AnyCodable)
 extension AnyCodable: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch value {
@@ -225,3 +228,4 @@ extension AnyCodable: Hashable {
         }
     }
 }
+#endif

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class AdditionalPropertiesClass: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class Animal: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class ApiResponse: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class ArrayOfArrayOfNumberOnly: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class ArrayOfNumberOnly: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class ArrayTest: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class Capitalization: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class Cat: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class CatAllOf: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class Category: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model with \&quot;_class\&quot; property */
 @objc public class ClassModel: NSObject, Codable {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class Client: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class Dog: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class DogAllOf: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class EnumArrays: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum EnumClass: String, Codable, CaseIterable {
     case abc = "_abc"

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class EnumTest: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Must be named &#x60;File&#x60; for test. */
 @objc public class File: NSObject, Codable {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class FileSchemaTestClass: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class FormatTest: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class HasOnlyReadOnly: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class List: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class MapTest: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class MixedPropertiesAndAdditionalPropertiesClass: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name starting with number */
 @objc public class Model200Response: NSObject, Codable {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name same as property name */
 @objc public class Name: NSObject, Codable {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class NumberOnly: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class Order: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class OuterComposite: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
     case placed = "placed"

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class Pet: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class ReadOnlyFirst: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing reserved words */
 @objc public class Return: NSObject, Codable {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class SpecialModelName: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class StringBooleanMap: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class Tag: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class TypeHolderDefault: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class TypeHolderExample: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 @objc public class User: NSObject, Codable {
 

--- a/samples/client/petstore/swift5/objcCompatible/project.yml
+++ b/samples/client/petstore/swift5/objcCompatible/project.yml
@@ -11,5 +11,5 @@ targets:
     settings:
       APPLICATION_EXTENSION_API_ONLY: true
     scheme: {}
-    
+    dependencies:
     - carthage: AnyCodable

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -5,7 +5,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 import PromiseKit
 
 extension Bool: JSONEncodable {
@@ -201,6 +203,7 @@ extension RequestBuilder {
     }
 }
 
+#if canImport(AnyCodable)
 extension AnyCodable: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch value {
@@ -241,3 +244,4 @@ extension AnyCodable: Hashable {
         }
     }
 }
+#endif

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Animal: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ApiResponse: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Capitalization: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Cat: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct CatAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Category: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model with \&quot;_class\&quot; property */
 public struct ClassModel: Codable, Hashable {

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Client: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Dog: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct DogAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumArrays: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum EnumClass: String, Codable, CaseIterable {
     case abc = "_abc"

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Must be named &#x60;File&#x60; for test. */
 public struct File: Codable, Hashable {

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FileSchemaTestClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FormatTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct HasOnlyReadOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct List: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MapTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name starting with number */
 public struct Model200Response: Codable, Hashable {

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name same as property name */
 public struct Name: Codable, Hashable {

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct NumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Order: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct OuterComposite: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
     case placed = "placed"

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Pet: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ReadOnlyFirst: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing reserved words */
 public struct Return: Codable, Hashable {

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct SpecialModelName: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct StringBooleanMap: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Tag: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderDefault: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderExample: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct User: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/promisekitLibrary/project.yml
+++ b/samples/client/petstore/swift5/promisekitLibrary/project.yml
@@ -12,5 +12,5 @@ targets:
       APPLICATION_EXTENSION_API_ONLY: true
     scheme: {}
     dependencies:
-    - carthage: PromiseKit
     - carthage: AnyCodable
+    - carthage: PromiseKit

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -5,7 +5,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 extension Bool: JSONEncodable {
     func encodeToJSON() -> Any { return self as Any }
@@ -185,6 +187,7 @@ extension HTTPURLResponse {
     }
 }
 
+#if canImport(AnyCodable)
 extension AnyCodable: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch value {
@@ -225,3 +228,4 @@ extension AnyCodable: Hashable {
         }
     }
 }
+#endif

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Animal: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ApiResponse: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Capitalization: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Cat: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct CatAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Category: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model with \&quot;_class\&quot; property */
 public struct ClassModel: Codable, Hashable {

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Client: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Dog: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct DogAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumArrays: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum EnumClass: String, Codable, CaseIterable {
     case abc = "_abc"

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Must be named &#x60;File&#x60; for test. */
 public struct File: Codable, Hashable {

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FileSchemaTestClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FormatTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct HasOnlyReadOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct List: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MapTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name starting with number */
 public struct Model200Response: Codable, Hashable {

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name same as property name */
 public struct Name: Codable, Hashable {

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct NumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Order: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct OuterComposite: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
     case placed = "placed"

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Pet: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ReadOnlyFirst: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing reserved words */
 public struct Return: Codable, Hashable {

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct SpecialModelName: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct StringBooleanMap: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Tag: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderDefault: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderExample: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct User: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/readonlyProperties/project.yml
+++ b/samples/client/petstore/swift5/readonlyProperties/project.yml
@@ -11,5 +11,5 @@ targets:
     settings:
       APPLICATION_EXTENSION_API_ONLY: true
     scheme: {}
-    
+    dependencies:
     - carthage: AnyCodable

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -5,7 +5,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 extension Bool: JSONEncodable {
     func encodeToJSON() -> Any { return self as Any }
@@ -185,6 +187,7 @@ extension HTTPURLResponse {
     }
 }
 
+#if canImport(AnyCodable)
 extension AnyCodable: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch value {
@@ -225,3 +228,4 @@ extension AnyCodable: Hashable {
         }
     }
 }
+#endif

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Animal: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ApiResponse: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Capitalization: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Cat: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct CatAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Category: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model with \&quot;_class\&quot; property */
 public struct ClassModel: Codable, Hashable {

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Client: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Dog: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct DogAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumArrays: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum EnumClass: String, Codable, CaseIterable {
     case abc = "_abc"

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Must be named &#x60;File&#x60; for test. */
 public struct File: Codable, Hashable {

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FileSchemaTestClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FormatTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct HasOnlyReadOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct List: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MapTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name starting with number */
 public struct Model200Response: Codable, Hashable {

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name same as property name */
 public struct Name: Codable, Hashable {

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct NumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Order: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct OuterComposite: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
     case placed = "placed"

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Pet: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ReadOnlyFirst: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing reserved words */
 public struct Return: Codable, Hashable {

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct SpecialModelName: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct StringBooleanMap: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Tag: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderDefault: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderExample: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct User: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/resultLibrary/project.yml
+++ b/samples/client/petstore/swift5/resultLibrary/project.yml
@@ -11,5 +11,5 @@ targets:
     settings:
       APPLICATION_EXTENSION_API_ONLY: true
     scheme: {}
-    
+    dependencies:
     - carthage: AnyCodable

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -5,7 +5,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 extension Bool: JSONEncodable {
     func encodeToJSON() -> Any { return self as Any }
@@ -185,6 +187,7 @@ extension HTTPURLResponse {
     }
 }
 
+#if canImport(AnyCodable)
 extension AnyCodable: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch value {
@@ -225,3 +228,4 @@ extension AnyCodable: Hashable {
         }
     }
 }
+#endif

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/AdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct AdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Animal.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Animal: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/AnimalFarm.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ApiResponse.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ApiResponse: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ArrayTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ArrayTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Capitalization.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Capitalization: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Cat.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Cat: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/CatAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct CatAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Category.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Category: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ClassModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model with \&quot;_class\&quot; property */
 public struct ClassModel: Codable, Hashable {

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Client.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Client: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Dog.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Dog: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/DogAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct DogAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumArrays.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumArrays: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum EnumClass: String, Codable, CaseIterable {
     case abc = "_abc"

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct EnumTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/File.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Must be named &#x60;File&#x60; for test. */
 public struct File: Codable, Hashable {

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/FileSchemaTestClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FileSchemaTestClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/FormatTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct FormatTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/HasOnlyReadOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct HasOnlyReadOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/List.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct List: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/MapTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MapTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Model200Response.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name starting with number */
 public struct Model200Response: Codable, Hashable {

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Name.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name same as property name */
 public struct Name: Codable, Hashable {

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/NumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct NumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Order.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Order: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterComposite.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct OuterComposite: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
     case placed = "placed"

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Pet.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Pet: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/ReadOnlyFirst.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct ReadOnlyFirst: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Return.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing reserved words */
 public struct Return: Codable, Hashable {

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/SpecialModelName.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct SpecialModelName: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/StringBooleanMap.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct StringBooleanMap: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/Tag.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct Tag: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderDefault.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderDefault: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/TypeHolderExample.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct TypeHolderExample: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/User.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public struct User: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/rxswiftLibrary/project.yml
+++ b/samples/client/petstore/swift5/rxswiftLibrary/project.yml
@@ -12,5 +12,5 @@ targets:
       APPLICATION_EXTENSION_API_ONLY: true
     scheme: {}
     dependencies:
-    - carthage: RxSwift
     - carthage: AnyCodable
+    - carthage: RxSwift

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Extensions.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Extensions.swift
@@ -5,7 +5,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 extension Bool: JSONEncodable {
     func encodeToJSON() -> Any { return self as Any }
@@ -185,6 +187,7 @@ extension HTTPURLResponse {
     }
 }
 
+#if canImport(AnyCodable)
 extension AnyCodable: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch value {
@@ -225,3 +228,4 @@ extension AnyCodable: Hashable {
         }
     }
 }
+#endif

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/AdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/AdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class AdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Animal.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Animal.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class Animal: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/AnimalFarm.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/AnimalFarm.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public typealias AnimalFarm = [Animal]

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ApiResponse.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ApiResponse.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class ApiResponse: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ArrayOfArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ArrayOfArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class ArrayOfArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ArrayOfNumberOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ArrayOfNumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class ArrayOfNumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ArrayTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ArrayTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class ArrayTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Capitalization.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Capitalization.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class Capitalization: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Cat.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Cat.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class Cat: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/CatAllOf.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/CatAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class CatAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Category.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Category.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class Category: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ClassModel.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ClassModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model with \&quot;_class\&quot; property */
 public final class ClassModel: Codable, Hashable {

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Client.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Client.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class Client: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Dog.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Dog.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class Dog: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/DogAllOf.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/DogAllOf.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class DogAllOf: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/EnumArrays.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/EnumArrays.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class EnumArrays: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/EnumClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/EnumClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum EnumClass: String, Codable, CaseIterable {
     case abc = "_abc"

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/EnumTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class EnumTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/File.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/File.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Must be named &#x60;File&#x60; for test. */
 public final class File: Codable, Hashable {

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/FileSchemaTestClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/FileSchemaTestClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class FileSchemaTestClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/FormatTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/FormatTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class FormatTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/HasOnlyReadOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/HasOnlyReadOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class HasOnlyReadOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/List.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/List.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class List: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/MapTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/MapTest.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class MapTest: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/MixedPropertiesAndAdditionalPropertiesClass.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class MixedPropertiesAndAdditionalPropertiesClass: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Model200Response.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Model200Response.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name starting with number */
 public final class Model200Response: Codable, Hashable {

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Name.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Name.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing model name same as property name */
 public final class Name: Codable, Hashable {

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/NumberOnly.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/NumberOnly.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class NumberOnly: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Order.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Order.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class Order: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/OuterComposite.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/OuterComposite.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class OuterComposite: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
     case placed = "placed"

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Pet.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Pet.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class Pet: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ReadOnlyFirst.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/ReadOnlyFirst.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class ReadOnlyFirst: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Return.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Return.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 /** Model for testing reserved words */
 public final class Return: Codable, Hashable {

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/SpecialModelName.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/SpecialModelName.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class SpecialModelName: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/StringBooleanMap.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/StringBooleanMap.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class StringBooleanMap: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Tag.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/Tag.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class Tag: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/TypeHolderDefault.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/TypeHolderDefault.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class TypeHolderDefault: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/TypeHolderExample.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/TypeHolderExample.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class TypeHolderExample: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/User.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/User.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(AnyCodable)
 import AnyCodable
+#endif
 
 public final class User: Codable, Hashable {
 

--- a/samples/client/petstore/swift5/urlsessionLibrary/project.yml
+++ b/samples/client/petstore/swift5/urlsessionLibrary/project.yml
@@ -11,5 +11,5 @@ targets:
     settings:
       APPLICATION_EXTENSION_API_ONLY: true
     scheme: {}
-    
+    dependencies:
     - carthage: AnyCodable


### PR DESCRIPTION
This PR makes the usage of AnyCodable.

If the users don't have any usage of `Any` in their API's, they can simply don't include the dependency `AnyCodable`, because it will not be needed.

This way it works for the users that need's this dependency and also for the users that don't need it.

This PR also fixes a small issue in the project.yml, when the only dependency is AnyCodable there was a missing tag `dependencies:`

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11)