### PR TITLE
[C++][Pistache] Fix compile break, error handling

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-header.mustache
@@ -42,13 +42,15 @@ private:
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during Parameter parsing and validation.
-    /// May be overriden to return custom error formats.
+    /// May be overriden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleParsingException(const std::exception& ex) const noexcept;
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.
-    /// May be overriden to return custom error formats.
+    /// May be overriden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleOperationException(const std::exception& ex) const noexcept;
 

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-source.mustache
@@ -36,11 +36,13 @@ void {{classname}}::setupRoutes() {
 std::pair<Pistache::Http::Code, std::string> {{classname}}::handleParsingException(const std::exception& ex) const noexcept
 {
     try {
-        throw ex;
+        throw;
     } catch (nlohmann::detail::exception &e) {
         return std::make_pair(Pistache::Http::Code::Bad_Request, e.what());
     } catch ({{helpersNamespace}}::ValidationException &e) {
         return std::make_pair(Pistache::Http::Code::Bad_Request, e.what());
+    } catch (std::exception &e) {
+        return std::make_pair(Pistache::Http::Code::Internal_Server_Error, e.what())
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-header.mustache
@@ -46,6 +46,12 @@ public:
     /// </summary>
     bool validate(std::stringstream& msg) const;
 
+    /// <summary>
+    /// Helper overload for validate. Used when one model stores another model and calls it's validate.
+    /// Not meant to be called outside that case.
+    /// </summary>
+    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
+
     bool operator==(const {{classname}}& rhs) const;
     bool operator!=(const {{classname}}& rhs) const;
 
@@ -77,9 +83,6 @@ protected:
     {{#isEnum}}
     {{classname}}::e{{classname}} m_value = {{classname}}::e{{classname}}::INVALID_VALUE_OPENAPI_GENERATED;
     {{/isEnum}}
-
-    // Helper overload for validate. Used when one model stores another model and calls it's validate.
-    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
 };
 
 } // namespace {{modelNamespace}}

--- a/samples/server/petstore/cpp-pistache/api/PetApi.cpp
+++ b/samples/server/petstore/cpp-pistache/api/PetApi.cpp
@@ -49,11 +49,13 @@ void PetApi::setupRoutes() {
 std::pair<Pistache::Http::Code, std::string> PetApi::handleParsingException(const std::exception& ex) const noexcept
 {
     try {
-        throw ex;
+        throw;
     } catch (nlohmann::detail::exception &e) {
         return std::make_pair(Pistache::Http::Code::Bad_Request, e.what());
     } catch (org::openapitools::server::helpers::ValidationException &e) {
         return std::make_pair(Pistache::Http::Code::Bad_Request, e.what());
+    } catch (std::exception &e) {
+        return std::make_pair(Pistache::Http::Code::Internal_Server_Error, e.what())
     }
 }
 

--- a/samples/server/petstore/cpp-pistache/api/PetApi.h
+++ b/samples/server/petstore/cpp-pistache/api/PetApi.h
@@ -58,13 +58,15 @@ private:
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during Parameter parsing and validation.
-    /// May be overriden to return custom error formats.
+    /// May be overriden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleParsingException(const std::exception& ex) const noexcept;
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.
-    /// May be overriden to return custom error formats.
+    /// May be overriden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleOperationException(const std::exception& ex) const noexcept;
 

--- a/samples/server/petstore/cpp-pistache/api/StoreApi.cpp
+++ b/samples/server/petstore/cpp-pistache/api/StoreApi.cpp
@@ -45,11 +45,13 @@ void StoreApi::setupRoutes() {
 std::pair<Pistache::Http::Code, std::string> StoreApi::handleParsingException(const std::exception& ex) const noexcept
 {
     try {
-        throw ex;
+        throw;
     } catch (nlohmann::detail::exception &e) {
         return std::make_pair(Pistache::Http::Code::Bad_Request, e.what());
     } catch (org::openapitools::server::helpers::ValidationException &e) {
         return std::make_pair(Pistache::Http::Code::Bad_Request, e.what());
+    } catch (std::exception &e) {
+        return std::make_pair(Pistache::Http::Code::Internal_Server_Error, e.what())
     }
 }
 

--- a/samples/server/petstore/cpp-pistache/api/StoreApi.h
+++ b/samples/server/petstore/cpp-pistache/api/StoreApi.h
@@ -54,13 +54,15 @@ private:
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during Parameter parsing and validation.
-    /// May be overriden to return custom error formats.
+    /// May be overriden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleParsingException(const std::exception& ex) const noexcept;
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.
-    /// May be overriden to return custom error formats.
+    /// May be overriden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleOperationException(const std::exception& ex) const noexcept;
 

--- a/samples/server/petstore/cpp-pistache/api/UserApi.cpp
+++ b/samples/server/petstore/cpp-pistache/api/UserApi.cpp
@@ -49,11 +49,13 @@ void UserApi::setupRoutes() {
 std::pair<Pistache::Http::Code, std::string> UserApi::handleParsingException(const std::exception& ex) const noexcept
 {
     try {
-        throw ex;
+        throw;
     } catch (nlohmann::detail::exception &e) {
         return std::make_pair(Pistache::Http::Code::Bad_Request, e.what());
     } catch (org::openapitools::server::helpers::ValidationException &e) {
         return std::make_pair(Pistache::Http::Code::Bad_Request, e.what());
+    } catch (std::exception &e) {
+        return std::make_pair(Pistache::Http::Code::Internal_Server_Error, e.what())
     }
 }
 

--- a/samples/server/petstore/cpp-pistache/api/UserApi.h
+++ b/samples/server/petstore/cpp-pistache/api/UserApi.h
@@ -58,13 +58,15 @@ private:
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during Parameter parsing and validation.
-    /// May be overriden to return custom error formats.
+    /// May be overriden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleParsingException(const std::exception& ex) const noexcept;
 
     /// <summary>
     /// Helper function to handle unexpected Exceptions during processing of the request in handler functions.
-    /// May be overriden to return custom error formats.
+    /// May be overriden to return custom error formats. This is called inside a catch block.
+    /// Important: When overriding, do not call `throw ex;`, but instead use `throw;`.
     /// </summary>
     virtual std::pair<Pistache::Http::Code, std::string> handleOperationException(const std::exception& ex) const noexcept;
 

--- a/samples/server/petstore/cpp-pistache/model/ApiResponse.h
+++ b/samples/server/petstore/cpp-pistache/model/ApiResponse.h
@@ -46,6 +46,12 @@ public:
     /// </summary>
     bool validate(std::stringstream& msg) const;
 
+    /// <summary>
+    /// Helper overload for validate. Used when one model stores another model and calls it's validate.
+    /// Not meant to be called outside that case.
+    /// </summary>
+    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
+
     bool operator==(const ApiResponse& rhs) const;
     bool operator!=(const ApiResponse& rhs) const;
 
@@ -83,9 +89,6 @@ protected:
     bool m_TypeIsSet;
     std::string m_Message;
     bool m_MessageIsSet;
-
-    // Helper overload for validate. Used when one model stores another model and calls it's validate.
-    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
 };
 
 } // namespace org::openapitools::server::model

--- a/samples/server/petstore/cpp-pistache/model/Category.h
+++ b/samples/server/petstore/cpp-pistache/model/Category.h
@@ -46,6 +46,12 @@ public:
     /// </summary>
     bool validate(std::stringstream& msg) const;
 
+    /// <summary>
+    /// Helper overload for validate. Used when one model stores another model and calls it's validate.
+    /// Not meant to be called outside that case.
+    /// </summary>
+    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
+
     bool operator==(const Category& rhs) const;
     bool operator!=(const Category& rhs) const;
 
@@ -74,9 +80,6 @@ protected:
     bool m_IdIsSet;
     std::string m_Name;
     bool m_NameIsSet;
-
-    // Helper overload for validate. Used when one model stores another model and calls it's validate.
-    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
 };
 
 } // namespace org::openapitools::server::model

--- a/samples/server/petstore/cpp-pistache/model/Order.h
+++ b/samples/server/petstore/cpp-pistache/model/Order.h
@@ -46,6 +46,12 @@ public:
     /// </summary>
     bool validate(std::stringstream& msg) const;
 
+    /// <summary>
+    /// Helper overload for validate. Used when one model stores another model and calls it's validate.
+    /// Not meant to be called outside that case.
+    /// </summary>
+    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
+
     bool operator==(const Order& rhs) const;
     bool operator!=(const Order& rhs) const;
 
@@ -110,9 +116,6 @@ protected:
     bool m_StatusIsSet;
     bool m_Complete;
     bool m_CompleteIsSet;
-
-    // Helper overload for validate. Used when one model stores another model and calls it's validate.
-    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
 };
 
 } // namespace org::openapitools::server::model

