### PR TITLE
Fix typescript-node installation due to @types/bluebird 3.5.35

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-node/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/package.mustache
@@ -15,7 +15,7 @@
     "dependencies": {
         "bluebird": "^3.5.0",
         "request": "^2.81.0",
-        "@types/bluebird": "*",
+        "@types/bluebird": "3.5.33",
         "@types/request": "*",
         "rewire": "^3.0.2"
     },

--- a/samples/client/petstore/typescript-node/npm/package.json
+++ b/samples/client/petstore/typescript-node/npm/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "bluebird": "^3.5.0",
         "request": "^2.81.0",
-        "@types/bluebird": "*",
+        "@types/bluebird": "3.5.33",
         "@types/request": "*",
         "rewire": "^3.0.2"
     },


### PR DESCRIPTION
Fix typescript-node installation due to @types/bluebird 3.5.35 (latest release) as reported by the CI:

```
> @openapitools/node-typescript-petstore@0.0.1 build
> tsc

node_modules/@types/bluebird/index.d.ts(42,47): error TS1005: '?' expected.
node_modules/@types/bluebird/index.d.ts(42,59): error TS1005: ';' expected.
node_modules/@types/bluebird/index.d.ts(43,34): error TS1110: Type expected.
node_modules/@types/bluebird/index.d.ts(44,27): error TS1110: Type expected.
node_modules/@types/bluebird/index.d.ts(54,17): error TS1005: ']' expected.
node_modules/@types/bluebird/index.d.ts(54,20): error TS1005: ';' expected.
node_modules/@types/bluebird/index.d.ts(54,39): error TS1005: '(' expected.
node_modules/@types/bluebird/index.d.ts(54,40): error TS1135: Argument expression expected.
node_modules/@types/bluebird/index.d.ts(54,66): error TS1005: '(' expected.
node_modules/@types/bluebird/index.d.ts(55,1): error TS1128: Declaration or statement expected.
node_modules/@types/bluebird/index.d.ts(58,17): error TS1005: ']' expected.
node_modules/@types/bluebird/index.d.ts(58,20): error TS1005: ';' expected.
node_modules/@types/bluebird/index.d.ts(58,25): error TS1005: ';' expected.
node_modules/@types/bluebird/index.d.ts(58,50): error TS1005: ';' expected.
node_modules/@types/bluebird/index.d.ts(58,51): error TS1128: Declaration or statement expected.
node_modules/@types/bluebird/index.d.ts(59,1): error TS1128: Declaration or statement expected.
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.2.1:exec (npm-run-build) on project TypeScriptNodeNPMPestoreClientTests: Command execution failed. Process exited with an error: 2 (Exit value: 2) -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.2.1:exec (npm-run-build) on project TypeScriptNodeNPMPestoreClientTests: Command execution failed.
```

Fix by hard-coding the version to 3.5.33 for the time being until someone can come up with a fix to make it work with 3.5.35.

cc @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
