### PR TITLE
Opt-in solution to remove unnecessary model for inline schema composition

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -248,6 +248,9 @@ public class Generate extends OpenApiGeneratorCommand {
     @Option(name = {"--legacy-discriminator-behavior"}, title = "Support legacy logic for evaluating discriminators", description = CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR_DESC)
     private Boolean legacyDiscriminatorBehavior;
 
+    @Option(name = {"--allow-inline-schemas"}, title = "Allow inline schemas without generating new models", description = CodegenConstants.ALLOW_INLINE_SCHEMAS)
+    private Boolean allowInlineSchema;
+
     @Option(name = {"--minimal-update"},
         title = "Minimal update",
         description = "Only write output files that have changed.")
@@ -416,6 +419,10 @@ public class Generate extends OpenApiGeneratorCommand {
 
         if (strictSpecBehavior != null) {
             configurator.setStrictSpecBehavior(strictSpecBehavior);
+        }
+
+        if (allowInlineSchema != null) {
+            configurator.setAllowInlineSchemas(allowInlineSchema);
         }
 
         if (globalProperties != null && !globalProperties.isEmpty()) {

--- a/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
+++ b/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
@@ -430,4 +430,10 @@ public class GenerateTest {
         verify(configurator).toContext();
         verifyNoMoreInteractions(configurator);
     }
+
+    @Test
+    public void testAllowInlineSchemasTrue() {
+        setupAndRunGenericTest("--allow-inline-schemas");
+        verify(configurator).setAllowInlineSchemas(true);
+    }
 }

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
@@ -50,6 +50,7 @@ public class WorkflowSettings {
     public static final boolean DEFAULT_ENABLE_MINIMAL_UPDATE = false;
     public static final boolean DEFAULT_STRICT_SPEC_BEHAVIOR = true;
     public static final boolean DEFAULT_GENERATE_ALIAS_AS_MODEL = false;
+    public static final boolean DEFAULT_ALLOW_INLINE_SCHEMAS = false;
     public static final String DEFAULT_TEMPLATING_ENGINE_NAME = "mustache";
     public static final ImmutableMap<String, String> DEFAULT_GLOBAL_PROPERTIES = ImmutableMap.of();
 
@@ -65,6 +66,7 @@ public class WorkflowSettings {
     private boolean enableMinimalUpdate = DEFAULT_ENABLE_MINIMAL_UPDATE;
     private boolean strictSpecBehavior = DEFAULT_STRICT_SPEC_BEHAVIOR;
     private boolean generateAliasAsModel = DEFAULT_GENERATE_ALIAS_AS_MODEL;
+    private boolean allowInlineSchemas = DEFAULT_ALLOW_INLINE_SCHEMAS;
     private String templateDir;
     private String templatingEngineName = DEFAULT_TEMPLATING_ENGINE_NAME;
     private String ignoreFileOverride;
@@ -86,6 +88,7 @@ public class WorkflowSettings {
         this.ignoreFileOverride = builder.ignoreFileOverride;
         this.globalProperties = ImmutableMap.copyOf(builder.globalProperties);
         this.generateAliasAsModel = builder.generateAliasAsModel;
+        this.allowInlineSchemas = builder.allowInlineSchemas;
     }
 
     /**
@@ -116,6 +119,7 @@ public class WorkflowSettings {
         builder.strictSpecBehavior = copy.isStrictSpecBehavior();
         builder.templatingEngineName = copy.getTemplatingEngineName();
         builder.ignoreFileOverride = copy.getIgnoreFileOverride();
+        builder.allowInlineSchemas = copy.isAllowInlineSchemas();
 
         // this, and any other collections, must be mutable in the builder.
         builder.globalProperties = new HashMap<>(copy.getGlobalProperties());
@@ -249,6 +253,10 @@ public class WorkflowSettings {
         return strictSpecBehavior;
     }
 
+    public boolean isAllowInlineSchemas() {
+        return allowInlineSchemas;
+    }
+
     /**
      * Gets the directory holding templates used in generation. This option allows users to extend or modify built-in templates, or to write their own.
      *
@@ -315,6 +323,7 @@ public class WorkflowSettings {
         private String templateDir;
         private String templatingEngineName = DEFAULT_TEMPLATING_ENGINE_NAME;
         private String ignoreFileOverride;
+        private boolean allowInlineSchemas = DEFAULT_ALLOW_INLINE_SCHEMAS;
 
         // NOTE: All collections must be mutable in the builder, and copied to a new immutable collection in .build()
         private Map<String, String> globalProperties = new HashMap<>();
@@ -558,6 +567,11 @@ public class WorkflowSettings {
             return this;
         }
 
+        public Builder withAllowInlineSchemas(Boolean allowInlineSchemas) {
+            this.allowInlineSchemas = allowInlineSchemas != null ? allowInlineSchemas : Boolean.valueOf(DEFAULT_ALLOW_INLINE_SCHEMAS);
+            return this;
+        }
+
         /**
          * Returns a {@code WorkflowSettings} built from the parameters previously set.
          *
@@ -590,6 +604,7 @@ public class WorkflowSettings {
                 ", ignoreFileOverride='" + ignoreFileOverride + '\'' +
                 ", globalProperties=" + globalProperties +
                 ", generateAliasAsModel=" + generateAliasAsModel +
+                ", allowInlineSchemas=" + allowInlineSchemas +
                 '}';
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -299,5 +299,9 @@ public interface CodegenConfig {
 
     void setRemoveEnumValuePrefix(boolean removeEnumValuePrefix);
 
+    boolean isAllowInlineSchemas();
+
+    void setAllowInlineSchemas(boolean allowInlineSchemas);
+
     Schema unaliasSchema(Schema schema, Map<String, String> usedImportMappings);
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -385,4 +385,9 @@ public class CodegenConstants {
         "If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.";
     public static final String USE_ONEOF_DISCRIMINATOR_LOOKUP = "useOneOfDiscriminatorLookup";
     public static final String USE_ONEOF_DISCRIMINATOR_LOOKUP_DESC = "Use the discriminator's mapping in oneOf to speed up the model lookup. IMPORTANT: Validation (e.g. one and only one match in oneOf's schemas) will be skipped.";
+
+    public static final String ALLOW_INLINE_SCHEMAS = "allowInlineSchemas";
+    public static final String ALLOW_INLINE_SCHEMAS_DESC =
+        "If false (default), generate a new model for each inline schema, independently of a discriminator's presence in a composed model (containing allOf, anyOf or oneOf). " +
+        "If true, compose the inline schema if there is no discriminator in it else generate a new model and use inheritance";
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -250,6 +250,9 @@ public class DefaultCodegen implements CodegenConfig {
     // See CodegenConstants.java for more details.
     protected boolean disallowAdditionalPropertiesIfNotPresent = true;
 
+    // flag to indicate whether or not a new model is generated for an inline schema without discriminator
+    protected boolean allowInlineSchemas = false;
+
     // make openapi available to all methods
     protected OpenAPI openAPI;
 
@@ -367,6 +370,10 @@ public class DefaultCodegen implements CodegenConfig {
         if (additionalProperties.containsKey(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT)) {
             this.setDisallowAdditionalPropertiesIfNotPresent(Boolean.parseBoolean(additionalProperties
                     .get(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT).toString()));
+        }
+        if (additionalProperties.containsKey(CodegenConstants.ALLOW_INLINE_SCHEMAS)) {
+            this.setAllowInlineSchemas(Boolean.parseBoolean(additionalProperties
+                    .get(CodegenConstants.ALLOW_INLINE_SCHEMAS).toString()));
         }
     }
 
@@ -1229,6 +1236,10 @@ public class DefaultCodegen implements CodegenConfig {
         this.useOneOfInterfaces = useOneOfInterfaces;
     }
 
+    public Boolean getAllowInlineSchemas() { return allowInlineSchemas; }
+
+    public void setAllowInlineSchemas(Boolean allowInlineSchemas) { this.allowInlineSchemas = allowInlineSchemas; }
+
     /**
      * Return the regular expression/JSON schema pattern (http://json-schema.org/latest/json-schema-validation.html#anchor33)
      *
@@ -1537,6 +1548,8 @@ public class DefaultCodegen implements CodegenConfig {
         cliOptions.add(disallowAdditionalPropertiesIfNotPresentOpt);
         this.setDisallowAdditionalPropertiesIfNotPresent(true);
 
+        cliOptions.add(CliOption.newBoolean(CodegenConstants.ALLOW_INLINE_SCHEMAS,
+                CodegenConstants.ALLOW_INLINE_SCHEMAS_DESC).defaultValue(Boolean.TRUE.toString()));
         // initialize special character mapping
         initializeSpecialCharacterMapping();
 
@@ -6505,6 +6518,21 @@ public class DefaultCodegen implements CodegenConfig {
         this.removeEnumValuePrefix = removeEnumValuePrefix;
     }
 
+    /**
+     * Get the boolean value indicating whether to allow inline schemas
+     */
+    @Override
+    public boolean isAllowInlineSchemas() { return this.allowInlineSchemas; }
+
+    /**
+     * Set the boolean value indicating whether to allow inline schemas
+     *
+     * @param allowInlineSchemas true to allow inline schemas
+     */
+    @Override
+    public void setAllowInlineSchemas(boolean allowInlineSchemas) {
+        this.allowInlineSchemas = allowInlineSchemas;
+    }
     //// Following methods are related to the "useOneOfInterfaces" feature
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -859,7 +859,7 @@ public class DefaultGenerator implements Generator {
 
         // resolve inline models
         InlineModelResolver inlineModelResolver = new InlineModelResolver();
-        inlineModelResolver.flatten(openAPI);
+        inlineModelResolver.flatten(openAPI, config);
 
         configureGeneratorProperties();
         configureOpenAPIInfo();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -477,6 +477,11 @@ public class CodegenConfigurator {
         return this;
     }
 
+    public CodegenConfigurator setAllowInlineSchemas(boolean allowInlineSchemas) {
+        workflowSettingsBuilder.withAllowInlineSchemas(allowInlineSchemas);
+        return this;
+    }
+
     @SuppressWarnings("WeakerAccess")
     public Context<?> toContext() {
         Validate.notEmpty(generatorName, "generator name must be specified");
@@ -592,6 +597,7 @@ public class CodegenConfigurator {
         config.setEnablePostProcessFile(workflowSettings.isEnablePostProcessFile());
         config.setEnableMinimalUpdate(workflowSettings.isEnableMinimalUpdate());
         config.setStrictSpecBehavior(workflowSettings.isStrictSpecBehavior());
+        config.setAllowInlineSchemas(workflowSettings.isAllowInlineSchemas());
 
         TemplatingEngineAdapter templatingEngine = TemplatingEngineLoader.byIdentifier(workflowSettings.getTemplatingEngineName());
         config.setTemplatingEngine(templatingEngine);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/BashClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/BashClientOptionsProvider.java
@@ -72,6 +72,7 @@ public class BashClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
 
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/DartClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/DartClientOptionsProvider.java
@@ -64,6 +64,7 @@ public class DartClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .put("serializationLibrary", "custom")
                 .build();
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/DartDioClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/DartDioClientOptionsProvider.java
@@ -68,6 +68,7 @@ public class DartDioClientOptionsProvider implements OptionsProvider {
                 .put(DartDioClientCodegen.NULLABLE_FIELDS, NULLABLE_FIELDS)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/DartDioNextClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/DartDioNextClientOptionsProvider.java
@@ -64,6 +64,7 @@ public class DartDioNextClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/ElixirClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/ElixirClientOptionsProvider.java
@@ -45,6 +45,7 @@ public class ElixirClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/HaskellServantOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/HaskellServantOptionsProvider.java
@@ -50,6 +50,7 @@ public class HaskellServantOptionsProvider implements OptionsProvider {
                 .put(HaskellServantCodegen.PROP_SERVE_STATIC, HaskellServantCodegen.PROP_SERVE_STATIC_DEFAULT.toString())
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpClientOptionsProvider.java
@@ -60,6 +60,7 @@ public class PhpClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpLumenServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpLumenServerOptionsProvider.java
@@ -59,6 +59,7 @@ public class PhpLumenServerOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSilexServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSilexServerOptionsProvider.java
@@ -44,6 +44,7 @@ public class PhpSilexServerOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlim4ServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlim4ServerOptionsProvider.java
@@ -62,6 +62,7 @@ public class PhpSlim4ServerOptionsProvider implements OptionsProvider {
                 .put(PhpSlim4ServerCodegen.PSR7_IMPLEMENTATION, PSR7_IMPLEMENTATION_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlimServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlimServerOptionsProvider.java
@@ -59,6 +59,7 @@ public class PhpSlimServerOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/RubyClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/RubyClientOptionsProvider.java
@@ -68,6 +68,7 @@ public class RubyClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.LIBRARY, LIBRARY)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/ScalaAkkaClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/ScalaAkkaClientOptionsProvider.java
@@ -57,6 +57,7 @@ public class ScalaAkkaClientOptionsProvider implements OptionsProvider {
                 .put("dateLibrary", DATE_LIBRARY)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/ScalaHttpClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/ScalaHttpClientOptionsProvider.java
@@ -54,6 +54,7 @@ public class ScalaHttpClientOptionsProvider implements OptionsProvider {
                 .put("dateLibrary", DATE_LIBRARY)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/Swift4OptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/Swift4OptionsProvider.java
@@ -83,6 +83,7 @@ public class Swift4OptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/Swift5OptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/Swift5OptionsProvider.java
@@ -97,6 +97,7 @@ public class Swift5OptionsProvider implements OptionsProvider {
                 .put(Swift5ClientCodegen.HASHABLE_MODELS, HASHABLE_MODELS_VALUE)
                 .put(Swift5ClientCodegen.MAP_FILE_BINARY_TO_DATA, "false")
                 .put(Swift5ClientCodegen.USE_CLASSES, "false")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAngularClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAngularClientOptionsProvider.java
@@ -91,6 +91,7 @@ public class TypeScriptAngularClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
                 .put(TypeScriptAngularClientCodegen.QUERY_PARAM_OBJECT_FORMAT, QUERY_PARAM_OBJECT_FORMAT_VALUE)
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAngularJsClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAngularJsClientOptionsProvider.java
@@ -57,6 +57,7 @@ public class TypeScriptAngularJsClientOptionsProvider implements OptionsProvider
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAureliaClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptAureliaClientOptionsProvider.java
@@ -63,6 +63,7 @@ public class TypeScriptAureliaClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptFetchClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptFetchClientOptionsProvider.java
@@ -72,6 +72,7 @@ public class TypeScriptFetchClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptNestjsClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptNestjsClientOptionsProvider.java
@@ -84,6 +84,7 @@ public class TypeScriptNestjsClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
                 .put(TypeScriptNestjsClientCodegen.FILE_NAMING, FILE_NAMING_VALUE)
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptNodeClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/TypeScriptNodeClientOptionsProvider.java
@@ -67,6 +67,7 @@ public class TypeScriptNodeClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
+                .put(CodegenConstants.ALLOW_INLINE_SCHEMAS, "false")
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/resources/3_0/issue_3100.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_3100.yaml
@@ -1,0 +1,100 @@
+openapi: 3.0.3
+info:
+  title: Test Allow inline schemas
+  description: Test Allow inline schemas
+  version: 1.0.0
+servers:
+  - url: /
+paths:
+  /customers:
+    get:
+      tags:
+        - Customer
+      summary: Get customers
+      operationId: queryCustomers
+      responses:
+        200:
+          description: Success
+components:
+  schemas:
+    PartyType:
+      type: string
+      description: type
+      enum:
+        - customer
+        - contact
+    CustomerType:
+      type: string
+      description: type
+      enum:
+        - person
+        - organization
+    Entity:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+    Party:
+      allOf:
+        - $ref: '#/components/schemas/Entity'
+        - required:
+            - party_type
+          type: object
+          properties:
+            party_type:
+              $ref: '#/components/schemas/PartyType'
+            tax_id_number:
+              type: string
+          discriminator:
+            propertyName: party_type
+    Contact:
+      type: object
+      required:
+        - should_be_kept
+      properties:
+        should_be_kept:
+          type: string
+      allOf:
+        - $ref: '#/components/schemas/Party'
+        - type: object
+          required:
+            - first_name
+            - last_name
+          properties:
+            first_name:
+              type: string
+            last_name:
+              type: string
+            suffix:
+              type: string
+            dob:
+              type: string
+              format: date
+      x-discriminator-value: contact
+    Customer:
+      allOf:
+        - $ref: '#/components/schemas/Party'
+        - required:
+            - customer_type
+          type: object
+          properties:
+            customer_type:
+              $ref: '#/components/schemas/CustomerType'
+            customer_num:
+              type: string
+            external_customer_num:
+              type: string
+          discriminator:
+            propertyName: customer_type
+      x-discriminator-value: customer
+    Organization:
+      allOf:
+        - $ref: '#/components/schemas/Customer'
+        - required:
+            - organization_name
+          type: object
+          properties:
+            organization_name:
+              type: string
+      x-discriminator-value: organization


### PR DESCRIPTION
fix #3100 fix #5171
# Description
When there is a `ComposedSchema` with inline schemas, the children are flatten. What is does is it's creating a new schema, by taking the parent's name and adding `_allOf`, `_anyOf` or `_oneOf`, or taking the `title` value and appending all the properties defined in the inline schema. Then the inline schema becomes just a reference to the newly created schema which is added to the `imports` of the parent. (example in this [issue](https://github.com/OpenAPITools/openapi-generator/issues/5171))

This is alright when we have a `discriminator` in our inline schema and what we wish for is **inheritance** but when all we want is **composition** it's just creating unused schemas.

A possible quick fix to prevent these unnecessary schemas is to ignore them in the `.openapi-generator-ignore` but it does not remove the schemas from the `allModels` instance meaning that you can have reference to them in your generated files (like some imports or exports, hence possibly breaking the build).

# Solution
The proposed solution is to generate the new models **only** when it's for inheritance and just adding the properties of the inline schema to the parent (overriding the parent's properties when there is a name's conflict) without generating a new model. This solution comes with an opt-in CLI parameter : `--allow-inline-schemas`, to ease the merge of this fix.
```
java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
   -i https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml \
   -g php \
   -o /var/tmp/php_api_client
   --allow-inline-schemas
```