### PR TITLE
Kotlin-Client: Fix kotlinx_serialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
     {{#jvm-retrofit2}}
     ext.retrofitVersion = '2.7.2'
     {{/jvm-retrofit2}}
@@ -72,7 +72,7 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.1"
     {{/jackson}}
     {{#kotlinx_serialization}}
-    compile "org.jetbrains.kotlinx:kotlinx-serialization-json:1.1.0"
+    compile "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.1"
     {{/kotlinx_serialization}}
     {{#jvm-okhttp3}}
     compile "com.squareup.okhttp3:okhttp:3.12.13"

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -70,7 +70,7 @@ import java.io.Serializable
      * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
      */
     {{#kotlinx_serialization}}
-    @KSerializable
+    {{#serializableModel}}@KSerializable{{/serializableModel}}{{^serializableModel}}@Serializable{{/serializableModel}}
     {{/kotlinx_serialization}}
     {{#nonPublicApi}}internal {{/nonPublicApi}}enum class {{{nameInCamelCase}}}(val value: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}kotlin.String{{/isContainer}}) {
     {{#allowableValues}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -22,7 +22,7 @@ import kotlinx.serialization.internal.CommonEnumSerializer
 * {{{description}}}
 * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
 */
-{{#multiplatform}}@Serializable(with = {{classname}}.Serializer::class){{/multiplatform}}{{#kotlinx_serialization}}@Serializable(with = {{classname}}.Serializer::class){{/kotlinx_serialization}}
+{{#multiplatform}}@Serializable(with = {{classname}}.Serializer::class){{/multiplatform}}{{#kotlinx_serialization}}@Serializable{{/kotlinx_serialization}}
 {{#nonPublicApi}}internal {{/nonPublicApi}}enum class {{classname}}(val value: {{{dataType}}}) {
 
 {{#allowableValues}}{{#enumVars}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/RequestConfig.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/RequestConfig.kt.mustache
@@ -8,10 +8,10 @@ package {{packageName}}.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-{{#nonPublicApi}}internal {{/nonPublicApi}}data class RequestConfig(
+{{#nonPublicApi}}internal {{/nonPublicApi}}data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
@@ -43,7 +43,7 @@ import {{packageName}}.infrastructure.toMultiValue
     {{^doNotUseRxAndCoroutines}}{{#useCoroutines}}suspend {{/useCoroutines}}{{/doNotUseRxAndCoroutines}}fun {{operationId}}({{#allParams}}{{{paramName}}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) : {{#returnType}}{{{returnType}}}{{#nullableReturnType}}?{{/nullableReturnType}}{{/returnType}}{{^returnType}}Unit{{/returnType}} {
         val localVariableConfig = {{operationId}}RequestConfig({{#allParams}}{{{paramName}}} = {{{paramName}}}{{^-last}}, {{/-last}}{{/allParams}})
 
-        val localVarResponse = request<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Any?{{/returnType}}>(
+        val localVarResponse = request<{{#hasBodyParam}}{{#bodyParams}}{{{dataType}}}{{/bodyParams}}{{/hasBodyParam}}{{^hasBodyParam}}{{^hasFormParams}}Unit{{/hasFormParams}}{{#hasFormParams}}Map<String, Any?>{{/hasFormParams}}{{/hasBodyParam}}, {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Unit{{/returnType}}>(
             localVariableConfig
         )
 
@@ -71,8 +71,8 @@ import {{packageName}}.infrastructure.toMultiValue
     {{#isDeprecated}}
     @Deprecated(message = "This operation is deprecated.")
     {{/isDeprecated}}
-    fun {{operationId}}RequestConfig({{#allParams}}{{{paramName}}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) : RequestConfig {
-        val localVariableBody: kotlin.Any? = {{#hasBodyParam}}{{#bodyParams}}{{{paramName}}}{{/bodyParams}}{{/hasBodyParam}}{{^hasBodyParam}}{{^hasFormParams}}null{{/hasFormParams}}{{#hasFormParams}}mapOf({{#formParams}}"{{{baseName}}}" to {{{paramName}}}{{^-last}}, {{/-last}}{{/formParams}}){{/hasFormParams}}{{/hasBodyParam}}
+    fun {{operationId}}RequestConfig({{#allParams}}{{{paramName}}}: {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}}) : RequestConfig<{{#hasBodyParam}}{{#bodyParams}}{{{dataType}}}{{/bodyParams}}{{/hasBodyParam}}{{^hasBodyParam}}{{^hasFormParams}}Unit{{/hasFormParams}}{{#hasFormParams}}Map<String, Any?>{{/hasFormParams}}{{/hasBodyParam}}> {
+        val localVariableBody = {{#hasBodyParam}}{{#bodyParams}}{{{paramName}}}{{/bodyParams}}{{/hasBodyParam}}{{^hasBodyParam}}{{^hasFormParams}}null{{/hasFormParams}}{{#hasFormParams}}mapOf({{#formParams}}"{{{baseName}}}" to {{{paramName}}}{{^-last}}, {{/-last}}{{/formParams}}){{/hasFormParams}}{{/hasBodyParam}}
         val localVariableQuery: MultiValueMap = {{^hasQueryParams}}mutableMapOf()
 {{/hasQueryParams}}{{#hasQueryParams}}mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
@@ -99,16 +99,14 @@ import {{packageName}}.infrastructure.toMultiValue
         {{#headerParams}}
         {{{paramName}}}{{^required}}?{{/required}}.apply { localVariableHeaders["{{baseName}}"] = {{#isContainer}}this.joinToString(separator = collectionDelimiter("{{collectionFormat}}")){{/isContainer}}{{^isContainer}}this.toString(){{/isContainer}} }
         {{/headerParams}}
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.{{httpMethod}},
             path = "{{path}}"{{#pathParams}}.replace("{"+"{{baseName}}"+"}", "${{{paramName}}}"){{/pathParams}},
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     {{/operation}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -27,11 +27,10 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
-import java.util.Date
 {{^threetenbp}}
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -39,6 +38,12 @@ import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
 {{/threetenbp}}
+import java.util.Date
+import java.util.Locale
+{{#kotlinx_serialization}}
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+{{/kotlinx_serialization}}
 {{#threetenbp}}
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
@@ -86,14 +91,10 @@ import org.threeten.bp.OffsetTime
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
             {{#jvm-okhttp3}}
-            content is File -> RequestBody.create(
-                MediaType.parse(mediaType), content
-            )
+            content is File -> RequestBody.create(MediaType.parse(mediaType), content)
             {{/jvm-okhttp3}}
             {{#jvm-okhttp4}}
-            content is File -> content.asRequestBody(
-                mediaType.toMediaTypeOrNull()
-            )
+            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
             {{/jvm-okhttp4}}
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
@@ -154,12 +155,12 @@ import org.threeten.bp.OffsetTime
                 MediaType.parse(mediaType), Serializer.jacksonObjectMapper.writeValueAsString(content)
                 {{/jackson}}
                 {{#kotlinx_serialization}}
-                MediaType.parse(mediaType), Serializer.jvmJson.decodeFromString<T>(content)
+                MediaType.parse(mediaType), Serializer.jvmJson.encodeToString(content)
                 {{/kotlinx_serialization}}
             )
             {{/jvm-okhttp3}}
             {{#jvm-okhttp4}}
-            mediaType == JsonMediaType -> {{#moshi}}Serializer.moshi.adapter(T::class.java).toJson(content){{/moshi}}{{#gson}}Serializer.gson.toJson(content, T::class.java){{/gson}}{{#jackson}}Serializer.jacksonObjectMapper.writeValueAsString(content){{/jackson}}{{#kotlinx_serialization}}Serializer.jvmJson.decodeFromString<T>(content){{/kotlinx_serialization}}.toRequestBody(
+            mediaType == JsonMediaType -> {{#moshi}}Serializer.moshi.adapter(T::class.java).toJson(content){{/moshi}}{{#gson}}Serializer.gson.toJson(content, T::class.java){{/gson}}{{#jackson}}Serializer.jacksonObjectMapper.writeValueAsString(content){{/jackson}}{{#kotlinx_serialization}}Serializer.jvmJson.encodeToString(content){{/kotlinx_serialization}}.toRequestBody(
                 mediaType.toMediaTypeOrNull()
             )
             {{/jvm-okhttp4}}
@@ -196,13 +197,13 @@ import org.threeten.bp.OffsetTime
             return f as T
         }
         return when(mediaType) {
-            JsonMediaType -> {{#moshi}}Serializer.moshi.adapter(T::class.java).fromJson(bodyContent){{/moshi}}{{#gson}}Serializer.gson.fromJson(bodyContent, T::class.java){{/gson}}{{#jackson}}Serializer.jacksonObjectMapper.readValue(bodyContent, T::class.java){{/jackson}}
+            JsonMediaType -> {{#moshi}}Serializer.moshi.adapter(T::class.java).fromJson(bodyContent){{/moshi}}{{#gson}}Serializer.gson.fromJson(bodyContent, T::class.java){{/gson}}{{#jackson}}Serializer.jacksonObjectMapper.readValue(bodyContent, T::class.java){{/jackson}}{{#kotlinx_serialization}}Serializer.jvmJson.decodeFromString<T>(bodyContent){{/kotlinx_serialization}}
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }
     }
 
     {{#hasAuthMethods}}
-    protected fun updateAuthParams(requestConfig: RequestConfig) {
+    protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         {{#authMethods}}
         {{#isApiKey}}
         {{#isKeyInHeader}}
@@ -259,7 +260,7 @@ import org.threeten.bp.OffsetTime
     }
     {{/hasAuthMethods}}
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         {{#jvm-okhttp3}}
         val httpUrl = HttpUrl.parse(baseUrl) ?: throw IllegalStateException("baseUrl is invalid.")
         {{/jvm-okhttp3}}
@@ -300,7 +301,7 @@ import org.threeten.bp.OffsetTime
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -315,57 +316,46 @@ import org.threeten.bp.OffsetTime
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
-                    response.headers{{#jvm-okhttp3}}(){{/jvm-okhttp3}}.toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
+                response.headers{{#jvm-okhttp3}}(){{/jvm-okhttp3}}.toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
-                    response.code{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
-                    response.headers{{#jvm-okhttp3}}(){{/jvm-okhttp3}}.toMultimap()
+            response.isInformational -> Informational(
+                response.message{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
+                response.code{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
+                response.headers{{#jvm-okhttp3}}(){{/jvm-okhttp3}}.toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body{{#jvm-okhttp3}}(){{/jvm-okhttp3}}, accept),
-                    response.code{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
-                    response.headers{{#jvm-okhttp3}}(){{/jvm-okhttp3}}.toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body{{#jvm-okhttp3}}(){{/jvm-okhttp3}}, accept),
+                response.code{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
+                response.headers{{#jvm-okhttp3}}(){{/jvm-okhttp3}}.toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
-                    response.body{{#jvm-okhttp3}}(){{/jvm-okhttp3}}?.string(),
-                    response.code{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
-                    response.headers{{#jvm-okhttp3}}(){{/jvm-okhttp3}}.toMultimap()
+            response.isClientError -> ClientError(
+                response.message{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
+                response.body{{#jvm-okhttp3}}(){{/jvm-okhttp3}}?.string(),
+                response.code{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
+                response.headers{{#jvm-okhttp3}}(){{/jvm-okhttp3}}.toMultimap()
             )
-            else -> return ServerError(
-                    response.message{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
-                    response.body{{#jvm-okhttp3}}(){{/jvm-okhttp3}}?.string(),
-                    response.code{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
-                    response.headers{{#jvm-okhttp3}}(){{/jvm-okhttp3}}.toMultimap()
+            else -> ServerError(
+                response.message{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
+                response.body{{#jvm-okhttp3}}(){{/jvm-okhttp3}}?.string(),
+                response.code{{#jvm-okhttp3}}(){{/jvm-okhttp3}},
+                response.headers{{#jvm-okhttp3}}(){{/jvm-okhttp3}}.toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/ApiClient.kt.mustache
@@ -155,7 +155,7 @@ import {{packageName}}.auth.*
         else request(requestConfig, authNames = authNames)
     }
 
-    protected suspend fun request(requestConfig: RequestConfig, body: OutgoingContent = EmptyContent, authNames: kotlin.collections.List<String>): HttpResponse {
+    protected suspend inline fun <reified T: Any?> request(requestConfig: RequestConfig<T>, body: OutgoingContent = EmptyContent, authNames: kotlin.collections.List<String>): HttpResponse {
         requestConfig.updateForAuth(authNames)
         val headers = requestConfig.headers
 

--- a/samples/client/petstore/kotlin-gson/build.gradle
+++ b/samples/client/petstore/kotlin-gson/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,7 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun addPet(body: Pet) : Unit {
         val localVariableConfig = addPetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -72,20 +72,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun addPetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun addPetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -102,7 +100,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
         val localVariableConfig = deletePetRequestConfig(petId = petId, apiKey = apiKey)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -128,21 +126,19 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param apiKey  (optional)
     * @return RequestConfig
     */
-    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -159,7 +155,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByStatusRequestConfig(status = status)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -184,23 +180,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Status values that need to be considered for filter 
     * @return RequestConfig
     */
-    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("status", toMultiValue(status.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByStatus",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -218,7 +212,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByTagsRequestConfig(tags = tags)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -244,23 +238,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @return RequestConfig
     */
     @Deprecated(message = "This operation is deprecated.")
-    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("tags", toMultiValue(tags.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByTags",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -277,7 +269,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getPetById(petId: kotlin.Long) : Pet {
         val localVariableConfig = getPetByIdRequestConfig(petId = petId)
 
-        val localVarResponse = request<Pet>(
+        val localVarResponse = request<Unit, Pet>(
             localVariableConfig
         )
 
@@ -302,20 +294,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param petId ID of pet to return 
     * @return RequestConfig
     */
-    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -331,7 +321,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePet(body: Pet) : Unit {
         val localVariableConfig = updatePetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -356,20 +346,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun updatePetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updatePetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -387,7 +375,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Map<String, Any?>, Unit>(
             localVariableConfig
         )
 
@@ -414,20 +402,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("name" to name, "status" to status)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -446,7 +432,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        val localVarResponse = request<ApiResponse>(
+        val localVarResponse = request<Map<String, Any?>, ApiResponse>(
             localVariableConfig
         )
 
@@ -473,20 +459,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,7 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableConfig = deleteOrderRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of the order that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getInventory() : kotlin.collections.Map<kotlin.String, kotlin.Int> {
         val localVariableConfig = getInventoryRequestConfig()
 
-        val localVarResponse = request<kotlin.collections.Map<kotlin.String, kotlin.Int>>(
+        val localVarResponse = request<Unit, kotlin.collections.Map<kotlin.String, kotlin.Int>>(
             localVariableConfig
         )
 
@@ -124,20 +122,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     *
     * @return RequestConfig
     */
-    fun getInventoryRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getInventoryRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/inventory",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getOrderById(orderId: kotlin.Long) : Order {
         val localVariableConfig = getOrderByIdRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Unit, Order>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of pet that needs to be fetched 
     * @return RequestConfig
     */
-    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -209,7 +203,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun placeOrder(body: Order) : Order {
         val localVariableConfig = placeOrderRequestConfig(body = body)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Order, Order>(
             localVariableConfig
         )
 
@@ -234,20 +228,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param body order placed for purchasing the pet 
     * @return RequestConfig
     */
-    fun placeOrderRequestConfig(body: Order) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun placeOrderRequestConfig(body: Order) : RequestConfig<Order> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/store/order",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,7 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUser(body: User) : Unit {
         val localVariableConfig = createUserRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Created user object 
     * @return RequestConfig
     */
-    fun createUserRequestConfig(body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUserRequestConfig(body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithArrayInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithArrayInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -125,20 +123,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithListInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithListInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -208,7 +202,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deleteUser(username: kotlin.String) : Unit {
         val localVariableConfig = deleteUserRequestConfig(username = username)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -233,20 +227,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -263,7 +255,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getUserByName(username: kotlin.String) : User {
         val localVariableConfig = getUserByNameRequestConfig(username = username)
 
-        val localVarResponse = request<User>(
+        val localVarResponse = request<Unit, User>(
             localVariableConfig
         )
 
@@ -288,20 +280,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return RequestConfig
     */
-    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -319,7 +309,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun loginUser(username: kotlin.String, password: kotlin.String) : kotlin.String {
         val localVariableConfig = loginUserRequestConfig(username = username, password = password)
 
-        val localVarResponse = request<kotlin.String>(
+        val localVarResponse = request<Unit, kotlin.String>(
             localVariableConfig
         )
 
@@ -345,24 +335,22 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param password The password for login in clear text 
     * @return RequestConfig
     */
-    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("username", listOf(username.toString()))
                 put("password", listOf(password.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/login",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -377,7 +365,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun logoutUser() : Unit {
         val localVariableConfig = logoutUserRequestConfig()
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -401,20 +389,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     *
     * @return RequestConfig
     */
-    fun logoutUserRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun logoutUserRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -431,7 +417,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updateUser(username: kotlin.String, body: User) : Unit {
         val localVariableConfig = updateUserRequestConfig(username = username, body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -457,20 +443,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Updated user object 
     * @return RequestConfig
     */
-    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -12,16 +12,17 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
-import java.util.Date
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
+import java.util.Date
+import java.util.Locale
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -61,9 +62,7 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> content.asRequestBody(
-                mediaType.toMediaTypeOrNull()
-            )
+            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -131,7 +130,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected fun updateAuthParams(requestConfig: RequestConfig) {
+    protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
             if (apiKey["api_key"] != null) {
                 if (apiKeyPrefix["api_key"] != null) {
@@ -148,7 +147,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         // take authMethod from operation
@@ -182,7 +181,7 @@ open class ApiClient(val baseUrl: String) {
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -197,57 +196,46 @@ open class ApiClient(val baseUrl: String) {
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code,
-                    response.headers.toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message,
-                    response.code,
-                    response.headers.toMultimap()
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body, accept),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
-            else -> return ServerError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig(
+data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/samples/client/petstore/kotlin-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jackson/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,7 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun addPet(body: Pet) : Unit {
         val localVariableConfig = addPetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -72,20 +72,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun addPetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun addPetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -102,7 +100,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
         val localVariableConfig = deletePetRequestConfig(petId = petId, apiKey = apiKey)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -128,21 +126,19 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param apiKey  (optional)
     * @return RequestConfig
     */
-    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -159,7 +155,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByStatusRequestConfig(status = status)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -184,23 +180,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Status values that need to be considered for filter 
     * @return RequestConfig
     */
-    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("status", toMultiValue(status.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByStatus",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -218,7 +212,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByTagsRequestConfig(tags = tags)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -244,23 +238,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @return RequestConfig
     */
     @Deprecated(message = "This operation is deprecated.")
-    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("tags", toMultiValue(tags.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByTags",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -277,7 +269,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getPetById(petId: kotlin.Long) : Pet {
         val localVariableConfig = getPetByIdRequestConfig(petId = petId)
 
-        val localVarResponse = request<Pet>(
+        val localVarResponse = request<Unit, Pet>(
             localVariableConfig
         )
 
@@ -302,20 +294,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param petId ID of pet to return 
     * @return RequestConfig
     */
-    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -331,7 +321,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePet(body: Pet) : Unit {
         val localVariableConfig = updatePetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -356,20 +346,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun updatePetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updatePetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -387,7 +375,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Map<String, Any?>, Unit>(
             localVariableConfig
         )
 
@@ -414,20 +402,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("name" to name, "status" to status)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -446,7 +432,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        val localVarResponse = request<ApiResponse>(
+        val localVarResponse = request<Map<String, Any?>, ApiResponse>(
             localVariableConfig
         )
 
@@ -473,20 +459,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,7 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableConfig = deleteOrderRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of the order that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getInventory() : kotlin.collections.Map<kotlin.String, kotlin.Int> {
         val localVariableConfig = getInventoryRequestConfig()
 
-        val localVarResponse = request<kotlin.collections.Map<kotlin.String, kotlin.Int>>(
+        val localVarResponse = request<Unit, kotlin.collections.Map<kotlin.String, kotlin.Int>>(
             localVariableConfig
         )
 
@@ -124,20 +122,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     *
     * @return RequestConfig
     */
-    fun getInventoryRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getInventoryRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/inventory",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getOrderById(orderId: kotlin.Long) : Order {
         val localVariableConfig = getOrderByIdRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Unit, Order>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of pet that needs to be fetched 
     * @return RequestConfig
     */
-    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -209,7 +203,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun placeOrder(body: Order) : Order {
         val localVariableConfig = placeOrderRequestConfig(body = body)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Order, Order>(
             localVariableConfig
         )
 
@@ -234,20 +228,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param body order placed for purchasing the pet 
     * @return RequestConfig
     */
-    fun placeOrderRequestConfig(body: Order) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun placeOrderRequestConfig(body: Order) : RequestConfig<Order> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/store/order",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,7 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUser(body: User) : Unit {
         val localVariableConfig = createUserRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Created user object 
     * @return RequestConfig
     */
-    fun createUserRequestConfig(body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUserRequestConfig(body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithArrayInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithArrayInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -125,20 +123,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithListInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithListInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -208,7 +202,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deleteUser(username: kotlin.String) : Unit {
         val localVariableConfig = deleteUserRequestConfig(username = username)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -233,20 +227,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -263,7 +255,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getUserByName(username: kotlin.String) : User {
         val localVariableConfig = getUserByNameRequestConfig(username = username)
 
-        val localVarResponse = request<User>(
+        val localVarResponse = request<Unit, User>(
             localVariableConfig
         )
 
@@ -288,20 +280,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return RequestConfig
     */
-    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -319,7 +309,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun loginUser(username: kotlin.String, password: kotlin.String) : kotlin.String {
         val localVariableConfig = loginUserRequestConfig(username = username, password = password)
 
-        val localVarResponse = request<kotlin.String>(
+        val localVarResponse = request<Unit, kotlin.String>(
             localVariableConfig
         )
 
@@ -345,24 +335,22 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param password The password for login in clear text 
     * @return RequestConfig
     */
-    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("username", listOf(username.toString()))
                 put("password", listOf(password.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/login",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -377,7 +365,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun logoutUser() : Unit {
         val localVariableConfig = logoutUserRequestConfig()
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -401,20 +389,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     *
     * @return RequestConfig
     */
-    fun logoutUserRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun logoutUserRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -431,7 +417,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updateUser(username: kotlin.String, body: User) : Unit {
         val localVariableConfig = updateUserRequestConfig(username = username, body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -457,20 +443,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Updated user object 
     * @return RequestConfig
     */
-    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -12,16 +12,17 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
-import java.util.Date
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
+import java.util.Date
+import java.util.Locale
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -61,9 +62,7 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> content.asRequestBody(
-                mediaType.toMediaTypeOrNull()
-            )
+            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -131,7 +130,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected fun updateAuthParams(requestConfig: RequestConfig) {
+    protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
             if (apiKey["api_key"] != null) {
                 if (apiKeyPrefix["api_key"] != null) {
@@ -148,7 +147,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         // take authMethod from operation
@@ -182,7 +181,7 @@ open class ApiClient(val baseUrl: String) {
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -197,57 +196,46 @@ open class ApiClient(val baseUrl: String) {
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code,
-                    response.headers.toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message,
-                    response.code,
-                    response.headers.toMultimap()
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body, accept),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
-            else -> return ServerError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig(
+data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/samples/client/petstore/kotlin-json-request-string/build.gradle
+++ b/samples/client/petstore/kotlin-json-request-string/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,7 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun addPet(body: Pet) : Unit {
         val localVariableConfig = addPetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -72,20 +72,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun addPetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun addPetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -102,7 +100,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
         val localVariableConfig = deletePetRequestConfig(petId = petId, apiKey = apiKey)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -128,21 +126,19 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param apiKey  (optional)
     * @return RequestConfig
     */
-    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -160,7 +156,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByTagsRequestConfig(tags = tags)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -186,23 +182,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @return RequestConfig
     */
     @Deprecated(message = "This operation is deprecated.")
-    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("tags", toMultiValue(tags.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByTags",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -219,7 +213,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getAllPets(lastUpdated: java.time.OffsetDateTime?) : kotlin.collections.List<Pet> {
         val localVariableConfig = getAllPetsRequestConfig(lastUpdated = lastUpdated)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -244,8 +238,8 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param lastUpdated When this endpoint was hit last to help indentify if the client already has the latest copy. (optional)
     * @return RequestConfig
     */
-    fun getAllPetsRequestConfig(lastUpdated: java.time.OffsetDateTime?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getAllPetsRequestConfig(lastUpdated: java.time.OffsetDateTime?) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 if (lastUpdated != null) {
@@ -253,16 +247,14 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
                 }
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/getAll",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -279,7 +271,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getPetById(petId: kotlin.Long) : Pet {
         val localVariableConfig = getPetByIdRequestConfig(petId = petId)
 
-        val localVarResponse = request<Pet>(
+        val localVarResponse = request<Unit, Pet>(
             localVariableConfig
         )
 
@@ -304,20 +296,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param petId ID of pet to return 
     * @return RequestConfig
     */
-    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -333,7 +323,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePet(body: Pet) : Unit {
         val localVariableConfig = updatePetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -358,20 +348,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun updatePetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updatePetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -389,7 +377,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Map<String, Any?>, Unit>(
             localVariableConfig
         )
 
@@ -416,20 +404,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("name" to name, "status" to status)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -448,7 +434,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        val localVarResponse = request<ApiResponse>(
+        val localVarResponse = request<Map<String, Any?>, ApiResponse>(
             localVariableConfig
         )
 
@@ -475,20 +461,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,7 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableConfig = deleteOrderRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of the order that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getInventory() : kotlin.collections.Map<kotlin.String, kotlin.Int> {
         val localVariableConfig = getInventoryRequestConfig()
 
-        val localVarResponse = request<kotlin.collections.Map<kotlin.String, kotlin.Int>>(
+        val localVarResponse = request<Unit, kotlin.collections.Map<kotlin.String, kotlin.Int>>(
             localVariableConfig
         )
 
@@ -124,20 +122,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     *
     * @return RequestConfig
     */
-    fun getInventoryRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getInventoryRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/inventory",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getOrderById(orderId: kotlin.Long) : Order {
         val localVariableConfig = getOrderByIdRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Unit, Order>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of pet that needs to be fetched 
     * @return RequestConfig
     */
-    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -209,7 +203,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun placeOrder(body: Order) : Order {
         val localVariableConfig = placeOrderRequestConfig(body = body)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Order, Order>(
             localVariableConfig
         )
 
@@ -234,20 +228,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param body order placed for purchasing the pet 
     * @return RequestConfig
     */
-    fun placeOrderRequestConfig(body: Order) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun placeOrderRequestConfig(body: Order) : RequestConfig<Order> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/store/order",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,7 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUser(body: User) : Unit {
         val localVariableConfig = createUserRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Created user object 
     * @return RequestConfig
     */
-    fun createUserRequestConfig(body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUserRequestConfig(body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithArrayInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithArrayInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -125,20 +123,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithListInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithListInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -208,7 +202,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deleteUser(username: kotlin.String) : Unit {
         val localVariableConfig = deleteUserRequestConfig(username = username)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -233,20 +227,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -263,7 +255,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getUserByName(username: kotlin.String) : User {
         val localVariableConfig = getUserByNameRequestConfig(username = username)
 
-        val localVarResponse = request<User>(
+        val localVarResponse = request<Unit, User>(
             localVariableConfig
         )
 
@@ -288,20 +280,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return RequestConfig
     */
-    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -319,7 +309,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun loginUser(username: kotlin.String, password: kotlin.String) : kotlin.String {
         val localVariableConfig = loginUserRequestConfig(username = username, password = password)
 
-        val localVarResponse = request<kotlin.String>(
+        val localVarResponse = request<Unit, kotlin.String>(
             localVariableConfig
         )
 
@@ -345,24 +335,22 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param password The password for login in clear text 
     * @return RequestConfig
     */
-    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("username", listOf(username.toString()))
                 put("password", listOf(password.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/login",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -377,7 +365,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun logoutUser() : Unit {
         val localVariableConfig = logoutUserRequestConfig()
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -401,20 +389,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     *
     * @return RequestConfig
     */
-    fun logoutUserRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun logoutUserRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -431,7 +417,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updateUser(username: kotlin.String, body: User) : Unit {
         val localVariableConfig = updateUserRequestConfig(username = username, body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -457,20 +443,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Updated user object 
     * @return RequestConfig
     */
-    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -13,16 +13,17 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
-import java.util.Date
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
+import java.util.Date
+import java.util.Locale
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -62,9 +63,7 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> content.asRequestBody(
-                mediaType.toMediaTypeOrNull()
-            )
+            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -137,7 +136,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected fun updateAuthParams(requestConfig: RequestConfig) {
+    protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
             if (apiKey["api_key"] != null) {
                 if (apiKeyPrefix["api_key"] != null) {
@@ -154,7 +153,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         // take authMethod from operation
@@ -188,7 +187,7 @@ open class ApiClient(val baseUrl: String) {
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -203,57 +202,46 @@ open class ApiClient(val baseUrl: String) {
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code,
-                    response.headers.toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message,
-                    response.code,
-                    response.headers.toMultimap()
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body, accept),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
-            else -> return ServerError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig(
+data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,7 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun addPet(body: Pet) : Unit {
         val localVariableConfig = addPetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -72,20 +72,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun addPetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun addPetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -102,7 +100,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
         val localVariableConfig = deletePetRequestConfig(petId = petId, apiKey = apiKey)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -128,21 +126,19 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param apiKey  (optional)
     * @return RequestConfig
     */
-    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -159,7 +155,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByStatusRequestConfig(status = status)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -184,23 +180,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Status values that need to be considered for filter 
     * @return RequestConfig
     */
-    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("status", toMultiValue(status.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByStatus",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -218,7 +212,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByTagsRequestConfig(tags = tags)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -244,23 +238,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @return RequestConfig
     */
     @Deprecated(message = "This operation is deprecated.")
-    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("tags", toMultiValue(tags.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByTags",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -277,7 +269,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun getPetById(petId: kotlin.Long) : Pet {
         val localVariableConfig = getPetByIdRequestConfig(petId = petId)
 
-        val localVarResponse = request<Pet>(
+        val localVarResponse = request<Unit, Pet>(
             localVariableConfig
         )
 
@@ -302,20 +294,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param petId ID of pet to return 
     * @return RequestConfig
     */
-    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -331,7 +321,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun updatePet(body: Pet) : Unit {
         val localVariableConfig = updatePetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -356,20 +346,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun updatePetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updatePetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -387,7 +375,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Map<String, Any?>, Unit>(
             localVariableConfig
         )
 
@@ -414,20 +402,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("name" to name, "status" to status)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -446,7 +432,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        val localVarResponse = request<ApiResponse>(
+        val localVarResponse = request<Map<String, Any?>, ApiResponse>(
             localVariableConfig
         )
 
@@ -473,20 +459,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,7 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     suspend fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableConfig = deleteOrderRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of the order that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     suspend fun getInventory() : kotlin.collections.Map<kotlin.String, kotlin.Int> {
         val localVariableConfig = getInventoryRequestConfig()
 
-        val localVarResponse = request<kotlin.collections.Map<kotlin.String, kotlin.Int>>(
+        val localVarResponse = request<Unit, kotlin.collections.Map<kotlin.String, kotlin.Int>>(
             localVariableConfig
         )
 
@@ -124,20 +122,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     *
     * @return RequestConfig
     */
-    fun getInventoryRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getInventoryRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/inventory",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     suspend fun getOrderById(orderId: kotlin.Long) : Order {
         val localVariableConfig = getOrderByIdRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Unit, Order>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of pet that needs to be fetched 
     * @return RequestConfig
     */
-    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -209,7 +203,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     suspend fun placeOrder(body: Order) : Order {
         val localVariableConfig = placeOrderRequestConfig(body = body)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Order, Order>(
             localVariableConfig
         )
 
@@ -234,20 +228,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param body order placed for purchasing the pet 
     * @return RequestConfig
     */
-    fun placeOrderRequestConfig(body: Order) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun placeOrderRequestConfig(body: Order) : RequestConfig<Order> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/store/order",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,7 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun createUser(body: User) : Unit {
         val localVariableConfig = createUserRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Created user object 
     * @return RequestConfig
     */
-    fun createUserRequestConfig(body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUserRequestConfig(body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun createUsersWithArrayInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithArrayInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -125,20 +123,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun createUsersWithListInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithListInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -208,7 +202,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun deleteUser(username: kotlin.String) : Unit {
         val localVariableConfig = deleteUserRequestConfig(username = username)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -233,20 +227,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -263,7 +255,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun getUserByName(username: kotlin.String) : User {
         val localVariableConfig = getUserByNameRequestConfig(username = username)
 
-        val localVarResponse = request<User>(
+        val localVarResponse = request<Unit, User>(
             localVariableConfig
         )
 
@@ -288,20 +280,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return RequestConfig
     */
-    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -319,7 +309,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun loginUser(username: kotlin.String, password: kotlin.String) : kotlin.String {
         val localVariableConfig = loginUserRequestConfig(username = username, password = password)
 
-        val localVarResponse = request<kotlin.String>(
+        val localVarResponse = request<Unit, kotlin.String>(
             localVariableConfig
         )
 
@@ -345,24 +335,22 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param password The password for login in clear text 
     * @return RequestConfig
     */
-    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("username", listOf(username.toString()))
                 put("password", listOf(password.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/login",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -377,7 +365,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun logoutUser() : Unit {
         val localVariableConfig = logoutUserRequestConfig()
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -401,20 +389,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     *
     * @return RequestConfig
     */
-    fun logoutUserRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun logoutUserRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -431,7 +417,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     suspend fun updateUser(username: kotlin.String, body: User) : Unit {
         val localVariableConfig = updateUserRequestConfig(username = username, body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -457,20 +443,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Updated user object 
     * @return RequestConfig
     */
-    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -12,16 +12,17 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
-import java.util.Date
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
+import java.util.Date
+import java.util.Locale
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -61,9 +62,7 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> content.asRequestBody(
-                mediaType.toMediaTypeOrNull()
-            )
+            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -131,7 +130,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected fun updateAuthParams(requestConfig: RequestConfig) {
+    protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
             if (apiKey["api_key"] != null) {
                 if (apiKeyPrefix["api_key"] != null) {
@@ -148,7 +147,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         // take authMethod from operation
@@ -182,7 +181,7 @@ open class ApiClient(val baseUrl: String) {
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -197,57 +196,46 @@ open class ApiClient(val baseUrl: String) {
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code,
-                    response.headers.toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message,
-                    response.code,
-                    response.headers.toMultimap()
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body, accept),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
-            else -> return ServerError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig(
+data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/samples/client/petstore/kotlin-moshi-codegen/build.gradle
+++ b/samples/client/petstore/kotlin-moshi-codegen/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,7 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun addPet(body: Pet) : Unit {
         val localVariableConfig = addPetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -72,20 +72,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun addPetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun addPetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -102,7 +100,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
         val localVariableConfig = deletePetRequestConfig(petId = petId, apiKey = apiKey)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -128,21 +126,19 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param apiKey  (optional)
     * @return RequestConfig
     */
-    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -159,7 +155,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByStatusRequestConfig(status = status)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -184,23 +180,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Status values that need to be considered for filter 
     * @return RequestConfig
     */
-    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("status", toMultiValue(status.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByStatus",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -218,7 +212,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByTagsRequestConfig(tags = tags)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -244,23 +238,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @return RequestConfig
     */
     @Deprecated(message = "This operation is deprecated.")
-    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("tags", toMultiValue(tags.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByTags",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -277,7 +269,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getPetById(petId: kotlin.Long) : Pet {
         val localVariableConfig = getPetByIdRequestConfig(petId = petId)
 
-        val localVarResponse = request<Pet>(
+        val localVarResponse = request<Unit, Pet>(
             localVariableConfig
         )
 
@@ -302,20 +294,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param petId ID of pet to return 
     * @return RequestConfig
     */
-    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -331,7 +321,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePet(body: Pet) : Unit {
         val localVariableConfig = updatePetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -356,20 +346,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun updatePetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updatePetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -387,7 +375,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Map<String, Any?>, Unit>(
             localVariableConfig
         )
 
@@ -414,20 +402,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("name" to name, "status" to status)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -446,7 +432,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        val localVarResponse = request<ApiResponse>(
+        val localVarResponse = request<Map<String, Any?>, ApiResponse>(
             localVariableConfig
         )
 
@@ -473,20 +459,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,7 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableConfig = deleteOrderRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of the order that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getInventory() : kotlin.collections.Map<kotlin.String, kotlin.Int> {
         val localVariableConfig = getInventoryRequestConfig()
 
-        val localVarResponse = request<kotlin.collections.Map<kotlin.String, kotlin.Int>>(
+        val localVarResponse = request<Unit, kotlin.collections.Map<kotlin.String, kotlin.Int>>(
             localVariableConfig
         )
 
@@ -124,20 +122,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     *
     * @return RequestConfig
     */
-    fun getInventoryRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getInventoryRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/inventory",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getOrderById(orderId: kotlin.Long) : Order {
         val localVariableConfig = getOrderByIdRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Unit, Order>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of pet that needs to be fetched 
     * @return RequestConfig
     */
-    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -209,7 +203,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun placeOrder(body: Order) : Order {
         val localVariableConfig = placeOrderRequestConfig(body = body)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Order, Order>(
             localVariableConfig
         )
 
@@ -234,20 +228,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param body order placed for purchasing the pet 
     * @return RequestConfig
     */
-    fun placeOrderRequestConfig(body: Order) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun placeOrderRequestConfig(body: Order) : RequestConfig<Order> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/store/order",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,7 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUser(body: User) : Unit {
         val localVariableConfig = createUserRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Created user object 
     * @return RequestConfig
     */
-    fun createUserRequestConfig(body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUserRequestConfig(body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithArrayInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithArrayInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -125,20 +123,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithListInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithListInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -208,7 +202,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deleteUser(username: kotlin.String) : Unit {
         val localVariableConfig = deleteUserRequestConfig(username = username)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -233,20 +227,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -263,7 +255,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getUserByName(username: kotlin.String) : User {
         val localVariableConfig = getUserByNameRequestConfig(username = username)
 
-        val localVarResponse = request<User>(
+        val localVarResponse = request<Unit, User>(
             localVariableConfig
         )
 
@@ -288,20 +280,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return RequestConfig
     */
-    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -319,7 +309,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun loginUser(username: kotlin.String, password: kotlin.String) : kotlin.String {
         val localVariableConfig = loginUserRequestConfig(username = username, password = password)
 
-        val localVarResponse = request<kotlin.String>(
+        val localVarResponse = request<Unit, kotlin.String>(
             localVariableConfig
         )
 
@@ -345,24 +335,22 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param password The password for login in clear text 
     * @return RequestConfig
     */
-    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("username", listOf(username.toString()))
                 put("password", listOf(password.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/login",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -377,7 +365,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun logoutUser() : Unit {
         val localVariableConfig = logoutUserRequestConfig()
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -401,20 +389,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     *
     * @return RequestConfig
     */
-    fun logoutUserRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun logoutUserRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -431,7 +417,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updateUser(username: kotlin.String, body: User) : Unit {
         val localVariableConfig = updateUserRequestConfig(username = username, body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -457,20 +443,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Updated user object 
     * @return RequestConfig
     */
-    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -12,16 +12,17 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
-import java.util.Date
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
+import java.util.Date
+import java.util.Locale
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -61,9 +62,7 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> content.asRequestBody(
-                mediaType.toMediaTypeOrNull()
-            )
+            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -131,7 +130,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected fun updateAuthParams(requestConfig: RequestConfig) {
+    protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
             if (apiKey["api_key"] != null) {
                 if (apiKeyPrefix["api_key"] != null) {
@@ -148,7 +147,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         // take authMethod from operation
@@ -182,7 +181,7 @@ open class ApiClient(val baseUrl: String) {
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -197,57 +196,46 @@ open class ApiClient(val baseUrl: String) {
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code,
-                    response.headers.toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message,
-                    response.code,
-                    response.headers.toMultimap()
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body, accept),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
-            else -> return ServerError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig(
+data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -155,7 +155,7 @@ open class ApiClient(
         else request(requestConfig, authNames = authNames)
     }
 
-    protected suspend fun request(requestConfig: RequestConfig, body: OutgoingContent = EmptyContent, authNames: kotlin.collections.List<String>): HttpResponse {
+    protected suspend inline fun <reified T: Any?> request(requestConfig: RequestConfig<T>, body: OutgoingContent = EmptyContent, authNames: kotlin.collections.List<String>): HttpResponse {
         requestConfig.updateForAuth(authNames)
         val headers = requestConfig.headers
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig(
+data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/samples/client/petstore/kotlin-nonpublic/build.gradle
+++ b/samples/client/petstore/kotlin-nonpublic/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,7 +47,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     fun addPet(body: Pet) : Unit {
         val localVariableConfig = addPetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -72,20 +72,18 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun addPetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun addPetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -102,7 +100,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
         val localVariableConfig = deletePetRequestConfig(petId = petId, apiKey = apiKey)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -128,21 +126,19 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     * @param apiKey  (optional)
     * @return RequestConfig
     */
-    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -159,7 +155,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByStatusRequestConfig(status = status)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -184,23 +180,21 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     * @param status Status values that need to be considered for filter 
     * @return RequestConfig
     */
-    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("status", toMultiValue(status.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByStatus",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -218,7 +212,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByTagsRequestConfig(tags = tags)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -244,23 +238,21 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     * @return RequestConfig
     */
     @Deprecated(message = "This operation is deprecated.")
-    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("tags", toMultiValue(tags.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByTags",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -277,7 +269,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     fun getPetById(petId: kotlin.Long) : Pet {
         val localVariableConfig = getPetByIdRequestConfig(petId = petId)
 
-        val localVarResponse = request<Pet>(
+        val localVarResponse = request<Unit, Pet>(
             localVariableConfig
         )
 
@@ -302,20 +294,18 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     * @param petId ID of pet to return 
     * @return RequestConfig
     */
-    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -331,7 +321,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     fun updatePet(body: Pet) : Unit {
         val localVariableConfig = updatePetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -356,20 +346,18 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun updatePetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updatePetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -387,7 +375,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Map<String, Any?>, Unit>(
             localVariableConfig
         )
 
@@ -414,20 +402,18 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("name" to name, "status" to status)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -446,7 +432,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        val localVarResponse = request<ApiResponse>(
+        val localVarResponse = request<Map<String, Any?>, ApiResponse>(
             localVariableConfig
         )
 
@@ -473,20 +459,18 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(bas
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,7 +46,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(b
     fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableConfig = deleteOrderRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(b
     * @param orderId ID of the order that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(b
     fun getInventory() : kotlin.collections.Map<kotlin.String, kotlin.Int> {
         val localVariableConfig = getInventoryRequestConfig()
 
-        val localVarResponse = request<kotlin.collections.Map<kotlin.String, kotlin.Int>>(
+        val localVarResponse = request<Unit, kotlin.collections.Map<kotlin.String, kotlin.Int>>(
             localVariableConfig
         )
 
@@ -124,20 +122,18 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(b
     *
     * @return RequestConfig
     */
-    fun getInventoryRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getInventoryRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/inventory",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(b
     fun getOrderById(orderId: kotlin.Long) : Order {
         val localVariableConfig = getOrderByIdRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Unit, Order>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(b
     * @param orderId ID of pet that needs to be fetched 
     * @return RequestConfig
     */
-    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -209,7 +203,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(b
     fun placeOrder(body: Order) : Order {
         val localVariableConfig = placeOrderRequestConfig(body = body)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Order, Order>(
             localVariableConfig
         )
 
@@ -234,20 +228,18 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(b
     * @param body order placed for purchasing the pet 
     * @return RequestConfig
     */
-    fun placeOrderRequestConfig(body: Order) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun placeOrderRequestConfig(body: Order) : RequestConfig<Order> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/store/order",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,7 +46,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     fun createUser(body: User) : Unit {
         val localVariableConfig = createUserRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     * @param body Created user object 
     * @return RequestConfig
     */
-    fun createUserRequestConfig(body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUserRequestConfig(body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     fun createUsersWithArrayInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithArrayInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -125,20 +123,18 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     fun createUsersWithListInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithListInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -208,7 +202,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     fun deleteUser(username: kotlin.String) : Unit {
         val localVariableConfig = deleteUserRequestConfig(username = username)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -233,20 +227,18 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     * @param username The name that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -263,7 +255,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     fun getUserByName(username: kotlin.String) : User {
         val localVariableConfig = getUserByNameRequestConfig(username = username)
 
-        val localVarResponse = request<User>(
+        val localVarResponse = request<Unit, User>(
             localVariableConfig
         )
 
@@ -288,20 +280,18 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return RequestConfig
     */
-    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -319,7 +309,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     fun loginUser(username: kotlin.String, password: kotlin.String) : kotlin.String {
         val localVariableConfig = loginUserRequestConfig(username = username, password = password)
 
-        val localVarResponse = request<kotlin.String>(
+        val localVarResponse = request<Unit, kotlin.String>(
             localVariableConfig
         )
 
@@ -345,24 +335,22 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     * @param password The password for login in clear text 
     * @return RequestConfig
     */
-    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("username", listOf(username.toString()))
                 put("password", listOf(password.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/login",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -377,7 +365,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     fun logoutUser() : Unit {
         val localVariableConfig = logoutUserRequestConfig()
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -401,20 +389,18 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     *
     * @return RequestConfig
     */
-    fun logoutUserRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun logoutUserRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -431,7 +417,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     fun updateUser(username: kotlin.String, body: User) : Unit {
         val localVariableConfig = updateUserRequestConfig(username = username, body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -457,20 +443,18 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(ba
     * @param body Updated user object 
     * @return RequestConfig
     */
-    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -12,16 +12,17 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
-import java.util.Date
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
+import java.util.Date
+import java.util.Locale
 
 internal open class ApiClient(val baseUrl: String) {
     internal companion object {
@@ -61,9 +62,7 @@ internal open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> content.asRequestBody(
-                mediaType.toMediaTypeOrNull()
-            )
+            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -131,7 +130,7 @@ internal open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected fun updateAuthParams(requestConfig: RequestConfig) {
+    protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
             if (apiKey["api_key"] != null) {
                 if (apiKeyPrefix["api_key"] != null) {
@@ -148,7 +147,7 @@ internal open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         // take authMethod from operation
@@ -182,7 +181,7 @@ internal open class ApiClient(val baseUrl: String) {
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -197,57 +196,46 @@ internal open class ApiClient(val baseUrl: String) {
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code,
-                    response.headers.toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message,
-                    response.code,
-                    response.headers.toMultimap()
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body, accept),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
-            else -> return ServerError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-internal data class RequestConfig(
+internal data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/samples/client/petstore/kotlin-nullable/build.gradle
+++ b/samples/client/petstore/kotlin-nullable/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,7 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun addPet(body: Pet) : Unit {
         val localVariableConfig = addPetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -72,20 +72,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun addPetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun addPetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -102,7 +100,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
         val localVariableConfig = deletePetRequestConfig(petId = petId, apiKey = apiKey)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -128,21 +126,19 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param apiKey  (optional)
     * @return RequestConfig
     */
-    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -159,7 +155,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet>? {
         val localVariableConfig = findPetsByStatusRequestConfig(status = status)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -184,23 +180,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Status values that need to be considered for filter 
     * @return RequestConfig
     */
-    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("status", toMultiValue(status.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByStatus",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -218,7 +212,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet>? {
         val localVariableConfig = findPetsByTagsRequestConfig(tags = tags)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -244,23 +238,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @return RequestConfig
     */
     @Deprecated(message = "This operation is deprecated.")
-    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("tags", toMultiValue(tags.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByTags",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -277,7 +269,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getPetById(petId: kotlin.Long) : Pet? {
         val localVariableConfig = getPetByIdRequestConfig(petId = petId)
 
-        val localVarResponse = request<Pet>(
+        val localVarResponse = request<Unit, Pet>(
             localVariableConfig
         )
 
@@ -302,20 +294,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param petId ID of pet to return 
     * @return RequestConfig
     */
-    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -331,7 +321,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePet(body: Pet) : Unit {
         val localVariableConfig = updatePetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -356,20 +346,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun updatePetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updatePetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -387,7 +375,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Map<String, Any?>, Unit>(
             localVariableConfig
         )
 
@@ -414,20 +402,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("name" to name, "status" to status)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -446,7 +432,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse? {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        val localVarResponse = request<ApiResponse>(
+        val localVarResponse = request<Map<String, Any?>, ApiResponse>(
             localVariableConfig
         )
 
@@ -473,20 +459,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,7 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableConfig = deleteOrderRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of the order that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getInventory() : kotlin.collections.Map<kotlin.String, kotlin.Int>? {
         val localVariableConfig = getInventoryRequestConfig()
 
-        val localVarResponse = request<kotlin.collections.Map<kotlin.String, kotlin.Int>>(
+        val localVarResponse = request<Unit, kotlin.collections.Map<kotlin.String, kotlin.Int>>(
             localVariableConfig
         )
 
@@ -124,20 +122,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     *
     * @return RequestConfig
     */
-    fun getInventoryRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getInventoryRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/inventory",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getOrderById(orderId: kotlin.Long) : Order? {
         val localVariableConfig = getOrderByIdRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Unit, Order>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of pet that needs to be fetched 
     * @return RequestConfig
     */
-    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -209,7 +203,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun placeOrder(body: Order) : Order? {
         val localVariableConfig = placeOrderRequestConfig(body = body)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Order, Order>(
             localVariableConfig
         )
 
@@ -234,20 +228,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param body order placed for purchasing the pet 
     * @return RequestConfig
     */
-    fun placeOrderRequestConfig(body: Order) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun placeOrderRequestConfig(body: Order) : RequestConfig<Order> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/store/order",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,7 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUser(body: User) : Unit {
         val localVariableConfig = createUserRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Created user object 
     * @return RequestConfig
     */
-    fun createUserRequestConfig(body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUserRequestConfig(body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithArrayInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithArrayInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -125,20 +123,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithListInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithListInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -208,7 +202,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deleteUser(username: kotlin.String) : Unit {
         val localVariableConfig = deleteUserRequestConfig(username = username)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -233,20 +227,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -263,7 +255,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getUserByName(username: kotlin.String) : User? {
         val localVariableConfig = getUserByNameRequestConfig(username = username)
 
-        val localVarResponse = request<User>(
+        val localVarResponse = request<Unit, User>(
             localVariableConfig
         )
 
@@ -288,20 +280,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return RequestConfig
     */
-    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -319,7 +309,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun loginUser(username: kotlin.String, password: kotlin.String) : kotlin.String? {
         val localVariableConfig = loginUserRequestConfig(username = username, password = password)
 
-        val localVarResponse = request<kotlin.String>(
+        val localVarResponse = request<Unit, kotlin.String>(
             localVariableConfig
         )
 
@@ -345,24 +335,22 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param password The password for login in clear text 
     * @return RequestConfig
     */
-    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("username", listOf(username.toString()))
                 put("password", listOf(password.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/login",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -377,7 +365,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun logoutUser() : Unit {
         val localVariableConfig = logoutUserRequestConfig()
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -401,20 +389,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     *
     * @return RequestConfig
     */
-    fun logoutUserRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun logoutUserRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -431,7 +417,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updateUser(username: kotlin.String, body: User) : Unit {
         val localVariableConfig = updateUserRequestConfig(username = username, body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -457,20 +443,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Updated user object 
     * @return RequestConfig
     */
-    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -12,16 +12,17 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
-import java.util.Date
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
+import java.util.Date
+import java.util.Locale
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -61,9 +62,7 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> content.asRequestBody(
-                mediaType.toMediaTypeOrNull()
-            )
+            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -131,7 +130,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected fun updateAuthParams(requestConfig: RequestConfig) {
+    protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
             if (apiKey["api_key"] != null) {
                 if (apiKeyPrefix["api_key"] != null) {
@@ -148,7 +147,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         // take authMethod from operation
@@ -182,7 +181,7 @@ open class ApiClient(val baseUrl: String) {
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -197,57 +196,46 @@ open class ApiClient(val baseUrl: String) {
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code,
-                    response.headers.toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message,
-                    response.code,
-                    response.headers.toMultimap()
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body, accept),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
-            else -> return ServerError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig(
+data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/samples/client/petstore/kotlin-okhttp3/build.gradle
+++ b/samples/client/petstore/kotlin-okhttp3/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,7 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun addPet(body: Pet) : Unit {
         val localVariableConfig = addPetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -72,20 +72,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun addPetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun addPetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -102,7 +100,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
         val localVariableConfig = deletePetRequestConfig(petId = petId, apiKey = apiKey)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -128,21 +126,19 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param apiKey  (optional)
     * @return RequestConfig
     */
-    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -159,7 +155,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByStatusRequestConfig(status = status)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -184,23 +180,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Status values that need to be considered for filter 
     * @return RequestConfig
     */
-    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("status", toMultiValue(status.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByStatus",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -218,7 +212,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByTagsRequestConfig(tags = tags)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -244,23 +238,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @return RequestConfig
     */
     @Deprecated(message = "This operation is deprecated.")
-    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("tags", toMultiValue(tags.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByTags",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -277,7 +269,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getPetById(petId: kotlin.Long) : Pet {
         val localVariableConfig = getPetByIdRequestConfig(petId = petId)
 
-        val localVarResponse = request<Pet>(
+        val localVarResponse = request<Unit, Pet>(
             localVariableConfig
         )
 
@@ -302,20 +294,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param petId ID of pet to return 
     * @return RequestConfig
     */
-    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -331,7 +321,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePet(body: Pet) : Unit {
         val localVariableConfig = updatePetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -356,20 +346,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun updatePetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updatePetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -387,7 +375,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Map<String, Any?>, Unit>(
             localVariableConfig
         )
 
@@ -414,20 +402,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("name" to name, "status" to status)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -446,7 +432,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        val localVarResponse = request<ApiResponse>(
+        val localVarResponse = request<Map<String, Any?>, ApiResponse>(
             localVariableConfig
         )
 
@@ -473,20 +459,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,7 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableConfig = deleteOrderRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of the order that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getInventory() : kotlin.collections.Map<kotlin.String, kotlin.Int> {
         val localVariableConfig = getInventoryRequestConfig()
 
-        val localVarResponse = request<kotlin.collections.Map<kotlin.String, kotlin.Int>>(
+        val localVarResponse = request<Unit, kotlin.collections.Map<kotlin.String, kotlin.Int>>(
             localVariableConfig
         )
 
@@ -124,20 +122,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     *
     * @return RequestConfig
     */
-    fun getInventoryRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getInventoryRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/inventory",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getOrderById(orderId: kotlin.Long) : Order {
         val localVariableConfig = getOrderByIdRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Unit, Order>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of pet that needs to be fetched 
     * @return RequestConfig
     */
-    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -209,7 +203,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun placeOrder(body: Order) : Order {
         val localVariableConfig = placeOrderRequestConfig(body = body)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Order, Order>(
             localVariableConfig
         )
 
@@ -234,20 +228,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param body order placed for purchasing the pet 
     * @return RequestConfig
     */
-    fun placeOrderRequestConfig(body: Order) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun placeOrderRequestConfig(body: Order) : RequestConfig<Order> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/store/order",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,7 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUser(body: User) : Unit {
         val localVariableConfig = createUserRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Created user object 
     * @return RequestConfig
     */
-    fun createUserRequestConfig(body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUserRequestConfig(body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithArrayInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithArrayInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -125,20 +123,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithListInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithListInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -208,7 +202,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deleteUser(username: kotlin.String) : Unit {
         val localVariableConfig = deleteUserRequestConfig(username = username)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -233,20 +227,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -263,7 +255,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getUserByName(username: kotlin.String) : User {
         val localVariableConfig = getUserByNameRequestConfig(username = username)
 
-        val localVarResponse = request<User>(
+        val localVarResponse = request<Unit, User>(
             localVariableConfig
         )
 
@@ -288,20 +280,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return RequestConfig
     */
-    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -319,7 +309,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun loginUser(username: kotlin.String, password: kotlin.String) : kotlin.String {
         val localVariableConfig = loginUserRequestConfig(username = username, password = password)
 
-        val localVarResponse = request<kotlin.String>(
+        val localVarResponse = request<Unit, kotlin.String>(
             localVariableConfig
         )
 
@@ -345,24 +335,22 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param password The password for login in clear text 
     * @return RequestConfig
     */
-    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("username", listOf(username.toString()))
                 put("password", listOf(password.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/login",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -377,7 +365,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun logoutUser() : Unit {
         val localVariableConfig = logoutUserRequestConfig()
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -401,20 +389,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     *
     * @return RequestConfig
     */
-    fun logoutUserRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun logoutUserRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -431,7 +417,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updateUser(username: kotlin.String, body: User) : Unit {
         val localVariableConfig = updateUserRequestConfig(username = username, body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -457,20 +443,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Updated user object 
     * @return RequestConfig
     */
-    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,16 +10,17 @@ import okhttp3.ResponseBody
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
-import java.util.Date
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
+import java.util.Date
+import java.util.Locale
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -59,9 +60,7 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> RequestBody.create(
-                MediaType.parse(mediaType), content
-            )
+            content is File -> RequestBody.create(MediaType.parse(mediaType), content)
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -129,7 +128,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected fun updateAuthParams(requestConfig: RequestConfig) {
+    protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
             if (apiKey["api_key"] != null) {
                 if (apiKeyPrefix["api_key"] != null) {
@@ -146,7 +145,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         val httpUrl = HttpUrl.parse(baseUrl) ?: throw IllegalStateException("baseUrl is invalid.")
 
         // take authMethod from operation
@@ -180,7 +179,7 @@ open class ApiClient(val baseUrl: String) {
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -195,57 +194,46 @@ open class ApiClient(val baseUrl: String) {
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code(),
-                    response.headers().toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code(),
+                response.headers().toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message(),
-                    response.code(),
-                    response.headers().toMultimap()
+            response.isInformational -> Informational(
+                response.message(),
+                response.code(),
+                response.headers().toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body(), accept),
-                    response.code(),
-                    response.headers().toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body(), accept),
+                response.code(),
+                response.headers().toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message(),
-                    response.body()?.string(),
-                    response.code(),
-                    response.headers().toMultimap()
+            response.isClientError -> ClientError(
+                response.message(),
+                response.body()?.string(),
+                response.code(),
+                response.headers().toMultimap()
             )
-            else -> return ServerError(
-                    response.message(),
-                    response.body()?.string(),
-                    response.code(),
-                    response.headers().toMultimap()
+            else -> ServerError(
+                response.message(),
+                response.body()?.string(),
+                response.code(),
+                response.headers().toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig(
+data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
     ext.retrofitVersion = '2.7.2'
 
     repositories {
@@ -32,7 +32,7 @@ test {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    compile "org.jetbrains.kotlinx:kotlinx-serialization-json:1.1.0"
+    compile "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.1"
     compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.0"
     compile "com.squareup.okhttp3:logging-interceptor:4.9.0"
     compile "com.squareup.retrofit2:retrofit:$retrofitVersion"

--- a/samples/client/petstore/kotlin-retrofit2-rx3/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
     ext.retrofitVersion = '2.7.2'
     ext.rxJava3Version = '3.0.10'
 

--- a/samples/client/petstore/kotlin-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
     ext.retrofitVersion = '2.7.2'
 
     repositories {

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,7 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun addPet(body: Pet) : Unit {
         val localVariableConfig = addPetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -72,20 +72,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun addPetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun addPetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -102,7 +100,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deletePet(apiKey: kotlin.String?, petId: kotlin.Long) : Unit {
         val localVariableConfig = deletePetRequestConfig(apiKey = apiKey, petId = petId)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -128,21 +126,19 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param petId Pet id to delete 
     * @return RequestConfig
     */
-    fun deletePetRequestConfig(apiKey: kotlin.String?, petId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deletePetRequestConfig(apiKey: kotlin.String?, petId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -159,7 +155,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByStatusRequestConfig(status = status)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -184,23 +180,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Status values that need to be considered for filter 
     * @return RequestConfig
     */
-    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("status", toMultiValue(status.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByStatus",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -218,7 +212,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByTagsRequestConfig(tags = tags)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -244,23 +238,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @return RequestConfig
     */
     @Deprecated(message = "This operation is deprecated.")
-    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("tags", toMultiValue(tags.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByTags",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -277,7 +269,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getPetById(petId: kotlin.Long) : Pet {
         val localVariableConfig = getPetByIdRequestConfig(petId = petId)
 
-        val localVarResponse = request<Pet>(
+        val localVarResponse = request<Unit, Pet>(
             localVariableConfig
         )
 
@@ -302,20 +294,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param petId ID of pet to return 
     * @return RequestConfig
     */
-    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -331,7 +321,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePet(body: Pet) : Unit {
         val localVariableConfig = updatePetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -356,20 +346,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun updatePetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updatePetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -387,7 +375,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Map<String, Any?>, Unit>(
             localVariableConfig
         )
 
@@ -414,20 +402,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("name" to name, "status" to status)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -446,7 +432,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        val localVarResponse = request<ApiResponse>(
+        val localVarResponse = request<Map<String, Any?>, ApiResponse>(
             localVariableConfig
         )
 
@@ -473,20 +459,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,7 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableConfig = deleteOrderRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of the order that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getInventory() : kotlin.collections.Map<kotlin.String, kotlin.Int> {
         val localVariableConfig = getInventoryRequestConfig()
 
-        val localVarResponse = request<kotlin.collections.Map<kotlin.String, kotlin.Int>>(
+        val localVarResponse = request<Unit, kotlin.collections.Map<kotlin.String, kotlin.Int>>(
             localVariableConfig
         )
 
@@ -124,20 +122,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     *
     * @return RequestConfig
     */
-    fun getInventoryRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getInventoryRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/inventory",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getOrderById(orderId: kotlin.Long) : Order {
         val localVariableConfig = getOrderByIdRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Unit, Order>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of pet that needs to be fetched 
     * @return RequestConfig
     */
-    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -209,7 +203,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun placeOrder(body: Order) : Order {
         val localVariableConfig = placeOrderRequestConfig(body = body)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Order, Order>(
             localVariableConfig
         )
 
@@ -234,20 +228,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param body order placed for purchasing the pet 
     * @return RequestConfig
     */
-    fun placeOrderRequestConfig(body: Order) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun placeOrderRequestConfig(body: Order) : RequestConfig<Order> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/store/order",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,7 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUser(body: User) : Unit {
         val localVariableConfig = createUserRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Created user object 
     * @return RequestConfig
     */
-    fun createUserRequestConfig(body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUserRequestConfig(body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithArrayInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithArrayInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -125,20 +123,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithListInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithListInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -208,7 +202,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deleteUser(username: kotlin.String) : Unit {
         val localVariableConfig = deleteUserRequestConfig(username = username)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -233,20 +227,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -263,7 +255,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getUserByName(username: kotlin.String) : User {
         val localVariableConfig = getUserByNameRequestConfig(username = username)
 
-        val localVarResponse = request<User>(
+        val localVarResponse = request<Unit, User>(
             localVariableConfig
         )
 
@@ -288,20 +280,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return RequestConfig
     */
-    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -319,7 +309,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun loginUser(username: kotlin.String, password: kotlin.String) : kotlin.String {
         val localVariableConfig = loginUserRequestConfig(username = username, password = password)
 
-        val localVarResponse = request<kotlin.String>(
+        val localVarResponse = request<Unit, kotlin.String>(
             localVariableConfig
         )
 
@@ -345,24 +335,22 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param password The password for login in clear text 
     * @return RequestConfig
     */
-    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("username", listOf(username.toString()))
                 put("password", listOf(password.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/login",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -377,7 +365,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun logoutUser() : Unit {
         val localVariableConfig = logoutUserRequestConfig()
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -401,20 +389,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     *
     * @return RequestConfig
     */
-    fun logoutUserRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun logoutUserRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -431,7 +417,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updateUser(username: kotlin.String, body: User) : Unit {
         val localVariableConfig = updateUserRequestConfig(username = username, body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -457,20 +443,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Updated user object 
     * @return RequestConfig
     */
-    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -12,16 +12,17 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
-import java.util.Date
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
+import java.util.Date
+import java.util.Locale
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -61,9 +62,7 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> content.asRequestBody(
-                mediaType.toMediaTypeOrNull()
-            )
+            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -131,7 +130,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected fun updateAuthParams(requestConfig: RequestConfig) {
+    protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
             if (apiKey["api_key"] != null) {
                 if (apiKeyPrefix["api_key"] != null) {
@@ -148,7 +147,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         // take authMethod from operation
@@ -182,7 +181,7 @@ open class ApiClient(val baseUrl: String) {
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -197,57 +196,46 @@ open class ApiClient(val baseUrl: String) {
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code,
-                    response.headers.toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message,
-                    response.code,
-                    response.headers.toMultimap()
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body, accept),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
-            else -> return ServerError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig(
+data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,7 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun addPet(body: Pet) : Unit {
         val localVariableConfig = addPetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -72,20 +72,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun addPetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun addPetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -102,7 +100,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
         val localVariableConfig = deletePetRequestConfig(petId = petId, apiKey = apiKey)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -128,21 +126,19 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param apiKey  (optional)
     * @return RequestConfig
     */
-    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -159,7 +155,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByStatusRequestConfig(status = status)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -184,23 +180,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Status values that need to be considered for filter 
     * @return RequestConfig
     */
-    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("status", toMultiValue(status.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByStatus",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -218,7 +212,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByTagsRequestConfig(tags = tags)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -244,23 +238,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @return RequestConfig
     */
     @Deprecated(message = "This operation is deprecated.")
-    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("tags", toMultiValue(tags.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByTags",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -277,7 +269,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getPetById(petId: kotlin.Long) : Pet {
         val localVariableConfig = getPetByIdRequestConfig(petId = petId)
 
-        val localVarResponse = request<Pet>(
+        val localVarResponse = request<Unit, Pet>(
             localVariableConfig
         )
 
@@ -302,20 +294,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param petId ID of pet to return 
     * @return RequestConfig
     */
-    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -331,7 +321,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePet(body: Pet) : Unit {
         val localVariableConfig = updatePetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -356,20 +346,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun updatePetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updatePetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -387,7 +375,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Map<String, Any?>, Unit>(
             localVariableConfig
         )
 
@@ -414,20 +402,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("name" to name, "status" to status)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -446,7 +432,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        val localVarResponse = request<ApiResponse>(
+        val localVarResponse = request<Map<String, Any?>, ApiResponse>(
             localVariableConfig
         )
 
@@ -473,20 +459,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,7 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableConfig = deleteOrderRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of the order that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getInventory() : kotlin.collections.Map<kotlin.String, kotlin.Int> {
         val localVariableConfig = getInventoryRequestConfig()
 
-        val localVarResponse = request<kotlin.collections.Map<kotlin.String, kotlin.Int>>(
+        val localVarResponse = request<Unit, kotlin.collections.Map<kotlin.String, kotlin.Int>>(
             localVariableConfig
         )
 
@@ -124,20 +122,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     *
     * @return RequestConfig
     */
-    fun getInventoryRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getInventoryRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/inventory",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getOrderById(orderId: kotlin.Long) : Order {
         val localVariableConfig = getOrderByIdRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Unit, Order>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of pet that needs to be fetched 
     * @return RequestConfig
     */
-    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -209,7 +203,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun placeOrder(body: Order) : Order {
         val localVariableConfig = placeOrderRequestConfig(body = body)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Order, Order>(
             localVariableConfig
         )
 
@@ -234,20 +228,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param body order placed for purchasing the pet 
     * @return RequestConfig
     */
-    fun placeOrderRequestConfig(body: Order) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun placeOrderRequestConfig(body: Order) : RequestConfig<Order> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/store/order",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,7 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUser(body: User) : Unit {
         val localVariableConfig = createUserRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Created user object 
     * @return RequestConfig
     */
-    fun createUserRequestConfig(body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUserRequestConfig(body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithArrayInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithArrayInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -125,20 +123,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithListInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithListInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -208,7 +202,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deleteUser(username: kotlin.String) : Unit {
         val localVariableConfig = deleteUserRequestConfig(username = username)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -233,20 +227,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -263,7 +255,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getUserByName(username: kotlin.String) : User {
         val localVariableConfig = getUserByNameRequestConfig(username = username)
 
-        val localVarResponse = request<User>(
+        val localVarResponse = request<Unit, User>(
             localVariableConfig
         )
 
@@ -288,20 +280,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return RequestConfig
     */
-    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -319,7 +309,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun loginUser(username: kotlin.String, password: kotlin.String) : kotlin.String {
         val localVariableConfig = loginUserRequestConfig(username = username, password = password)
 
-        val localVarResponse = request<kotlin.String>(
+        val localVarResponse = request<Unit, kotlin.String>(
             localVariableConfig
         )
 
@@ -345,24 +335,22 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param password The password for login in clear text 
     * @return RequestConfig
     */
-    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("username", listOf(username.toString()))
                 put("password", listOf(password.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/login",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -377,7 +365,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun logoutUser() : Unit {
         val localVariableConfig = logoutUserRequestConfig()
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -401,20 +389,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     *
     * @return RequestConfig
     */
-    fun logoutUserRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun logoutUserRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -431,7 +417,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updateUser(username: kotlin.String, body: User) : Unit {
         val localVariableConfig = updateUserRequestConfig(username = username, body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -457,20 +443,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Updated user object 
     * @return RequestConfig
     */
-    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -12,11 +12,12 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
 import java.util.Date
+import java.util.Locale
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.LocalTime
@@ -61,9 +62,7 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> content.asRequestBody(
-                mediaType.toMediaTypeOrNull()
-            )
+            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -131,7 +130,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected fun updateAuthParams(requestConfig: RequestConfig) {
+    protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
             if (apiKey["api_key"] != null) {
                 if (apiKeyPrefix["api_key"] != null) {
@@ -148,7 +147,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         // take authMethod from operation
@@ -182,7 +181,7 @@ open class ApiClient(val baseUrl: String) {
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -197,57 +196,46 @@ open class ApiClient(val baseUrl: String) {
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code,
-                    response.headers.toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message,
-                    response.code,
-                    response.headers.toMultimap()
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body, accept),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
-            else -> return ServerError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig(
+data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/samples/client/petstore/kotlin-uppercase-enum/build.gradle
+++ b/samples/client/petstore/kotlin-uppercase-enum/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/apis/EnumApi.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/apis/EnumApi.kt
@@ -46,7 +46,7 @@ class EnumApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getEnum() : PetEnum {
         val localVariableConfig = getEnumRequestConfig()
 
-        val localVarResponse = request<PetEnum>(
+        val localVarResponse = request<Unit, PetEnum>(
             localVariableConfig
         )
 
@@ -70,20 +70,18 @@ class EnumApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     *
     * @return RequestConfig
     */
-    fun getEnumRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getEnumRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/enum",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -12,16 +12,17 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
-import java.util.Date
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
+import java.util.Date
+import java.util.Locale
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -61,9 +62,7 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> content.asRequestBody(
-                mediaType.toMediaTypeOrNull()
-            )
+            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -132,7 +131,7 @@ open class ApiClient(val baseUrl: String) {
     }
 
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         val url = httpUrl.newBuilder()
@@ -163,7 +162,7 @@ open class ApiClient(val baseUrl: String) {
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -178,57 +177,46 @@ open class ApiClient(val baseUrl: String) {
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code,
-                    response.headers.toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message,
-                    response.code,
-                    response.headers.toMultimap()
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body, accept),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
-            else -> return ServerError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig(
+data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
+    ext.kotlin_version = '1.5.0'
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,7 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun addPet(body: Pet) : Unit {
         val localVariableConfig = addPetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -72,20 +72,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun addPetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun addPetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -102,7 +100,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
         val localVariableConfig = deletePetRequestConfig(petId = petId, apiKey = apiKey)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -128,21 +126,19 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param apiKey  (optional)
     * @return RequestConfig
     */
-    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deletePetRequestConfig(petId: kotlin.Long, apiKey: kotlin.String?) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -159,7 +155,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByStatus(status: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByStatusRequestConfig(status = status)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -184,23 +180,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Status values that need to be considered for filter 
     * @return RequestConfig
     */
-    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByStatusRequestConfig(status: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("status", toMultiValue(status.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByStatus",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -218,7 +212,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun findPetsByTags(tags: kotlin.collections.List<kotlin.String>) : kotlin.collections.List<Pet> {
         val localVariableConfig = findPetsByTagsRequestConfig(tags = tags)
 
-        val localVarResponse = request<kotlin.collections.List<Pet>>(
+        val localVarResponse = request<Unit, kotlin.collections.List<Pet>>(
             localVariableConfig
         )
 
@@ -244,23 +238,21 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @return RequestConfig
     */
     @Deprecated(message = "This operation is deprecated.")
-    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun findPetsByTagsRequestConfig(tags: kotlin.collections.List<kotlin.String>) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("tags", toMultiValue(tags.toList(), "csv"))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByTags",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -277,7 +269,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getPetById(petId: kotlin.Long) : Pet {
         val localVariableConfig = getPetByIdRequestConfig(petId = petId)
 
-        val localVarResponse = request<Pet>(
+        val localVarResponse = request<Unit, Pet>(
             localVariableConfig
         )
 
@@ -302,20 +294,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param petId ID of pet to return 
     * @return RequestConfig
     */
-    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getPetByIdRequestConfig(petId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -331,7 +321,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePet(body: Pet) : Unit {
         val localVariableConfig = updatePetRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Pet, Unit>(
             localVariableConfig
         )
 
@@ -356,20 +346,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Pet object that needs to be added to the store 
     * @return RequestConfig
     */
-    fun updatePetRequestConfig(body: Pet) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updatePetRequestConfig(body: Pet) : RequestConfig<Pet> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -387,7 +375,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
         val localVariableConfig = updatePetWithFormRequestConfig(petId = petId, name = name, status = status)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Map<String, Any?>, Unit>(
             localVariableConfig
         )
 
@@ -414,20 +402,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param status Updated status of the pet (optional)
     * @return RequestConfig
     */
-    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("name" to name, "status" to status)
+    fun updatePetWithFormRequestConfig(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("name" to name, "status" to status)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -446,7 +432,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun uploadFile(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : ApiResponse {
         val localVariableConfig = uploadFileRequestConfig(petId = petId, additionalMetadata = additionalMetadata, file = file)
 
-        val localVarResponse = request<ApiResponse>(
+        val localVarResponse = request<Map<String, Any?>, ApiResponse>(
             localVariableConfig
         )
 
@@ -473,20 +459,18 @@ class PetApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param file file to upload (optional)
     * @return RequestConfig
     */
-    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig {
-        val localVariableBody: kotlin.Any? = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
+    fun uploadFileRequestConfig(petId: kotlin.Long, additionalMetadata: kotlin.String?, file: java.io.File?) : RequestConfig<Map<String, Any?>> {
+        val localVariableBody = mapOf("additionalMetadata" to additionalMetadata, "file" to file)
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", "$petId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,7 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun deleteOrder(orderId: kotlin.String) : Unit {
         val localVariableConfig = deleteOrderRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of the order that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteOrderRequestConfig(orderId: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getInventory() : kotlin.collections.Map<kotlin.String, kotlin.Int> {
         val localVariableConfig = getInventoryRequestConfig()
 
-        val localVarResponse = request<kotlin.collections.Map<kotlin.String, kotlin.Int>>(
+        val localVarResponse = request<Unit, kotlin.collections.Map<kotlin.String, kotlin.Int>>(
             localVariableConfig
         )
 
@@ -124,20 +122,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     *
     * @return RequestConfig
     */
-    fun getInventoryRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getInventoryRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/inventory",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun getOrderById(orderId: kotlin.Long) : Order {
         val localVariableConfig = getOrderByIdRequestConfig(orderId = orderId)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Unit, Order>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param orderId ID of pet that needs to be fetched 
     * @return RequestConfig
     */
-    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getOrderByIdRequestConfig(orderId: kotlin.Long) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/order/{orderId}".replace("{"+"orderId"+"}", "$orderId"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -209,7 +203,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     fun placeOrder(body: Order) : Order {
         val localVariableConfig = placeOrderRequestConfig(body = body)
 
-        val localVarResponse = request<Order>(
+        val localVarResponse = request<Order, Order>(
             localVariableConfig
         )
 
@@ -234,20 +228,18 @@ class StoreApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) 
     * @param body order placed for purchasing the pet 
     * @return RequestConfig
     */
-    fun placeOrderRequestConfig(body: Order) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun placeOrderRequestConfig(body: Order) : RequestConfig<Order> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/store/order",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,7 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUser(body: User) : Unit {
         val localVariableConfig = createUserRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -71,20 +71,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Created user object 
     * @return RequestConfig
     */
-    fun createUserRequestConfig(body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUserRequestConfig(body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -100,7 +98,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithArrayInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithArrayInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -125,20 +123,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithArrayInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -154,7 +150,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun createUsersWithListInput(body: kotlin.collections.List<User>) : Unit {
         val localVariableConfig = createUsersWithListInputRequestConfig(body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<kotlin.collections.List<User>, Unit>(
             localVariableConfig
         )
 
@@ -179,20 +175,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body List of user object 
     * @return RequestConfig
     */
-    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun createUsersWithListInputRequestConfig(body: kotlin.collections.List<User>) : RequestConfig<kotlin.collections.List<User>> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -208,7 +202,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun deleteUser(username: kotlin.String) : Unit {
         val localVariableConfig = deleteUserRequestConfig(username = username)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -233,20 +227,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be deleted 
     * @return RequestConfig
     */
-    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun deleteUserRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.DELETE,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -263,7 +255,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun getUserByName(username: kotlin.String) : User {
         val localVariableConfig = getUserByNameRequestConfig(username = username)
 
-        val localVarResponse = request<User>(
+        val localVarResponse = request<Unit, User>(
             localVariableConfig
         )
 
@@ -288,20 +280,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param username The name that needs to be fetched. Use user1 for testing. 
     * @return RequestConfig
     */
-    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun getUserByNameRequestConfig(username: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -319,7 +309,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun loginUser(username: kotlin.String, password: kotlin.String) : kotlin.String {
         val localVariableConfig = loginUserRequestConfig(username = username, password = password)
 
-        val localVarResponse = request<kotlin.String>(
+        val localVarResponse = request<Unit, kotlin.String>(
             localVariableConfig
         )
 
@@ -345,24 +335,22 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param password The password for login in clear text 
     * @return RequestConfig
     */
-    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun loginUserRequestConfig(username: kotlin.String, password: kotlin.String) : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, List<kotlin.String>>()
             .apply {
                 put("username", listOf(username.toString()))
                 put("password", listOf(password.toString()))
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/login",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -377,7 +365,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun logoutUser() : Unit {
         val localVariableConfig = logoutUserRequestConfig()
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<Unit, Unit>(
             localVariableConfig
         )
 
@@ -401,20 +389,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     *
     * @return RequestConfig
     */
-    fun logoutUserRequestConfig() : RequestConfig {
-        val localVariableBody: kotlin.Any? = null
+    fun logoutUserRequestConfig() : RequestConfig<Unit> {
+        val localVariableBody = null
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
     /**
@@ -431,7 +417,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     fun updateUser(username: kotlin.String, body: User) : Unit {
         val localVariableConfig = updateUserRequestConfig(username = username, body = body)
 
-        val localVarResponse = request<Any?>(
+        val localVarResponse = request<User, Unit>(
             localVariableConfig
         )
 
@@ -457,20 +443,18 @@ class UserApi(basePath: kotlin.String = defaultBasePath) : ApiClient(basePath) {
     * @param body Updated user object 
     * @return RequestConfig
     */
-    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig {
-        val localVariableBody: kotlin.Any? = body
+    fun updateUserRequestConfig(username: kotlin.String, body: User) : RequestConfig<User> {
+        val localVariableBody = body
         val localVariableQuery: MultiValueMap = mutableMapOf()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
-        
-        val localVariableConfig = RequestConfig(
+
+        return RequestConfig(
             method = RequestMethod.PUT,
             path = "/user/{username}".replace("{"+"username"+"}", "$username"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             body = localVariableBody
         )
-
-        return localVariableConfig
     }
 
 }

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -12,16 +12,17 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Headers
 import okhttp3.MultipartBody
-import java.io.File
 import java.io.BufferedWriter
+import java.io.File
 import java.io.FileWriter
 import java.net.URLConnection
-import java.util.Date
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
+import java.util.Date
+import java.util.Locale
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -61,9 +62,7 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> content.asRequestBody(
-                mediaType.toMediaTypeOrNull()
-            )
+            content is File -> content.asRequestBody(mediaType.toMediaTypeOrNull())
             mediaType == FormDataMediaType -> {
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -131,7 +130,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected fun updateAuthParams(requestConfig: RequestConfig) {
+    protected fun <T> updateAuthParams(requestConfig: RequestConfig<T>) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
             if (apiKey["api_key"] != null) {
                 if (apiKeyPrefix["api_key"] != null) {
@@ -148,7 +147,7 @@ open class ApiClient(val baseUrl: String) {
         }
     }
 
-    protected inline fun <reified T: Any?> request(requestConfig: RequestConfig): ApiInfrastructureResponse<T?> {
+    protected inline fun <reified I, reified T: Any?> request(requestConfig: RequestConfig<I>): ApiInfrastructureResponse<T?> {
         val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         // take authMethod from operation
@@ -182,7 +181,7 @@ open class ApiClient(val baseUrl: String) {
         }
 
         // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").toLowerCase()
+        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))
@@ -197,57 +196,46 @@ open class ApiClient(val baseUrl: String) {
         }.build()
 
         val response = client.newCall(request).execute()
-        val accept = response.header(ContentType)?.substringBefore(";")?.toLowerCase()
+        val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())
 
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
-        when {
-            response.isRedirect -> return Redirection(
-                    response.code,
-                    response.headers.toMultimap()
+        return when {
+            response.isRedirect -> Redirection(
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isInformational -> return Informational(
-                    response.message,
-                    response.code,
-                    response.headers.toMultimap()
+            response.isInformational -> Informational(
+                response.message,
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isSuccessful -> return Success(
-                    responseBody(response.body, accept),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isSuccessful -> Success(
+                responseBody(response.body, accept),
+                response.code,
+                response.headers.toMultimap()
             )
-            response.isClientError -> return ClientError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            response.isClientError -> ClientError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
-            else -> return ServerError(
-                    response.message,
-                    response.body?.string(),
-                    response.code,
-                    response.headers.toMultimap()
+            else -> ServerError(
+                response.message,
+                response.body?.string(),
+                response.code,
+                response.headers.toMultimap()
             )
         }
     }
 
-    protected fun parameterToString(value: Any?): String {
-        when (value) {
-            null -> {
-                return ""
-            }
-            is Array<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is Iterable<*> -> {
-                return toMultiValue(value, "csv").toString()
-            }
-            is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date -> {
-                return parseDateToQueryString<Any>(value)
-            }
-            else -> {
-                return value.toString()
-            }
-        }
+    protected fun parameterToString(value: Any?): String = when (value) {
+        null -> ""
+        is Array<*> -> toMultiValue(value, "csv").toString()
+        is Iterable<*> -> toMultiValue(value, "csv").toString()
+        is OffsetDateTime, is OffsetTime, is LocalDateTime, is LocalDate, is LocalTime, is Date ->
+            parseDateToQueryString(value)
+        else -> value.toString()
     }
 
     protected inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig(
+data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: kotlin.Any? = null
+    val body: T? = null
 )


### PR DESCRIPTION
And update to Kotlin 1.5.0 and kotlinx.serialization 1.2.1. Fix nested
enum annotation '@Serializable' instead of '@KSerializable' when
'kotlinx_serialization' is used. Fix missing JsonMediaType in
ApiClient.kt (#9242). Add 'kotlinx_serialization' serialization library
to documentation.

Resolves #9242

@jimschubert @rsinukov @wing328 @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m

Tested with `serializationLibrary` set to `gson`, `kotlinx_serialization` and default (`moshi`) as well as `library` set to `multiplatform` and default (`jvm-okhttp4`).

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
