### PR TITLE
[cpp-restsdk] Update json double/float parse.

### DIFF
--- a/docs/generators/tiny-cpp.md
+++ b/docs/generators/tiny-cpp.md
@@ -165,7 +165,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |Maps|✗|ToolingExtension
 |CollectionFormat|✓|OAS2
 |CollectionFormatMulti|✓|OAS2
-|Enum|✓|OAS2,OAS3
+|Enum|✗|OAS2,OAS3
 |ArrayOfEnum|✓|ToolingExtension
 |ArrayOfModel|✓|ToolingExtension
 |ArrayOfCollectionOfPrimitives|✓|ToolingExtension

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/modelbase-source.mustache
@@ -249,13 +249,13 @@ bool ModelBase::fromJson( const web::json::value& val, bool & outVal )
 }
 bool ModelBase::fromJson( const web::json::value& val, float & outVal )
 {
-    outVal = !val.is_double() ? std::numeric_limits<float>::quiet_NaN(): static_cast<float>(val.as_double());
-    return val.is_double();
+    outVal = (!val.is_double() && !val.is_integer()) ? std::numeric_limits<float>::quiet_NaN(): static_cast<float>(val.as_double());
+    return val.is_double() || val.is_integer();
 }
 bool ModelBase::fromJson( const web::json::value& val, double & outVal )
 {
-    outVal = !val.is_double() ? std::numeric_limits<double>::quiet_NaN(): val.as_double();
-    return val.is_double() ;
+    outVal = (!val.is_double() && !val.is_integer()) ? std::numeric_limits<double>::quiet_NaN(): val.as_double();
+    return val.is_double() || val.is_integer();
 }
 bool ModelBase::fromJson( const web::json::value& val, int32_t & outVal )
 {

--- a/samples/client/petstore/cpp-restsdk/client/ModelBase.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/ModelBase.cpp
@@ -260,13 +260,13 @@ bool ModelBase::fromJson( const web::json::value& val, bool & outVal )
 }
 bool ModelBase::fromJson( const web::json::value& val, float & outVal )
 {
-    outVal = !val.is_double() ? std::numeric_limits<float>::quiet_NaN(): static_cast<float>(val.as_double());
-    return val.is_double();
+    outVal = (!val.is_double() && !val.is_integer()) ? std::numeric_limits<float>::quiet_NaN(): static_cast<float>(val.as_double());
+    return val.is_double() || val.is_integer();
 }
 bool ModelBase::fromJson( const web::json::value& val, double & outVal )
 {
-    outVal = !val.is_double() ? std::numeric_limits<double>::quiet_NaN(): val.as_double();
-    return val.is_double() ;
+    outVal = (!val.is_double() && !val.is_integer()) ? std::numeric_limits<double>::quiet_NaN(): val.as_double();
+    return val.is_double() || val.is_integer();
 }
 bool ModelBase::fromJson( const web::json::value& val, int32_t & outVal )
 {


### PR DESCRIPTION
Fix cpp-restsdk double and float parse.

double.NaN was parsed when server doesn't ensure the floating point value has decimal point in in.

Fixed incorrect server response json parsing. For example the following json:

```json
{
    "double_value": 42
}
```

As of now, the value 42 is parsed as NaN, because json library returns false on is_double().
Additional condition ensures NaN is not returned when not needed.
Implemented for both float & double data types.