### PR TITLE
Add nullable annotation support to AspNetCoreServer

### DIFF
--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -19,6 +19,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |licenseUrl|The URL of the license| |http://localhost|
 |modelClassModifier|Model Class Modifier can be nothing or partial| |partial|
 |newtonsoftVersion|Version for Microsoft.AspNetCore.Mvc.NewtonsoftJson for ASP.NET Core 3.0+| |3.0.0|
+|nullableReferenceTypes|Annotate Project with &lt;Nullable&gt;annotations&lt;/Nullable&gt; and use ? annotation on all nullable attributes. Only supported on C# 8 / ASP.NET Core 3.0 or newer.| |false|
 |operationIsAsync|Set methods to async or sync (default).| |false|
 |operationModifier|Operation Modifier can be virtual or abstract|<dl><dt>**virtual**</dt><dd>Keep method virtual</dd><dt>**abstract**</dt><dd>Make method abstract</dd></dl>|virtual|
 |operationResultTask|Set methods result to Task&lt;&gt;.| |false|
@@ -38,7 +39,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useDefaultRouting|Use default routing for the ASP.NET Core version.| |true|
 |useFrameworkReference|Use frameworkReference for ASP.NET Core 3.0+ and PackageReference ASP.NET Core 2.2 or earlier.| |false|
 |useNewtonsoft|Uses the Newtonsoft JSON library.| |true|
-|useNullableAnnotation|Annotate Project with &lt;Nullable&gt;annotations&lt;/Nullable&gt; and use ? annotation on all nullable attributes. Only supported on C# 8 / ASP.NET Core 3.0 or newer.| |false|
 |useSwashbuckle|Uses the Swashbuckle.AspNetCore NuGet package for documentation.| |true|
 
 ## IMPORT MAPPING

--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -38,6 +38,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useDefaultRouting|Use default routing for the ASP.NET Core version.| |true|
 |useFrameworkReference|Use frameworkReference for ASP.NET Core 3.0+ and PackageReference ASP.NET Core 2.2 or earlier.| |false|
 |useNewtonsoft|Uses the Newtonsoft JSON library.| |true|
+|useNullableAnnotation|Annotate Project with &lt;Nullable&gt;annotations&lt;/Nullable&gt; and use ? annotation on all nullable attributes. Only supported on C# 8 / ASP.NET Core 3.0 or newer.| |false|
 |useSwashbuckle|Uses the Swashbuckle.AspNetCore NuGet package for documentation.| |true|
 
 ## IMPORT MAPPING

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -60,7 +60,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     public static final String USE_NEWTONSOFT = "useNewtonsoft";
     public static final String USE_DEFAULT_ROUTING = "useDefaultRouting";
     public static final String NEWTONSOFT_VERSION = "newtonsoftVersion";
-    public static final String USE_NULLABLE_ANNOTATION = "useNullableAnnotation";
+    public static final String NULLABLE_REFERENCE_TYPES = "nullableReferenceTypes";
 
     private String packageGuid = "{" + randomUUID().toString().toUpperCase(Locale.ROOT) + "}";
     private String userSecretsGuid = randomUUID().toString();
@@ -85,7 +85,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private boolean useFrameworkReference = false;
     private boolean useNewtonsoft = true;
     private boolean useDefaultRouting = true;
-    private boolean useNullableAnnotation = false;
+    private boolean nullableReferenceTypes = false;
     private String newtonsoftVersion = "3.0.0";
 
     public AspNetCoreServerCodegen() {
@@ -251,10 +251,10 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                 "Use default routing for the ASP.NET Core version.",
                 useDefaultRouting);
 
