### PR TITLE
[java][native] Remove JAX-RS dependency from generated java-native client.

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/AbstractOpenApiSchema.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/AbstractOpenApiSchema.mustache
@@ -6,7 +6,6 @@ import {{invokerPackage}}.ApiException;
 import java.util.Objects;
 import java.lang.reflect.Type;
 import java.util.Map;
-import javax.ws.rs.core.GenericType;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -35,7 +34,7 @@ public abstract class AbstractOpenApiSchema {
      *
      * @return an instance of the actual schema/object
      */
-    public abstract Map<String, GenericType> getSchemas();
+    public abstract Map<String, Class<?>> getSchemas();
 
     /**
      * Get the actual instance

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/JSON.mustache
@@ -26,11 +26,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.ext.ContextResolver;
 
 {{>generatedAnnotation}}
-public class JSON implements ContextResolver<ObjectMapper> {
+public class JSON {
   private ObjectMapper mapper;
 
   public JSON() {
@@ -68,11 +66,6 @@ public class JSON implements ContextResolver<ObjectMapper> {
    */
   public void setDateFormat(DateFormat dateFormat) {
     mapper.setDateFormat(dateFormat);
-  }
-
-  @Override
-  public ObjectMapper getContext(Class<?> type) {
-    return mapper;
   }
 
   /**
@@ -207,10 +200,10 @@ public class JSON implements ContextResolver<ObjectMapper> {
     visitedClasses.add(modelClass);
 
     // Traverse the oneOf/anyOf composed schemas.
-    Map<String, GenericType> descendants = modelDescendants.get(modelClass);
+    Map<String, Class<?>> descendants = modelDescendants.get(modelClass);
     if (descendants != null) {
-      for (GenericType childType : descendants.values()) {
-        if (isInstanceOf(childType.getRawType(), inst, visitedClasses)) {
+      for (Class<?> childType : descendants.values()) {
+        if (isInstanceOf(childType, inst, visitedClasses)) {
           return true;
         }
       }
@@ -221,12 +214,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, Class<?>>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.
@@ -246,7 +239,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     * @param modelClass the model class
     * @param descendants a map of oneOf/anyOf descendants.
     */
-  public static void registerDescendants(Class<?> modelClass, Map<String, GenericType> descendants) {
+  public static void registerDescendants(Class<?> modelClass, Map<String, Class<?>> descendants) {
     modelDescendants.put(modelClass, descendants);
   }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/anyof_model.mustache
@@ -1,5 +1,3 @@
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -10,7 +8,6 @@ import java.util.HashSet;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -99,7 +96,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     // store a list of schema names defined in anyOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, Class<?>> schemas = new HashMap<String, Class<?>>();
 
     public {{classname}}() {
         super("anyOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});
@@ -128,8 +125,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     {{/anyOf}}
     static {
         {{#anyOf}}
-        schemas.put("{{{.}}}", new GenericType<{{{.}}}>() {
-        });
+        schemas.put("{{{.}}}", {{{.}}}.class);
         {{/anyOf}}
         JSON.registerDescendants({{classname}}.class, Collections.unmodifiableMap(schemas));
         {{#discriminator}}
@@ -144,7 +140,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     @Override
-    public Map<String, GenericType> getSchemas() {
+    public Map<String, Class<?>> getSchemas() {
         return {{classname}}.schemas;
     }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
@@ -22,6 +22,17 @@ apply plugin: 'maven'
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
+// Some text from the schema is copy pasted into the source files as UTF-8
+// but the default still seems to be to use platform encoding
+tasks.withType(JavaCompile) {
+    configure(options) {
+        options.encoding = 'UTF-8'
+    }
+}
+javadoc {
+    options.encoding = 'UTF-8'
+}
+
 install {
     repositories.mavenInstaller {
         pom.artifactId = '{{artifactId}}'
@@ -53,7 +64,6 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.10.4"
     junit_version = "4.13.1"
-    ws_rs_version = "2.1.1"
     {{#threetenbp}}
     threetenbp_version = "2.9.10"
     {{/threetenbp}}
@@ -68,7 +78,6 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "org.openapitools:jackson-databind-nullable:0.2.1"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
-    implementation "javax.ws.rs:javax.ws.rs-api:$ws_rs_version"
     {{#threetenbp}}
     implementation "com.github.joschi.jackson:jackson-datatype-threetenbp:$threetenbp_version"
     {{/threetenbp}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/oneof_model.mustache
@@ -1,5 +1,3 @@
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -11,7 +9,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -132,7 +129,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, Class<?>> schemas = new HashMap<>();
 
     public {{classname}}() {
         super("oneOf", {{#isNullable}}Boolean.TRUE{{/isNullable}}{{^isNullable}}Boolean.FALSE{{/isNullable}});
@@ -161,8 +158,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     {{/oneOf}}
     static {
         {{#oneOf}}
-        schemas.put("{{{.}}}", new GenericType<{{{.}}}>() {
-        });
+        schemas.put("{{{.}}}", {{{.}}}.class);
         {{/oneOf}}
         JSON.registerDescendants({{classname}}.class, Collections.unmodifiableMap(schemas));
         {{#discriminator}}
@@ -177,7 +173,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
     }
 
     @Override
-    public Map<String, GenericType> getSchemas() {
+    public Map<String, Class<?>> getSchemas() {
         return {{classname}}.schemas;
     }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
@@ -214,13 +214,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api -->
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>${javax-ws-rs-api-version}</version>
-        </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -238,7 +231,6 @@
         <jackson-version>2.10.4</jackson-version>
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <javax-annotation-version>1.3.2</javax-annotation-version>
-        <javax-ws-rs-api-version>2.1.1</javax-ws-rs-api-version>
         {{#threetenbp}}
         <threetenbp-version>2.9.10</threetenbp-version>
         {{/threetenbp}}

--- a/samples/client/petstore/java/native-async/build.gradle
+++ b/samples/client/petstore/java/native-async/build.gradle
@@ -22,6 +22,17 @@ apply plugin: 'maven'
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
+// Some text from the schema is copy pasted into the source files as UTF-8
+// but the default still seems to be to use platform encoding
+tasks.withType(JavaCompile) {
+    configure(options) {
+        options.encoding = 'UTF-8'
+    }
+}
+javadoc {
+    options.encoding = 'UTF-8'
+}
+
 install {
     repositories.mavenInstaller {
         pom.artifactId = 'petstore-native'
@@ -53,7 +64,6 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.10.4"
     junit_version = "4.13.1"
-    ws_rs_version = "2.1.1"
 }
 
 dependencies {
@@ -65,6 +75,5 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "org.openapitools:jackson-databind-nullable:0.2.1"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
-    implementation "javax.ws.rs:javax.ws.rs-api:$ws_rs_version"
     testImplementation "junit:junit:$junit_version"
 }

--- a/samples/client/petstore/java/native-async/pom.xml
+++ b/samples/client/petstore/java/native-async/pom.xml
@@ -200,13 +200,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api -->
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>${javax-ws-rs-api-version}</version>
-        </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -224,7 +217,6 @@
         <jackson-version>2.10.4</jackson-version>
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <javax-annotation-version>1.3.2</javax-annotation-version>
-        <javax-ws-rs-api-version>2.1.1</javax-ws-rs-api-version>
         <junit-version>4.13.1</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/JSON.java
@@ -11,11 +11,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.ext.ContextResolver;
 
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
-public class JSON implements ContextResolver<ObjectMapper> {
+public class JSON {
   private ObjectMapper mapper;
 
   public JSON() {
@@ -39,11 +37,6 @@ public class JSON implements ContextResolver<ObjectMapper> {
    */
   public void setDateFormat(DateFormat dateFormat) {
     mapper.setDateFormat(dateFormat);
-  }
-
-  @Override
-  public ObjectMapper getContext(Class<?> type) {
-    return mapper;
   }
 
   /**
@@ -178,10 +171,10 @@ public class JSON implements ContextResolver<ObjectMapper> {
     visitedClasses.add(modelClass);
 
     // Traverse the oneOf/anyOf composed schemas.
-    Map<String, GenericType> descendants = modelDescendants.get(modelClass);
+    Map<String, Class<?>> descendants = modelDescendants.get(modelClass);
     if (descendants != null) {
-      for (GenericType childType : descendants.values()) {
-        if (isInstanceOf(childType.getRawType(), inst, visitedClasses)) {
+      for (Class<?> childType : descendants.values()) {
+        if (isInstanceOf(childType, inst, visitedClasses)) {
           return true;
         }
       }
@@ -192,12 +185,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, Class<?>>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.
@@ -217,7 +210,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     * @param modelClass the model class
     * @param descendants a map of oneOf/anyOf descendants.
     */
-  public static void registerDescendants(Class<?> modelClass, Map<String, GenericType> descendants) {
+  public static void registerDescendants(Class<?> modelClass, Map<String, Class<?>> descendants) {
     modelDescendants.put(modelClass, descendants);
   }
 

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -17,7 +17,6 @@ import org.openapitools.client.ApiException;
 import java.util.Objects;
 import java.lang.reflect.Type;
 import java.util.Map;
-import javax.ws.rs.core.GenericType;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -46,7 +45,7 @@ public abstract class AbstractOpenApiSchema {
      *
      * @return an instance of the actual schema/object
      */
-    public abstract Map<String, GenericType> getSchemas();
+    public abstract Map<String, Class<?>> getSchemas();
 
     /**
      * Get the actual instance

--- a/samples/client/petstore/java/native/build.gradle
+++ b/samples/client/petstore/java/native/build.gradle
@@ -22,6 +22,17 @@ apply plugin: 'maven'
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
+// Some text from the schema is copy pasted into the source files as UTF-8
+// but the default still seems to be to use platform encoding
+tasks.withType(JavaCompile) {
+    configure(options) {
+        options.encoding = 'UTF-8'
+    }
+}
+javadoc {
+    options.encoding = 'UTF-8'
+}
+
 install {
     repositories.mavenInstaller {
         pom.artifactId = 'petstore-native'
@@ -53,7 +64,6 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.10.4"
     junit_version = "4.13.1"
-    ws_rs_version = "2.1.1"
 }
 
 dependencies {
@@ -65,6 +75,5 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "org.openapitools:jackson-databind-nullable:0.2.1"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
-    implementation "javax.ws.rs:javax.ws.rs-api:$ws_rs_version"
     testImplementation "junit:junit:$junit_version"
 }

--- a/samples/client/petstore/java/native/pom.xml
+++ b/samples/client/petstore/java/native/pom.xml
@@ -200,13 +200,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api -->
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>${javax-ws-rs-api-version}</version>
-        </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -224,7 +217,6 @@
         <jackson-version>2.10.4</jackson-version>
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <javax-annotation-version>1.3.2</javax-annotation-version>
-        <javax-ws-rs-api-version>2.1.1</javax-ws-rs-api-version>
         <junit-version>4.13.1</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/JSON.java
@@ -11,11 +11,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.ext.ContextResolver;
 
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
-public class JSON implements ContextResolver<ObjectMapper> {
+public class JSON {
   private ObjectMapper mapper;
 
   public JSON() {
@@ -39,11 +37,6 @@ public class JSON implements ContextResolver<ObjectMapper> {
    */
   public void setDateFormat(DateFormat dateFormat) {
     mapper.setDateFormat(dateFormat);
-  }
-
-  @Override
-  public ObjectMapper getContext(Class<?> type) {
-    return mapper;
   }
 
   /**
@@ -178,10 +171,10 @@ public class JSON implements ContextResolver<ObjectMapper> {
     visitedClasses.add(modelClass);
 
     // Traverse the oneOf/anyOf composed schemas.
-    Map<String, GenericType> descendants = modelDescendants.get(modelClass);
+    Map<String, Class<?>> descendants = modelDescendants.get(modelClass);
     if (descendants != null) {
-      for (GenericType childType : descendants.values()) {
-        if (isInstanceOf(childType.getRawType(), inst, visitedClasses)) {
+      for (Class<?> childType : descendants.values()) {
+        if (isInstanceOf(childType, inst, visitedClasses)) {
           return true;
         }
       }
@@ -192,12 +185,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, Class<?>>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.
@@ -217,7 +210,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     * @param modelClass the model class
     * @param descendants a map of oneOf/anyOf descendants.
     */
-  public static void registerDescendants(Class<?> modelClass, Map<String, GenericType> descendants) {
+  public static void registerDescendants(Class<?> modelClass, Map<String, Class<?>> descendants) {
     modelDescendants.put(modelClass, descendants);
   }
 

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -17,7 +17,6 @@ import org.openapitools.client.ApiException;
 import java.util.Objects;
 import java.lang.reflect.Type;
 import java.util.Map;
-import javax.ws.rs.core.GenericType;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -46,7 +45,7 @@ public abstract class AbstractOpenApiSchema {
      *
      * @return an instance of the actual schema/object
      */
-    public abstract Map<String, GenericType> getSchemas();
+    public abstract Map<String, Class<?>> getSchemas();
 
     /**
      * Get the actual instance

--- a/samples/openapi3/client/petstore/java/native/build.gradle
+++ b/samples/openapi3/client/petstore/java/native/build.gradle
@@ -22,6 +22,17 @@ apply plugin: 'maven'
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
+// Some text from the schema is copy pasted into the source files as UTF-8
+// but the default still seems to be to use platform encoding
+tasks.withType(JavaCompile) {
+    configure(options) {
+        options.encoding = 'UTF-8'
+    }
+}
+javadoc {
+    options.encoding = 'UTF-8'
+}
+
 install {
     repositories.mavenInstaller {
         pom.artifactId = 'petstore-openapi3-native'
@@ -53,7 +64,6 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.10.4"
     junit_version = "4.13.1"
-    ws_rs_version = "2.1.1"
 }
 
 dependencies {
@@ -65,6 +75,5 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "org.openapitools:jackson-databind-nullable:0.2.1"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
-    implementation "javax.ws.rs:javax.ws.rs-api:$ws_rs_version"
     testImplementation "junit:junit:$junit_version"
 }

--- a/samples/openapi3/client/petstore/java/native/pom.xml
+++ b/samples/openapi3/client/petstore/java/native/pom.xml
@@ -200,13 +200,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api -->
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>${javax-ws-rs-api-version}</version>
-        </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -224,7 +217,6 @@
         <jackson-version>2.10.4</jackson-version>
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <javax-annotation-version>1.3.2</javax-annotation-version>
-        <javax-ws-rs-api-version>2.1.1</javax-ws-rs-api-version>
         <junit-version>4.13.1</junit-version>
     </properties>
 </project>

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/JSON.java
@@ -11,11 +11,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.ext.ContextResolver;
 
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
-public class JSON implements ContextResolver<ObjectMapper> {
+public class JSON {
   private ObjectMapper mapper;
 
   public JSON() {
@@ -39,11 +37,6 @@ public class JSON implements ContextResolver<ObjectMapper> {
    */
   public void setDateFormat(DateFormat dateFormat) {
     mapper.setDateFormat(dateFormat);
-  }
-
-  @Override
-  public ObjectMapper getContext(Class<?> type) {
-    return mapper;
   }
 
   /**
@@ -178,10 +171,10 @@ public class JSON implements ContextResolver<ObjectMapper> {
     visitedClasses.add(modelClass);
 
     // Traverse the oneOf/anyOf composed schemas.
-    Map<String, GenericType> descendants = modelDescendants.get(modelClass);
+    Map<String, Class<?>> descendants = modelDescendants.get(modelClass);
     if (descendants != null) {
-      for (GenericType childType : descendants.values()) {
-        if (isInstanceOf(childType.getRawType(), inst, visitedClasses)) {
+      for (Class<?> childType : descendants.values()) {
+        if (isInstanceOf(childType, inst, visitedClasses)) {
           return true;
         }
       }
@@ -192,12 +185,12 @@ public class JSON implements ContextResolver<ObjectMapper> {
   /**
    * A map of discriminators for all model classes.
    */
-  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<Class<?>, ClassDiscriminatorMapping>();
+  private static Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators = new HashMap<>();
 
   /**
    * A map of oneOf/anyOf descendants for each model class.
    */
-  private static Map<Class<?>, Map<String, GenericType>> modelDescendants = new HashMap<Class<?>, Map<String, GenericType>>();
+  private static Map<Class<?>, Map<String, Class<?>>> modelDescendants = new HashMap<>();
 
   /**
     * Register a model class discriminator.
@@ -217,7 +210,7 @@ public class JSON implements ContextResolver<ObjectMapper> {
     * @param modelClass the model class
     * @param descendants a map of oneOf/anyOf descendants.
     */
-  public static void registerDescendants(Class<?> modelClass, Map<String, GenericType> descendants) {
+  public static void registerDescendants(Class<?> modelClass, Map<String, Class<?>> descendants) {
     modelDescendants.put(modelClass, descendants);
   }
 

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/AbstractOpenApiSchema.java
@@ -17,7 +17,6 @@ import org.openapitools.client.ApiException;
 import java.util.Objects;
 import java.lang.reflect.Type;
 import java.util.Map;
-import javax.ws.rs.core.GenericType;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -46,7 +45,7 @@ public abstract class AbstractOpenApiSchema {
      *
      * @return an instance of the actual schema/object
      */
-    public abstract Map<String, GenericType> getSchemas();
+    public abstract Map<String, Class<?>> getSchemas();
 
     /**
      * Get the actual instance

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Fruit.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Fruit.java
@@ -31,8 +31,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -44,7 +42,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -163,7 +160,7 @@ public class Fruit extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, Class<?>> schemas = new HashMap<>();
 
     public Fruit() {
         super("oneOf", Boolean.FALSE);
@@ -180,15 +177,13 @@ public class Fruit extends AbstractOpenApiSchema {
     }
 
     static {
-        schemas.put("Apple", new GenericType<Apple>() {
-        });
-        schemas.put("Banana", new GenericType<Banana>() {
-        });
+        schemas.put("Apple", Apple.class);
+        schemas.put("Banana", Banana.class);
         JSON.registerDescendants(Fruit.class, Collections.unmodifiableMap(schemas));
     }
 
     @Override
-    public Map<String, GenericType> getSchemas() {
+    public Map<String, Class<?>> getSchemas() {
         return Fruit.schemas;
     }
 

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/FruitReq.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/FruitReq.java
@@ -31,8 +31,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -44,7 +42,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -165,7 +162,7 @@ public class FruitReq extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, Class<?>> schemas = new HashMap<>();
 
     public FruitReq() {
         super("oneOf", Boolean.TRUE);
@@ -182,15 +179,13 @@ public class FruitReq extends AbstractOpenApiSchema {
     }
 
     static {
-        schemas.put("AppleReq", new GenericType<AppleReq>() {
-        });
-        schemas.put("BananaReq", new GenericType<BananaReq>() {
-        });
+        schemas.put("AppleReq", AppleReq.class);
+        schemas.put("BananaReq", BananaReq.class);
         JSON.registerDescendants(FruitReq.class, Collections.unmodifiableMap(schemas));
     }
 
     @Override
-    public Map<String, GenericType> getSchemas() {
+    public Map<String, Class<?>> getSchemas() {
         return FruitReq.schemas;
     }
 

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -30,8 +30,6 @@ import org.openapitools.client.model.Banana;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -42,7 +40,6 @@ import java.util.HashSet;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -123,7 +120,7 @@ public class GmFruit extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in anyOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, Class<?>> schemas = new HashMap<String, Class<?>>();
 
     public GmFruit() {
         super("anyOf", Boolean.FALSE);
@@ -140,15 +137,13 @@ public class GmFruit extends AbstractOpenApiSchema {
     }
 
     static {
-        schemas.put("Apple", new GenericType<Apple>() {
-        });
-        schemas.put("Banana", new GenericType<Banana>() {
-        });
+        schemas.put("Apple", Apple.class);
+        schemas.put("Banana", Banana.class);
         JSON.registerDescendants(GmFruit.class, Collections.unmodifiableMap(schemas));
     }
 
     @Override
-    public Map<String, GenericType> getSchemas() {
+    public Map<String, Class<?>> getSchemas() {
         return GmFruit.schemas;
     }
 

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Mammal.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Mammal.java
@@ -33,8 +33,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -46,7 +44,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -211,7 +208,7 @@ public class Mammal extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, Class<?>> schemas = new HashMap<>();
 
     public Mammal() {
         super("oneOf", Boolean.FALSE);
@@ -233,12 +230,9 @@ public class Mammal extends AbstractOpenApiSchema {
     }
 
     static {
-        schemas.put("Pig", new GenericType<Pig>() {
-        });
-        schemas.put("Whale", new GenericType<Whale>() {
-        });
-        schemas.put("Zebra", new GenericType<Zebra>() {
-        });
+        schemas.put("Pig", Pig.class);
+        schemas.put("Whale", Whale.class);
+        schemas.put("Zebra", Zebra.class);
         JSON.registerDescendants(Mammal.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
         Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
@@ -250,7 +244,7 @@ public class Mammal extends AbstractOpenApiSchema {
     }
 
     @Override
-    public Map<String, GenericType> getSchemas() {
+    public Map<String, Class<?>> getSchemas() {
         return Mammal.schemas;
     }
 

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/NullableShape.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/NullableShape.java
@@ -32,8 +32,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -45,7 +43,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -182,7 +179,7 @@ public class NullableShape extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, Class<?>> schemas = new HashMap<>();
 
     public NullableShape() {
         super("oneOf", Boolean.TRUE);
@@ -199,10 +196,8 @@ public class NullableShape extends AbstractOpenApiSchema {
     }
 
     static {
-        schemas.put("Quadrilateral", new GenericType<Quadrilateral>() {
-        });
-        schemas.put("Triangle", new GenericType<Triangle>() {
-        });
+        schemas.put("Quadrilateral", Quadrilateral.class);
+        schemas.put("Triangle", Triangle.class);
         JSON.registerDescendants(NullableShape.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
         Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
@@ -213,7 +208,7 @@ public class NullableShape extends AbstractOpenApiSchema {
     }
 
     @Override
-    public Map<String, GenericType> getSchemas() {
+    public Map<String, Class<?>> getSchemas() {
         return NullableShape.schemas;
     }
 

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pig.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pig.java
@@ -32,8 +32,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -45,7 +43,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -180,7 +177,7 @@ public class Pig extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, Class<?>> schemas = new HashMap<>();
 
     public Pig() {
         super("oneOf", Boolean.FALSE);
@@ -197,10 +194,8 @@ public class Pig extends AbstractOpenApiSchema {
     }
 
     static {
-        schemas.put("BasquePig", new GenericType<BasquePig>() {
-        });
-        schemas.put("DanishPig", new GenericType<DanishPig>() {
-        });
+        schemas.put("BasquePig", BasquePig.class);
+        schemas.put("DanishPig", DanishPig.class);
         JSON.registerDescendants(Pig.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
         Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
@@ -211,7 +206,7 @@ public class Pig extends AbstractOpenApiSchema {
     }
 
     @Override
-    public Map<String, GenericType> getSchemas() {
+    public Map<String, Class<?>> getSchemas() {
         return Pig.schemas;
     }
 

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Quadrilateral.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Quadrilateral.java
@@ -32,8 +32,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -45,7 +43,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -180,7 +177,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, Class<?>> schemas = new HashMap<>();
 
     public Quadrilateral() {
         super("oneOf", Boolean.FALSE);
@@ -197,10 +194,8 @@ public class Quadrilateral extends AbstractOpenApiSchema {
     }
 
     static {
-        schemas.put("ComplexQuadrilateral", new GenericType<ComplexQuadrilateral>() {
-        });
-        schemas.put("SimpleQuadrilateral", new GenericType<SimpleQuadrilateral>() {
-        });
+        schemas.put("ComplexQuadrilateral", ComplexQuadrilateral.class);
+        schemas.put("SimpleQuadrilateral", SimpleQuadrilateral.class);
         JSON.registerDescendants(Quadrilateral.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
         Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
@@ -211,7 +206,7 @@ public class Quadrilateral extends AbstractOpenApiSchema {
     }
 
     @Override
-    public Map<String, GenericType> getSchemas() {
+    public Map<String, Class<?>> getSchemas() {
         return Quadrilateral.schemas;
     }
 

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Shape.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Shape.java
@@ -32,8 +32,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -45,7 +43,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -180,7 +177,7 @@ public class Shape extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, Class<?>> schemas = new HashMap<>();
 
     public Shape() {
         super("oneOf", Boolean.FALSE);
@@ -197,10 +194,8 @@ public class Shape extends AbstractOpenApiSchema {
     }
 
     static {
-        schemas.put("Quadrilateral", new GenericType<Quadrilateral>() {
-        });
-        schemas.put("Triangle", new GenericType<Triangle>() {
-        });
+        schemas.put("Quadrilateral", Quadrilateral.class);
+        schemas.put("Triangle", Triangle.class);
         JSON.registerDescendants(Shape.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
         Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
@@ -211,7 +206,7 @@ public class Shape extends AbstractOpenApiSchema {
     }
 
     @Override
-    public Map<String, GenericType> getSchemas() {
+    public Map<String, Class<?>> getSchemas() {
         return Shape.schemas;
     }
 

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ShapeOrNull.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/ShapeOrNull.java
@@ -32,8 +32,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -45,7 +43,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -182,7 +179,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, Class<?>> schemas = new HashMap<>();
 
     public ShapeOrNull() {
         super("oneOf", Boolean.TRUE);
@@ -199,10 +196,8 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
     }
 
     static {
-        schemas.put("Quadrilateral", new GenericType<Quadrilateral>() {
-        });
-        schemas.put("Triangle", new GenericType<Triangle>() {
-        });
+        schemas.put("Quadrilateral", Quadrilateral.class);
+        schemas.put("Triangle", Triangle.class);
         JSON.registerDescendants(ShapeOrNull.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
         Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
@@ -213,7 +208,7 @@ public class ShapeOrNull extends AbstractOpenApiSchema {
     }
 
     @Override
-    public Map<String, GenericType> getSchemas() {
+    public Map<String, Class<?>> getSchemas() {
         return ShapeOrNull.schemas;
     }
 

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Triangle.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/model/Triangle.java
@@ -33,8 +33,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -46,7 +44,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -211,7 +208,7 @@ public class Triangle extends AbstractOpenApiSchema {
     }
 
     // store a list of schema names defined in oneOf
-    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+    public static final Map<String, Class<?>> schemas = new HashMap<>();
 
     public Triangle() {
         super("oneOf", Boolean.FALSE);
@@ -233,12 +230,9 @@ public class Triangle extends AbstractOpenApiSchema {
     }
 
     static {
-        schemas.put("EquilateralTriangle", new GenericType<EquilateralTriangle>() {
-        });
-        schemas.put("IsoscelesTriangle", new GenericType<IsoscelesTriangle>() {
-        });
-        schemas.put("ScaleneTriangle", new GenericType<ScaleneTriangle>() {
-        });
+        schemas.put("EquilateralTriangle", EquilateralTriangle.class);
+        schemas.put("IsoscelesTriangle", IsoscelesTriangle.class);
+        schemas.put("ScaleneTriangle", ScaleneTriangle.class);
         JSON.registerDescendants(Triangle.class, Collections.unmodifiableMap(schemas));
         // Initialize and register the discriminator mappings.
         Map<String, Class<?>> mappings = new HashMap<String, Class<?>>();
@@ -250,7 +244,7 @@ public class Triangle extends AbstractOpenApiSchema {
     }
 
     @Override
-    public Map<String, GenericType> getSchemas() {
+    public Map<String, Class<?>> getSchemas() {
         return Triangle.schemas;
     }
 


### PR DESCRIPTION
This removes the dependency on JAX-RS from the Java native client template by making the following changes:

1) Remove use of GenericType
This was originally introduced in #7263 by presumably copy pasting a piece of code for OneOf/AnyOf support from the Jersey client. It was using `GenericType` from JAX-RS, which seems unnecessary since it doesn't seem to generate generic type instantiations (the anyOf/oneOf deserializer will also use `{{.}}.class`, and not GenericType or similar type tokens).

2) Remove ContextResolver implementation
The `JSON` class implements the JAX-RS ContextResolver interface, which seems unnecessary for a native Java client in a non JAX-RS environment  (probably copy paste)

3) Removed the respective dependencies from build.gradle/pom.xml.

4) [OPTIONAL] Set source encoding to UTF-8 in build.gradle
I had to set the source encoding in the build.gradle template, as the samples were not even building for me otherwise.
The pet store API spec seems to contain UTF-8 characters which are copied into the source, breaking the build with windows default encoding for me. (This should probably be split into a separate PR; but I was unable to build and validate the sample without this fix).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @nmuesch (2021/01)
