### PR TITLE
[cleanup] erefactor/AutoRefactor - Log parameters rather than log message

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -396,14 +396,15 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
         // model name cannot use reserved keyword, e.g. return
         if (isReservedWord(camelizedName)) {
             camelizedName = "Model" + camelizedName;
-            LOGGER.warn(camelizedName + " (reserved word) cannot be used as model name. Renamed to " + camelizedName);
+            LOGGER.warn("{} (reserved word) cannot be used as model name. Renamed to {}", camelizedName, camelizedName);
         }
 
         // model name starts with number
         else if (camelizedName.matches("^\\d.*")) {
             // e.g. 200Response => Model200Response (after camelize)
             camelizedName = "Model" + camelizedName;
-            LOGGER.warn(name + " (model name starts with number) cannot be used as model name. Renamed to " + camelizedName);
+            LOGGER.warn("{} (model name starts with number) cannot be used as model name. Renamed to {}", name,
+                    camelizedName);
         }
 
         return camelizedName;
@@ -435,10 +436,11 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
     public String toOperationId(String operationId) {
         // method name cannot use reserved keyword, e.g. return
         if (isReservedWord(operationId)) {
-            LOGGER.warn(operationId + " (reserved word) cannot be used as method name. Renamed to " + camelize("call_" + operationId));
+            LOGGER.warn("{} (reserved word) cannot be used as method name. Renamed to {}", operationId, camelize("call_" + operationId));
             operationId = "call_" + operationId;
         } else if (operationId.matches("\\d.*")) {
-            LOGGER.warn(operationId + " cannot be used as method name because it starts with a digit. Renamed to " + camelize("call_" + operationId));
+            LOGGER.warn("{} cannot be used as method name because it starts with a digit. Renamed to {}", operationId,
+                    camelize("call_" + operationId));
             operationId = "call_" + operationId;
         }
 
@@ -459,7 +461,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
 
         // model name cannot use reserved keyword, e.g. return
         if (isReservedWord(name)) {
-            LOGGER.warn(name + " (reserved word) cannot be used as model name. Renamed to " + camelize("model_" + name));
+            LOGGER.warn("{} (reserved word) cannot be used as model name. Renamed to {}", name, camelize("model_" + name));
             name = "model_" + name; // e.g. return => ModelReturn (after camelize)
         }
 
@@ -1098,7 +1100,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
             co, Map<String, List<CodegenOperation>> operations) {
         // only generate operation for the first tag of the tags
         if (tag != null && co.tags.size() > 1 && !tag.equals(co.tags.get(0).getName())) {
-            LOGGER.info("generated skip additional tag `" + tag + "` with operationId=" + co.operationId);
+            LOGGER.info("generated skip additional tag `{}` with operationId={}", tag, co.operationId);
             return;
         }
         super.addOperationToGroup(tag, resourcePath, operation, co, operations);
@@ -1163,7 +1165,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
                     datatype = "models::" + datatype;
                 }
             } catch (Exception e) {
-                LOGGER.warn("Error obtaining the datatype from schema (model):" + p + ". Datatype default to Object");
+                LOGGER.warn("Error obtaining the datatype from schema (model):{}. Datatype default to Object", p);
                 datatype = "Object";
                 LOGGER.error(e.getMessage(), e);
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaHttpServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaHttpServerCodegen.java
@@ -245,7 +245,7 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
                 }
 
             } catch (NumberFormatException e) {
-                LOGGER.warn("Unable to parse " + AKKA_HTTP_VERSION + ": " + akkaHttpVersion + ", fallback to " + DEFAULT_AKKA_HTTP_VERSION);
+                LOGGER.warn("Unable to parse {}: {}, fallback to {}", AKKA_HTTP_VERSION, akkaHttpVersion, DEFAULT_AKKA_HTTP_VERSION);
                 akkaHttpVersion = DEFAULT_AKKA_HTTP_VERSION;
                 is10_1_10AndAbove = true;
             }
