### PR TITLE
[BUG][Haskell]Fix returning NoContent

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
@@ -564,7 +564,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
         // Add the HTTP method and return type
         String returnType = op.returnType;
         if (returnType == null || returnType.equals("null")) {
-            returnType = "()";
+            returnType = "NoContent";
         }
         if (returnType.indexOf(" ") >= 0) {
             returnType = "(" + returnType + ")";


### PR DESCRIPTION
Verbs with no content returned are now shown as having return type of `()`. This makes `servant` to try to parse resulting object.
Thus replacement with `NoContent` type fixes the issue.

Fixes: #9829

@wing328 @jimschubert @burberius