### PR TITLE
(#9673) Fix to allow tests to be generated under pythonSrcRoot. This change also adds AssertJ.

### DIFF
--- a/docs/generators/python-aiohttp.md
+++ b/docs/generators/python-aiohttp.md
@@ -14,6 +14,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |featureCORS|use flask-cors for handling CORS requests| |false|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C#have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
+|moveTestsPythonSrcRoot|generates test under the pythonSrcRoot folder.| |false|
 |packageName|python package name (convention: snake_case).| |openapi_server|
 |packageVersion|python package version.| |1.0.0|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/docs/generators/python-blueplanet.md
+++ b/docs/generators/python-blueplanet.md
@@ -14,6 +14,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |featureCORS|use flask-cors for handling CORS requests| |false|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C#have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
+|moveTestsPythonSrcRoot|generates test under the pythonSrcRoot folder.| |false|
 |packageName|python package name (convention: snake_case).| |openapi_server|
 |packageVersion|python package version.| |1.0.0|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/docs/generators/python-flask.md
+++ b/docs/generators/python-flask.md
@@ -14,6 +14,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
 |featureCORS|use flask-cors for handling CORS requests| |false|
 |legacyDiscriminatorBehavior|Set to false for generators with better support for discriminators. (Python, Java, Go, PowerShell, C#have this enabled by default).|<dl><dt>**true**</dt><dd>The mapping in the discriminator includes descendent schemas that allOf inherit from self and the discriminator mapping schemas in the OAS document.</dd><dt>**false**</dt><dd>The mapping in the discriminator includes any descendent schemas that allOf inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values, and the discriminator mapping schemas in the OAS document AND Codegen validates that oneOf and anyOf schemas contain the required discriminator and throws an error if the discriminator is missing.</dd></dl>|true|
+|moveTestsPythonSrcRoot|generates test under the pythonSrcRoot folder.| |false|
 |packageName|python package name (convention: snake_case).| |openapi_server|
 |packageVersion|python package version.| |1.0.0|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -433,6 +433,12 @@
             <artifactId>caffeine</artifactId>
             <version>2.8.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.19.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
@@ -53,6 +53,7 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
     public static final String USE_NOSE = "useNose";
     public static final String PYTHON_SRC_ROOT = "pythonSrcRoot";
     public static final String USE_PYTHON_SRC_ROOT_IN_IMPORTS = "usePythonSrcRootInImports";
+    public static final String MOVE_TESTS_UNDER_PYTHON_SRC_ROOT = "moveTestsPythonSrcRoot";
     static final String MEDIA_TYPE = "mediaType";
 
     protected int serverPort = 8080;
@@ -64,6 +65,7 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
     protected boolean useNose = Boolean.FALSE;
     protected String pythonSrcRoot;
     protected boolean usePythonSrcRootInImports = Boolean.FALSE;
+    protected boolean moveTestsUnderPythonSrcRoot = Boolean.FALSE;
 
     public AbstractPythonConnexionServerCodegen(String templateDirectory, boolean fixBodyNameValue) {
         super();
@@ -136,6 +138,8 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
                 defaultValue(""));
         cliOptions.add(new CliOption(USE_PYTHON_SRC_ROOT_IN_IMPORTS, "include pythonSrcRoot in import namespaces.").
                 defaultValue("false"));
+        cliOptions.add(new CliOption(MOVE_TESTS_UNDER_PYTHON_SRC_ROOT, "generates test under the pythonSrcRoot folder.")
+            .defaultValue("false"));
     }
 
     protected void addSupportingFiles() {
@@ -183,11 +187,17 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
         if (additionalProperties.containsKey(USE_PYTHON_SRC_ROOT_IN_IMPORTS)) {
             setUsePythonSrcRootInImports((String) additionalProperties.get(USE_PYTHON_SRC_ROOT_IN_IMPORTS));
         }
+        if (additionalProperties.containsKey(MOVE_TESTS_UNDER_PYTHON_SRC_ROOT)) {
+            setMoveTestsUnderPythonSrcRoot((String) additionalProperties.get(MOVE_TESTS_UNDER_PYTHON_SRC_ROOT));
+        }
         if (additionalProperties.containsKey(PYTHON_SRC_ROOT)) {
             String pythonSrcRoot = (String) additionalProperties.get(PYTHON_SRC_ROOT);
+            if (moveTestsUnderPythonSrcRoot) {
+                testPackage = pythonSrcRoot + "." + testPackage;
+            }
             if (usePythonSrcRootInImports) {
-                // if we prepend the package name if the pythonSrcRoot we get the desired effect.
-                // but we also need to set pythonSrcRoot itself to "" to ensure all the paths are
+                // if we prepend the package name with the pythonSrcRoot we get the desired effect.
+                // But, we also need to set pythonSrcRoot itself to "" to ensure all the paths are
                 // what we expect.
                 setPackageName(pythonSrcRoot + "." + packageName);
                 pythonSrcRoot = "";
@@ -196,6 +206,7 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
         } else {
             setPythonSrcRoot("");
         }
+
         supportingFiles.add(new SupportingFile("__main__.mustache", packagePath(), "__main__.py"));
         supportingFiles.add(new SupportingFile("util.mustache", packagePath(), "util.py"));
         supportingFiles.add(new SupportingFile("typing_utils.mustache", packagePath(), "typing_utils.py"));
@@ -238,6 +249,9 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
         this.usePythonSrcRootInImports = Boolean.parseBoolean(val);
     }
 
+    public void setMoveTestsUnderPythonSrcRoot(String val) {
+        this.moveTestsUnderPythonSrcRoot = Boolean.parseBoolean(val);
+    }
 
     public String pythonSrcOutputFolder() {
         return outputFolder + File.separator + pythonSrcRoot;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/AbstractPythonConnexionServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/AbstractPythonConnexionServerCodegenTest.java
@@ -1,5 +1,7 @@
 package org.openapitools.codegen.python;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openapitools.codegen.languages.AbstractPythonConnexionServerCodegen.MOVE_TESTS_UNDER_PYTHON_SRC_ROOT;
 import static org.openapitools.codegen.languages.AbstractPythonConnexionServerCodegen.PYTHON_SRC_ROOT;
 import static org.openapitools.codegen.languages.AbstractPythonConnexionServerCodegen.USE_PYTHON_SRC_ROOT_IN_IMPORTS;
 
@@ -9,11 +11,9 @@ import java.util.Map;
 import java.util.Objects;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.languages.AbstractPythonConnexionServerCodegen;
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -29,11 +29,12 @@ public class AbstractPythonConnexionServerCodegenTest {
         codegen.additionalProperties().putAll(additionalProperties);
         codegen.processOpts();
         String pythonSrcRoot = Objects.toString(codegen.additionalProperties().get(PYTHON_SRC_ROOT), null);
-        Assert.assertEquals(pythonSrcRoot, expectedValues.pythonSrcRoot);
-        Assert.assertEquals(codegen.apiPackage(), expectedValues.expectedApiPackage);
-        Assert.assertEquals(codegen.modelFileFolder(), expectedValues.expectedModelFileFolder);
-        Assert.assertEquals(codegen.apiFileFolder(), expectedValues.expectedApiFileFolder);
-        Assert.assertEquals(codegen.toModelImport(modelName), expectedValues.expectedImport);
+        assertThat(pythonSrcRoot).isEqualTo(expectedValues.pythonSrcRoot);
+        assertThat(codegen.apiPackage()).isEqualTo(expectedValues.expectedApiPackage);
+        assertThat(codegen.modelFileFolder()).isEqualTo(expectedValues.expectedModelFileFolder);
+        assertThat(codegen.apiFileFolder()).isEqualTo(expectedValues.expectedApiFileFolder);
+        assertThat(codegen.apiTestFileFolder()).isEqualTo(expectedValues.expectedApiTestFileFolder);
+        assertThat(codegen.toModelImport(modelName)).isEqualTo(expectedValues.expectedImport);
     }
 
     @DataProvider
@@ -47,6 +48,7 @@ public class AbstractPythonConnexionServerCodegenTest {
                     "openapi_server.controllers",
                     platformAgnosticPath("generated-code", "connexion", "openapi_server", "models"),
                     platformAgnosticPath("generated-code", "connexion", "openapi_server", "controllers"),
+                    platformAgnosticPath("generated-code", "connexion", "test"),
                     null)
             },
             new Object[]{
@@ -57,6 +59,7 @@ public class AbstractPythonConnexionServerCodegenTest {
                     "openapi_server.controllers",
                     platformAgnosticPath("generated-code", "connexion", "test_root", "openapi_server", "models"),
                     platformAgnosticPath("generated-code", "connexion", "test_root", "openapi_server", "controllers"),
+                    platformAgnosticPath("generated-code", "connexion", "test"),
                     "test_root")
             },
             new Object[]{
@@ -67,6 +70,19 @@ public class AbstractPythonConnexionServerCodegenTest {
                     "test_root.openapi_server.controllers",
                     platformAgnosticPath("generated-code", "connexion", "test_root", "openapi_server", "models"),
                     platformAgnosticPath("generated-code", "connexion", "test_root", "openapi_server", "controllers"),
+                    platformAgnosticPath("generated-code", "connexion", "test"),
+                    null)
+            },
+            new Object[]{
+                "Python src in import and tests under python src root",
+                ImmutableMap.of(PYTHON_SRC_ROOT, "test_root", USE_PYTHON_SRC_ROOT_IN_IMPORTS, "true",
+                    MOVE_TESTS_UNDER_PYTHON_SRC_ROOT, "true"),
+                "TestModel",
+                new ExpectedValues("from test_root.openapi_server.models.test_model import TestModel",
+                    "test_root.openapi_server.controllers",
+                    platformAgnosticPath("generated-code", "connexion", "test_root", "openapi_server", "models"),
+                    platformAgnosticPath("generated-code", "connexion", "test_root", "openapi_server", "controllers"),
+                    platformAgnosticPath("generated-code", "connexion", "test_root", "test"),
                     null)
             },
             new Object[]{
@@ -79,13 +95,24 @@ public class AbstractPythonConnexionServerCodegenTest {
                     "test_root.test_package.controllers",
                     platformAgnosticPath("generated-code", "connexion", "test_root", "test_package", "models"),
                     platformAgnosticPath("generated-code", "connexion", "test_root", "test_package", "controllers"),
+                    platformAgnosticPath("generated-code", "connexion", "test"),
+                    null)
+            },
+            new Object[]{
+                "Python src in import with specified package and tests under python src root",
+                ImmutableMap.of(PYTHON_SRC_ROOT, "test_root",
+                    USE_PYTHON_SRC_ROOT_IN_IMPORTS, "true",
+                    CodegenConstants.PACKAGE_NAME, "test_package",
+                    MOVE_TESTS_UNDER_PYTHON_SRC_ROOT, "true"),
+                "TestModel",
+                new ExpectedValues("from test_root.test_package.models.test_model import TestModel",
+                    "test_root.test_package.controllers",
+                    platformAgnosticPath("generated-code", "connexion", "test_root", "test_package", "models"),
+                    platformAgnosticPath("generated-code", "connexion", "test_root", "test_package", "controllers"),
+                    platformAgnosticPath("generated-code", "connexion", "test_root", "test"),
                     null)
             }
         };
-    }
-
-    private static String platformAgnosticPath(String... nodes) {
-        return StringUtils.join(nodes, File.separatorChar);
     }
 
     private static class MockAbstractPythonConnexionServerCodegen extends AbstractPythonConnexionServerCodegen {
@@ -99,16 +126,22 @@ public class AbstractPythonConnexionServerCodegenTest {
         public final String expectedApiPackage;
         public final String expectedModelFileFolder;
         public final String expectedApiFileFolder;
+        public final String expectedApiTestFileFolder;
         public final String pythonSrcRoot;
 
         public ExpectedValues(String expectedImport, String expectedApiPackage, String expectedModelFileFolder,
-                              String expectedApiFileFolder, String pythonSrcRoot) {
+                              String expectedApiFileFolder, String expectedApiTestFileFolder, String pythonSrcRoot) {
             this.expectedImport = expectedImport;
             this.expectedApiPackage = expectedApiPackage;
             this.expectedModelFileFolder = expectedModelFileFolder;
             this.expectedApiFileFolder = expectedApiFileFolder;
+            this.expectedApiTestFileFolder = expectedApiTestFileFolder;
             this.pythonSrcRoot = pythonSrcRoot != null ? pythonSrcRoot + File.separatorChar : null;
         }
+    }
+
+    private static String platformAgnosticPath(String... nodes) {
+        return StringUtils.join(nodes, File.separatorChar);
     }
 
 }


### PR DESCRIPTION
This change introduces a flag to have tests generated under the pythonSrcRoot directory if it's specified.

This change also introduces AssertJ as a new dependency.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc: @taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @Jyhess @arun-nalla @spacether