### PR TITLE
[Erlang] Return empty body for 304

### DIFF
--- a/modules/openapi-generator/src/main/resources/erlang-server/handler.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/handler.mustache
@@ -244,5 +244,7 @@ validate_headers(_, Req) -> {true, Req}.
 
 prepare_body(204, Body) when map_size(Body) == 0; length(Body) == 0 ->
     <<>>;
+prepare_body(304, Body) when map_size(Body) == 0; length(Body) == 0 ->
+    <<>>;
 prepare_body(_Code, Body) ->
     jsx:encode(Body).


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Similar to https://github.com/OpenAPITools/openapi-generator/pull/9512. This PR just adds 304 to the condition that should return an empty body to cowboy, as it has the same validation as 204: https://github.com/ninenines/cowboy/blob/2a082504996afccf78185182cd168123800bd4f0/src/cowboy_req.erl#L807-L824

@tsloughter (2017/11) @jfacorro (2018/10) @robertoaloi (2018/10)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
