### PR TITLE
[Java] [JavaJaxRS] Respect readOnly/writeOnly markers for @NotNull annotation generation

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/beanValidation.mustache
@@ -1,4 +1,4 @@
-{{#required}}
+{{#required}}{{^isReadOnly}}{{^isWriteOnly}}
   @NotNull
-{{/required}}
+{{/isWriteOnly}}{{/isReadOnly}}{{/required}}
 {{>beanValidationCore}}

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -46,6 +46,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_string")
+
   public Map<String, String> getMapString() {
     return mapString;
   }
@@ -67,6 +68,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_number")
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
@@ -88,6 +90,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_integer")
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
@@ -109,6 +112,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_boolean")
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
@@ -130,6 +134,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_integer")
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
@@ -151,6 +156,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_anytype")
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
@@ -172,6 +178,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_string")
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
@@ -193,6 +200,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_anytype")
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
@@ -214,6 +222,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("anytype_1")
+
   public Object getAnytype1() {
     return anytype1;
   }
@@ -235,6 +244,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("anytype_2")
+
   public Object getAnytype2() {
     return anytype2;
   }
@@ -256,6 +266,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("anytype_3")
+
   public Object getAnytype3() {
     return anytype3;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Animal.java
@@ -41,7 +41,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("className")
+
   @NotNull
+
   public String getClassName() {
     return className;
   }
@@ -63,6 +65,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("color")
+
   public String getColor() {
     return color;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayArrayNumber")
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayNumber")
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_of_string")
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
@@ -58,6 +59,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_integer")
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
@@ -79,6 +81,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_model")
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCat.java
@@ -67,6 +67,7 @@ public enum KindEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("kind")
+
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCatAllOf.java
@@ -65,6 +65,7 @@ public enum KindEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("kind")
+
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Capitalization.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("smallCamel")
+
   public String getSmallCamel() {
     return smallCamel;
   }
@@ -58,6 +59,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("CapitalCamel")
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
@@ -79,6 +81,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("small_Snake")
+
   public String getSmallSnake() {
     return smallSnake;
   }
@@ -100,6 +103,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("Capital_Snake")
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
@@ -121,6 +125,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("SCA_ETH_Flow_Points")
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
@@ -143,6 +148,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "Name of the pet ")
   @JsonProperty("ATT_NAME")
+
   public String getATTNAME() {
     return ATT_NAME;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Cat.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("declawed")
+
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/CatAllOf.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/CatAllOf.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("declawed")
+
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Category.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("id")
+
   public Long getId() {
     return id;
   }
@@ -54,7 +55,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
+
   @NotNull
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ClassModel.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("_class")
+
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Client.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("client")
+
   public String getClient() {
     return client;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Dog.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("breed")
+
   public String getBreed() {
     return breed;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/DogAllOf.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/DogAllOf.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("breed")
+
   public String getBreed() {
     return breed;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -101,6 +101,7 @@ public enum ArrayEnumEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("just_symbol")
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
@@ -122,6 +123,7 @@ public enum ArrayEnumEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_enum")
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
@@ -169,6 +169,7 @@ public enum EnumNumberEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("enum_string")
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
@@ -190,7 +191,9 @@ public enum EnumNumberEnum {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("enum_string_required")
+
   @NotNull
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
@@ -212,6 +215,7 @@ public enum EnumNumberEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("enum_integer")
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
@@ -233,6 +237,7 @@ public enum EnumNumberEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("enum_number")
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
@@ -254,6 +259,7 @@ public enum EnumNumberEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("outerEnum")
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("file")
+
   public java.io.File getFile() {
     return file;
   }
@@ -56,6 +57,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("files")
+
   public List<java.io.File> getFiles() {
     return files;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FormatTest.java
@@ -52,6 +52,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("integer")
+
  @Min(10) @Max(100)  public Integer getInteger() {
     return integer;
   }
@@ -75,6 +76,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("int32")
+
  @Min(20) @Max(200)  public Integer getInt32() {
     return int32;
   }
@@ -96,6 +98,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("int64")
+
   public Long getInt64() {
     return int64;
   }
@@ -119,7 +122,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number")
+
   @NotNull
+
  @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
     return number;
   }
@@ -143,6 +148,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("float")
+
  @DecimalMin("54.3") @DecimalMax("987.6")  public Float getFloat() {
     return _float;
   }
@@ -166,6 +172,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("double")
+
  @DecimalMin("67.8") @DecimalMax("123.4")  public Double getDouble() {
     return _double;
   }
@@ -187,6 +194,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("string")
+
  @Pattern(regexp="/[a-z]/i")  public String getString() {
     return string;
   }
@@ -208,7 +216,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("byte")
+
   @NotNull
+
  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  public byte[] getByte() {
     return _byte;
   }
@@ -230,6 +240,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("binary")
+
   public File getBinary() {
     return binary;
   }
@@ -251,7 +262,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("date")
+
   @NotNull
+
   public LocalDate getDate() {
     return date;
   }
@@ -273,6 +286,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
+
   public Date getDateTime() {
     return dateTime;
   }
@@ -294,6 +308,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   @JsonProperty("uuid")
+
   public UUID getUuid() {
     return uuid;
   }
@@ -315,7 +330,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("password")
+
   @NotNull
+
  @Size(min=10,max=64)  public String getPassword() {
     return password;
   }
@@ -337,6 +354,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("BigDecimal")
+
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("bar")
+
   public String getBar() {
     return bar;
   }
@@ -54,6 +55,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("foo")
+
   public String getFoo() {
     return foo;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
@@ -71,6 +71,7 @@ public enum InnerEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_of_string")
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
@@ -92,6 +93,7 @@ public enum InnerEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_of_enum_string")
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
@@ -113,6 +115,7 @@ public enum InnerEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("direct_map")
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
@@ -134,6 +137,7 @@ public enum InnerEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("indirect_map")
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("uuid")
+
   public UUID getUuid() {
     return uuid;
   }
@@ -61,6 +62,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
+
   public Date getDateTime() {
     return dateTime;
   }
@@ -82,6 +84,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map")
+
   public Map<String, Animal> getMap() {
     return map;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Model200Response.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public Integer getName() {
     return name;
   }
@@ -56,6 +57,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("class")
+
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("code")
+
   public Integer getCode() {
     return code;
   }
@@ -55,6 +56,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("type")
+
   public String getType() {
     return type;
   }
@@ -76,6 +78,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("message")
+
   public String getMessage() {
     return message;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("return")
+
   public Integer getReturn() {
     return _return;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Name.java
@@ -37,7 +37,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
+
   @NotNull
+
   public Integer getName() {
     return name;
   }
@@ -59,6 +61,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("snake_case")
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -80,6 +83,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("property")
+
   public String getProperty() {
     return property;
   }
@@ -101,6 +105,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("123Number")
+
   public Integer get123number() {
     return _123number;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("JustNumber")
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
@@ -71,6 +71,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("id")
+
   public Long getId() {
     return id;
   }
@@ -92,6 +93,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("petId")
+
   public Long getPetId() {
     return petId;
   }
@@ -113,6 +115,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("quantity")
+
   public Integer getQuantity() {
     return quantity;
   }
@@ -134,6 +137,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
+
   public Date getShipDate() {
     return shipDate;
   }
@@ -156,6 +160,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "Order Status")
   @JsonProperty("status")
+
   public StatusEnum getStatus() {
     return status;
   }
@@ -177,6 +182,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
+
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_number")
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
@@ -56,6 +57,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_string")
+
   public String getMyString() {
     return myString;
   }
@@ -77,6 +79,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_boolean")
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
@@ -76,6 +76,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("id")
+
   public Long getId() {
     return id;
   }
@@ -97,6 +98,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("category")
+
   public Category getCategory() {
     return category;
   }
@@ -118,7 +120,9 @@ public enum StatusEnum {
   
   @ApiModelProperty(example = "doggie", required = true, value = "")
   @JsonProperty("name")
+
   @NotNull
+
   public String getName() {
     return name;
   }
@@ -140,7 +144,9 @@ public enum StatusEnum {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
+
   @NotNull
+
   public Set<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -162,6 +168,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("tags")
+
   public List<Tag> getTags() {
     return tags;
   }
@@ -184,6 +191,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "pet status in the store")
   @JsonProperty("status")
+
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("bar")
+
   public String getBar() {
     return bar;
   }
@@ -54,6 +55,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("baz")
+
   public String getBaz() {
     return baz;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("$special[property.name]")
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Tag.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("id")
+
   public Long getId() {
     return id;
   }
@@ -54,6 +55,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -39,7 +39,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("string_item")
+
   @NotNull
+
   public String getStringItem() {
     return stringItem;
   }
@@ -61,7 +63,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number_item")
+
   @NotNull
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -83,7 +87,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("integer_item")
+
   @NotNull
+
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -105,7 +111,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("bool_item")
+
   @NotNull
+
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -127,7 +135,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("array_item")
+
   @NotNull
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -40,7 +40,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "what", required = true, value = "")
   @JsonProperty("string_item")
+
   @NotNull
+
   public String getStringItem() {
     return stringItem;
   }
@@ -62,7 +64,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("number_item")
+
   @NotNull
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -84,7 +88,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("float_item")
+
   @NotNull
+
   public Float getFloatItem() {
     return floatItem;
   }
@@ -106,7 +112,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "-2", required = true, value = "")
   @JsonProperty("integer_item")
+
   @NotNull
+
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -128,7 +136,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "true", required = true, value = "")
   @JsonProperty("bool_item")
+
   @NotNull
+
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -150,7 +160,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   @JsonProperty("array_item")
+
   @NotNull
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/User.java
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("id")
+
   public Long getId() {
     return id;
   }
@@ -60,6 +61,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("username")
+
   public String getUsername() {
     return username;
   }
@@ -81,6 +83,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("firstName")
+
   public String getFirstName() {
     return firstName;
   }
@@ -102,6 +105,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("lastName")
+
   public String getLastName() {
     return lastName;
   }
@@ -123,6 +127,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("email")
+
   public String getEmail() {
     return email;
   }
@@ -144,6 +149,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("password")
+
   public String getPassword() {
     return password;
   }
@@ -165,6 +171,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("phone")
+
   public String getPhone() {
     return phone;
   }
@@ -187,6 +194,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "User Status")
   @JsonProperty("userStatus")
+
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/XmlItem.java
@@ -63,6 +63,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "string", value = "")
   @JsonProperty("attribute_string")
+
   public String getAttributeString() {
     return attributeString;
   }
@@ -84,6 +85,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("attribute_number")
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
@@ -105,6 +107,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "-2", value = "")
   @JsonProperty("attribute_integer")
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
@@ -126,6 +129,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "true", value = "")
   @JsonProperty("attribute_boolean")
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
@@ -147,6 +151,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("wrapped_array")
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
@@ -168,6 +173,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "string", value = "")
   @JsonProperty("name_string")
+
   public String getNameString() {
     return nameString;
   }
@@ -189,6 +195,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("name_number")
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
@@ -210,6 +217,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "-2", value = "")
   @JsonProperty("name_integer")
+
   public Integer getNameInteger() {
     return nameInteger;
   }
@@ -231,6 +239,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "true", value = "")
   @JsonProperty("name_boolean")
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
@@ -252,6 +261,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name_array")
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
@@ -273,6 +283,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name_wrapped_array")
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
@@ -294,6 +305,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "string", value = "")
   @JsonProperty("prefix_string")
+
   public String getPrefixString() {
     return prefixString;
   }
@@ -315,6 +327,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_number")
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
@@ -336,6 +349,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "-2", value = "")
   @JsonProperty("prefix_integer")
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
@@ -357,6 +371,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "true", value = "")
   @JsonProperty("prefix_boolean")
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
@@ -378,6 +393,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("prefix_array")
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
@@ -399,6 +415,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("prefix_wrapped_array")
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
@@ -420,6 +437,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "string", value = "")
   @JsonProperty("namespace_string")
+
   public String getNamespaceString() {
     return namespaceString;
   }
@@ -441,6 +459,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("namespace_number")
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
@@ -462,6 +481,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "-2", value = "")
   @JsonProperty("namespace_integer")
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
@@ -483,6 +503,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "true", value = "")
   @JsonProperty("namespace_boolean")
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
@@ -504,6 +525,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("namespace_array")
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
@@ -525,6 +547,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("namespace_wrapped_array")
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
@@ -546,6 +569,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "string", value = "")
   @JsonProperty("prefix_ns_string")
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
@@ -567,6 +591,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_ns_number")
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
@@ -588,6 +613,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "-2", value = "")
   @JsonProperty("prefix_ns_integer")
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
@@ -609,6 +635,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "true", value = "")
   @JsonProperty("prefix_ns_boolean")
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
@@ -630,6 +657,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("prefix_ns_array")
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
@@ -651,6 +679,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("prefix_ns_wrapped_array")
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -46,6 +46,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_string")
+
   public Map<String, String> getMapString() {
     return mapString;
   }
