### PR TITLE
[Java] [Native] Remove trailing slashes from the baseUri

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
@@ -294,7 +294,7 @@ public class ApiClient {
    * resolved against.
    */
   public String getBaseUri() {
-    return scheme + "://" + host + (port == -1 ? "" : ":" + port) + basePath;
+    return scheme + "://" + host + (port == -1 ? "" : ":" + port) + basePath.replaceFirst("/+$", "");
   }
 
   /**

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiClient.java
@@ -297,7 +297,7 @@ public class ApiClient {
    * resolved against.
    */
   public String getBaseUri() {
-    return scheme + "://" + host + (port == -1 ? "" : ":" + port) + basePath;
+    return scheme + "://" + host + (port == -1 ? "" : ":" + port) + basePath.replaceFirst("/+$", "");
   }
 
   /**

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -297,7 +297,7 @@ public class ApiClient {
    * resolved against.
    */
   public String getBaseUri() {
-    return scheme + "://" + host + (port == -1 ? "" : ":" + port) + basePath;
+    return scheme + "://" + host + (port == -1 ? "" : ":" + port) + basePath.replaceFirst("/+$", "");
   }
 
   /**

--- a/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -297,7 +297,7 @@ public class ApiClient {
    * resolved against.
    */
   public String getBaseUri() {
-    return scheme + "://" + host + (port == -1 ? "" : ":" + port) + basePath;
+    return scheme + "://" + host + (port == -1 ? "" : ":" + port) + basePath.replaceFirst("/+$", "");
   }
 
   /**


### PR DESCRIPTION
Otherwise, you can end up with double slashes, e.g. https://example.com//path. Some severs are actually ok with that, but you can't rely on it.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @nmuesch (2021/01)