### PR TITLE
[haskell][server] Export the Wai Application for the server

### DIFF
--- a/modules/openapi-generator/src/main/resources/haskell-servant/API.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-servant/API.mustache
@@ -27,6 +27,8 @@ module {{title}}.API
   , {{title}}ClientError(..)
   -- ** Servant
   , {{title}}API
+  -- ** Plain WAI Application
+  , serverWaiApplication{{title}}
   ) where
 
 import           {{title}}.Types
@@ -232,7 +234,13 @@ run{{title}}MiddlewareServer Config{..} middleware backend = do
   let warpSettings = Warp.defaultSettings
         & Warp.setPort (baseUrlPort url)
         & Warp.setHost (fromString $ baseUrlHost url)
-  liftIO $ Warp.runSettings warpSettings $ middleware $ serve (Proxy :: Proxy {{title}}API) (serverFromBackend backend)
+  liftIO $ Warp.runSettings warpSettings $ middleware $ serverWaiApplication{{title}} backend
+
+-- | Plain "Network.Wai" Application for the {{title}} server.
+--
+-- Can be used to implement e.g. tests that call the API without a full webserver.
+serverWaiApplication{{title}} :: {{title}}Backend (ExceptT ServerError IO) -> Application
+serverWaiApplication{{title}} backend = serve (Proxy :: Proxy {{title}}API) (serverFromBackend backend)
   where
     serverFromBackend {{title}}Backend{..} =
       ({{#apis}}{{#operations}}{{#operation}}coerce {{operationId}}{{^-last}} :<|>


### PR DESCRIPTION
For tests it’s useful to have direct access to the Wai `Application`,
which is the plain function from `Request` to `Response`.

Then you don’t need to use a full-blown http server to run requests.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