--- a/samples/server/petstore/cpp-pistache/model/Pet.h
+++ b/samples/server/petstore/cpp-pistache/model/Pet.h
@@ -49,6 +49,12 @@ public:
     /// </summary>
     bool validate(std::stringstream& msg) const;
 
+    /// <summary>
+    /// Helper overload for validate. Used when one model stores another model and calls it's validate.
+    /// Not meant to be called outside that case.
+    /// </summary>
+    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
+
     bool operator==(const Pet& rhs) const;
     bool operator!=(const Pet& rhs) const;
 
@@ -109,9 +115,6 @@ protected:
     bool m_TagsIsSet;
     std::string m_Status;
     bool m_StatusIsSet;
-
-    // Helper overload for validate. Used when one model stores another model and calls it's validate.
-    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
 };
 
 } // namespace org::openapitools::server::model

--- a/samples/server/petstore/cpp-pistache/model/Tag.h
+++ b/samples/server/petstore/cpp-pistache/model/Tag.h
@@ -46,6 +46,12 @@ public:
     /// </summary>
     bool validate(std::stringstream& msg) const;
 
+    /// <summary>
+    /// Helper overload for validate. Used when one model stores another model and calls it's validate.
+    /// Not meant to be called outside that case.
+    /// </summary>
+    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
+
     bool operator==(const Tag& rhs) const;
     bool operator!=(const Tag& rhs) const;
 
