### PR TITLE
[dart][dart-dio] Fix gitignore comment style

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/gitignore.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/gitignore.mustache
@@ -30,8 +30,12 @@ pubspec.lock
 # Don’t commit files and directories created by other development environments.
 # For example, if your development environment creates any of the following files,
 # consider putting them in a global ignore file:
-*.iml         // IntelliJ
-*.ipr         // IntelliJ
-*.iws         // IntelliJ
-.idea/        // IntelliJ
-.DS_Store     // Mac
+
+# IntelliJ
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Mac
+.DS_Store

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/gitignore.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/gitignore.mustache
@@ -30,8 +30,12 @@ pubspec.lock
 # Don’t commit files and directories created by other development environments.
 # For example, if your development environment creates any of the following files,
 # consider putting them in a global ignore file:
-*.iml         // IntelliJ
-*.ipr         // IntelliJ
-*.iws         // IntelliJ
-.idea/        // IntelliJ
-.DS_Store     // Mac
+
+# IntelliJ
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Mac
+.DS_Store

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/.gitignore
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/.gitignore
@@ -30,8 +30,12 @@ pubspec.lock
 # Don’t commit files and directories created by other development environments.
 # For example, if your development environment creates any of the following files,
 # consider putting them in a global ignore file:
-*.iml         // IntelliJ
-*.ipr         // IntelliJ
-*.iws         // IntelliJ
-.idea/        // IntelliJ
-.DS_Store     // Mac
+
+# IntelliJ
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Mac
+.DS_Store

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/.gitignore
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/.gitignore
@@ -30,8 +30,12 @@ pubspec.lock
 # Don’t commit files and directories created by other development environments.
 # For example, if your development environment creates any of the following files,
 # consider putting them in a global ignore file:
-*.iml         // IntelliJ
-*.ipr         // IntelliJ
-*.iws         // IntelliJ
-.idea/        // IntelliJ
-.DS_Store     // Mac
+
+# IntelliJ
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Mac
+.DS_Store

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/.gitignore
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/.gitignore
@@ -30,8 +30,12 @@ pubspec.lock
 # Don’t commit files and directories created by other development environments.
 # For example, if your development environment creates any of the following files,
 # consider putting them in a global ignore file:
-*.iml         // IntelliJ
-*.ipr         // IntelliJ
-*.iws         // IntelliJ
-.idea/        // IntelliJ
-.DS_Store     // Mac
+
+# IntelliJ
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Mac
+.DS_Store


### PR DESCRIPTION
Fixes the invalid gitignore comment style present in the templates of dart-dio and dart-dio-next generators

Fixes #9553

CC(Dart): @swipesight (2018/09) @jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
