### PR TITLE
[ci] Build kotlin samples via github

### DIFF
--- a/.github/workflows/samples-kotlin.yaml
+++ b/.github/workflows/samples-kotlin.yaml
@@ -1,0 +1,64 @@
+name: Samples Kotlin
+
+on:
+  push:
+    branches:
+      - master
+      - '[5-9]+.[0-9]+.x'
+  pull_request:
+    branches:
+      - master
+      - '[5-9]+.[0-9]+.x'
+
+env:
+  GRADLE_VERSION: 6.9
+
+jobs:
+  build:
+    name: Build Kotlin
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sample:
+          - samples/client/petstore/kotlin
+          - samples/client/petstore/kotlin-gson
+          - samples/client/petstore/kotlin-jackson
+          # needs Android configured
+          #- samples/client/petstore/kotlin-json-request-string
+          - samples/client/petstore/kotlin-jvm-okhttp4-coroutines
+          - samples/client/petstore/kotlin-moshi-codegen
+          # need some special setup
+          #- samples/client/petstore/kotlin-multiplatform
+          - samples/client/petstore/kotlin-nonpublic
+          - samples/client/petstore/kotlin-nullable
+          - samples/client/petstore/kotlin-okhttp3
+          - samples/client/petstore/kotlin-retrofit2
+          - samples/client/petstore/kotlin-retrofit2-kotlinx_serialization
+          - samples/client/petstore/kotlin-retrofit2-rx3
+          - samples/client/petstore/kotlin-string
+          - samples/client/petstore/kotlin-threetenbp
+          - samples/client/petstore/kotlin-uppercase-enum
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 8
+      - name: Cache maven dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: maven-repository
+        with:
+          path: |
+            ~/.gradle
+          key: ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+      - name: Install Gradle wrapper
+        uses: eskatos/gradle-command-action@v1
+        with:
+          gradle-version: ${{ env.GRADLE_VERSION }}
+          build-root-directory: ${{ matrix.sample }}
+          arguments: wrapper
+      - name: Build
+        working-directory: ${{ matrix.sample }}
+        run: ./gradlew build -x test


### PR DESCRIPTION
First try to run Kotlin samples via Github.
- [ ] `kotlin-json-request-string` now seems to require Android to be build
- [ ] `kotlin-multiplatform` has no `test` task so it doesn't work with the current matrix

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
