### PR TITLE
fix: handle deepcopy of openapi objects

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_templates/methods_shared.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/methods_shared.mustache
@@ -13,3 +13,22 @@
     def __getattr__(self, attr):
         """get the value of an attribute using dot notation: `instance.attr`"""
         return self.{{#attrNoneIfUnset}}get{{/attrNoneIfUnset}}{{^attrNoneIfUnset}}__getitem__{{/attrNoneIfUnset}}(attr)
+
+    def __copy__(self):
+        cls = self.__class__
+        if self.get("_spec_property_naming", False):
+            return cls._new_from_openapi_data(**self.__dict__)
+        else:
+            return new_cls.__new__(cls, **self.__dict__)
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+
+        if self.get("_spec_property_naming", False):
+            new_inst = cls._new_from_openapi_data()
+        else:
+            new_inst = cls.__new__(cls)
+
+        for k, v in self.__dict__.items():
+            setattr(new_inst, k, deepcopy(v, memo))
+        return new_inst

--- a/modules/openapi-generator/src/main/resources/python/model_utils.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_utils.mustache
@@ -1,6 +1,7 @@
 {{>partial_header}}
 
 from datetime import date, datetime  # noqa: F401
+from copy import deepcopy
 import inspect
 import io
 import os
@@ -223,8 +224,13 @@ class OpenApiModel(object):
             self_inst = super(OpenApiModel, cls).__new__(cls)
             self_inst.__init__(*args, **kwargs)
 
-        new_inst = new_cls.__new__(new_cls, *args, **kwargs)
-        new_inst.__init__(*args, **kwargs)
+        if kwargs.get("_spec_property_naming", False):
+            # when true, implies new is from deserialization
+            new_inst = new_cls._new_from_openapi_data(*args, **kwargs)
+        else:
+            new_inst = new_cls.__new__(new_cls, *args, **kwargs)
+            new_inst.__init__(*args, **kwargs)
+
         return new_inst
 
 

--- a/samples/openapi3/client/petstore/python/tests_manual/test_copy.py
+++ b/samples/openapi3/client/petstore/python/tests_manual/test_copy.py
@@ -1,0 +1,34 @@
+from copy import deepcopy
+import unittest
+from petstore_api.model.mammal import Mammal
+from petstore_api.model.triangle import Triangle
+
+
+class TestCopy(unittest.TestCase):
+    """TestCopy unit test stubs"""
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def testDeepCopyOneOf(self):
+        """test deepcopy"""
+        obj = deepcopy(Mammal(class_name="whale"))
+        assert id(deepcopy(obj)) != id(obj)
+        assert deepcopy(obj) == obj
+
+    def testDeepCopyAllOf(self):
+        """test deepcopy"""
+        obj = Triangle(shape_type="Triangle", triangle_type="EquilateralTriangle", foo="blah")
+        assert id(deepcopy(obj)) != id(obj)
+        assert deepcopy(obj) == obj
+
+        obj = Triangle._new_from_openapi_data(shape_type="Triangle", triangle_type="EquilateralTriangle", foo="blah")
+        assert id(deepcopy(obj)) != id(obj)
+        assert deepcopy(obj) == obj
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- addresses issue #9669
- Add __deepcopy__ and __copy__ to OpenApiModel
- pass discriminator inside deepcopy if exists
- add test cases for deepcopy of models

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @arun-nalla (2019/11) @spacether (2019/11)