### PR TITLE
[ci] Move openapi-generator build/docs/samples to github actions

### DIFF
--- a/.github/workflows/openapi-generator-test-results.yaml
+++ b/.github/workflows/openapi-generator-test-results.yaml
@@ -1,0 +1,19 @@
+name: OpenAPI Generator Test Report
+
+on:
+  workflow_run:
+    workflows: ['OpenAPI Generator']
+    types:
+      - completed
+
+# separate workflow required due to https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v1
+        with:
+          artifact: surefire-test-results
+          name: JUnit Test results
+          path: '**/surefire-reports/TEST-*.xml'
+          reporter: java-junit

--- a/.github/workflows/openapi-generator.yaml
+++ b/.github/workflows/openapi-generator.yaml
@@ -79,7 +79,7 @@ jobs:
           path: '**/surefire-reports/TEST-*.xml'
 
   documentation:
-    name: Check docs up-to-date
+    name: Docs up-to-date
     runs-on: ubuntu-latest
     needs:
       - build
@@ -117,7 +117,7 @@ jobs:
           fi
 
   samples:
-    name: Check samples up-to-date
+    name: Samples up-to-date
     needs:
       - build
     runs-on: ubuntu-latest

--- a/.github/workflows/openapi-generator.yaml
+++ b/.github/workflows/openapi-generator.yaml
@@ -1,0 +1,214 @@
+name: OpenAPI Generator
+
+on:
+  push:
+    branches:
+      - master
+      - '[5-9]+.[0-9]+.x'
+  pull_request:
+    branches:
+      - master
+      - '[5-9]+.[0-9]+.x'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Cache maven dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-maven-repository
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gradle
+            !~/.gradle/caches/*/plugin-resolution/
+            !~/.m2/repository/org/openapitools/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+      - name: Run maven
+        run: mvn --no-snapshot-updates --batch-mode --quiet install -DskipTests -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+      - run: ls -la  modules/openapi-generator-cli/target
+      - name: Upload openapi-generator-cli.jar artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: openapi-generator-cli.jar
+          path: modules/openapi-generator-cli/target/openapi-generator-cli.jar
+          retention-days: 1
+
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Cache maven dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-maven-repository
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gradle
+            !~/.gradle/caches/*/plugin-resolution/
+            !~/.m2/repository/org/openapitools/
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+      - name: Run unit tests
+        run: mvn --no-snapshot-updates --batch-mode --quiet --fail-at-end test -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+      - name: Publish unit test reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: surefire-test-results
+          path: '**/surefire-reports/TEST-*.xml'
+
+  documentation:
+    name: Check docs up-to-date
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Download openapi-generator-cli.jar artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: openapi-generator-cli.jar
+          path: modules/openapi-generator-cli/target
+      - name: Generate docs
+        run: |
+          bash bin/meta-codegen.sh
+          bash bin/utils/export_docs_generators.sh
+          bash bin/utils/copy-to-website.sh
+          bash bin/utils/export_generators_readme.sh
+      - name: Verify git status
+        run: |
+          if [[ "$(git status --porcelain)" != "" ]]; then
+            echo "UNCOMMITTED CHANGES ERROR"
+            echo "There are uncommitted changes in working tree after execution of 'bin/ensure-up-to-date'"
+            echo "Perform git diff"
+            git --no-pager diff
+            echo "Perform git status"
+            git status
+            echo -e "\nThis script runs in pull requests against the anticipated merge commit (as if the PR was merged now)."
+            echo "When you see unexpected files here, it likely means that there are newer commits in master that you need to "
+            echo -e "rebase or merge into your branch.\n"
+            echo "Please run 'bin/utils/ensure-up-to-date' locally and commit changes (UNCOMMITTED CHANGES ERROR)"
+            exit 1
+          fi
+
+  samples:
+    name: Check samples up-to-date
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Download openapi-generator-cli.jar artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: openapi-generator-cli.jar
+          path: modules/openapi-generator-cli/target
+      - name: Generate samples
+        run: bash bin/generate-samples.sh
+      - name: Verify git status
+        run: |
+          if [[ "$(git status --porcelain)" != "" ]]; then
+            echo "UNCOMMITTED CHANGES ERROR"
+            echo "There are uncommitted changes in working tree after execution of 'bin/generate-samples.sh'"
+            echo "Perform git diff"
+            git --no-pager diff
+            echo "Perform git status"
+            git status
+            echo -e "\nThis script runs in pull requests against the anticipated merge commit (as if the PR was merged now)."
+            echo "When you see unexpected files here, it likely means that there are newer commits in master that you need to "
+            echo -e "rebase or merge into your branch.\n"
+            echo "Please run 'bin/generate-samples.sh' locally and commit changes (UNCOMMITTED CHANGES ERROR)"
+            exit 1
+          fi
+
+  test-maven-plugin:
+    name: Maven plugin tests
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache maven dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-maven-repository
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gradle
+            !~/.gradle/caches/*/plugin-resolution/
+            !~/.m2/repository/org/openapitools/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-maven-plugin-${{ env.cache-name }}-
+            ${{ runner.os }}-test-maven-plugin-
+      - name: Run tests
+        run: |
+          mvn --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/java-client.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+          mvn --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/multi-module/pom.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+          mvn --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/kotlin.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+          mvn --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/spring.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+
+  test-gradle-plugin:
+    name: Gradle plugin tests
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache maven dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-maven-repository
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gradle
+            !~/.gradle/caches/modules-2/modules-2.lock
+            !~/.gradle/caches/*/plugin-resolution/
+            !~/.m2/repository/org/openapitools/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-gradle-plugin-${{ env.cache-name }}-
+            ${{ runner.os }}-test-gradle-plugin-
+      - name: Run tests
+        run: |
+          (cd modules/openapi-generator-gradle-plugin/samples/local-spec && ./gradlew buildGoSdk)
+          (cd modules/openapi-generator-gradle-plugin/samples/local-spec && ./gradlew openApiGenerate)

