### PR TITLE
[bug][kotlin] sanitize model names according to convention

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -604,7 +604,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
             return importMapping.get(name);
         }
 
-        String modifiedName = sanitizeName(name);
+        String modifiedName = name.replaceAll("\\.", "").replaceAll("-", "_");
         String sanitizedName = sanitizeKotlinSpecificNames(modifiedName);
 
         String nameWithPrefixSuffix = sanitizedName;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -604,7 +604,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
             return importMapping.get(name);
         }
 
-        String modifiedName = name.replaceAll("\\.", "");
+        String modifiedName = sanitizeName(name);
         String sanitizedName = sanitizeKotlinSpecificNames(modifiedName);
 
         String nameWithPrefixSuffix = sanitizedName;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -113,21 +113,13 @@ public class AbstractKotlinCodegenTest {
 
     @Test
     public void convertModelName() {
-        Assert.assertEquals(codegen.toModelName("name"), "Name");
-        Assert.assertEquals(codegen.toModelName("$name"), "Name");
-        Assert.assertEquals(codegen.toModelName("nam#e"), "Name");
-        Assert.assertEquals(codegen.toModelName("$another-fake?"), "AnotherFake");
-        Assert.assertEquals(codegen.toModelName("1a"), "Model1a");
-        Assert.assertEquals(codegen.toModelName("1A"), "Model1A");
-        Assert.assertEquals(codegen.toModelName("AAAb"), "AAAb");
-        Assert.assertEquals(codegen.toModelName("aBB"), "ABB");
-        Assert.assertEquals(codegen.toModelName("AaBBa"), "AaBBa");
-        Assert.assertEquals(codegen.toModelName("A_B"), "AB");
-        Assert.assertEquals(codegen.toModelName("A-B"), "AB");
-        Assert.assertEquals(codegen.toModelName("Aa_Bb"), "AaBb");
-        Assert.assertEquals(codegen.toModelName("Aa-Bb"), "AaBb");
-        Assert.assertEquals(codegen.toModelName("Aa_bb"), "AaBb");
-        Assert.assertEquals(codegen.toModelName("Aa-bb"), "AaBb");
+        assertEquals(codegen.toModelName("$"), "Dollar");
+        assertEquals(codegen.toModelName("$$"), "DollarDollar");
+        assertEquals(codegen.toModelName("Pony?"), "PonyQuestionMark");
+        assertEquals(codegen.toModelName("$name"), "DollarName");
+        assertEquals(codegen.toModelName("nam#e"), "NamHashE");
+        assertEquals(codegen.toModelName("$another-fake?"), "DollarAnotherFakeQuestionMark");
+        assertEquals(codegen.toModelName("Pony>=>="), "PonyGreaterThanEqualGreaterThanEqual");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -113,13 +113,21 @@ public class AbstractKotlinCodegenTest {
 
     @Test
     public void convertModelName() {
-        assertEquals(codegen.toModelName("$"), "Dollar");
-        assertEquals(codegen.toModelName("$$"), "DollarDollar");
-        assertEquals(codegen.toModelName("Pony?"), "PonyQuestionMark");
-        assertEquals(codegen.toModelName("$name"), "DollarName");
-        assertEquals(codegen.toModelName("nam#e"), "NamHashE");
-        assertEquals(codegen.toModelName("$another-fake?"), "DollarAnotherMinusFakeQuestionMark");
-        assertEquals(codegen.toModelName("Pony>=>="), "PonyGreaterThanEqualGreaterThanEqual");
+        Assert.assertEquals(codegen.toModelName("name"), "Name");
+        Assert.assertEquals(codegen.toModelName("$name"), "Name");
+        Assert.assertEquals(codegen.toModelName("nam#e"), "Name");
+        Assert.assertEquals(codegen.toModelName("$another-fake?"), "AnotherFake");
+        Assert.assertEquals(codegen.toModelName("1a"), "Model1a");
+        Assert.assertEquals(codegen.toModelName("1A"), "Model1A");
+        Assert.assertEquals(codegen.toModelName("AAAb"), "AAAb");
+        Assert.assertEquals(codegen.toModelName("aBB"), "ABB");
+        Assert.assertEquals(codegen.toModelName("AaBBa"), "AaBBa");
+        Assert.assertEquals(codegen.toModelName("A_B"), "AB");
+        Assert.assertEquals(codegen.toModelName("A-B"), "AB");
+        Assert.assertEquals(codegen.toModelName("Aa_Bb"), "AaBb");
+        Assert.assertEquals(codegen.toModelName("Aa-Bb"), "AaBb");
+        Assert.assertEquals(codegen.toModelName("Aa_bb"), "AaBb");
+        Assert.assertEquals(codegen.toModelName("Aa-bb"), "AaBb");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -322,9 +322,10 @@ public class KotlinClientCodegenModelTest {
     public static Object[][] modelNames() {
         return new Object[][]{
                 {"TestNs.TestClass", new ModelNameTest("TestNs.TestClass", "TestNsTestClass")},
-                {"$", new ModelNameTest("$", "Value")},
+                {"$", new ModelNameTest("$", "Dollar")},
                 {"for", new ModelNameTest("`for`", "For")},
-                {"One<Two", new ModelNameTest("One<Two", "OneTwo")},
+                {"One<Two", new ModelNameTest("One<Two", "OneLessThanTwo")},
+                {"One-Two", new ModelNameTest("One-Two", "OneTwo")},
                 {"this is a test", new ModelNameTest("this is a test", "ThisIsATest")}
         };
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -322,9 +322,9 @@ public class KotlinClientCodegenModelTest {
     public static Object[][] modelNames() {
         return new Object[][]{
                 {"TestNs.TestClass", new ModelNameTest("TestNs.TestClass", "TestNsTestClass")},
-                {"$", new ModelNameTest("$", "Dollar")},
+                {"$", new ModelNameTest("$", "Value")},
                 {"for", new ModelNameTest("`for`", "For")},
-                {"One<Two", new ModelNameTest("One<Two", "OneLessThanTwo")},
+                {"One<Two", new ModelNameTest("One<Two", "OneTwo")},
                 {"this is a test", new ModelNameTest("this is a test", "ThisIsATest")}
         };
     }


### PR DESCRIPTION
Fixes #9683 by ensuring Kotlin model names are generated by escaping sanitized characters rather than describing them. This is essentially the same change as introduced in https://github.com/OpenAPITools/openapi-generator/pull/7598 for variable names, but for model names. The fix works by calling the more generic `sanitizeNames` before calling the language-specific sanitize method; prior to this comment only the period (".") character and some kotlin-specific characters were being escaped.

_note: the steps to update the samples did not result in changes to any committed files._

## Breaking Change Warning

Note that this could be considered a breaking change, since it changes the way model names and file names are generated. This is especially true given a couple different tests validated the pre-existing behavior.

### Technical Committee Mentions
* @jimschubert 
* @dr4ke616 
* @karismann 
* @Zomzog
* @andrewemery
* @4brunu
* @yutaka0m 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.