### PR TITLE
Adding Api per operation option to JaxRS and Spring server generators.

### DIFF
--- a/docs/generators/java-msf4j.md
+++ b/docs/generators/java-msf4j.md
@@ -11,6 +11,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations)| |null|
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |org.openapitools.api|
+|apiPerOperation|Create interface and controller per operation| |false|
 |artifactDescription|artifact description in generated pom.xml| |OpenAPI Java|
 |artifactId|artifactId in generated pom.xml. This also becomes part of the generated library's filename| |openapi-jaxrs-server|
 |artifactUrl|artifact URL in generated pom.xml| |https://github.com/openapitools/openapi-generator|

--- a/docs/generators/jaxrs-cxf-cdi.md
+++ b/docs/generators/jaxrs-cxf-cdi.md
@@ -11,6 +11,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations)| |null|
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |org.openapitools.api|
+|apiPerOperation|Create interface and controller per operation| |false|
 |artifactDescription|artifact description in generated pom.xml| |OpenAPI Java|
 |artifactId|artifactId in generated pom.xml. This also becomes part of the generated library's filename| |openapi-jaxrs-cxf-cdi-server|
 |artifactUrl|artifact URL in generated pom.xml| |https://github.com/openapitools/openapi-generator|

--- a/docs/generators/jaxrs-cxf-extended.md
+++ b/docs/generators/jaxrs-cxf-extended.md
@@ -12,6 +12,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations)| |null|
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |org.openapitools.api|
+|apiPerOperation|Create interface and controller per operation| |false|
 |artifactDescription|artifact description in generated pom.xml| |OpenAPI Java|
 |artifactId|artifactId in generated pom.xml. This also becomes part of the generated library's filename| |openapi-cxf-server|
 |artifactUrl|artifact URL in generated pom.xml| |https://github.com/openapitools/openapi-generator|

--- a/docs/generators/jaxrs-cxf.md
+++ b/docs/generators/jaxrs-cxf.md
@@ -12,6 +12,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations)| |null|
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |org.openapitools.api|
+|apiPerOperation|Create interface and controller per operation| |false|
 |artifactDescription|artifact description in generated pom.xml| |OpenAPI Java|
 |artifactId|artifactId in generated pom.xml. This also becomes part of the generated library's filename| |openapi-cxf-server|
 |artifactUrl|artifact URL in generated pom.xml| |https://github.com/openapitools/openapi-generator|

--- a/docs/generators/jaxrs-jersey.md
+++ b/docs/generators/jaxrs-jersey.md
@@ -11,6 +11,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations)| |null|
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |org.openapitools.api|
+|apiPerOperation|Create interface and controller per operation| |false|
 |artifactDescription|artifact description in generated pom.xml| |OpenAPI Java|
 |artifactId|artifactId in generated pom.xml. This also becomes part of the generated library's filename| |openapi-jaxrs-server|
 |artifactUrl|artifact URL in generated pom.xml| |https://github.com/openapitools/openapi-generator|

--- a/docs/generators/jaxrs-resteasy-eap.md
+++ b/docs/generators/jaxrs-resteasy-eap.md
@@ -11,6 +11,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations)| |null|
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |org.openapitools.api|
+|apiPerOperation|Create interface and controller per operation| |false|
 |artifactDescription|artifact description in generated pom.xml| |OpenAPI Java|
 |artifactId|artifactId in generated pom.xml. This also becomes part of the generated library's filename| |openapi-jaxrs-resteasy-eap-server|
 |artifactUrl|artifact URL in generated pom.xml| |https://github.com/openapitools/openapi-generator|

--- a/docs/generators/jaxrs-resteasy.md
+++ b/docs/generators/jaxrs-resteasy.md
@@ -11,6 +11,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations)| |null|
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |org.openapitools.api|
+|apiPerOperation|Create interface and controller per operation| |false|
 |artifactDescription|artifact description in generated pom.xml| |OpenAPI Java|
 |artifactId|artifactId in generated pom.xml. This also becomes part of the generated library's filename| |openapi-jaxrs-resteasy-server|
 |artifactUrl|artifact URL in generated pom.xml| |https://github.com/openapitools/openapi-generator|

--- a/docs/generators/jaxrs-spec.md
+++ b/docs/generators/jaxrs-spec.md
@@ -11,6 +11,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |additionalModelTypeAnnotations|Additional annotations for model type(class level annotations)| |null|
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |org.openapitools.api|
+|apiPerOperation|Create interface and controller per operation| |false|
 |artifactDescription|artifact description in generated pom.xml| |OpenAPI Java|
 |artifactId|artifactId in generated pom.xml. This also becomes part of the generated library's filename| |openapi-jaxrs-server|
 |artifactUrl|artifact URL in generated pom.xml| |https://github.com/openapitools/openapi-generator|

