### PR TITLE
fix: dart2 mustache templates minor improvements

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/api_exception.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_exception.mustache
@@ -10,6 +10,7 @@ class ApiException implements Exception {
   Exception innerException;
   StackTrace stackTrace;
 
+  @override
   String toString() {
     if (message == null) {
       return 'ApiException';

--- a/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
@@ -19,7 +19,7 @@ Iterable<QueryParam> _convertParametersForCollectionFormat(
   final params = <QueryParam>[];
 
   // preconditions
-  if (name != null && !name.isEmpty && value != null) {
+  if (name != null && name.isNotEmpty && value != null) {
     if (value is List) {
       // get the collection format, default: csv
       collectionFormat = (collectionFormat == null || collectionFormat.isEmpty)

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_exception.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_exception.dart
@@ -19,6 +19,7 @@ class ApiException implements Exception {
   Exception innerException;
   StackTrace stackTrace;
 
+  @override
   String toString() {
     if (message == null) {
       return 'ApiException';

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_helper.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_helper.dart
@@ -28,7 +28,7 @@ Iterable<QueryParam> _convertParametersForCollectionFormat(
   final params = <QueryParam>[];
 
   // preconditions
-  if (name != null && !name.isEmpty && value != null) {
+  if (name != null && name.isNotEmpty && value != null) {
     if (value is List) {
       // get the collection format, default: csv
       collectionFormat = (collectionFormat == null || collectionFormat.isEmpty)

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_exception.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_exception.dart
@@ -19,6 +19,7 @@ class ApiException implements Exception {
   Exception innerException;
   StackTrace stackTrace;
 
+  @override
   String toString() {
     if (message == null) {
       return 'ApiException';

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_helper.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_helper.dart
@@ -28,7 +28,7 @@ Iterable<QueryParam> _convertParametersForCollectionFormat(
   final params = <QueryParam>[];
 
   // preconditions
-  if (name != null && !name.isEmpty && value != null) {
+  if (name != null && name.isNotEmpty && value != null) {
     if (value is List) {
       // get the collection format, default: csv
       collectionFormat = (collectionFormat == null || collectionFormat.isEmpty)

--- a/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/lib/api_exception.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/lib/api_exception.dart
@@ -19,6 +19,7 @@ class ApiException implements Exception {
   Exception innerException;
   StackTrace stackTrace;
 
+  @override
   String toString() {
     if (message == null) {
       return 'ApiException';

--- a/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/lib/api_helper.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/lib/api_helper.dart
@@ -28,7 +28,7 @@ Iterable<QueryParam> _convertParametersForCollectionFormat(
   final params = <QueryParam>[];
 
   // preconditions
-  if (name != null && !name.isEmpty && value != null) {
+  if (name != null && name.isNotEmpty && value != null) {
     if (value is List) {
       // get the collection format, default: csv
       collectionFormat = (collectionFormat == null || collectionFormat.isEmpty)


### PR DESCRIPTION
Fixes two nits in `dart2` mustache templates that should satisfy linter:
- add `@override` toString (rule `annotate_overrides`)
- use String's `isNotEmpty` instead of `!isEmpty`  (rule `prefer_is_not_emty`)

@kuhnroyal

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