@@ -74,9 +80,6 @@ protected:
     bool m_IdIsSet;
     std::string m_Name;
     bool m_NameIsSet;
-
-    // Helper overload for validate. Used when one model stores another model and calls it's validate.
-    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
 };
 
 } // namespace org::openapitools::server::model

--- a/samples/server/petstore/cpp-pistache/model/User.h
+++ b/samples/server/petstore/cpp-pistache/model/User.h
@@ -46,6 +46,12 @@ public:
     /// </summary>
     bool validate(std::stringstream& msg) const;
 
+    /// <summary>
+    /// Helper overload for validate. Used when one model stores another model and calls it's validate.
+    /// Not meant to be called outside that case.
+    /// </summary>
+    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
+
     bool operator==(const User& rhs) const;
     bool operator!=(const User& rhs) const;
 
@@ -128,9 +134,6 @@ protected:
     bool m_PhoneIsSet;
     int32_t m_UserStatus;
     bool m_UserStatusIsSet;
-
-    // Helper overload for validate. Used when one model stores another model and calls it's validate.
-    bool validate(std::stringstream& msg, const std::string& pathPrefix) const;
 };
 
 } // namespace org::openapitools::server::model


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Here I am fixing bugs I myself have created.

#### Fix a compile break for validation code:

The overload for the models `validate(std::stringstream&, const std::string&)` was marked as private, which lead to model classes being unable to use the helper when validating other classes. The function was made public, with a summary comment noting that it is not of much use for the user.

#### Fix error handling in `handleParsingException`:

The defaultl implementation of `handleParsingException` handles exceptions based on their type. In order to check the type, the caught exception is rethrown in a `try` block. However, it is important to rethrow using `throw;` and not with `throw exVariable;`.
The latter does not preserve derived class information (See https://stackoverflow.com/questions/2360597/c-exceptions-questions-on-rethrow-of-original-exception). This lead to all runtime exceptions being treated like generic exceptions and raised an internal server error (500).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @ravinikam (2017/07) @stkrwork (2017/07) @etherealjoy (2018/02) @martindelille (2018/03) @muttleyxd (2019/08)



