### PR TITLE
[C++][Pistache] fix missing default values for string and enum types

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -401,7 +401,11 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
         } else if (!StringUtils.isEmpty(p.get$ref())) { // model
             return toModelName(ModelUtils.getSimpleRef(p.get$ref())) + "()";
         } else if (ModelUtils.isStringSchema(p)) {
-            return "\"\"";
+            if (p.getDefault() == null) {
+                return "\"\"";
+            } else {
+                return "\"" + p.getDefault().toString() + "\"";
+            }
         }
 
         return "";


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
The current generated codes for the C++ pistache server does not pass the correct default value for strings (and thus enums) to the templates. This PR just fixes that.

That way, non-required enum values are not set to an empty string in the constructor of a model, if a corresponding default value is specified.

yaml example
```yaml
Pet:
  type: object
  required:
    - someEnum
    - someOtherEnum
    - someString
    - someOtherString
  properties:
    someEnum:
      type: string
      enum: [EnumVal1, EnumVal2, EnumVal3]
      default: EnumVal1
    someOtherEnum:
      type: string
      enum: [OtherEnumVal1, OtherEnumVal2, OtherEnumVal3]
    someString:
      type: string
      default: "hello world"
    someOtherString:
      type: string
```

generated constructor:
```cpp
Pet::Pet()
{
    m_SomeEnum = "EnumVal1";
    m_SomeOtherEnum = "";
    m_SomeString = "hello world";
    m_SomeOtherString = "";
}
```

Please note that the `someOtherEnum` value still receives an invalid value, since no valid default was defined!

**NOTE:** I did run the generate-samples script, but it did not generate differing files. I suspect that the samples don't have this edge case anywhere.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@ravinikam @stkrwork @etherealjoy @martindelille @muttleyxd
