### PR TITLE
bump swagger-parser-version to v2.0.26 to close #9086

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/yaml/YamlGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/yaml/YamlGeneratorTest.java
@@ -17,6 +17,7 @@
 
 package org.openapitools.codegen.yaml;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.TestUtils;
@@ -84,5 +85,37 @@ public class YamlGeneratorTest {
         TestUtils.ensureContainsFile(files, output, ".openapi-generator/VERSION");
 
         output.deleteOnExit();
+    }
+
+    @Test
+    public void testIssue9086() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(OpenAPIYamlGenerator.OUTPUT_NAME, "issue_9086.yaml");
+
+        File output = Files.createTempDirectory("issue_9086").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("openapi-yaml")
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/2_0/issue_9086.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+        Assert.assertEquals(files.size(), 5);
+        TestUtils.ensureContainsFile(files, output, "issue_9086.yaml");
+
+        TestUtils.ensureContainsFile(files, output, "README.md");
+        TestUtils.ensureContainsFile(files, output, ".openapi-generator-ignore");
+        TestUtils.ensureContainsFile(files, output, ".openapi-generator/FILES");
+        TestUtils.ensureContainsFile(files, output, ".openapi-generator/VERSION");
+
+        OpenAPI generated = TestUtils.parseSpec(new File(output, "issue_9086.yaml").getPath());
+        OpenAPI expected = TestUtils.parseSpec("src/test/resources/2_0/issue_9086_expected.yaml");
+
+        // use #toString because the equals methods is a little stricter than necessary for this test
+        Assert.assertEquals(expected.toString(), generated.toString());
     }
 }

--- a/modules/openapi-generator/src/test/resources/2_0/issue_9086.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/issue_9086.yaml
@@ -1,0 +1,34 @@
+swagger: '2.0'
+info:
+  title: 'Buggy Api'
+  version: '1.0'
+consumes:
+  - application/json
+paths:
+  /foo/bar:
+    post:
+      responses:
+        '200':
+          description: ok
+          schema:
+            type: object
+            additionalProperties: false
+            properties:
+              n:
+                type: number
+                example: 1.23
+  /foo/bar2:
+    post:
+      responses:
+        '200':
+          description: ok
+          schema:
+            $ref: '#/definitions/bar2'
+definitions:
+  bar2:
+    type: object
+    additionalProperties: false
+    properties:
+      n:
+        type: number
+        example: 4.56

--- a/modules/openapi-generator/src/test/resources/2_0/issue_9086_expected.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/issue_9086_expected.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.1
+info:
+  title: 'Buggy Api'
+  version: '1.0'
+paths:
+  /foo/bar:
+    post:
+      responses:
+        '200':
+          description: ok
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/inline_response_200'
+
+  /foo/bar2:
+    post:
+      responses:
+        '200':
+          description: ok
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/bar2'
+components:
+  schemas:
+    bar2:
+      type: object
+      example: { n: 4.56 }
+      properties:
+        n:
+          type: number
+          example: 4.56
+    inline_response_200:
+      type: object
+      example: { n: 1.23 }
+      properties:
+        n:
+          type: number
+          example: 1.23

--- a/pom.xml
+++ b/pom.xml
@@ -1575,7 +1575,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <swagger-core-version>2.1.2</swagger-core-version>
         <swagger-parser-groupid>io.swagger.parser.v3</swagger-parser-groupid>
-        <swagger-parser-version>2.0.24</swagger-parser-version>
+        <swagger-parser-version>2.0.26</swagger-parser-version>
         <felix-version>3.3.1</felix-version>
         <commons-io-version>2.4</commons-io-version>
         <commons-cli-version>1.2</commons-cli-version>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

A bug in the upstream schema parser was causing generation issues for swagger v2.0 #9086 

This PR updates the upstream version and adds a test for this issue

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
