### PR TITLE
[haskell][server]: Set "AnyType" to `Aeson.Value`

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
@@ -201,6 +201,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
         typeMapping.put("number", "Double");
         typeMapping.put("BigDecimal", "Double");
         typeMapping.put("any", "Value");
+        typeMapping.put("AnyType", "Value");
         typeMapping.put("UUID", "UUID");
         typeMapping.put("URI", "Text");
         typeMapping.put("ByteArray", "Text");

--- a/modules/openapi-generator/src/main/resources/haskell-servant/API.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-servant/API.mustache
@@ -14,8 +14,8 @@
 -fno-warn-unused-binds -fno-warn-unused-imports -freduction-depth=328 #-}
 
 module {{title}}.API
-  -- * Client and Server
-  ( Config(..)
+  ( -- * Client and Server
+    Config(..)
   , {{title}}Backend(..)
   , create{{title}}Client
   , run{{title}}Server


### PR DESCRIPTION
`AnyType` would not be translated to the json value type.
This fixes that.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
