### PR TITLE
[Ruby] [Faraday] Adds 'params_encoder' config option for clients

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -10,9 +10,10 @@
         :client_cert => @config.ssl_client_cert,
         :client_key => @config.ssl_client_key
       }
-
-      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options) do |conn|
-        conn.proxy = config.proxy if config.proxy
+      request_options = {
+        :params_encoder => @config.params_encoder
+      }
+      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options, :request => request_options) do |conn|
         conn.request(:basic_auth, config.username, config.password)
         @config.configure_middleware(conn)
         if opts[:header_params]["Content-Type"] == "multipart/form-data"
@@ -84,7 +85,7 @@
       request.body = req_body
 
       # Overload default options only if provided
-      request.options.params_encoding = @config.params_encoding if @config.params_encoding
+      request.options.params_encoder = @config.params_encoder if @config.params_encoder
       request.options.timeout         = @config.timeout         if @config.timeout
       request.options.verbose         = @config.debugging       if @config.debugging
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -84,17 +84,11 @@ module {{moduleName}}
     attr_accessor :client_side_validation
 
 {{^isFaraday}}
-{{> configuration_tls_typhoeus_partial}}
+{{> configuration_typhoeus_partial}}
 {{/isFaraday}}
 {{#isFaraday}}
-{{> configuration_tls_faraday_partial}}
+{{> configuration_faraday_partial}}
 {{/isFaraday}}
-    # Set this to customize parameters encoding of array parameter with multi collectionFormat.
-    # Default to nil.
-    #
-    # @see The params_encoding option of Ethon. Related source code:
-    # https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L96
-    attr_accessor :params_encoding
 
     attr_accessor :inject_format
 
@@ -123,14 +117,15 @@ module {{moduleName}}
       @timeout = 60
       # return data as binary instead of file
       @return_binary_data = false
+      @params_encoder = nil
       {{/isFaraday}}
       {{^isFaraday}}
       @verify_ssl = true
       @verify_ssl_host = true
-      @params_encoding = nil
       @cert_file = nil
       @key_file = nil
       @timeout = 0
+      @params_encoding = nil
       {{/isFaraday}}
       @debugging = false
       @inject_format = false

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration_faraday_partial.mustache
@@ -31,3 +31,10 @@
     ### Proxy setting
     # HTTP Proxy settings
     attr_accessor :proxy
+
+    # Set this to customize parameters encoder of array parameter.
+    # Default to nil. Faraday uses NestedParamsEncoder when nil.
+    #
+    # @see The params_encoder option of Faraday. Related source code:
+    # https://github.com/lostisland/faraday/tree/main/lib/faraday/encoders
+    attr_accessor :params_encoder

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration_typhoeus_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration_typhoeus_partial.mustache
@@ -32,3 +32,10 @@
     ### TLS/SSL setting
     # Client private key file (for client certificate)
     attr_accessor :key_file
+
+    # Set this to customize parameters encoding of array parameter with multi collectionFormat.
+    # Default to nil.
+    #
+    # @see The params_encoding option of Ethon. Related source code:
+    # https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L96
+    attr_accessor :params_encoding

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -54,9 +54,10 @@ module Petstore
         :client_cert => @config.ssl_client_cert,
         :client_key => @config.ssl_client_key
       }
-
-      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options) do |conn|
-        conn.proxy = config.proxy if config.proxy
+      request_options = {
+        :params_encoder => @config.params_encoder
+      }
+      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options, :request => request_options) do |conn|
         conn.request(:basic_auth, config.username, config.password)
         @config.configure_middleware(conn)
         if opts[:header_params]["Content-Type"] == "multipart/form-data"
@@ -128,7 +129,7 @@ module Petstore
       request.body = req_body
 
       # Overload default options only if provided
-      request.options.params_encoding = @config.params_encoding if @config.params_encoding
+      request.options.params_encoder = @config.params_encoder if @config.params_encoder
       request.options.timeout         = @config.timeout         if @config.timeout
       request.options.verbose         = @config.debugging       if @config.debugging
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -125,12 +125,13 @@ module Petstore
     # HTTP Proxy settings
     attr_accessor :proxy
 
-    # Set this to customize parameters encoding of array parameter with multi collectionFormat.
-    # Default to nil.
+    # Set this to customize parameters encoder of array parameter.
+    # Default to nil. Faraday uses NestedParamsEncoder when nil.
     #
-    # @see The params_encoding option of Ethon. Related source code:
-    # https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L96
-    attr_accessor :params_encoding
+    # @see The params_encoder option of Faraday. Related source code:
+    # https://github.com/lostisland/faraday/tree/main/lib/faraday/encoders
+    attr_accessor :params_encoder
+
 
     attr_accessor :inject_format
 
@@ -158,6 +159,7 @@ module Petstore
       @timeout = 60
       # return data as binary instead of file
       @return_binary_data = false
+      @params_encoder = nil
       @debugging = false
       @inject_format = false
       @force_ending_format = false

--- a/samples/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby/lib/petstore/configuration.rb
@@ -133,6 +133,7 @@ module Petstore
     # https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L96
     attr_accessor :params_encoding
 
+
     attr_accessor :inject_format
 
     attr_accessor :force_ending_format
@@ -150,10 +151,10 @@ module Petstore
       @client_side_validation = true
       @verify_ssl = true
       @verify_ssl_host = true
-      @params_encoding = nil
       @cert_file = nil
       @key_file = nil
       @timeout = 0
+      @params_encoding = nil
       @debugging = false
       @inject_format = false
       @force_ending_format = false

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/configuration.rb
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/lib/x_auth_id_alias/configuration.rb
@@ -133,6 +133,7 @@ module XAuthIDAlias
     # https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L96
     attr_accessor :params_encoding
 
+
     attr_accessor :inject_format
 
     attr_accessor :force_ending_format
@@ -150,10 +151,10 @@ module XAuthIDAlias
       @client_side_validation = true
       @verify_ssl = true
       @verify_ssl_host = true
-      @params_encoding = nil
       @cert_file = nil
       @key_file = nil
       @timeout = 0
+      @params_encoding = nil
       @debugging = false
       @inject_format = false
       @force_ending_format = false

--- a/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/configuration.rb
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/lib/dynamic_servers/configuration.rb
@@ -133,6 +133,7 @@ module DynamicServers
     # https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L96
     attr_accessor :params_encoding
 
+
     attr_accessor :inject_format
 
     attr_accessor :force_ending_format
@@ -150,10 +151,10 @@ module DynamicServers
       @client_side_validation = true
       @verify_ssl = true
       @verify_ssl_host = true
-      @params_encoding = nil
       @cert_file = nil
       @key_file = nil
       @timeout = 0
+      @params_encoding = nil
       @debugging = false
       @inject_format = false
       @force_ending_format = false

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/configuration.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/configuration.rb
@@ -133,6 +133,7 @@ module Petstore
     # https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L96
     attr_accessor :params_encoding
 
+
     attr_accessor :inject_format
 
     attr_accessor :force_ending_format
@@ -150,10 +151,10 @@ module Petstore
       @client_side_validation = true
       @verify_ssl = true
       @verify_ssl_host = true
-      @params_encoding = nil
       @cert_file = nil
       @key_file = nil
       @timeout = 0
+      @params_encoding = nil
       @debugging = false
       @inject_format = false
       @force_ending_format = false


### PR DESCRIPTION
The partial templates were renamed because they no longer hold tls
settings exclusively.

fixes: #9838