### PR TITLE
[erlang-server] minor bug fixes

### DIFF
--- a/modules/openapi-generator/src/main/resources/erlang-server/logic_handler.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/logic_handler.mustache
@@ -15,8 +15,7 @@
 -type handler_response() ::{
     Status :: cowboy:http_status(),
     Headers :: cowboy:http_headers(),
-    Body :: #{}
-}.
+    Body :: jsx:json_term()}.
 
 -export_type([handler_response/0]).
 

--- a/modules/openapi-generator/src/main/resources/erlang-server/server.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/server.mustache
@@ -64,4 +64,4 @@ get_default_opts(LogicHandler) ->
     #{env => get_default_dispatch(LogicHandler)}.
 
 store_key(Key, Value, Opts) ->
-    lists:keystore(Key, 1, Opts, {Key, Value}).
+    maps:put(Key, Value, Opts).


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

dialyzer fixes for erlang-server

ping @tsloughter (2017/11) @jfacorro (2018/10) @robertoaloi (2018/10)

solves two dialyzer problems.
First one is this issue #6354 and the corresponding dialyzer output
```
X_server.erl
Line 54 Column 66: The call X_server:store_key('env', NewEnv::[any()], Opts::#{'env':=#{'dispatch':=cowboy_router:dispatch_rules()}}) will never return since it differs in the 3rd argument from the success typing arguments: (any(), any(), [tuple()])

Line 57 Column 65: The call X_server:store_key(Key::any(), Value::any(), Opts::#{'env':=#{'dispatch':=cowboy_router:dispatch_rules()}}) will never return since it differs in the 3rd argument from the success typing arguments: (any(), any(), [tuple()])

Line 66 Column 1: Function store_key/3 has no local return

Line 67 Column 28: The call lists:keystore(Key::any(), 1, Opts::#{'env':=#{'dispatch':=cowboy_router:dispatch_rules()}}, {_,_}) will never return since the success typing is (any(), pos_integer(), maybe_improper_list(), tuple()) -> nonempty_maybe_improper_list() and the contract is (Key, N, TupleList1, NewTuple) -> TupleList2 when Key :: term(), N :: pos_integer(), TupleList1 :: [Tuple], TupleList2 :: [Tuple,...], NewTuple :: Tuple, Tuple :: tuple()
```

The second dialyzer problem is
```
X_default_logic_handler.erl
Line 8 Column 2: The return type {binary() | non_neg_integer(),#{binary()=>binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | [])},atom() | binary() | [any()] | number() | {{non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()}} | {'with_tail',_,binary()} | #{atom() | binary()=>_}} in the specification of handle_request/3 is not a subtype of {binary() | non_neg_integer(),#{binary()=>binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | [])},#{}}, which is the expected return type for the callback of X_logic_handler behaviour
```
It's coming from `#{}` in logic_handler.mustache but the from default_logic_handler.mustache it's `jsx:json_term()`
https://github.com/OpenAPITools/openapi-generator/blob/77e1ca56cf329bfb22b05f853587263fd0ff6503/modules/openapi-generator/src/main/resources/erlang-server/default_logic_handler.mustache#L25


<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