--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -12,6 +12,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiFirst|Generate the API from the OAI spec at server compile time (API first approach)| |false|
 |apiPackage|package for generated api classes| |org.openapitools.api|
+|apiPerOperation|create one interface and controller classnames per operation| |false|
 |artifactDescription|artifact description in generated pom.xml| |OpenAPI Java|
 |artifactId|artifactId in generated pom.xml. This also becomes part of the generated library's filename| |openapi-spring|
 |artifactUrl|artifact URL in generated pom.xml| |https://github.com/openapitools/openapi-generator|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.models.PathItem;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
+import org.openapitools.codegen.utils.ProcessUtils;
 import org.openapitools.codegen.utils.URLPathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +36,7 @@ import java.util.*;
 public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen implements BeanValidationFeatures {
     public static final String SERVER_PORT = "serverPort";
     public static final String USE_TAGS = "useTags";
+    public static final String API_PER_OPERATION = "apiPerOperation";
 
     /**
      * Name of the sub-directory in "src/main/resource" where to find the
@@ -48,6 +50,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
 
     protected boolean useBeanValidation = true;
     protected boolean useTags = false;
+    protected boolean apiPerOperation = false;
 
     private final Logger LOGGER = LoggerFactory.getLogger(AbstractJavaJAXRSServerCodegen.class);
 
@@ -77,6 +80,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations",useBeanValidation));
         cliOptions.add(new CliOption(SERVER_PORT, "The port on which the server should be started").defaultValue(serverPort));
         cliOptions.add(CliOption.newBoolean(USE_TAGS, "use tags for creating interface and controller classnames"));
+        cliOptions.add(CliOption.newBoolean(API_PER_OPERATION, "Create interface and controller per operation"));
     }
 
 
@@ -105,6 +109,10 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
             setUseTags(convertPropertyToBoolean(USE_TAGS));
         }
 
+        if (additionalProperties.containsKey(API_PER_OPERATION)) {
+            setApiPerOperation(convertPropertyToBoolean(API_PER_OPERATION));
+        }
+
         writePropertyBack(USE_BEANVALIDATION, useBeanValidation);
     }
 
@@ -116,6 +124,8 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         }
         if (useTags) {
             super.addOperationToGroup(tag, resourcePath, operation, co, operations);
+        } else if (apiPerOperation) {
+            ProcessUtils.operationPerApi(resourcePath, co, operations);
         } else {
             co.baseName = basePath;
             if (StringUtils.isEmpty(co.baseName) || StringUtils.containsAny(co.baseName, "{", "}")) {
@@ -312,5 +322,10 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
     @VisibleForTesting
     public void setUseTags(boolean useTags) {
         this.useTags = useTags;
+    }
+
+    @VisibleForTesting
+    public void setApiPerOperation(boolean apiPerOperation) {
+        this.apiPerOperation = apiPerOperation;
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFServerCodegen.java
@@ -78,6 +78,7 @@ public class JavaCXFServerCodegen extends AbstractJavaJAXRSServerCodegen
         // clioOptions default redifinition need to be updated
         updateOption(CodegenConstants.ARTIFACT_ID, this.getArtifactId());
         updateOption(USE_TAGS, String.valueOf(true));
+        updateOption(API_PER_OPERATION, String.valueOf(false));
 
         apiTemplateFiles.put("apiServiceImpl.mustache", ".java");
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ProcessUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ProcessUtils.java
@@ -1,8 +1,14 @@
 package org.openapitools.codegen.utils;
 
+import static org.openapitools.codegen.utils.StringUtils.camelize;
+
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Collectors;
 import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenSecurity;
 
@@ -251,6 +257,21 @@ public class ProcessUtils {
         } else {
             return openAPI.getComponents() != null ? openAPI.getComponents().getSecuritySchemes() : null;
         }
+    }
+
+    public static void operationPerApi(String resourcePath, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
+        String base = buildApiName(resourcePath, co.httpMethod);
+        List<CodegenOperation> opList = operations.computeIfAbsent(base, k -> new ArrayList<>());
+        opList.add(co);
+        co.baseName = base;
+    }
+
+    static String buildApiName(String resourcePath, String httpMethod) {
+        String base = Arrays.stream(resourcePath.split("/"))
+                .map(s -> s.replaceAll("([{}/])", ""))
+                .map(org.openapitools.codegen.utils.StringUtils::camelize)
+                .collect(Collectors.joining());
+        return base + camelize(httpMethod.toLowerCase(Locale.ROOT));
     }
 }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -419,4 +419,34 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
 
         assertFileContains(path, "\nimport java.util.Set;\n");
     }
+
+    @Test
+    public void givenTwoOperationAndApiPerOperationTrueWhenAddOperationThenAdd2OperationsWithExpectedName() {
+        String resourcePath = "/primaryresource";
+
+        CodegenOperation getOperation = buildOperation(resourcePath, "GET");
+        CodegenOperation putOperation = buildOperation(resourcePath, "PUT");
+
+        codegen.setApiPerOperation(true);
+
+        Operation operation = new Operation();
+        Map<String, List<CodegenOperation>> operationList = new HashMap<>();
+
+        codegen.addOperationToGroup("Primaryresource", resourcePath, operation, getOperation, operationList);
+        codegen.addOperationToGroup("Primaryresource", resourcePath, operation, putOperation, operationList);
+
+        Assert.assertEquals(operationList.size(), 2);
+        Assert.assertTrue(operationList.containsKey("PrimaryresourceGet"));
+        Assert.assertTrue(operationList.containsKey("PrimaryresourcePut"));
+        Assert.assertEquals(getOperation.baseName, "PrimaryresourceGet");
+        Assert.assertEquals(putOperation.baseName, "PrimaryresourcePut");
+    }
+
+    private CodegenOperation buildOperation(String resourcePath, String put) {
+        CodegenOperation putOperation = new CodegenOperation();
+        putOperation.httpMethod = put;
+        putOperation.path = resourcePath;
+        return putOperation;
+    }
+
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.parser.core.models.ParseOptions;
+import java.util.HashMap;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.SpringCodegen;
 import org.openapitools.codegen.languages.features.CXFServerFeatures;
@@ -652,5 +653,35 @@ public class SpringCodegenTest {
         assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/api/SomeApiDelegate.java"), "Mono<Map<String, DummyRequest>>");
         assertFileNotContains(Paths.get(outputPath + "/src/main/java/org/openapitools/api/SomeApi.java"), "Mono<DummyRequest>");
         assertFileNotContains(Paths.get(outputPath + "/src/main/java/org/openapitools/api/SomeApiDelegate.java"), "Mono<DummyRequest>");
+    }
+
+    @Test
+    public void givenTwoOperationAndApiPerOperationTrueWhenAddOperationThenAdd2OperationsWithExpectedName() {
+        SpringCodegen codegen = new SpringCodegen();
+        String resourcePath = "/primaryresource";
+
+        CodegenOperation getOperation = buildOperation(resourcePath, "GET");
+        CodegenOperation putOperation = buildOperation(resourcePath, "PUT");
+
+        codegen.setApiPerOperation(true);
+
+        Operation operation = new Operation();
+        Map<String, List<CodegenOperation>> operationList = new HashMap<>();
+
+        codegen.addOperationToGroup("Primaryresource", resourcePath, operation, getOperation, operationList);
+        codegen.addOperationToGroup("Primaryresource", resourcePath, operation, putOperation, operationList);
+
+        Assert.assertEquals(operationList.size(), 2);
+        Assert.assertTrue(operationList.containsKey("PrimaryresourceGet"));
+        Assert.assertTrue(operationList.containsKey("PrimaryresourcePut"));
+        Assert.assertEquals(getOperation.baseName, "PrimaryresourceGet");
+        Assert.assertEquals(putOperation.baseName, "PrimaryresourcePut");
+    }
+
+    private CodegenOperation buildOperation(String resourcePath, String put) {
+        CodegenOperation putOperation = new CodegenOperation();
+        putOperation.httpMethod = put;
+        putOperation.path = resourcePath;
+        return putOperation;
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ProcessUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ProcessUtilsTest.java
@@ -1,0 +1,33 @@
+package org.openapitools.codegen.utils;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ProcessUtilsTest {
+
+
+    @DataProvider(name = "pathMethodValues")
+    public static Object[][] dataProvider() {
+        return new Object[][]{
+                {"/pet", "POST", "PetPost"},
+                {"/pet", "PUT", "PetPut"},
+                {"/pet/findByStatus", "GET", "PetFindByStatusGet"},
+                {"/pet/findByTags", "GET", "PetFindByTagsGet"},
+                {"/pet/{petId}", "GET", "PetPetIdGet"},
+                {"/pet/{petId}", "POST", "PetPetIdPost"},
+                {"/pet/{petId}", "DELETE", "PetPetIdDelete"},
+                {"/pet/{petId}/uploadImage", "POST", "PetPetIdUploadImagePost"},
+                {"/store/order/{orderId}", "GET", "StoreOrderOrderIdGet"},
+                {"/store/order/{orderId}", "DELETE", "StoreOrderOrderIdDelete"},
+        };
+    }
+
+    @Test(dataProvider = "pathMethodValues")
+    public void givenPathAndMethodBuildApiName(String givenPath, String givenMethod, String expected) {
+        String result = ProcessUtils.buildApiName(givenPath, givenMethod);
+
+        assertEquals(result, expected);
+    }
+}


### PR DESCRIPTION
Added the option `apiPerOperation` which work similar to `useTags` but instead of generate a Java class per each annotation, this will tells to Spring and JaxRS server generators to create a Class per each operation (_url + method_).

2 new unit tests were added, one per each generator.

fix #9219

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

--

cc. @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @nmuesch