@@ -318,10 +318,9 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
                     if (pathParam.baseName.equals(parameterName)) {
                         String matcher = pathTypeToMatcher.get(pathParam.dataType);
                         if (matcher == null) {
-                            LOGGER.warn("The path parameter " + pathParam.baseName +
-                                    " with the datatype " + pathParam.dataType +
-                                    " could not be translated to a corresponding path matcher of akka http" +
-                                    " and therefore has been translated to string.");
+                            LOGGER.warn(
+                                    "The path parameter {} with the datatype {} could not be translated to a corresponding path matcher of akka http and therefore has been translated to string.",
+                                    pathParam.baseName, pathParam.dataType);
                             matcher = pathTypeToMatcher.get("String");
                         }
                         if (pathParam.pattern != null && !pathParam.pattern.isEmpty()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaPlayFrameworkServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaPlayFrameworkServerCodegen.java
@@ -317,7 +317,7 @@ public class ScalaPlayFrameworkServerCodegen extends AbstractScalaCodegen implem
         }
 
         if (null == openAPIType) {
-            LOGGER.error("No Type defined for Schema " + p);
+            LOGGER.error("No Type defined for Schema {}", p);
         }
         return toModelName(openAPIType);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -229,7 +229,7 @@ public class SpringCodegen extends AbstractJavaCodegen
             // set invokerPackage as basePackage:
             this.setBasePackage((String) additionalProperties.get(CodegenConstants.INVOKER_PACKAGE));
             additionalProperties.put(BASE_PACKAGE, basePackage);
-            LOGGER.info("Set base package to invoker package (" + basePackage + ")");
+            LOGGER.info("Set base package to invoker package ({})", basePackage);
         }
 
         super.processOpts();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/StaticHtml2Generator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/StaticHtml2Generator.java
