### PR TITLE
[typescript-fetch] runtime: pass init and url as returned by the premiddleware to the postmiddleware

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -79,8 +79,8 @@ export class BaseAPI {
             if (middleware.post) {
                 response = await middleware.post({
                     fetch: this.fetchApi,
-                    url,
-                    init,
+                    url: fetchParams.url,
+                    init: fetchParams.init,
                     response: response.clone(),
                 }) || response;
             }


### PR DESCRIPTION
Current implementation will always pass the initial url and init object. However if a pre middleware changes returns an object whose `init` or `url` property refer to a different url string or object, any following post middleware wont have access to it. Effectively providing the post middleware with a completely different request information then what was actually used to make the fetch call.

The change here is very minimal to use the `init` and `url` from the `fetchParams` as potentially returned by the pre middleware.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