-        addSwitch(USE_NULLABLE_ANNOTATION,
+        addSwitch(NULLABLE_REFERENCE_TYPES,
                 "Annotate Project with <Nullable>annotations</Nullable> and use ? annotation on all nullable attributes. " +
                           "Only supported on C# 8 / ASP.NET Core 3.0 or newer.",
-                useNullableAnnotation);
+                nullableReferenceTypes);
 
         addOption(CodegenConstants.ENUM_NAME_SUFFIX,
                 CodegenConstants.ENUM_NAME_SUFFIX_DESC,
@@ -373,7 +373,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         setIsFramework();
         setUseNewtonsoft();
         setUseEndpointRouting();
-        setUseNullableAnnotation();
+        setNullableReferenceTypes();
 
         supportingFiles.add(new SupportingFile("build.sh.mustache", "", "build.sh"));
         supportingFiles.add(new SupportingFile("build.bat.mustache", "", "build.bat"));
@@ -528,7 +528,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     @Override
     public String getNullableType(Schema p, String type) {
         if (languageSpecificPrimitives.contains(type)) {
-            if (isSupportNullable() && ModelUtils.isNullable(p) && (nullableType.contains(type) || useNullableAnnotation)) {
+            if (isSupportNullable() && ModelUtils.isNullable(p) && (nullableType.contains(type) || nullableReferenceTypes)) {
                 return type + "?";
             } else {
                 return type;
@@ -657,16 +657,16 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         }
     }
 
-    private void setUseNullableAnnotation() {
-        if (additionalProperties.containsKey(USE_NULLABLE_ANNOTATION)) {
+    private void setNullableReferenceTypes() {
+        if (additionalProperties.containsKey(NULLABLE_REFERENCE_TYPES)) {
             if (aspnetCoreVersion.getOptValue().startsWith("2.")) {
-                LOGGER.warn("Nullable annotation are not supported in ASP.NET core version 2. Setting " + USE_NULLABLE_ANNOTATION + " to false");
-                additionalProperties.put(USE_NULLABLE_ANNOTATION, false);
+                LOGGER.warn("Nullable annotation are not supported in ASP.NET core version 2. Setting " + NULLABLE_REFERENCE_TYPES + " to false");
+                additionalProperties.put(NULLABLE_REFERENCE_TYPES, false);
             } else {
-                useNullableAnnotation = convertPropertyToBooleanAndWriteBack(USE_NULLABLE_ANNOTATION);
+                nullableReferenceTypes = convertPropertyToBooleanAndWriteBack(NULLABLE_REFERENCE_TYPES);
             }
         } else {
-            additionalProperties.put(USE_NULLABLE_ANNOTATION, useNullableAnnotation);
+            additionalProperties.put(NULLABLE_REFERENCE_TYPES, nullableReferenceTypes);
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Project.csproj.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Project.csproj.mustache
@@ -7,9 +7,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <Version>{{packageVersion}}</Version>
-{{#useNullableAnnotation}}
+{{#nullableReferenceTypes}}
     <Nullable>annotations</Nullable>
-{{/useNullableAnnotation}}
+{{/nullableReferenceTypes}}
 {{#isLibrary}}
     <OutputType>Library</OutputType>
 {{/isLibrary}}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Project.csproj.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/3.0/Project.csproj.mustache
@@ -7,6 +7,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <Version>{{packageVersion}}</Version>
+{{#useNullableAnnotation}}
+    <Nullable>annotations</Nullable>
+{{/useNullableAnnotation}}
 {{#isLibrary}}
     <OutputType>Library</OutputType>
 {{/isLibrary}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CSharpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CSharpModelTest.java
@@ -266,7 +266,7 @@ public class CSharpModelTest {
     }
 
     @Test(description = "convert a model with a nullable property without nullable annotation")
-    public void nullablePropertyWithoutNullableAnnotationTest() {
+    public void nullablePropertyWithoutNullableReferenceTypesTest() {
         final Schema model = new Schema()
                 .description("a sample model")
                 .addProperties("id",  new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT).nullable(true))
@@ -325,7 +325,7 @@ public class CSharpModelTest {
     }
 
     @Test(description = "convert a model with a nullable property using nullable annotation")
-    public void nullablePropertyWithNullableAnnotationTest() {
+    public void nullablePropertyWithNullableReferenceTypesTest() {
         final Schema model = new Schema()
                 .description("a sample model")
                 .addProperties("id",  new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT).nullable(true))
@@ -335,7 +335,7 @@ public class CSharpModelTest {
                 .addProperties("subObject",  new Schema().addProperties("name", new StringSchema()).nullable(true))
                 .addRequiredItem("id");
         final DefaultCodegen codegen = new AspNetCoreServerCodegen();
-        codegen.additionalProperties().put(AspNetCoreServerCodegen.USE_NULLABLE_ANNOTATION, true);
+        codegen.additionalProperties().put(AspNetCoreServerCodegen.NULLABLE_REFERENCE_TYPES, true);
         codegen.processOpts();
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
         codegen.setOpenAPI(openAPI);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CSharpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CSharpModelTest.java
@@ -25,6 +25,7 @@ import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultCodegen;
 import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.languages.AspNetCoreServerCodegen;
 import org.openapitools.codegen.languages.CSharpClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -262,6 +263,126 @@ public class CSharpModelTest {
         Assert.assertEquals(property3.baseType, "string");
         Assert.assertFalse(property3.required);
         Assert.assertTrue(property3.isPrimitiveType);
+    }
+
+    @Test(description = "convert a model with a nullable property without nullable annotation")
+    public void nullablePropertyWithoutNullableAnnotationTest() {
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperties("id",  new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT).nullable(true))
+                .addProperties("urls", new ArraySchema()
+                        .items(new StringSchema()).nullable(true))
+                .addProperties("name", new StringSchema().nullable(true))
+                .addProperties("subObject",  new Schema().addProperties("name", new StringSchema()).nullable(true))
+                .addRequiredItem("id");
+        final DefaultCodegen codegen = new AspNetCoreServerCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 4);
+
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "id");
+        Assert.assertEquals(property1.dataType, "long?");
+        Assert.assertEquals(property1.name, "Id");
+        Assert.assertNull(property1.defaultValue);
+        Assert.assertEquals(property1.baseType, "long?");
+        Assert.assertTrue(property1.required);
+        Assert.assertTrue(property1.isPrimitiveType);
+
+        final CodegenProperty property2 = cm.vars.get(1);
+        Assert.assertEquals(property2.baseName, "urls");
+        Assert.assertEquals(property2.dataType, "List<string>");
+        Assert.assertEquals(property2.name, "Urls");
+        Assert.assertNull(property2.defaultValue);
+        Assert.assertEquals(property2.baseType, "List");
+        Assert.assertEquals(property2.containerType, "array");
+        Assert.assertFalse(property2.required);
+        Assert.assertTrue(property2.isPrimitiveType);
+        Assert.assertTrue(property2.isContainer);
+
+        final CodegenProperty property3 = cm.vars.get(2);
+        Assert.assertEquals(property3.baseName, "name");
+        Assert.assertEquals(property3.dataType, "string");
+        Assert.assertEquals(property3.name, "Name");
+        Assert.assertNull(property3.defaultValue);
+        Assert.assertEquals(property3.baseType, "string");
+        Assert.assertFalse(property3.required);
+        Assert.assertTrue(property3.isPrimitiveType);
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "subObject");
+        Assert.assertEquals(property4.dataType, "Object");
+        Assert.assertEquals(property4.name, "SubObject");
+        Assert.assertNull(property4.defaultValue);
+        Assert.assertEquals(property4.baseType, "Object");
+        Assert.assertFalse(property4.required);
+        Assert.assertTrue(property4.isPrimitiveType);
+    }
+
+    @Test(description = "convert a model with a nullable property using nullable annotation")
+    public void nullablePropertyWithNullableAnnotationTest() {
+        final Schema model = new Schema()
+                .description("a sample model")
+                .addProperties("id",  new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT).nullable(true))
+                .addProperties("urls", new ArraySchema()
+                        .items(new StringSchema()).nullable(true))
+                .addProperties("name", new StringSchema().nullable(true))
+                .addProperties("subObject",  new Schema().addProperties("name", new StringSchema()).nullable(true))
+                .addRequiredItem("id");
+        final DefaultCodegen codegen = new AspNetCoreServerCodegen();
+        codegen.additionalProperties().put(AspNetCoreServerCodegen.USE_NULLABLE_ANNOTATION, true);
+        codegen.processOpts();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", model);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.description, "a sample model");
+        Assert.assertEquals(cm.vars.size(), 4);
+
+        final CodegenProperty property1 = cm.vars.get(0);
+        Assert.assertEquals(property1.baseName, "id");
+        Assert.assertEquals(property1.dataType, "long?");
+        Assert.assertEquals(property1.name, "Id");
+        Assert.assertNull(property1.defaultValue);
+        Assert.assertEquals(property1.baseType, "long?");
+        Assert.assertTrue(property1.required);
+        Assert.assertTrue(property1.isPrimitiveType);
+
+        final CodegenProperty property2 = cm.vars.get(1);
+        Assert.assertEquals(property2.baseName, "urls");
+        Assert.assertEquals(property2.dataType, "List<string>");
+        Assert.assertEquals(property2.name, "Urls");
+        Assert.assertNull(property2.defaultValue);
+        Assert.assertEquals(property2.baseType, "List?");
+        Assert.assertEquals(property2.containerType, "array");
+        Assert.assertFalse(property2.required);
+        Assert.assertTrue(property2.isPrimitiveType);
+        Assert.assertTrue(property2.isContainer);
+
+        final CodegenProperty property3 = cm.vars.get(2);
+        Assert.assertEquals(property3.baseName, "name");
+        Assert.assertEquals(property3.dataType, "string?");
+        Assert.assertEquals(property3.name, "Name");
+        Assert.assertNull(property3.defaultValue);
+        Assert.assertEquals(property3.baseType, "string?");
+        Assert.assertFalse(property3.required);
+        Assert.assertFalse(property3.isPrimitiveType);
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "subObject");
+        Assert.assertEquals(property4.dataType, "Object?");
+        Assert.assertEquals(property4.name, "SubObject");
+        Assert.assertNull(property4.defaultValue);
+        Assert.assertEquals(property4.baseType, "Object?");
+        Assert.assertFalse(property4.required);
+        Assert.assertFalse(property4.isPrimitiveType);
     }
 
     @Test(description = "convert a model with list property")


### PR DESCRIPTION
Since c# 8 / .net core 3.0 it is possible to add a nullable annotation to a project file. 
This allows to use the ? annotation not only on non-nullable types but on all types. 

Using this annotations can improve the readability within the code and also improves API behavior in regards to optional (nullable) properties.

The default behavior is not altered, it should stay compatible with everything.

Tests were added to ensure correct behavior.

This PR is a possible solution for:
#9190 
#9022

 @shibayan @Blackclaws @lucamazzanti 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