--- a/CI/.drone.yml
+++ b/CI/.drone.yml
@@ -7,8 +7,6 @@ steps:
   commands:
   - ./mvnw --quiet clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
   - ./mvnw --quiet verify -Psamples.droneio -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-  # run ensure up-to-date
-  - /bin/bash bin/utils/ensure-up-to-date
   # test java native client
   - ./mvnw clean test -f samples/client/petstore/java/native/pom.xml
   - ./mvnw clean test -f samples/client/petstore/java/native-async/pom.xml

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -24,19 +24,6 @@ if [ "$NODE_INDEX" = "1" ]; then
   ls -l /home/circleci/.ivy2/cache
 
 elif [ "$NODE_INDEX" = "2" ]; then
-  # run ensure-up-to-date sample script on SNAPSHOT version only
-  project_version=`mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout`
-  if [[ $project_version == *"-SNAPSHOT" ]]; then
-    echo "Running node $NODE_INDEX to test ensure-up-to-date"
-    java -version
-
-    # clear any changes to the samples
-    git checkout -- .
-
-    # look for outdated samples
-    #./bin/utils/ensure-up-to-date
-    # UPDATE: moved to drone.io
-  fi
   echo "Running node $NODE_INDEX to test haskell"
   # install haskell
   curl -sSL https://get.haskellstack.org/ | sh

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioNextClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioNextClientCodegen.java
@@ -72,6 +72,8 @@ public class DartDioNextClientCodegen extends AbstractDartCodegen {
         apiPackage = "lib.src.api";
         modelPackage = "lib.src.model";
 
+        languageSpecificPrimitives.add("bar");
+
         supportedLibraries.put(SERIALIZATION_LIBRARY_BUILT_VALUE, "[DEFAULT] built_value");
         final CliOption serializationLibrary = CliOption.newString(CodegenConstants.SERIALIZATION_LIBRARY, "Specify serialization library");
         serializationLibrary.setEnum(supportedLibraries);
@@ -182,7 +184,7 @@ public class DartDioNextClientCodegen extends AbstractDartCodegen {
         typeMapping.put("List", "BuiltList");
         typeMapping.put("set", "BuiltSet");
         typeMapping.put("map", "BuiltMap");
-        typeMapping.put("file", "Uint8List");
+        typeMapping.put("file", "MultipartFile");
         typeMapping.put("binary", "Uint8List");
         typeMapping.put("object", "JsonObject");
         typeMapping.put("AnyType", "JsonObject");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioNextClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioNextClientCodegen.java
@@ -72,8 +72,6 @@ public class DartDioNextClientCodegen extends AbstractDartCodegen {
         apiPackage = "lib.src.api";
         modelPackage = "lib.src.model";
 
-        languageSpecificPrimitives.add("bar");
-
         supportedLibraries.put(SERIALIZATION_LIBRARY_BUILT_VALUE, "[DEFAULT] built_value");
         final CliOption serializationLibrary = CliOption.newString(CodegenConstants.SERIALIZATION_LIBRARY, "Specify serialization library");
         serializationLibrary.setEnum(supportedLibraries);
@@ -184,7 +182,7 @@ public class DartDioNextClientCodegen extends AbstractDartCodegen {
         typeMapping.put("List", "BuiltList");
         typeMapping.put("set", "BuiltSet");
         typeMapping.put("map", "BuiltMap");
-        typeMapping.put("file", "MultipartFile");
+        typeMapping.put("file", "Uint8List");
         typeMapping.put("binary", "Uint8List");
         typeMapping.put("object", "JsonObject");
         typeMapping.put("AnyType", "JsonObject");

--- a/shippable.yml
+++ b/shippable.yml
@@ -21,7 +21,6 @@ build:
     - export PATH=/opt/gradle/gradle-5.6.4/bin:$PATH 
     - gradle -v
     - java -version
-    - mvn --no-snapshot-updates --quiet clean install -Dmaven.javadoc.skip=true
     # ensure all modifications created by 'mature' generators are in the git repo
     # below move to CircleCI ./bin/utils/ensure-up-to-date
     # prepare environment for tests
@@ -49,12 +48,3 @@ build:
     - mix --version
     # test samples defined in pom.xml
     - mvn --no-snapshot-updates --quiet verify -P samples.shippable -Dmaven.javadoc.skip=true
-    # test maven plugin
-    - mvn --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/java-client.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-    - mvn --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/multi-module/pom.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-    - mvn --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/kotlin.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-    - mvn --no-snapshot-updates --quiet clean compile -f modules/openapi-generator-maven-plugin/examples/spring.xml -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-    # test gradle plugin
-    - (cd modules/openapi-generator-gradle-plugin/samples/local-spec && ./gradlew buildGoSdk)
-    - (cd modules/openapi-generator-gradle-plugin/samples/local-spec && ./gradlew openApiGenerate)
-


### PR DESCRIPTION
I think this should be the next step for migration to Github actions.
This will give faster and explicit feedback on
* build failures related to generator/plugins
* failing unit tests related to generator/plugins
* outdated docs
* outdated samples

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
