### PR TITLE
[#9805][Kotlin][multiplatform] Make the template work with Kotlin 1.5.x

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -29,7 +29,6 @@ import kotlinx.parcelize.Parcelize
 {{/multiplatform}}
 {{#multiplatform}}
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.CommonEnumSerializer
 {{/multiplatform}}
 {{#serializableModel}}
 import java.io.Serializable
@@ -72,6 +71,9 @@ import java.io.Serializable
     {{#kotlinx_serialization}}
     {{#serializableModel}}@KSerializable{{/serializableModel}}{{^serializableModel}}@Serializable{{/serializableModel}}
     {{/kotlinx_serialization}}
+    {{#multiplatform}}
+    @Serializable
+    {{/multiplatform}}
     {{#nonPublicApi}}internal {{/nonPublicApi}}enum class {{{nameInCamelCase}}}(val value: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}kotlin.String{{/isContainer}}) {
     {{#allowableValues}}
     {{#enumVars}}
@@ -90,7 +92,7 @@ import java.io.Serializable
         {{/kotlinx_serialization}}
         {{/multiplatform}}
         {{#multiplatform}}
-        {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+        @SerialName(value = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
         {{/multiplatform}}
     {{/enumVars}}
     {{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -15,7 +15,6 @@ import kotlinx.serialization.Serializable
 {{/multiplatform}}
 {{#multiplatform}}
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.CommonEnumSerializer
 {{/multiplatform}}
 
 /**

--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/RequestConfig.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/RequestConfig.kt.mustache
@@ -8,10 +8,21 @@ package {{packageName}}.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
+{{^multiplatform}}
 {{#nonPublicApi}}internal {{/nonPublicApi}}data class RequestConfig<T>(
+{{/multiplatform}}
+{{#multiplatform}}
+{{! Migrating the 'multiplatform' template to RequestConfig<T> is considered a separate piece of effort. }}
+{{#nonPublicApi}}internal {{/nonPublicApi}}data class RequestConfig(
+{{/multiplatform}}
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
+    {{^multiplatform}}
     val body: T? = null
+    {{/multiplatform}}
+    {{#multiplatform}}
+    val body: kotlin.Any? = null
+    {{/multiplatform}}
 )

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
@@ -6,28 +6,25 @@ package {{apiPackage}}
 
 import {{packageName}}.infrastructure.*
 import io.ktor.client.request.forms.formData
-import kotlinx.serialization.UnstableDefault
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.serializer.KotlinxSerializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
 import io.ktor.http.ParametersBuilder
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.StringDescriptor
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 {{#operations}}
-{{#nonPublicApi}}internal {{/nonPublicApi}}class {{classname}} @UseExperimental(UnstableDefault::class) constructor(
+{{#nonPublicApi}}internal {{/nonPublicApi}}class {{classname}} constructor(
     baseUrl: kotlin.String = "{{{basePath}}}",
     httpClientEngine: HttpClientEngine? = null,
-    serializer: KotlinxSerializer
+    serializer: KotlinxSerializer = KotlinxSerializer(Json { ignoreUnknownKeys = true }),
 ) : ApiClient(baseUrl, httpClientEngine, serializer) {
-
-    @UseExperimental(UnstableDefault::class)
-    constructor(
-        baseUrl: kotlin.String = "{{{basePath}}}",
-        httpClientEngine: HttpClientEngine? = null,
-        jsonConfiguration: JsonConfiguration = JsonConfiguration.Default
-    ) : this(baseUrl, httpClientEngine, KotlinxSerializer(Json(jsonConfiguration)))
 
     {{#operation}}
     /**
@@ -103,23 +100,5 @@ import kotlinx.serialization.internal.StringDescriptor
 {{/isMap}}
 
     {{/operation}}
-
-    {{#nonPublicApi}}internal {{/nonPublicApi}}companion object {
-        internal fun setMappers(serializer: KotlinxSerializer) {
-            {{#operation}}
-            {{#hasBodyParam}}
-            {{#bodyParam}}
-            {{#isArray}}serializer.setMapper({{operationIdCamelCase}}Request::class, {{operationIdCamelCase}}Request.serializer()){{/isArray}}{{#isMap}}serializer.setMapper({{operationIdCamelCase}}Request::class, {{operationIdCamelCase}}Request.serializer()){{/isMap}}
-            {{/bodyParam}}
-            {{/hasBodyParam}}
-            {{#isArray}}
-            serializer.setMapper({{operationIdCamelCase}}Response::class, {{operationIdCamelCase}}Response.serializer())
-            {{/isArray}}
-            {{#isMap}}
-            serializer.setMapper({{operationIdCamelCase}}Response::class, {{operationIdCamelCase}}Response.serializer())
-            {{/isMap}}
-            {{/operation}}
-        }
-    }
 }
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/build.gradle.mustache
@@ -5,11 +5,12 @@ group '{{groupId}}'
 version '{{artifactVersion}}'
 
 ext {
-    kotlin_version = '1.3.50'
-    kotlinx_version = '1.1.0'
-    coroutines_version = '1.3.1'
-    serialization_version = '0.12.0'
-    ktor_version = '1.2.4'
+    // Recommended library versions for the used version of Kotlin were taken from
+    // https://kotlinlang.org/docs/releases.html#release-details
+    kotlin_version = '1.5.10'
+    coroutines_version = '1.5.0'
+    serialization_version = '1.2.1'
+    ktor_version = '1.5.4'
 }
 
 buildscript {
@@ -17,8 +18,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50" // $kotlin_version
-        classpath "org.jetbrains.kotlin:kotlin-serialization:1.3.50" // $kotlin_version
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10" // $kotlin_version
+        classpath "org.jetbrains.kotlin:kotlin-serialization:1.5.10" // $kotlin_version
     }
 }
 
@@ -28,16 +29,16 @@ repositories {
 
 kotlin {
     jvm()
-    iosArm64() { binaries { framework { freeCompilerArgs.add("-Xobjc-generics") } } }
-    iosX64() { binaries { framework { freeCompilerArgs.add("-Xobjc-generics") } } }
+    iosArm64() { binaries { framework { freeCompilerArgs += "-Xobjc-generics" } } }
+    iosX64() { binaries { framework { freeCompilerArgs += "-Xobjc-generics" } } }
     js()
 
     sourceSets {
         commonMain {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlin_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:$coroutines_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:$serialization_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:$serialization_version"
                 api "io.ktor:ktor-client-core:$ktor_version"
                 api "io.ktor:ktor-client-json:$ktor_version"
                 api "io.ktor:ktor-client-serialization:$ktor_version"
@@ -57,7 +58,8 @@ kotlin {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$serialization_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:$serialization_version"
+                implementation "io.ktor:ktor-client-cio-jvm:$ktor_version"
                 api "io.ktor:ktor-client-core-jvm:$ktor_version"
                 api "io.ktor:ktor-client-json-jvm:$ktor_version"
                 api "io.ktor:ktor-client-serialization-jvm:$ktor_version"
@@ -77,7 +79,7 @@ kotlin {
             dependsOn commonMain
             dependencies {
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-native:$coroutines_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:$serialization_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-core-native:$serialization_version"
                 api "io.ktor:ktor-client-ios:$ktor_version"
             }
         }
@@ -116,7 +118,7 @@ kotlin {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$coroutines_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-js:$serialization_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-core-js:$serialization_version"
                 api "io.ktor:ktor-client-js:$ktor_version"
                 api "io.ktor:ktor-client-json-js:$ktor_version"
                 api "io.ktor:ktor-client-serialization-js:$ktor_version"

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/ApiClient.kt.mustache
@@ -7,19 +7,16 @@ import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.JsonSerializer
 import io.ktor.client.features.json.serializer.KotlinxSerializer
-import io.ktor.client.request.accept
+import io.ktor.client.request.request
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
-import io.ktor.client.response.HttpResponse
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.utils.EmptyContent
 import io.ktor.http.*
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.content.PartData
-import kotlinx.serialization.UnstableDefault
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
 
 import {{apiPackage}}.*
 import {{modelPackage}}.*
@@ -28,18 +25,7 @@ import {{packageName}}.auth.*
 {{#nonPublicApi}}internal {{/nonPublicApi}}open class ApiClient(
         private val baseUrl: String,
         httpClientEngine: HttpClientEngine?,
-        serializer: KotlinxSerializer) {
-
-    @UseExperimental(UnstableDefault::class)
-    constructor(
-            baseUrl: String,
-            httpClientEngine: HttpClientEngine?,
-            jsonConfiguration: JsonConfiguration) :
-            this(baseUrl, httpClientEngine, KotlinxSerializer(Json(jsonConfiguration)))
-
-    private val serializer: JsonSerializer by lazy {
-        serializer.apply { setMappers(this) }.ignoreOutgoingContent()
-    }
+        private val serializer: KotlinxSerializer) {
 
     private val client: HttpClient by lazy {
         val jsonConfig: JsonFeature.Config.() -> Unit = { this.serializer = this@ApiClient.serializer }
@@ -61,15 +47,6 @@ import {{packageName}}.auth.*
 
     {{#nonPublicApi}}internal {{/nonPublicApi}}companion object {
         protected val UNSAFE_HEADERS = listOf(HttpHeaders.ContentType)
-
-        private fun setMappers(serializer: KotlinxSerializer) {
-            {{#apiInfo}}{{#apis}}
-            {{classname}}.setMappers(serializer)
-            {{/apis}}{{/apiInfo}}
-            {{#models}}
-            {{#model}}{{^isAlias}}serializer.setMapper({{modelPackage}}.{{classname}}::class, {{modelPackage}}.{{classname}}.{{#isEnum}}Serializer{{/isEnum}}{{^isEnum}}serializer(){{/isEnum}}){{/isAlias}}{{/model}}
-            {{/models}}
-        }
     }
 
     /**
@@ -155,11 +132,11 @@ import {{packageName}}.auth.*
         else request(requestConfig, authNames = authNames)
     }
 
-    protected suspend inline fun <reified T: Any?> request(requestConfig: RequestConfig<T>, body: OutgoingContent = EmptyContent, authNames: kotlin.collections.List<String>): HttpResponse {
+    protected suspend fun request(requestConfig: RequestConfig, body: OutgoingContent = EmptyContent, authNames: kotlin.collections.List<String>): HttpResponse {
         requestConfig.updateForAuth(authNames)
         val headers = requestConfig.headers
 
-        return client.call {
+        return client.request {
             this.url {
                 this.takeFrom(URLBuilder(baseUrl))
                 appendPath(requestConfig.path.trimStart('/').split('/'))
@@ -174,7 +151,7 @@ import {{packageName}}.auth.*
             if (requestConfig.method in listOf(RequestMethod.PUT, RequestMethod.POST, RequestMethod.PATCH))
                 this.body = body
 
-        }.response
+        }
     }
 
     private fun RequestConfig.updateForAuth(authNames: kotlin.collections.List<String>) {
@@ -198,14 +175,4 @@ import {{packageName}}.auth.*
             RequestMethod.POST -> HttpMethod.Post
             RequestMethod.OPTIONS -> HttpMethod.Options
         }
-}
-
-// https://github.com/ktorio/ktor/issues/851
-private fun JsonSerializer.ignoreOutgoingContent() = IgnoreOutgoingContentJsonSerializer(this)
-
-private class IgnoreOutgoingContentJsonSerializer(private val delegate: JsonSerializer) : JsonSerializer by delegate {
-    override fun write(data: Any): OutgoingContent {
-        if (data is OutgoingContent) return data
-        return delegate.write(data)
-    }
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/Base64ByteArray.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/Base64ByteArray.kt.mustache
@@ -1,13 +1,16 @@
 package {{packageName}}.infrastructure
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.StringDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 class Base64ByteArray(val value: ByteArray) {
     @Serializer(Base64ByteArray::class)
     companion object : KSerializer<Base64ByteArray> {
-        override val descriptor = StringDescriptor.withName("Base64ByteArray")
+        override val descriptor = PrimitiveSerialDescriptor("Base64ByteArray", PrimitiveKind.STRING)
         override fun serialize(encoder: Encoder, obj: Base64ByteArray) = encoder.encodeString(obj.value.encodeBase64())
         override fun deserialize(decoder: Decoder) = Base64ByteArray(decoder.decodeString().decodeBase64Bytes())
     }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/Bytes.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/Bytes.kt.mustache
@@ -1,6 +1,6 @@
 package {{packageName}}.infrastructure
 
-import kotlinx.io.core.*
+import io.ktor.utils.io.core.*
 import kotlin.experimental.and
 
 private val digits = "0123456789abcdef".toCharArray()
@@ -32,7 +32,7 @@ internal fun hex(bytes: ByteArray): String {
         result[resultIndex++] = digits[b and 0x0f]
     }
 
-    return String(result)
+    return result.concatToString()
 }
 
 /**

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/HttpResponse.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/HttpResponse.kt.mustache
@@ -5,7 +5,7 @@ import io.ktor.client.call.typeInfo
 import io.ktor.http.Headers
 import io.ktor.http.isSuccess
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}open class HttpResponse<T : Any>(val response: io.ktor.client.response.HttpResponse, val provider: BodyProvider<T>) {
+{{#nonPublicApi}}internal {{/nonPublicApi}}open class HttpResponse<T : Any>(val response: io.ktor.client.statement.HttpResponse, val provider: BodyProvider<T>) {
     val status: Int = response.status.value
     val success: Boolean = response.status.isSuccess()
     val headers: Map<String, List<String>> = response.headers.mapEntries()
@@ -22,29 +22,29 @@ import io.ktor.http.isSuccess
 }
 
 {{#nonPublicApi}}internal {{/nonPublicApi}}interface BodyProvider<T : Any> {
-    suspend fun body(response: io.ktor.client.response.HttpResponse): T
-    suspend fun <V : Any> typedBody(response: io.ktor.client.response.HttpResponse, type: TypeInfo): V
+    suspend fun body(response: io.ktor.client.statement.HttpResponse): T
+    suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V
 }
 
 {{#nonPublicApi}}internal {{/nonPublicApi}}class TypedBodyProvider<T : Any>(private val type: TypeInfo) : BodyProvider<T> {
     @Suppress("UNCHECKED_CAST")
-    override suspend fun body(response: io.ktor.client.response.HttpResponse): T =
+    override suspend fun body(response: io.ktor.client.statement.HttpResponse): T =
             response.call.receive(type) as T
 
     @Suppress("UNCHECKED_CAST")
-    override suspend fun <V : Any> typedBody(response: io.ktor.client.response.HttpResponse, type: TypeInfo): V =
+    override suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
             response.call.receive(type) as V
 }
 
 {{#nonPublicApi}}internal {{/nonPublicApi}}class MappedBodyProvider<S : Any, T : Any>(private val provider: BodyProvider<S>, private val block: S.() -> T) : BodyProvider<T> {
-    override suspend fun body(response: io.ktor.client.response.HttpResponse): T =
+    override suspend fun body(response: io.ktor.client.statement.HttpResponse): T =
             block(provider.body(response))
 
-    override suspend fun <V : Any> typedBody(response: io.ktor.client.response.HttpResponse, type: TypeInfo): V =
+    override suspend fun <V : Any> typedBody(response: io.ktor.client.statement.HttpResponse, type: TypeInfo): V =
             provider.typedBody(response, type)
 }
 
-{{#nonPublicApi}}internal {{/nonPublicApi}}inline fun <reified T : Any> io.ktor.client.response.HttpResponse.wrap(): HttpResponse<T> =
+{{#nonPublicApi}}internal {{/nonPublicApi}}inline fun <reified T : Any> io.ktor.client.statement.HttpResponse.wrap(): HttpResponse<T> =
         HttpResponse(this, TypedBodyProvider(typeInfo<T>()))
 
 {{#nonPublicApi}}internal {{/nonPublicApi}}fun <T : Any, V : Any> HttpResponse<T>.map(block: T.() -> V): HttpResponse<V> =

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/OctetByteArray.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/infrastructure/OctetByteArray.kt.mustache
@@ -1,13 +1,16 @@
 package {{packageName}}.infrastructure
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.StringDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 class OctetByteArray(val value: ByteArray) {
     @Serializer(OctetByteArray::class)
     companion object : KSerializer<OctetByteArray> {
-        override val descriptor = StringDescriptor.withName("OctetByteArray")
+        override val descriptor = PrimitiveSerialDescriptor("OctetByteArray", PrimitiveKind.STRING)
         override fun serialize(encoder: Encoder, obj: OctetByteArray) = encoder.encodeString(hex(obj.value))
         override fun deserialize(decoder: Decoder) = OctetByteArray(hex(decoder.decodeString()))
     }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_request_list.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_request_list.mustache
@@ -2,8 +2,8 @@
     private class {{operationIdCamelCase}}Request(val value: List<{{#bodyParam}}{{baseType}}{{/bodyParam}}>) {
         @Serializer({{operationIdCamelCase}}Request::class)
         {{#nonPublicApi}}internal {{/nonPublicApi}}companion object : KSerializer<{{operationIdCamelCase}}Request> {
-            private val serializer: KSerializer<List<{{#bodyParam}}{{baseType}}{{/bodyParam}}>> = {{#bodyParam}}{{baseType}}{{/bodyParam}}.serializer().list
-                override val descriptor = StringDescriptor.withName("{{operationIdCamelCase}}Request")
+            private val serializer: KSerializer<List<{{#bodyParam}}{{baseType}}{{/bodyParam}}>> = ListSerializer({{#bodyParam}}{{baseType}}{{/bodyParam}}.serializer())
+                override val descriptor = PrimitiveSerialDescriptor("{{operationIdCamelCase}}Request", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: {{operationIdCamelCase}}Request) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = {{operationIdCamelCase}}Request(serializer.deserialize(decoder))
         }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_request_map.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_request_map.mustache
@@ -2,8 +2,8 @@
     private class {{operationIdCamelCase}}Request(val value: Map<kotlin.String, {{#bodyParam}}{{baseType}}{{/bodyParam}}>) {
         @Serializer({{operationIdCamelCase}}Request::class)
         {{#nonPublicApi}}internal {{/nonPublicApi}}companion object : KSerializer<{{operationIdCamelCase}}Request> {
-            private val serializer: KSerializer<Map<kotlin.String, {{#bodyParam}}{{baseType}}{{/bodyParam}}>> = (kotlin.String.serializer() to {{#bodyParam}}{{baseType}}{{/bodyParam}}.serializer()).map
-                override val descriptor = StringDescriptor.withName("{{operationIdCamelCase}}Request")
+            private val serializer: KSerializer<Map<kotlin.String, {{#bodyParam}}{{baseType}}{{/bodyParam}}>> = MapSerializer(kotlin.String.serializer(), {{#bodyParam}}{{baseType}}{{/bodyParam}}.serializer())
+                override val descriptor = PrimitiveSerialDescriptor("{{operationIdCamelCase}}Request", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: {{operationIdCamelCase}}Request) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = {{operationIdCamelCase}}Request(serializer.deserialize(decoder))
         }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_response_list.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_response_list.mustache
@@ -2,8 +2,8 @@
     private class {{operationIdCamelCase}}Response(val value: List<{{returnBaseType}}>) {
         @Serializer({{operationIdCamelCase}}Response::class)
         {{#nonPublicApi}}internal {{/nonPublicApi}}companion object : KSerializer<{{operationIdCamelCase}}Response> {
-            private val serializer: KSerializer<List<{{returnBaseType}}>> = {{returnBaseType}}.serializer().list
-                override val descriptor = StringDescriptor.withName("{{operationIdCamelCase}}Response")
+            private val serializer: KSerializer<List<{{returnBaseType}}>> = ListSerializer({{returnBaseType}}.serializer())
+                override val descriptor = PrimitiveSerialDescriptor("{{operationIdCamelCase}}Response", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: {{operationIdCamelCase}}Response) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = {{operationIdCamelCase}}Response(serializer.deserialize(decoder))
         }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_response_map.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_response_map.mustache
@@ -2,8 +2,8 @@
     private class {{operationIdCamelCase}}Response(val value: Map<kotlin.String, {{returnBaseType}}>) {
         @Serializer({{operationIdCamelCase}}Response::class)
         {{#nonPublicApi}}internal {{/nonPublicApi}}companion object : KSerializer<{{operationIdCamelCase}}Response> {
-            private val serializer: KSerializer<Map<kotlin.String, {{returnBaseType}}>> = (kotlin.String.serializer() to {{returnBaseType}}.serializer()).map
-                override val descriptor = StringDescriptor.withName("{{operationIdCamelCase}}Response")
+            private val serializer: KSerializer<Map<kotlin.String, {{returnBaseType}}>> = MapSerializer(kotlin.String.serializer(), {{returnBaseType}}.serializer())
+                override val descriptor = PrimitiveSerialDescriptor("{{operationIdCamelCase}}Response", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: {{operationIdCamelCase}}Response) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = {{operationIdCamelCase}}Response(serializer.deserialize(decoder))
         }

--- a/samples/client/petstore/kotlin-multiplatform/build.gradle
+++ b/samples/client/petstore/kotlin-multiplatform/build.gradle
@@ -5,11 +5,12 @@ group 'org.openapitools'
 version '1.0.0'
 
 ext {
-    kotlin_version = '1.3.50'
-    kotlinx_version = '1.1.0'
-    coroutines_version = '1.3.1'
-    serialization_version = '0.12.0'
-    ktor_version = '1.2.4'
+    // Recommended library versions for the used version of Kotlin were taken from
+    // https://kotlinlang.org/docs/releases.html#release-details
+    kotlin_version = '1.5.10'
+    coroutines_version = '1.5.0'
+    serialization_version = '1.2.1'
+    ktor_version = '1.5.4'
 }
 
 buildscript {
@@ -17,8 +18,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50" // $kotlin_version
-        classpath "org.jetbrains.kotlin:kotlin-serialization:1.3.50" // $kotlin_version
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10" // $kotlin_version
+        classpath "org.jetbrains.kotlin:kotlin-serialization:1.5.10" // $kotlin_version
     }
 }
 
@@ -28,16 +29,16 @@ repositories {
 
 kotlin {
     jvm()
-    iosArm64() { binaries { framework { freeCompilerArgs.add("-Xobjc-generics") } } }
-    iosX64() { binaries { framework { freeCompilerArgs.add("-Xobjc-generics") } } }
+    iosArm64() { binaries { framework { freeCompilerArgs += "-Xobjc-generics" } } }
+    iosX64() { binaries { framework { freeCompilerArgs += "-Xobjc-generics" } } }
     js()
 
     sourceSets {
         commonMain {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlin_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:$coroutines_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:$serialization_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:$serialization_version"
                 api "io.ktor:ktor-client-core:$ktor_version"
                 api "io.ktor:ktor-client-json:$ktor_version"
                 api "io.ktor:ktor-client-serialization:$ktor_version"
@@ -57,7 +58,8 @@ kotlin {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$serialization_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:$serialization_version"
+                implementation "io.ktor:ktor-client-cio-jvm:$ktor_version"
                 api "io.ktor:ktor-client-core-jvm:$ktor_version"
                 api "io.ktor:ktor-client-json-jvm:$ktor_version"
                 api "io.ktor:ktor-client-serialization-jvm:$ktor_version"
@@ -77,7 +79,7 @@ kotlin {
             dependsOn commonMain
             dependencies {
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-native:$coroutines_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:$serialization_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-core-native:$serialization_version"
                 api "io.ktor:ktor-client-ios:$ktor_version"
             }
         }
@@ -116,7 +118,7 @@ kotlin {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib-js:$kotlin_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$coroutines_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-js:$serialization_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-core-js:$serialization_version"
                 api "io.ktor:ktor-client-js:$ktor_version"
                 api "io.ktor:ktor-client-json-js:$ktor_version"
                 api "io.ktor:ktor-client-serialization-js:$ktor_version"

--- a/samples/client/petstore/kotlin-multiplatform/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/client/petstore/kotlin-multiplatform/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -16,27 +16,24 @@ import org.openapitools.client.models.Pet
 
 import org.openapitools.client.infrastructure.*
 import io.ktor.client.request.forms.formData
-import kotlinx.serialization.UnstableDefault
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.serializer.KotlinxSerializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
 import io.ktor.http.ParametersBuilder
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.StringDescriptor
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-class PetApi @UseExperimental(UnstableDefault::class) constructor(
+class PetApi constructor(
     baseUrl: kotlin.String = "http://petstore.swagger.io/v2",
     httpClientEngine: HttpClientEngine? = null,
-    serializer: KotlinxSerializer
+    serializer: KotlinxSerializer = KotlinxSerializer(Json { ignoreUnknownKeys = true }),
 ) : ApiClient(baseUrl, httpClientEngine, serializer) {
-
-    @UseExperimental(UnstableDefault::class)
-    constructor(
-        baseUrl: kotlin.String = "http://petstore.swagger.io/v2",
-        httpClientEngine: HttpClientEngine? = null,
-        jsonConfiguration: JsonConfiguration = JsonConfiguration.Default
-    ) : this(baseUrl, httpClientEngine, KotlinxSerializer(Json(jsonConfiguration)))
 
     /**
      * Add a new pet to the store
@@ -141,8 +138,8 @@ class PetApi @UseExperimental(UnstableDefault::class) constructor(
     private class FindPetsByStatusResponse(val value: List<Pet>) {
         @Serializer(FindPetsByStatusResponse::class)
         companion object : KSerializer<FindPetsByStatusResponse> {
-            private val serializer: KSerializer<List<Pet>> = Pet.serializer().list
-                override val descriptor = StringDescriptor.withName("FindPetsByStatusResponse")
+            private val serializer: KSerializer<List<Pet>> = ListSerializer(Pet.serializer())
+                override val descriptor = PrimitiveSerialDescriptor("FindPetsByStatusResponse", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: FindPetsByStatusResponse) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = FindPetsByStatusResponse(serializer.deserialize(decoder))
         }
@@ -185,8 +182,8 @@ class PetApi @UseExperimental(UnstableDefault::class) constructor(
     private class FindPetsByTagsResponse(val value: List<Pet>) {
         @Serializer(FindPetsByTagsResponse::class)
         companion object : KSerializer<FindPetsByTagsResponse> {
-            private val serializer: KSerializer<List<Pet>> = Pet.serializer().list
-                override val descriptor = StringDescriptor.withName("FindPetsByTagsResponse")
+            private val serializer: KSerializer<List<Pet>> = ListSerializer(Pet.serializer())
+                override val descriptor = PrimitiveSerialDescriptor("FindPetsByTagsResponse", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: FindPetsByTagsResponse) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = FindPetsByTagsResponse(serializer.deserialize(decoder))
         }
@@ -332,13 +329,4 @@ class PetApi @UseExperimental(UnstableDefault::class) constructor(
     }
 
 
-
-    companion object {
-        internal fun setMappers(serializer: KotlinxSerializer) {
-            
-            serializer.setMapper(FindPetsByStatusResponse::class, FindPetsByStatusResponse.serializer())
-            serializer.setMapper(FindPetsByTagsResponse::class, FindPetsByTagsResponse.serializer())
-            
-        }
-    }
 }

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -15,27 +15,24 @@ import org.openapitools.client.models.Order
 
 import org.openapitools.client.infrastructure.*
 import io.ktor.client.request.forms.formData
-import kotlinx.serialization.UnstableDefault
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.serializer.KotlinxSerializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
 import io.ktor.http.ParametersBuilder
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.StringDescriptor
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-class StoreApi @UseExperimental(UnstableDefault::class) constructor(
+class StoreApi constructor(
     baseUrl: kotlin.String = "http://petstore.swagger.io/v2",
     httpClientEngine: HttpClientEngine? = null,
-    serializer: KotlinxSerializer
+    serializer: KotlinxSerializer = KotlinxSerializer(Json { ignoreUnknownKeys = true }),
 ) : ApiClient(baseUrl, httpClientEngine, serializer) {
-
-    @UseExperimental(UnstableDefault::class)
-    constructor(
-        baseUrl: kotlin.String = "http://petstore.swagger.io/v2",
-        httpClientEngine: HttpClientEngine? = null,
-        jsonConfiguration: JsonConfiguration = JsonConfiguration.Default
-    ) : this(baseUrl, httpClientEngine, KotlinxSerializer(Json(jsonConfiguration)))
 
     /**
      * Delete purchase order by ID
@@ -104,8 +101,8 @@ class StoreApi @UseExperimental(UnstableDefault::class) constructor(
     private class GetInventoryResponse(val value: Map<kotlin.String, kotlin.Int>) {
         @Serializer(GetInventoryResponse::class)
         companion object : KSerializer<GetInventoryResponse> {
-            private val serializer: KSerializer<Map<kotlin.String, kotlin.Int>> = (kotlin.String.serializer() to kotlin.Int.serializer()).map
-                override val descriptor = StringDescriptor.withName("GetInventoryResponse")
+            private val serializer: KSerializer<Map<kotlin.String, kotlin.Int>> = MapSerializer(kotlin.String.serializer(), kotlin.Int.serializer())
+                override val descriptor = PrimitiveSerialDescriptor("GetInventoryResponse", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: GetInventoryResponse) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = GetInventoryResponse(serializer.deserialize(decoder))
         }
@@ -177,11 +174,4 @@ class StoreApi @UseExperimental(UnstableDefault::class) constructor(
 
 
 
-
-    companion object {
-        internal fun setMappers(serializer: KotlinxSerializer) {
-            serializer.setMapper(GetInventoryResponse::class, GetInventoryResponse.serializer())
-            
-        }
-    }
 }

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -15,27 +15,24 @@ import org.openapitools.client.models.User
 
 import org.openapitools.client.infrastructure.*
 import io.ktor.client.request.forms.formData
-import kotlinx.serialization.UnstableDefault
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.serializer.KotlinxSerializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
 import io.ktor.http.ParametersBuilder
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.StringDescriptor
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-class UserApi @UseExperimental(UnstableDefault::class) constructor(
+class UserApi constructor(
     baseUrl: kotlin.String = "http://petstore.swagger.io/v2",
     httpClientEngine: HttpClientEngine? = null,
-    serializer: KotlinxSerializer
+    serializer: KotlinxSerializer = KotlinxSerializer(Json { ignoreUnknownKeys = true }),
 ) : ApiClient(baseUrl, httpClientEngine, serializer) {
-
-    @UseExperimental(UnstableDefault::class)
-    constructor(
-        baseUrl: kotlin.String = "http://petstore.swagger.io/v2",
-        httpClientEngine: HttpClientEngine? = null,
-        jsonConfiguration: JsonConfiguration = JsonConfiguration.Default
-    ) : this(baseUrl, httpClientEngine, KotlinxSerializer(Json(jsonConfiguration)))
 
     /**
      * Create user
@@ -103,8 +100,8 @@ class UserApi @UseExperimental(UnstableDefault::class) constructor(
     private class CreateUsersWithArrayInputRequest(val value: List<User>) {
         @Serializer(CreateUsersWithArrayInputRequest::class)
         companion object : KSerializer<CreateUsersWithArrayInputRequest> {
-            private val serializer: KSerializer<List<User>> = User.serializer().list
-                override val descriptor = StringDescriptor.withName("CreateUsersWithArrayInputRequest")
+            private val serializer: KSerializer<List<User>> = ListSerializer(User.serializer())
+                override val descriptor = PrimitiveSerialDescriptor("CreateUsersWithArrayInputRequest", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: CreateUsersWithArrayInputRequest) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = CreateUsersWithArrayInputRequest(serializer.deserialize(decoder))
         }
@@ -144,8 +141,8 @@ class UserApi @UseExperimental(UnstableDefault::class) constructor(
     private class CreateUsersWithListInputRequest(val value: List<User>) {
         @Serializer(CreateUsersWithListInputRequest::class)
         companion object : KSerializer<CreateUsersWithListInputRequest> {
-            private val serializer: KSerializer<List<User>> = User.serializer().list
-                override val descriptor = StringDescriptor.withName("CreateUsersWithListInputRequest")
+            private val serializer: KSerializer<List<User>> = ListSerializer(User.serializer())
+                override val descriptor = PrimitiveSerialDescriptor("CreateUsersWithListInputRequest", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: CreateUsersWithListInputRequest) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = CreateUsersWithListInputRequest(serializer.deserialize(decoder))
         }
@@ -316,13 +313,4 @@ class UserApi @UseExperimental(UnstableDefault::class) constructor(
 
 
 
-
-    companion object {
-        internal fun setMappers(serializer: KotlinxSerializer) {
-            
-            serializer.setMapper(CreateUsersWithArrayInputRequest::class, CreateUsersWithArrayInputRequest.serializer())
-            serializer.setMapper(CreateUsersWithListInputRequest::class, CreateUsersWithListInputRequest.serializer())
-            
-        }
-    }
 }

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -7,19 +7,16 @@ import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.JsonSerializer
 import io.ktor.client.features.json.serializer.KotlinxSerializer
-import io.ktor.client.request.accept
+import io.ktor.client.request.request
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
-import io.ktor.client.response.HttpResponse
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.utils.EmptyContent
 import io.ktor.http.*
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.content.PartData
-import kotlinx.serialization.UnstableDefault
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
 
 import org.openapitools.client.apis.*
 import org.openapitools.client.models.*
@@ -28,18 +25,7 @@ import org.openapitools.client.auth.*
 open class ApiClient(
         private val baseUrl: String,
         httpClientEngine: HttpClientEngine?,
-        serializer: KotlinxSerializer) {
-
-    @UseExperimental(UnstableDefault::class)
-    constructor(
-            baseUrl: String,
-            httpClientEngine: HttpClientEngine?,
-            jsonConfiguration: JsonConfiguration) :
-            this(baseUrl, httpClientEngine, KotlinxSerializer(Json(jsonConfiguration)))
-
-    private val serializer: JsonSerializer by lazy {
-        serializer.apply { setMappers(this) }.ignoreOutgoingContent()
-    }
+        private val serializer: KotlinxSerializer) {
 
     private val client: HttpClient by lazy {
         val jsonConfig: JsonFeature.Config.() -> Unit = { this.serializer = this@ApiClient.serializer }
@@ -54,22 +40,6 @@ open class ApiClient(
 
     companion object {
         protected val UNSAFE_HEADERS = listOf(HttpHeaders.ContentType)
-
-        private fun setMappers(serializer: KotlinxSerializer) {
-            
-            PetApi.setMappers(serializer)
-            
-            StoreApi.setMappers(serializer)
-            
-            UserApi.setMappers(serializer)
-            
-            serializer.setMapper(org.openapitools.client.models.ApiResponse::class, org.openapitools.client.models.ApiResponse.serializer())
-            serializer.setMapper(org.openapitools.client.models.Category::class, org.openapitools.client.models.Category.serializer())
-            serializer.setMapper(org.openapitools.client.models.Order::class, org.openapitools.client.models.Order.serializer())
-            serializer.setMapper(org.openapitools.client.models.Pet::class, org.openapitools.client.models.Pet.serializer())
-            serializer.setMapper(org.openapitools.client.models.Tag::class, org.openapitools.client.models.Tag.serializer())
-            serializer.setMapper(org.openapitools.client.models.User::class, org.openapitools.client.models.User.serializer())
-        }
     }
 
     /**
@@ -155,11 +125,11 @@ open class ApiClient(
         else request(requestConfig, authNames = authNames)
     }
 
-    protected suspend inline fun <reified T: Any?> request(requestConfig: RequestConfig<T>, body: OutgoingContent = EmptyContent, authNames: kotlin.collections.List<String>): HttpResponse {
+    protected suspend fun request(requestConfig: RequestConfig, body: OutgoingContent = EmptyContent, authNames: kotlin.collections.List<String>): HttpResponse {
         requestConfig.updateForAuth(authNames)
         val headers = requestConfig.headers
 
-        return client.call {
+        return client.request {
             this.url {
                 this.takeFrom(URLBuilder(baseUrl))
                 appendPath(requestConfig.path.trimStart('/').split('/'))
@@ -174,7 +144,7 @@ open class ApiClient(
             if (requestConfig.method in listOf(RequestMethod.PUT, RequestMethod.POST, RequestMethod.PATCH))
                 this.body = body
 
-        }.response
+        }
     }
 
     private fun RequestConfig.updateForAuth(authNames: kotlin.collections.List<String>) {
@@ -198,14 +168,4 @@ open class ApiClient(
             RequestMethod.POST -> HttpMethod.Post
             RequestMethod.OPTIONS -> HttpMethod.Options
         }
-}
-
-// https://github.com/ktorio/ktor/issues/851
-private fun JsonSerializer.ignoreOutgoingContent() = IgnoreOutgoingContentJsonSerializer(this)
-
-private class IgnoreOutgoingContentJsonSerializer(private val delegate: JsonSerializer) : JsonSerializer by delegate {
-    override fun write(data: Any): OutgoingContent {
-        if (data is OutgoingContent) return data
-        return delegate.write(data)
-    }
 }

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/Base64ByteArray.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/Base64ByteArray.kt
@@ -1,13 +1,16 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.StringDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 class Base64ByteArray(val value: ByteArray) {
     @Serializer(Base64ByteArray::class)
     companion object : KSerializer<Base64ByteArray> {
-        override val descriptor = StringDescriptor.withName("Base64ByteArray")
+        override val descriptor = PrimitiveSerialDescriptor("Base64ByteArray", PrimitiveKind.STRING)
         override fun serialize(encoder: Encoder, obj: Base64ByteArray) = encoder.encodeString(obj.value.encodeBase64())
         override fun deserialize(decoder: Decoder) = Base64ByteArray(decoder.decodeString().decodeBase64Bytes())
     }

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/Bytes.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/Bytes.kt
@@ -1,6 +1,6 @@
 package org.openapitools.client.infrastructure
 
-import kotlinx.io.core.*
+import io.ktor.utils.io.core.*
 import kotlin.experimental.and
 
 private val digits = "0123456789abcdef".toCharArray()
@@ -32,7 +32,7 @@ internal fun hex(bytes: ByteArray): String {
         result[resultIndex++] = digits[b and 0x0f]
     }
 
-    return String(result)
+    return result.concatToString()
 }
 
 /**

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/OctetByteArray.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/OctetByteArray.kt
@@ -1,13 +1,16 @@
 package org.openapitools.client.infrastructure
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.StringDescriptor
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Serializable
 class OctetByteArray(val value: ByteArray) {
     @Serializer(OctetByteArray::class)
     companion object : KSerializer<OctetByteArray> {
-        override val descriptor = StringDescriptor.withName("OctetByteArray")
+        override val descriptor = PrimitiveSerialDescriptor("OctetByteArray", PrimitiveKind.STRING)
         override fun serialize(encoder: Encoder, obj: OctetByteArray) = encoder.encodeString(hex(obj.value))
         override fun deserialize(decoder: Decoder) = OctetByteArray(hex(decoder.decodeString()))
     }

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -8,10 +8,10 @@ package org.openapitools.client.infrastructure
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
  */
-data class RequestConfig<T>(
+data class RequestConfig(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
-    val body: T? = null
+    val body: kotlin.Any? = null
 )

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -13,7 +13,6 @@ package org.openapitools.client.models
 
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.CommonEnumSerializer
 
 /**
  * Describes the result of uploading an image resource

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Category.kt
@@ -13,7 +13,6 @@ package org.openapitools.client.models
 
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.CommonEnumSerializer
 
 /**
  * A category for a pet

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Order.kt
@@ -13,7 +13,6 @@ package org.openapitools.client.models
 
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.CommonEnumSerializer
 
 /**
  * An order for a pets from the pet store
@@ -39,10 +38,11 @@ data class Order (
      * Order Status
      * Values: placed,approved,delivered
      */
+    @Serializable
     enum class Status(val value: kotlin.String) {
-        placed("placed"),
-        approved("approved"),
-        delivered("delivered");
+        @SerialName(value = "placed") placed("placed"),
+        @SerialName(value = "approved") approved("approved"),
+        @SerialName(value = "delivered") delivered("delivered");
     }
 }
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Pet.kt
@@ -15,7 +15,6 @@ import org.openapitools.client.models.Category
 import org.openapitools.client.models.Tag
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.CommonEnumSerializer
 
 /**
  * A pet for sale in the pet store
@@ -41,10 +40,11 @@ data class Pet (
      * pet status in the store
      * Values: available,pending,sold
      */
+    @Serializable
     enum class Status(val value: kotlin.String) {
-        available("available"),
-        pending("pending"),
-        sold("sold");
+        @SerialName(value = "available") available("available"),
+        @SerialName(value = "pending") pending("pending"),
+        @SerialName(value = "sold") sold("sold");
     }
 }
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/Tag.kt
@@ -13,7 +13,6 @@ package org.openapitools.client.models
 
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.CommonEnumSerializer
 
 /**
  * A tag for a pet

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/models/User.kt
@@ -13,7 +13,6 @@ package org.openapitools.client.models
 
 
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.CommonEnumSerializer
 
 /**
  * A User who is purchasing from the pet store


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

### Issue
[[BUG][kotlin-client][multiplatform] "NoSuchMethodError" in runtime when starting ktor server with Kotlin 1.5.10 · Issue #9805 · OpenAPITools/openapi-generator](https://github.com/OpenAPITools/openapi-generator/issues/9805) (https://github.com/OpenAPITools/openapi-generator/issues/9805)

### Details

The goal of this change is to make Kotlin multiplatform template work with the newest Kotlin version (1.5.10).
Without these changes, consuming generated module from a Kotlin 1.5-based module with a Ktor server
results in a runtime exception when installing the JSON feature.

My guess is that due to some breaking changes kotlinx.serialization. For consistency, all kotlinx libraries were
updated, to adhere to the recommended versions mentioned here: https://kotlinlang.org/docs/releases.html#release-details

This change is meant to be as simple as possible - just bumping the versions and making minimal necessary adjustments.
I'm planning to introduce other changes (remove unneeded stuff, address warnings which will become errors in the future, add end-to-end tests if not present, and so on) in separate PR(s).

### Testing done

* ran integration tests (`mvn integration-test -f samples/client/petstore/kotlin-multiplatform`)
* created an entry point in the generated sample project and made a few test calls. I didn't test all APIs, it was rather meant to be a smoke test


### To be clarified
* are there any end-to-end tests that actually try to call the Petstore service with the generated module?
* how to ensure there are no regressions in other Kotlin templates that reuse the shared pieces of template?
* is `master` the right target branch for this change? The policy is confusing to me

I'd expect there are some tests ran by the CI that will address my above concerns. That's why I'm posting this PR anyway, to see what workflows GitHub will trigger, and to get feedback from the community.

### FYI

Kotlin technical committee: @jimschubert, @dr4ke616, @karismann, @Zomzog, @andrewemery, @4brunu, @yutaka0m

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