@@ -229,7 +229,7 @@ public class StaticHtml2Generator extends DefaultCodegen implements CodegenConfi
             Markdown markInstance = new Markdown();
             openAPI.getInfo().setDescription(markInstance.toHtml(currentDescription));
         } else {
-            LOGGER.error("OpenAPI object description is empty [" + openAPI.getInfo().getTitle() + "]");
+            LOGGER.error("OpenAPI object description is empty [{}]", openAPI.getInfo().getTitle());
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift4Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift4Codegen.java
@@ -568,8 +568,7 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
         // model name cannot use reserved keyword, e.g. return
         if (isReservedWord(name)) {
             String modelName = "Model" + name;
-            LOGGER.warn(name + " (reserved word) cannot be used as model name. Renamed to "
-                    + modelName);
+            LOGGER.warn("{} (reserved word) cannot be used as model name. Renamed to {}", name, modelName);
             return modelName;
         }
 
@@ -577,9 +576,8 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
         if (name.matches("^\\d.*")) {
             // e.g. 200Response => Model200Response (after camelize)
             String modelName = "Model" + name;
-            LOGGER.warn(name
-                    + " (model name starts with number) cannot be used as model name."
-                    + " Renamed to " + modelName);
+            LOGGER.warn("{} (model name starts with number) cannot be used as model name. Renamed to {}", name,
+                    modelName);
             return modelName;
         }
 
@@ -674,14 +672,13 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
         // method name cannot use reserved keyword, e.g. return
         if (isReservedWord(operationId)) {
             String newOperationId = camelize(("call_" + operationId), true);
-            LOGGER.warn(operationId + " (reserved word) cannot be used as method name."
-                    + " Renamed to " + newOperationId);
+            LOGGER.warn("{} (reserved word) cannot be used as method name. Renamed to {}", operationId, newOperationId);
             return newOperationId;
         }
 
         // operationId starts with a number
         if (operationId.matches("^\\d.*")) {
-            LOGGER.warn(operationId + " (starting with a number) cannot be used as method name. Renamed to " + camelize(sanitizeName("call_" + operationId), true));
+            LOGGER.warn("{} (starting with a number) cannot be used as method name. Renamed to {}", operationId, camelize(sanitizeName("call_" + operationId), true));
             operationId = camelize(sanitizeName("call_" + operationId), true);
         }
 
@@ -973,7 +970,7 @@ public class Swift4Codegen extends DefaultCodegen implements CodegenConfig {
                 if (exitValue != 0) {
                     LOGGER.error("Error running the command ({}). Exit value: {}", command, exitValue);
                 } else {
-                    LOGGER.info("Successfully executed: " + command);
+                    LOGGER.info("Successfully executed: {}", command);
                 }
             } catch (InterruptedException | IOException e) {
                 LOGGER.error("Error running the command ({}). Exception: {}", command, e.getMessage());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/Swift5ClientCodegen.java
@@ -674,8 +674,7 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
         // model name cannot use reserved keyword, e.g. return
         if (isReservedWord(name)) {
             String modelName = "Model" + name;
-            LOGGER.warn(name + " (reserved word) cannot be used as model name. Renamed to "
-                    + modelName);
+            LOGGER.warn("{} (reserved word) cannot be used as model name. Renamed to {}", name, modelName);
             return modelName;
         }
 
@@ -683,9 +682,8 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
         if (name.matches("^\\d.*")) {
             // e.g. 200Response => Model200Response (after camelize)
             String modelName = "Model" + name;
-            LOGGER.warn(name
-                    + " (model name starts with number) cannot be used as model name."
-                    + " Renamed to " + modelName);
+            LOGGER.warn("{} (model name starts with number) cannot be used as model name. Renamed to {}", name,
+                    modelName);
             return modelName;
         }
 
@@ -785,14 +783,13 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
         // method name cannot use reserved keyword, e.g. return
         if (isReservedWord(operationId)) {
             String newOperationId = camelize(("call_" + operationId), true);
-            LOGGER.warn(operationId + " (reserved word) cannot be used as method name."
-                    + " Renamed to " + newOperationId);
+            LOGGER.warn("{} (reserved word) cannot be used as method name. Renamed to {}", operationId, newOperationId);
             return newOperationId;
         }
 
         // operationId starts with a number
         if (operationId.matches("^\\d.*")) {
-            LOGGER.warn(operationId + " (starting with a number) cannot be used as method name. Renamed to " + camelize(sanitizeName("call_" + operationId), true));
+            LOGGER.warn("{} (starting with a number) cannot be used as method name. Renamed to {}", operationId, camelize(sanitizeName("call_" + operationId), true));
             operationId = camelize(sanitizeName("call_" + operationId), true);
         }
 
@@ -1107,7 +1104,7 @@ public class Swift5ClientCodegen extends DefaultCodegen implements CodegenConfig
                 if (exitValue != 0) {
                     LOGGER.error("Error running the command ({}). Exit value: {}", command, exitValue);
                 } else {
-                    LOGGER.info("Successfully executed: " + command);
+                    LOGGER.info("Successfully executed: {}", command);
                 }
             } catch (InterruptedException | IOException e) {
                 LOGGER.error("Error running the command ({}). Exception: {}", command, e.getMessage());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -410,20 +410,22 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
         // this is unlikely to happen, because we have just camelized the name, while reserved words are usually all lowcase
         if (isReservedWord(sanName)) {
             String modelName = safePrefix + sanName;
-            LOGGER.warn(sanName + " (reserved word) cannot be used as model name. Renamed to " + modelName);
+            LOGGER.warn("{} (reserved word) cannot be used as model name. Renamed to {}", sanName, modelName);
             return modelName;
         }
 
         // model name starts with number
         if (sanName.matches("^\\d.*")) {
             String modelName = safePrefix + sanName; // e.g. 200Response => Model200Response
-            LOGGER.warn(sanName + " (model name starts with number) cannot be used as model name. Renamed to " + modelName);
+            LOGGER.warn("{} (model name starts with number) cannot be used as model name. Renamed to {}", sanName,
+                    modelName);
             return modelName;
         }
 
         if (languageSpecificPrimitives.contains(sanName)) {
             String modelName = safePrefix + sanName;
-            LOGGER.warn(sanName + " (model name matches existing language type) cannot be used as a model name. Renamed to " + modelName);
+            LOGGER.warn("{} (model name matches existing language type) cannot be used as a model name. Renamed to {}",
+                    sanName, modelName);
             return modelName;
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
@@ -271,7 +271,7 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
 
                 if(this.reservedParamNames.contains(p.paramName)){
                     paramNameAlternative = p.paramName + "Alias";
-                    LOGGER.info("param: "+p.paramName+" isReserved ––> "+paramNameAlternative);
+                    LOGGER.info("param: {} isReserved ––> {}", p.paramName, paramNameAlternative);
                 }
                 setParamNameAlternative(p, p.paramName, paramNameAlternative);
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/JsonCacheImpl.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/JsonCacheImpl.java
@@ -1602,23 +1602,23 @@ class JsonCacheImpl implements JsonCache.Root {
                                 destObject.set(fieldName, srcChild);
                                 // Mark the cache as dirty as we've added items from another file.
                                 isDirty = true;
-                                LOGGER.info("Existing root property '" + fieldName
-                                        + "' has been overwritten by incoming data");
+                                LOGGER.info("Existing root property '{}' has been overwritten by incoming data",
+                                        fieldName);
                                 break;
                             case MERGE_RECURSIVE:
                                 if (destChild.isContainerNode() && srcChild.isContainerNode())
                                     merge((ContainerNode<?>) destChild, (ContainerNode<?>) srcChild);
                                 break;
                             case KEEP_EXISTING:
-                                LOGGER.info("Existing root property '" + fieldName
-                                        + "' will not be overwritten by incoming data");
+                                LOGGER.info("Existing root property '{}' will not be overwritten by incoming data",
+                                        fieldName);
                             default:
                                 // Nothing to do.
                                 break;
                         }
                     } else {
                         destObject.set(fieldName, srcChild);
-                        LOGGER.info("New property '" + fieldName + "' has been added from incoming data");
+                        LOGGER.info("New property '{}' has been added from incoming data", fieldName);
                         // Mark the cache as dirty as we've added items from another file.
                         isDirty = true;
                     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocGeneratorTest.java
@@ -85,7 +85,7 @@ public class AsciidocGeneratorTest {
     public void testAdditionalDirectoriesGeneratedIntoHeaderAttributes() throws Exception {
         File output = Files.createTempDirectory("test").toFile();
 
-        LOGGER.info("test: generating sample markup " + output.getAbsolutePath());
+        LOGGER.info("test: generating sample markup {}", output.getAbsolutePath());
 
         Map<String, Object> props = new TreeMap<String, Object>();
         props.put("specDir", "spec");
@@ -117,7 +117,7 @@ public class AsciidocGeneratorTest {
     public void testHeaderAttributesFlagRemovesAttributesFromMarkupHeaderSection() throws Exception {
         File output = Files.createTempDirectory("test").toFile();
 
-        LOGGER.info("test: generating sample markup " + output.getAbsolutePath());
+        LOGGER.info("test: generating sample markup {}", output.getAbsolutePath());
 
         Map<String, Object> props = new TreeMap<String, Object>();
         props.put("specDir", "spec");


### PR DESCRIPTION
@OpenAPITools/generator-core-team

Please note that the changes are technically as correct as the code was before but that
for example the log message in RustServerCodegen.java and other files is (and was)
printing wrong or incomplete information.
I don't have the time to fix this but the PR may be useful nevertheless.
Please note that this is the last PR that addresses LogParametersRatherThanLogMessage.
All log calls erefactor found are done with this PR.

I saw that a lot of test asserttions have wrong argument order. I plan to provide PRs for
that when I find some time.

Best regards,
   Cal


AutoRefactor cleanup 'LogParametersRatherThanLogMessage' applied by erefactor:

Replaces a string concatenation as parameter of a logger method by a
string template followed by objects.

For AutoRefactor see https://github.com/JnRouvignac/AutoRefactor
For erefactor see https://github.com/cal101/erefactor

Dear Project Team!

This pull request is provided in the hope that it will be useful.

Changes are manually reviewed after they passed the test suite of
your project. Only successful reviews become project PRs.
Errors found are reported upstream to support the cleanup providers.

But please do a careful review of your own as usual because tools
have bugs and bugs in the changes may have been overlooked.

For scalability and out of fun and laziness, the creation of commits
and PRs and parts of the change handling are automated.

If you are not interested or want to discuss issues just comment the
PR as usual.

Have fun,
Cal