### PR TITLE
[Java] [Native] Unify exception messages for async, add the status code

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -57,20 +57,25 @@ public class {{classname}} {
   }
   {{#asyncNative}}
 
-  private ApiException getApiException(String operationId, HttpResponse<String>localVarResponse) {
-    return new ApiException(localVarResponse.statusCode(),
-        operationId + " call received non-success response",
-        localVarResponse.headers(),
-        localVarResponse.body());
+  private ApiException getApiException(String operationId, HttpResponse<String> response) {
+    String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+    return new ApiException(response.statusCode(), message, response.headers(), response.body());
+  }
+  {{/asyncNative}}
+  {{^asyncNative}}
+
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
+    String body = response.body() == null ? null : new String(response.body().readAllBytes());
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
   }
   {{/asyncNative}}
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   {{#operation}}
@@ -215,7 +220,7 @@ public class {{classname}} {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "{{operationId}} call received non-success response");
+        throw getApiException("{{operationId}}", localVarResponse);
       }
       return new ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>(
           localVarResponse.statusCode(),

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -72,7 +72,7 @@ public class {{classname}} {
   {{/asyncNative}}
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -60,19 +60,16 @@ public class AnotherFakeApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  private ApiException getApiException(String operationId, HttpResponse<String>localVarResponse) {
-    return new ApiException(localVarResponse.statusCode(),
-        operationId + " call received non-success response",
-        localVarResponse.headers(),
-        localVarResponse.body());
+  private ApiException getApiException(String operationId, HttpResponse<String> response) {
+    String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+    return new ApiException(response.statusCode(), message, response.headers(), response.body());
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -66,7 +66,7 @@ public class AnotherFakeApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -68,19 +68,16 @@ public class FakeApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  private ApiException getApiException(String operationId, HttpResponse<String>localVarResponse) {
-    return new ApiException(localVarResponse.statusCode(),
-        operationId + " call received non-success response",
-        localVarResponse.headers(),
-        localVarResponse.body());
+  private ApiException getApiException(String operationId, HttpResponse<String> response) {
+    String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+    return new ApiException(response.statusCode(), message, response.headers(), response.body());
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -74,7 +74,7 @@ public class FakeApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -66,7 +66,7 @@ public class FakeClassnameTags123Api {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -60,19 +60,16 @@ public class FakeClassnameTags123Api {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  private ApiException getApiException(String operationId, HttpResponse<String>localVarResponse) {
-    return new ApiException(localVarResponse.statusCode(),
-        operationId + " call received non-success response",
-        localVarResponse.headers(),
-        localVarResponse.body());
+  private ApiException getApiException(String operationId, HttpResponse<String> response) {
+    String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+    return new ApiException(response.statusCode(), message, response.headers(), response.body());
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/PetApi.java
@@ -69,7 +69,7 @@ public class PetApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/PetApi.java
@@ -63,19 +63,16 @@ public class PetApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  private ApiException getApiException(String operationId, HttpResponse<String>localVarResponse) {
-    return new ApiException(localVarResponse.statusCode(),
-        operationId + " call received non-success response",
-        localVarResponse.headers(),
-        localVarResponse.body());
+  private ApiException getApiException(String operationId, HttpResponse<String> response) {
+    String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+    return new ApiException(response.statusCode(), message, response.headers(), response.body());
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -66,7 +66,7 @@ public class StoreApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -60,19 +60,16 @@ public class StoreApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  private ApiException getApiException(String operationId, HttpResponse<String>localVarResponse) {
-    return new ApiException(localVarResponse.statusCode(),
-        operationId + " call received non-success response",
-        localVarResponse.headers(),
-        localVarResponse.body());
+  private ApiException getApiException(String operationId, HttpResponse<String> response) {
+    String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+    return new ApiException(response.statusCode(), message, response.headers(), response.body());
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/UserApi.java
@@ -60,19 +60,16 @@ public class UserApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  private ApiException getApiException(String operationId, HttpResponse<String>localVarResponse) {
-    return new ApiException(localVarResponse.statusCode(),
-        operationId + " call received non-success response",
-        localVarResponse.headers(),
-        localVarResponse.body());
+  private ApiException getApiException(String operationId, HttpResponse<String> response) {
+    String message = formatExceptionMessage(operationId, response.statusCode(), response.body());
+    return new ApiException(response.statusCode(), message, response.headers(), response.body());
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
-    String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/UserApi.java
@@ -66,7 +66,7 @@ public class UserApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -58,12 +58,17 @@ public class AnotherFakeApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -95,7 +100,7 @@ public class AnotherFakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "call123testSpecialTags call received non-success response");
+        throw getApiException("call123testSpecialTags", localVarResponse);
       }
       return new ApiResponse<Client>(
           localVarResponse.statusCode(),

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -65,7 +65,7 @@ public class AnotherFakeApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -73,7 +73,7 @@ public class FakeApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -66,12 +66,17 @@ public class FakeApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -101,7 +106,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "createXmlItem call received non-success response");
+        throw getApiException("createXmlItem", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -175,7 +180,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "fakeOuterBooleanSerialize call received non-success response");
+        throw getApiException("fakeOuterBooleanSerialize", localVarResponse);
       }
       return new ApiResponse<Boolean>(
           localVarResponse.statusCode(),
@@ -245,7 +250,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "fakeOuterCompositeSerialize call received non-success response");
+        throw getApiException("fakeOuterCompositeSerialize", localVarResponse);
       }
       return new ApiResponse<OuterComposite>(
           localVarResponse.statusCode(),
@@ -315,7 +320,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "fakeOuterNumberSerialize call received non-success response");
+        throw getApiException("fakeOuterNumberSerialize", localVarResponse);
       }
       return new ApiResponse<BigDecimal>(
           localVarResponse.statusCode(),
@@ -385,7 +390,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "fakeOuterStringSerialize call received non-success response");
+        throw getApiException("fakeOuterStringSerialize", localVarResponse);
       }
       return new ApiResponse<String>(
           localVarResponse.statusCode(),
@@ -453,7 +458,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testBodyWithFileSchema call received non-success response");
+        throw getApiException("testBodyWithFileSchema", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -527,7 +532,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testBodyWithQueryParams call received non-success response");
+        throw getApiException("testBodyWithQueryParams", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -614,7 +619,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testClientModel call received non-success response");
+        throw getApiException("testClientModel", localVarResponse);
       }
       return new ApiResponse<Client>(
           localVarResponse.statusCode(),
@@ -712,7 +717,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testEndpointParameters call received non-success response");
+        throw getApiException("testEndpointParameters", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -804,7 +809,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testEnumParameters call received non-success response");
+        throw getApiException("testEnumParameters", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -927,7 +932,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testGroupParameters call received non-success response");
+        throw getApiException("testGroupParameters", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -1096,7 +1101,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testInlineAdditionalProperties call received non-success response");
+        throw getApiException("testInlineAdditionalProperties", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -1170,7 +1175,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testJsonFormData call received non-success response");
+        throw getApiException("testJsonFormData", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -1248,7 +1253,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testQueryParameterCollectionFormat call received non-success response");
+        throw getApiException("testQueryParameterCollectionFormat", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -65,7 +65,7 @@ public class FakeClassnameTags123Api {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -58,12 +58,17 @@ public class FakeClassnameTags123Api {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -95,7 +100,7 @@ public class FakeClassnameTags123Api {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testClassname call received non-success response");
+        throw getApiException("testClassname", localVarResponse);
       }
       return new ApiResponse<Client>(
           localVarResponse.statusCode(),

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
@@ -68,7 +68,7 @@ public class PetApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
@@ -61,12 +61,17 @@ public class PetApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -96,7 +101,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "addPet call received non-success response");
+        throw getApiException("addPet", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -170,7 +175,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "deletePet call received non-success response");
+        throw getApiException("deletePet", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -242,7 +247,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "findPetsByStatus call received non-success response");
+        throw getApiException("findPetsByStatus", localVarResponse);
       }
       return new ApiResponse<List<Pet>>(
           localVarResponse.statusCode(),
@@ -323,7 +328,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "findPetsByTags call received non-success response");
+        throw getApiException("findPetsByTags", localVarResponse);
       }
       return new ApiResponse<Set<Pet>>(
           localVarResponse.statusCode(),
@@ -400,7 +405,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "getPetById call received non-success response");
+        throw getApiException("getPetById", localVarResponse);
       }
       return new ApiResponse<Pet>(
           localVarResponse.statusCode(),
@@ -467,7 +472,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "updatePet call received non-success response");
+        throw getApiException("updatePet", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -543,7 +548,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "updatePetWithForm call received non-success response");
+        throw getApiException("updatePetWithForm", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -616,7 +621,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "uploadFile call received non-success response");
+        throw getApiException("uploadFile", localVarResponse);
       }
       return new ApiResponse<ModelApiResponse>(
           localVarResponse.statusCode(),
@@ -689,7 +694,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "uploadFileWithRequiredFile call received non-success response");
+        throw getApiException("uploadFileWithRequiredFile", localVarResponse);
       }
       return new ApiResponse<ModelApiResponse>(
           localVarResponse.statusCode(),

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -58,12 +58,17 @@ public class StoreApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -93,7 +98,7 @@ public class StoreApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "deleteOrder call received non-success response");
+        throw getApiException("deleteOrder", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -160,7 +165,7 @@ public class StoreApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "getInventory call received non-success response");
+        throw getApiException("getInventory", localVarResponse);
       }
       return new ApiResponse<Map<String, Integer>>(
           localVarResponse.statusCode(),
@@ -224,7 +229,7 @@ public class StoreApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "getOrderById call received non-success response");
+        throw getApiException("getOrderById", localVarResponse);
       }
       return new ApiResponse<Order>(
           localVarResponse.statusCode(),
@@ -293,7 +298,7 @@ public class StoreApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "placeOrder call received non-success response");
+        throw getApiException("placeOrder", localVarResponse);
       }
       return new ApiResponse<Order>(
           localVarResponse.statusCode(),

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -65,7 +65,7 @@ public class StoreApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
@@ -58,12 +58,17 @@ public class UserApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -93,7 +98,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "createUser call received non-success response");
+        throw getApiException("createUser", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -165,7 +170,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "createUsersWithArrayInput call received non-success response");
+        throw getApiException("createUsersWithArrayInput", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -237,7 +242,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "createUsersWithListInput call received non-success response");
+        throw getApiException("createUsersWithListInput", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -309,7 +314,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "deleteUser call received non-success response");
+        throw getApiException("deleteUser", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -378,7 +383,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "getUserByName call received non-success response");
+        throw getApiException("getUserByName", localVarResponse);
       }
       return new ApiResponse<User>(
           localVarResponse.statusCode(),
@@ -449,7 +454,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "loginUser call received non-success response");
+        throw getApiException("loginUser", localVarResponse);
       }
       return new ApiResponse<String>(
           localVarResponse.statusCode(),
@@ -527,7 +532,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "logoutUser call received non-success response");
+        throw getApiException("logoutUser", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -591,7 +596,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "updateUser call received non-success response");
+        throw getApiException("updateUser", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
@@ -65,7 +65,7 @@ public class UserApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -58,12 +58,17 @@ public class AnotherFakeApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -95,7 +100,7 @@ public class AnotherFakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "call123testSpecialTags call received non-success response");
+        throw getApiException("call123testSpecialTags", localVarResponse);
       }
       return new ApiResponse<Client>(
           localVarResponse.statusCode(),

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -65,7 +65,7 @@ public class AnotherFakeApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -58,12 +58,17 @@ public class DefaultApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -93,7 +98,7 @@ public class DefaultApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "fooGet call received non-success response");
+        throw getApiException("fooGet", localVarResponse);
       }
       return new ApiResponse<InlineResponseDefault>(
           localVarResponse.statusCode(),

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -65,7 +65,7 @@ public class DefaultApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -74,7 +74,7 @@ public class FakeApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -67,12 +67,17 @@ public class FakeApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -102,7 +107,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "fakeHealthGet call received non-success response");
+        throw getApiException("fakeHealthGet", localVarResponse);
       }
       return new ApiResponse<HealthCheckResult>(
           localVarResponse.statusCode(),
@@ -166,7 +171,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "fakeOuterBooleanSerialize call received non-success response");
+        throw getApiException("fakeOuterBooleanSerialize", localVarResponse);
       }
       return new ApiResponse<Boolean>(
           localVarResponse.statusCode(),
@@ -236,7 +241,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "fakeOuterCompositeSerialize call received non-success response");
+        throw getApiException("fakeOuterCompositeSerialize", localVarResponse);
       }
       return new ApiResponse<OuterComposite>(
           localVarResponse.statusCode(),
@@ -306,7 +311,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "fakeOuterNumberSerialize call received non-success response");
+        throw getApiException("fakeOuterNumberSerialize", localVarResponse);
       }
       return new ApiResponse<BigDecimal>(
           localVarResponse.statusCode(),
@@ -376,7 +381,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "fakeOuterStringSerialize call received non-success response");
+        throw getApiException("fakeOuterStringSerialize", localVarResponse);
       }
       return new ApiResponse<String>(
           localVarResponse.statusCode(),
@@ -444,7 +449,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "getArrayOfEnums call received non-success response");
+        throw getApiException("getArrayOfEnums", localVarResponse);
       }
       return new ApiResponse<List<OuterEnum>>(
           localVarResponse.statusCode(),
@@ -506,7 +511,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testBodyWithFileSchema call received non-success response");
+        throw getApiException("testBodyWithFileSchema", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -580,7 +585,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testBodyWithQueryParams call received non-success response");
+        throw getApiException("testBodyWithQueryParams", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -667,7 +672,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testClientModel call received non-success response");
+        throw getApiException("testClientModel", localVarResponse);
       }
       return new ApiResponse<Client>(
           localVarResponse.statusCode(),
@@ -765,7 +770,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testEndpointParameters call received non-success response");
+        throw getApiException("testEndpointParameters", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -857,7 +862,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testEnumParameters call received non-success response");
+        throw getApiException("testEnumParameters", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -980,7 +985,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testGroupParameters call received non-success response");
+        throw getApiException("testGroupParameters", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -1149,7 +1154,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testInlineAdditionalProperties call received non-success response");
+        throw getApiException("testInlineAdditionalProperties", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -1223,7 +1228,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testJsonFormData call received non-success response");
+        throw getApiException("testJsonFormData", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -1301,7 +1306,7 @@ public class FakeApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testQueryParameterCollectionFormat call received non-success response");
+        throw getApiException("testQueryParameterCollectionFormat", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -65,7 +65,7 @@ public class FakeClassnameTags123Api {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -58,12 +58,17 @@ public class FakeClassnameTags123Api {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -95,7 +100,7 @@ public class FakeClassnameTags123Api {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "testClassname call received non-success response");
+        throw getApiException("testClassname", localVarResponse);
       }
       return new ApiResponse<Client>(
           localVarResponse.statusCode(),

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
@@ -67,7 +67,7 @@ public class PetApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
@@ -60,12 +60,17 @@ public class PetApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -95,7 +100,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "addPet call received non-success response");
+        throw getApiException("addPet", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -169,7 +174,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "deletePet call received non-success response");
+        throw getApiException("deletePet", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -241,7 +246,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "findPetsByStatus call received non-success response");
+        throw getApiException("findPetsByStatus", localVarResponse);
       }
       return new ApiResponse<List<Pet>>(
           localVarResponse.statusCode(),
@@ -322,7 +327,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "findPetsByTags call received non-success response");
+        throw getApiException("findPetsByTags", localVarResponse);
       }
       return new ApiResponse<List<Pet>>(
           localVarResponse.statusCode(),
@@ -399,7 +404,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "getPetById call received non-success response");
+        throw getApiException("getPetById", localVarResponse);
       }
       return new ApiResponse<Pet>(
           localVarResponse.statusCode(),
@@ -466,7 +471,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "updatePet call received non-success response");
+        throw getApiException("updatePet", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -542,7 +547,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "updatePetWithForm call received non-success response");
+        throw getApiException("updatePetWithForm", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -615,7 +620,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "uploadFile call received non-success response");
+        throw getApiException("uploadFile", localVarResponse);
       }
       return new ApiResponse<ModelApiResponse>(
           localVarResponse.statusCode(),
@@ -688,7 +693,7 @@ public class PetApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "uploadFileWithRequiredFile call received non-success response");
+        throw getApiException("uploadFileWithRequiredFile", localVarResponse);
       }
       return new ApiResponse<ModelApiResponse>(
           localVarResponse.statusCode(),

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -58,12 +58,17 @@ public class StoreApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -93,7 +98,7 @@ public class StoreApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "deleteOrder call received non-success response");
+        throw getApiException("deleteOrder", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -160,7 +165,7 @@ public class StoreApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "getInventory call received non-success response");
+        throw getApiException("getInventory", localVarResponse);
       }
       return new ApiResponse<Map<String, Integer>>(
           localVarResponse.statusCode(),
@@ -224,7 +229,7 @@ public class StoreApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "getOrderById call received non-success response");
+        throw getApiException("getOrderById", localVarResponse);
       }
       return new ApiResponse<Order>(
           localVarResponse.statusCode(),
@@ -293,7 +298,7 @@ public class StoreApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "placeOrder call received non-success response");
+        throw getApiException("placeOrder", localVarResponse);
       }
       return new ApiResponse<Order>(
           localVarResponse.statusCode(),

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -65,7 +65,7 @@ public class StoreApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
@@ -58,12 +58,17 @@ public class UserApi {
     memberVarResponseInterceptor = apiClient.getResponseInterceptor();
   }
 
-  protected ApiException createApiException(HttpResponse<InputStream> response, String msgPrefix) throws IOException {
+  protected ApiException getApiException(String operationId, HttpResponse<InputStream> response) throws IOException {
     String body = response.body() == null ? null : new String(response.body().readAllBytes());
-    if (body != null) {
-      msgPrefix += ": " + body;
+    String message = formatExceptionMessage(operationId, response.statusCode(), body);
+    return new ApiException(response.statusCode(), message, response.headers(), body);
+  }
+
+  private String formatExceptionMessage(String operationId, int statusCode, String body) {
+    if (body == null) {
+      body = "[no body]";
     }
-    return new ApiException(response.statusCode(), msgPrefix, response.headers(), body);
+    return operationId + " call failed with: " + statusCode + " - " + body;
   }
 
   /**
@@ -93,7 +98,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "createUser call received non-success response");
+        throw getApiException("createUser", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -165,7 +170,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "createUsersWithArrayInput call received non-success response");
+        throw getApiException("createUsersWithArrayInput", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -237,7 +242,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "createUsersWithListInput call received non-success response");
+        throw getApiException("createUsersWithListInput", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -309,7 +314,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "deleteUser call received non-success response");
+        throw getApiException("deleteUser", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -378,7 +383,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "getUserByName call received non-success response");
+        throw getApiException("getUserByName", localVarResponse);
       }
       return new ApiResponse<User>(
           localVarResponse.statusCode(),
@@ -449,7 +454,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "loginUser call received non-success response");
+        throw getApiException("loginUser", localVarResponse);
       }
       return new ApiResponse<String>(
           localVarResponse.statusCode(),
@@ -527,7 +532,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "logoutUser call received non-success response");
+        throw getApiException("logoutUser", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),
@@ -591,7 +596,7 @@ public class UserApi {
         memberVarResponseInterceptor.accept(localVarResponse);
       }
       if (localVarResponse.statusCode()/ 100 != 2) {
-        throw createApiException(localVarResponse, "updateUser call received non-success response");
+        throw getApiException("updateUser", localVarResponse);
       }
       return new ApiResponse<Void>(
           localVarResponse.statusCode(),

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
@@ -65,7 +65,7 @@ public class UserApi {
   }
 
   private String formatExceptionMessage(String operationId, int statusCode, String body) {
-    if (body == null) {
+    if (body == null || body.isEmpty()) {
       body = "[no body]";
     }
     return operationId + " call failed with: " + statusCode + " - " + body;


### PR DESCRIPTION
The template has two methods for creating API exceptions, and the enhancements from #9169 didn't make it to the async version.

- unify the signatures of the two methods (name, arguments)
- make sure the sync version is not generated with asyncNative
- extract the formatting logic into a common formatExceptionMessage() method
- add the status code to the exception message as well, not just the body
- shortened "call received non-success response" to a more concise "call failed with"

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