@@ -67,6 +68,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_number")
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
@@ -88,6 +90,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_integer")
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
@@ -109,6 +112,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_boolean")
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
@@ -130,6 +134,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_integer")
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
@@ -151,6 +156,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_anytype")
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
@@ -172,6 +178,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_string")
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
@@ -193,6 +200,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_anytype")
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
@@ -214,6 +222,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("anytype_1")
+
   public Object getAnytype1() {
     return anytype1;
   }
@@ -235,6 +244,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("anytype_2")
+
   public Object getAnytype2() {
     return anytype2;
   }
@@ -256,6 +266,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("anytype_3")
+
   public Object getAnytype3() {
     return anytype3;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Animal.java
@@ -41,7 +41,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("className")
+
   @NotNull
+
   public String getClassName() {
     return className;
   }
@@ -63,6 +65,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("color")
+
   public String getColor() {
     return color;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayArrayNumber")
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayNumber")
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_of_string")
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
@@ -58,6 +59,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_integer")
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
@@ -79,6 +81,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_model")
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/BigCat.java
@@ -67,6 +67,7 @@ public enum KindEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("kind")
+
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/BigCatAllOf.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/BigCatAllOf.java
@@ -65,6 +65,7 @@ public enum KindEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("kind")
+
   public KindEnum getKind() {
     return kind;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Capitalization.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("smallCamel")
+
   public String getSmallCamel() {
     return smallCamel;
   }
@@ -58,6 +59,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("CapitalCamel")
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
@@ -79,6 +81,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("small_Snake")
+
   public String getSmallSnake() {
     return smallSnake;
   }
@@ -100,6 +103,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("Capital_Snake")
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
@@ -121,6 +125,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("SCA_ETH_Flow_Points")
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
@@ -143,6 +148,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "Name of the pet ")
   @JsonProperty("ATT_NAME")
+
   public String getATTNAME() {
     return ATT_NAME;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("declawed")
+
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/CatAllOf.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/CatAllOf.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("declawed")
+
   public Boolean getDeclawed() {
     return declawed;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Category.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("id")
+
   public Long getId() {
     return id;
   }
@@ -54,7 +55,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
+
   @NotNull
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ClassModel.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("_class")
+
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Client.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("client")
+
   public String getClient() {
     return client;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Dog.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("breed")
+
   public String getBreed() {
     return breed;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/DogAllOf.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/DogAllOf.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("breed")
+
   public String getBreed() {
     return breed;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -101,6 +101,7 @@ public enum ArrayEnumEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("just_symbol")
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
@@ -122,6 +123,7 @@ public enum ArrayEnumEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_enum")
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
@@ -169,6 +169,7 @@ public enum EnumNumberEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("enum_string")
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
@@ -190,7 +191,9 @@ public enum EnumNumberEnum {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("enum_string_required")
+
   @NotNull
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
@@ -212,6 +215,7 @@ public enum EnumNumberEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("enum_integer")
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
@@ -233,6 +237,7 @@ public enum EnumNumberEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("enum_number")
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
@@ -254,6 +259,7 @@ public enum EnumNumberEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("outerEnum")
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("file")
+
   public java.io.File getFile() {
     return file;
   }
@@ -56,6 +57,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("files")
+
   public List<java.io.File> getFiles() {
     return files;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FormatTest.java
@@ -52,6 +52,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("integer")
+
  @Min(10) @Max(100)  public Integer getInteger() {
     return integer;
   }
@@ -75,6 +76,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("int32")
+
  @Min(20) @Max(200)  public Integer getInt32() {
     return int32;
   }
@@ -96,6 +98,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("int64")
+
   public Long getInt64() {
     return int64;
   }
@@ -119,7 +122,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number")
+
   @NotNull
+
  @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
     return number;
   }
@@ -143,6 +148,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("float")
+
  @DecimalMin("54.3") @DecimalMax("987.6")  public Float getFloat() {
     return _float;
   }
@@ -166,6 +172,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("double")
+
  @DecimalMin("67.8") @DecimalMax("123.4")  public Double getDouble() {
     return _double;
   }
@@ -187,6 +194,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("string")
+
  @Pattern(regexp="/[a-z]/i")  public String getString() {
     return string;
   }
@@ -208,7 +216,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("byte")
+
   @NotNull
+
  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  public byte[] getByte() {
     return _byte;
   }
@@ -230,6 +240,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("binary")
+
   public File getBinary() {
     return binary;
   }
@@ -251,7 +262,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("date")
+
   @NotNull
+
   public LocalDate getDate() {
     return date;
   }
@@ -273,6 +286,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
+
   public Date getDateTime() {
     return dateTime;
   }
@@ -294,6 +308,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   @JsonProperty("uuid")
+
   public UUID getUuid() {
     return uuid;
   }
@@ -315,7 +330,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("password")
+
   @NotNull
+
  @Size(min=10,max=64)  public String getPassword() {
     return password;
   }
@@ -337,6 +354,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("BigDecimal")
+
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("bar")
+
   public String getBar() {
     return bar;
   }
@@ -54,6 +55,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("foo")
+
   public String getFoo() {
     return foo;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
@@ -71,6 +71,7 @@ public enum InnerEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_of_string")
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
@@ -92,6 +93,7 @@ public enum InnerEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_of_enum_string")
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
@@ -113,6 +115,7 @@ public enum InnerEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("direct_map")
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
@@ -134,6 +137,7 @@ public enum InnerEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("indirect_map")
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("uuid")
+
   public UUID getUuid() {
     return uuid;
   }
@@ -61,6 +62,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
+
   public Date getDateTime() {
     return dateTime;
   }
@@ -82,6 +84,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("map")
+
   public Map<String, Animal> getMap() {
     return map;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Model200Response.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public Integer getName() {
     return name;
   }
@@ -56,6 +57,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("class")
+
   public String getPropertyClass() {
     return propertyClass;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("code")
+
   public Integer getCode() {
     return code;
   }
@@ -55,6 +56,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("type")
+
   public String getType() {
     return type;
   }
@@ -76,6 +78,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("message")
+
   public String getMessage() {
     return message;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("return")
+
   public Integer getReturn() {
     return _return;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Name.java
@@ -37,7 +37,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
+
   @NotNull
+
   public Integer getName() {
     return name;
   }
@@ -59,6 +61,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("snake_case")
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
@@ -80,6 +83,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("property")
+
   public String getProperty() {
     return property;
   }
@@ -101,6 +105,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("123Number")
+
   public Integer get123number() {
     return _123number;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("JustNumber")
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
@@ -71,6 +71,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("id")
+
   public Long getId() {
     return id;
   }
@@ -92,6 +93,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("petId")
+
   public Long getPetId() {
     return petId;
   }
@@ -113,6 +115,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("quantity")
+
   public Integer getQuantity() {
     return quantity;
   }
@@ -134,6 +137,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
+
   public Date getShipDate() {
     return shipDate;
   }
@@ -156,6 +160,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "Order Status")
   @JsonProperty("status")
+
   public StatusEnum getStatus() {
     return status;
   }
@@ -177,6 +182,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
+
   public Boolean getComplete() {
     return complete;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_number")
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
@@ -56,6 +57,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_string")
+
   public String getMyString() {
     return myString;
   }
@@ -77,6 +79,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_boolean")
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
@@ -76,6 +76,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("id")
+
   public Long getId() {
     return id;
   }
@@ -97,6 +98,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("category")
+
   public Category getCategory() {
     return category;
   }
@@ -118,7 +120,9 @@ public enum StatusEnum {
   
   @ApiModelProperty(example = "doggie", required = true, value = "")
   @JsonProperty("name")
+
   @NotNull
+
   public String getName() {
     return name;
   }
@@ -140,7 +144,9 @@ public enum StatusEnum {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
+
   @NotNull
+
   public Set<String> getPhotoUrls() {
     return photoUrls;
   }
@@ -162,6 +168,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("tags")
+
   public List<Tag> getTags() {
     return tags;
   }
@@ -184,6 +191,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "pet status in the store")
   @JsonProperty("status")
+
   public StatusEnum getStatus() {
     return status;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("bar")
+
   public String getBar() {
     return bar;
   }
@@ -54,6 +55,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("baz")
+
   public String getBaz() {
     return baz;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("$special[property.name]")
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Tag.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("id")
+
   public Long getId() {
     return id;
   }
@@ -54,6 +55,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name")
+
   public String getName() {
     return name;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -39,7 +39,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("string_item")
+
   @NotNull
+
   public String getStringItem() {
     return stringItem;
   }
@@ -61,7 +63,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number_item")
+
   @NotNull
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -83,7 +87,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("integer_item")
+
   @NotNull
+
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -105,7 +111,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("bool_item")
+
   @NotNull
+
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -127,7 +135,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("array_item")
+
   @NotNull
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -40,7 +40,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "what", required = true, value = "")
   @JsonProperty("string_item")
+
   @NotNull
+
   public String getStringItem() {
     return stringItem;
   }
@@ -62,7 +64,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("number_item")
+
   @NotNull
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
@@ -84,7 +88,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("float_item")
+
   @NotNull
+
   public Float getFloatItem() {
     return floatItem;
   }
@@ -106,7 +112,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "-2", required = true, value = "")
   @JsonProperty("integer_item")
+
   @NotNull
+
   public Integer getIntegerItem() {
     return integerItem;
   }
@@ -128,7 +136,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "true", required = true, value = "")
   @JsonProperty("bool_item")
+
   @NotNull
+
   public Boolean getBoolItem() {
     return boolItem;
   }
@@ -150,7 +160,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   @JsonProperty("array_item")
+
   @NotNull
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/User.java
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("id")
+
   public Long getId() {
     return id;
   }
@@ -60,6 +61,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("username")
+
   public String getUsername() {
     return username;
   }
@@ -81,6 +83,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("firstName")
+
   public String getFirstName() {
     return firstName;
   }
@@ -102,6 +105,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("lastName")
+
   public String getLastName() {
     return lastName;
   }
@@ -123,6 +127,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("email")
+
   public String getEmail() {
     return email;
   }
@@ -144,6 +149,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("password")
+
   public String getPassword() {
     return password;
   }
@@ -165,6 +171,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("phone")
+
   public String getPhone() {
     return phone;
   }
@@ -187,6 +194,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "User Status")
   @JsonProperty("userStatus")
+
   public Integer getUserStatus() {
     return userStatus;
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/XmlItem.java
@@ -63,6 +63,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "string", value = "")
   @JsonProperty("attribute_string")
+
   public String getAttributeString() {
     return attributeString;
   }
@@ -84,6 +85,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("attribute_number")
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
@@ -105,6 +107,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "-2", value = "")
   @JsonProperty("attribute_integer")
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
@@ -126,6 +129,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "true", value = "")
   @JsonProperty("attribute_boolean")
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
@@ -147,6 +151,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("wrapped_array")
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
@@ -168,6 +173,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "string", value = "")
   @JsonProperty("name_string")
+
   public String getNameString() {
     return nameString;
   }
@@ -189,6 +195,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("name_number")
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
@@ -210,6 +217,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "-2", value = "")
   @JsonProperty("name_integer")
+
   public Integer getNameInteger() {
     return nameInteger;
   }
@@ -231,6 +239,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "true", value = "")
   @JsonProperty("name_boolean")
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
@@ -252,6 +261,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name_array")
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
@@ -273,6 +283,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("name_wrapped_array")
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
@@ -294,6 +305,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "string", value = "")
   @JsonProperty("prefix_string")
+
   public String getPrefixString() {
     return prefixString;
   }
@@ -315,6 +327,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_number")
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
@@ -336,6 +349,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "-2", value = "")
   @JsonProperty("prefix_integer")
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
@@ -357,6 +371,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "true", value = "")
   @JsonProperty("prefix_boolean")
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
@@ -378,6 +393,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("prefix_array")
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
@@ -399,6 +415,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("prefix_wrapped_array")
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
@@ -420,6 +437,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "string", value = "")
   @JsonProperty("namespace_string")
+
   public String getNamespaceString() {
     return namespaceString;
   }
@@ -441,6 +459,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("namespace_number")
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
@@ -462,6 +481,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "-2", value = "")
   @JsonProperty("namespace_integer")
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
@@ -483,6 +503,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "true", value = "")
   @JsonProperty("namespace_boolean")
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
@@ -504,6 +525,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("namespace_array")
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
@@ -525,6 +547,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("namespace_wrapped_array")
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
@@ -546,6 +569,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "string", value = "")
   @JsonProperty("prefix_ns_string")
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
@@ -567,6 +591,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_ns_number")
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
@@ -588,6 +613,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "-2", value = "")
   @JsonProperty("prefix_ns_integer")
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
@@ -609,6 +635,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(example = "true", value = "")
   @JsonProperty("prefix_ns_boolean")
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
@@ -630,6 +657,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("prefix_ns_array")
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
@@ -651,6 +679,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
   
   @ApiModelProperty(value = "")
   @JsonProperty("prefix_ns_wrapped_array")
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }


### PR DESCRIPTION
Fixes #9654

For required attributes, generate `@NotNull` only, if attribute is neither `readOnly` nor `writeOnly`.
This reflects the spec https://swagger.io/docs/specification/data-models/data-types/#readonly-writeonly
> If a readOnly or writeOnly property is included in the required list, required affects just the relevant scope – responses only or requests only. That is, read-only required properties apply to responses only, and write-only required properties – to requests only. 

Using `@NotNull` for these cases would fail validation in the other direction, where the attribute is intentionally not present.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
@nmuesch

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
