### PR TITLE
[cleanup] erefactor/EclipseJdt - Add missing @Override annotation - include interface implementations

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -678,10 +678,12 @@ public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperti
         this.maxProperties = maxProperties;
     }
 
+    @Override
     public Number getMultipleOf() {
         return multipleOf;
     }
 
+    @Override
     public void setMultipleOf(Number multipleOf) {
         this.multipleOf = multipleOf;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -256,10 +256,12 @@ public class DefaultCodegen implements CodegenConfig {
     // A cache to efficiently lookup a Schema instance based on the return value of `toModelName()`.
     private Map<String, Schema> modelNameToSchemaCache;
 
+    @Override
     public List<CliOption> cliOptions() {
         return cliOptions;
     }
 
+    @Override
     public void processOpts() {
         if (additionalProperties.containsKey(CodegenConstants.TEMPLATE_DIR)) {
             this.setTemplateDir((String) additionalProperties.get(CodegenConstants.TEMPLATE_DIR));
@@ -410,6 +412,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     // override with any special post-processing for all models
+    @Override
     @SuppressWarnings({"static-method", "unchecked"})
     public Map<String, Object> postProcessAllModels(Map<String, Object> objs) {
         if (this.useOneOfInterfaces) {
@@ -512,6 +515,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param objs Map of models
      * @return maps of models with various updates
      */
+    @Override
     public Map<String, Object> updateAllModels(Map<String, Object> objs) {
         Map<String, CodegenModel> allModels = getAllModels(objs);
 
@@ -624,6 +628,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     // override with any special post-processing
+    @Override
     @SuppressWarnings("static-method")
     public Map<String, Object> postProcessModels(Map<String, Object> objs) {
         return objs;
@@ -768,6 +773,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     // override with any message to be shown right before the process finishes
+    @Override
     @SuppressWarnings("static-method")
     public void postProcess() {
         System.out.println("################################################################################");
@@ -778,28 +784,33 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     // override with any special post-processing
+    @Override
     @SuppressWarnings("static-method")
     public Map<String, Object> postProcessOperationsWithModels(Map<String, Object> objs, List<Object> allModels) {
         return objs;
     }
 
     // override with any special post-processing
+    @Override
     @SuppressWarnings("static-method")
     public Map<String, Object> postProcessSupportingFileData(Map<String, Object> objs) {
         return objs;
     }
 
     // override to post-process any model properties
+    @Override
     @SuppressWarnings("unused")
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
     }
 
     // override to post-process any parameters
+    @Override
     @SuppressWarnings("unused")
     public void postProcessParameter(CodegenParameter parameter) {
     }
 
     //override with any special handling of the entire OpenAPI spec document
+    @Override
     @SuppressWarnings("unused")
     public void preprocessOpenAPI(OpenAPI openAPI) {
         if (useOneOfInterfaces) {
@@ -884,23 +895,27 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     // override with any special handling of the entire OpenAPI spec document
+    @Override
     @SuppressWarnings("unused")
     public void processOpenAPI(OpenAPI openAPI) {
     }
 
     // override with any special handling of the JMustache compiler
+    @Override
     @SuppressWarnings("unused")
     public Compiler processCompiler(Compiler compiler) {
         return compiler;
     }
 
     // override with any special handling for the templating engine
+    @Override
     @SuppressWarnings("unused")
     public TemplatingEngineAdapter processTemplatingEngine(TemplatingEngineAdapter templatingEngine) {
         return templatingEngine;
     }
 
     // override with any special text escaping logic
+    @Override
     @SuppressWarnings("static-method")
     public String escapeText(String input) {
         if (input == null) {
@@ -927,6 +942,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param input String to be escaped
      * @return escaped string
      */
+    @Override
     public String escapeTextWhileAllowingNewLines(String input) {
         if (input == null) {
             return input;
@@ -947,6 +963,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     // override with any special encoding and escaping logic
+    @Override
     @SuppressWarnings("static-method")
     public String encodePath(String input) {
         return escapeText(input);
@@ -959,6 +976,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param input String to be cleaned up
      * @return string with unsafe characters removed or escaped
      */
+    @Override
     public String escapeUnsafeCharacters(String input) {
         LOGGER.warn("escapeUnsafeCharacters should be overridden in the code generator with proper logic to escape " +
                 "unsafe characters");
@@ -975,56 +993,69 @@ public class DefaultCodegen implements CodegenConfig {
      * @param input String to be cleaned up
      * @return string with quotation mark removed or escaped
      */
+    @Override
     public String escapeQuotationMark(String input) {
         LOGGER.warn("escapeQuotationMark should be overridden in the code generator with proper logic to escape " +
                 "single/double quote");
         return input.replace("\"", "\\\"");
     }
 
+    @Override
     public Set<String> defaultIncludes() {
         return defaultIncludes;
     }
 
+    @Override
     public Map<String, String> typeMapping() {
         return typeMapping;
     }
 
+    @Override
     public Map<String, String> instantiationTypes() {
         return instantiationTypes;
     }
 
+    @Override
     public Set<String> reservedWords() {
         return reservedWords;
     }
 
+    @Override
     public Set<String> languageSpecificPrimitives() {
         return languageSpecificPrimitives;
     }
 
+    @Override
     public Map<String, String> importMapping() {
         return importMapping;
     }
 
+    @Override
     public String testPackage() {
         return testPackage;
     }
 
+    @Override
     public String modelPackage() {
         return modelPackage;
     }
 
+    @Override
     public String apiPackage() {
         return apiPackage;
     }
 
+    @Override
     public String fileSuffix() {
         return fileSuffix;
     }
 
+    @Override
     public String templateDir() {
         return templateDir;
     }
 
+    @Override
     public String embeddedTemplateDir() {
         if (embeddedTemplateDir != null) {
             return embeddedTemplateDir;
@@ -1033,90 +1064,112 @@ public class DefaultCodegen implements CodegenConfig {
         }
     }
 
+    @Override
     public Map<String, String> apiDocTemplateFiles() {
         return apiDocTemplateFiles;
     }
 
+    @Override
     public Map<String, String> modelDocTemplateFiles() {
         return modelDocTemplateFiles;
     }
 
+    @Override
     public Map<String, String> reservedWordsMappings() {
         return reservedWordsMappings;
     }
 
+    @Override
     public Map<String, String> apiTestTemplateFiles() {
         return apiTestTemplateFiles;
     }
 
+    @Override
     public Map<String, String> modelTestTemplateFiles() {
         return modelTestTemplateFiles;
     }
 
+    @Override
     public Map<String, String> apiTemplateFiles() {
         return apiTemplateFiles;
     }
 
+    @Override
     public Map<String, String> modelTemplateFiles() {
         return modelTemplateFiles;
     }
 
+    @Override
     public String apiFileFolder() {
         return outputFolder + File.separator + apiPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + File.separator + modelPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String apiTestFileFolder() {
         return outputFolder + File.separator + testPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String modelTestFileFolder() {
         return outputFolder + File.separator + testPackage().replace('.', File.separatorChar);
     }
 
+    @Override
     public String apiDocFileFolder() {
         return outputFolder;
     }
 
+    @Override
     public String modelDocFileFolder() {
         return outputFolder;
     }
 
+    @Override
     public Map<String, Object> additionalProperties() {
         return additionalProperties;
     }
 
+    @Override
     public Map<String, String> serverVariableOverrides() {
         return serverVariables;
     }
 
+    @Override
     public Map<String, Object> vendorExtensions() {
         return vendorExtensions;
     }
 
+    @Override
     public List<SupportingFile> supportingFiles() {
         return supportingFiles;
     }
 
+    @Override
     public String outputFolder() {
         return outputFolder;
     }
 
+    @Override
     public void setOutputDir(String dir) {
         this.outputFolder = dir;
     }
 
+    @Override
     public String getOutputDir() {
         return outputFolder();
     }
 
+    @Override
     public String getInputSpec() {
         return inputSpec;
     }
 
+    @Override
     public void setInputSpec(String inputSpec) {
         this.inputSpec = inputSpec;
     }
@@ -1245,6 +1298,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the file name of the Api
      * @return the file name of the Api
      */
+    @Override
     public String toApiFilename(String name) {
         return toApiName(name);
     }
@@ -1255,6 +1309,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the file name of the Api
      * @return the file name of the Api
      */
+    @Override
     public String toApiDocFilename(String name) {
         return toApiName(name);
     }
@@ -1265,6 +1320,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the file name of the Api
      * @return the file name of the Api
      */
+    @Override
     public String toApiTestFilename(String name) {
         return toApiName(name) + "Test";
     }
@@ -1275,6 +1331,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the varible name of the Api
      * @return the snake-cased variable name
      */
+    @Override
     public String toApiVarName(String name) {
         return lowerCamelCase(name);
     }
@@ -1285,6 +1342,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the model name
      * @return the file name of the model
      */
+    @Override
     public String toModelFilename(String name) {
         return camelize(name);
     }
@@ -1295,6 +1353,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the model name
      * @return the file name of the model
      */
+    @Override
     public String toModelTestFilename(String name) {
         return camelize(name) + "Test";
     }
@@ -1305,6 +1364,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the model name
      * @return the file name of the model
      */
+    @Override
     public String toModelDocFilename(String name) {
         return camelize(name);
     }
@@ -1358,6 +1418,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name Codegen property object
      * @return the sanitized parameter name
      */
+    @Override
     public String toParamName(String name) {
         name = removeNonNameElementToCamelCase(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
         if (reservedWords.contains(name)) {
@@ -1398,6 +1459,7 @@ public class DefaultCodegen implements CodegenConfig {
      * <p>
      * throws Runtime exception as reserved word is not allowed (default behavior)
      */
+    @Override
     @SuppressWarnings("static-method")
     public String escapeReservedWord(String name) {
         throw new RuntimeException("reserved word " + name + " not allowed");
@@ -1409,6 +1471,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the name of the "Model"
      * @return the fully-qualified "Model" name for import
      */
+    @Override
     public String toModelImport(String name) {
         if ("".equals(modelPackage())) {
             return name;
@@ -1423,6 +1486,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the name of the "Model"
      * @return Map of fully-qualified models.
      */
+    @Override
     public Map<String,String> toModelImportMap(String name){
         return Collections.singletonMap(this.toModelImport(name),name);
     }
@@ -1433,6 +1497,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the name of the "Api"
      * @return the fully-qualified "Api" name for import
      */
+    @Override
     public String toApiImport(String name) {
         return apiPackage() + "." + name;
     }
@@ -1604,6 +1669,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param operation OAS operation object
      * @return string presentation of the example path
      */
+    @Override
     @SuppressWarnings("static-method")
     public String generateExamplePath(String path, Operation operation) {
         StringBuilder sb = new StringBuilder();
@@ -2012,6 +2078,7 @@ public class DefaultCodegen implements CodegenConfig {
         return "oneOf<" + String.join(",", names) + ">";
     }
 
+    @Override
     public Schema unaliasSchema(Schema schema, Map<String, String> usedImportMappings) {
         return ModelUtils.unaliasSchema(this.openAPI, schema, usedImportMappings);
     }
@@ -2154,6 +2221,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name name
      * @return a string presentation of the type
      */
+    @Override
     @SuppressWarnings("static-method")
     public String getTypeDeclaration(String name) {
         return name;
@@ -2165,6 +2233,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param schema property schema
      * @return a string presentation of the property type
      */
+    @Override
     public String getTypeDeclaration(Schema schema) {
         if (schema == null) {
             LOGGER.warn("Null schema found. Default type to `NULL_SCHEMA_ERR`");
@@ -2201,6 +2270,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the name of the property
      * @return getter name based on naming convention
      */
+    @Override
     public String toBooleanGetter(String name) {
         return "get" + getterAndSetterCapitalize(name);
     }
@@ -2211,6 +2281,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the name of the property
      * @return getter name based on naming convention
      */
+    @Override
     public String toGetter(String name) {
         return "get" + getterAndSetterCapitalize(name);
     }
@@ -2221,6 +2292,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the name of the property
      * @return setter name based on naming convention
      */
+    @Override
     public String toSetter(String name) {
         return "set" + getterAndSetterCapitalize(name);
     }
@@ -2232,6 +2304,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the name of the Api
      * @return capitalized Api name
      */
+    @Override
     public String toApiName(String name) {
         if (name.length() == 0) {
             return "DefaultApi";
@@ -2247,6 +2320,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name the name of the model
      * @return capitalized model name
      */
+    @Override
     public String toModelName(final String name) {
         return camelize(modelNamePrefix + "_" + name + "_" + modelNameSuffix);
     }
@@ -2283,6 +2357,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param schema OAS Model object
      * @return Codegen Model object
      */
+    @Override
     public CodegenModel fromModel(String name, Schema schema) {
         Map<String, Schema> allDefinitions = ModelUtils.getSchemas(this.openAPI);
         if (typeAliases == null) {
@@ -3713,6 +3788,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param servers    list of servers
      * @return Codegen Operation object
      */
+    @Override
     public CodegenOperation fromOperation(String path,
                                           String httpMethod,
                                           Operation operation,
@@ -4528,6 +4604,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param securitySchemeMap a map of OAS SecuritySchemeDefinition object
      * @return a list of Codegen Security objects
      */
+    @Override
     @SuppressWarnings("static-method")
     public List<CodegenSecurity> fromSecurity(Map<String, SecurityScheme> securitySchemeMap) {
         if (securitySchemeMap == null) {
@@ -4749,6 +4826,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param co           Codegen Operation object
      * @param operations   map of Codegen operations
      */
+    @Override
     @SuppressWarnings("static-method")
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation
             co, Map<String, List<CodegenOperation>> operations) {
@@ -5036,11 +5114,13 @@ public class DefaultCodegen implements CodegenConfig {
         return result;
     }
 
+    @Override
     public String apiFilename(String templateName, String tag) {
         String suffix = apiTemplateFiles().get(templateName);
         return apiFileFolder() + File.separator + toApiFilename(tag) + suffix;
     }
 
+    @Override
     public String modelFilename(String templateName, String modelName) {
         String suffix = modelTemplateFiles().get(templateName);
         return modelFileFolder() + File.separator + toModelFilename(modelName) + suffix;
@@ -5053,6 +5133,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param tag          tag
      * @return the API documentation file name with full path
      */
+    @Override
     public String apiDocFilename(String templateName, String tag) {
         String docExtension = getDocExtension();
         String suffix = docExtension != null ? docExtension : apiDocTemplateFiles().get(templateName);
@@ -5066,31 +5147,38 @@ public class DefaultCodegen implements CodegenConfig {
      * @param tag          tag
      * @return the API test file name with full path
      */
+    @Override
     public String apiTestFilename(String templateName, String tag) {
         String suffix = apiTestTemplateFiles().get(templateName);
         return apiTestFileFolder() + File.separator + toApiTestFilename(tag) + suffix;
     }
 
+    @Override
     public boolean shouldOverwrite(String filename) {
         return !(skipOverwrite && new File(filename).exists());
     }
 
+    @Override
     public boolean isSkipOverwrite() {
         return skipOverwrite;
     }
 
+    @Override
     public void setSkipOverwrite(boolean skipOverwrite) {
         this.skipOverwrite = skipOverwrite;
     }
 
+    @Override
     public boolean isRemoveOperationIdPrefix() {
         return removeOperationIdPrefix;
     }
 
+    @Override
     public boolean isSkipOperationExample() {
         return skipOperationExample;
     }
 
+    @Override
     public void setRemoveOperationIdPrefix(boolean removeOperationIdPrefix) {
         this.removeOperationIdPrefix = removeOperationIdPrefix;
     }
@@ -5111,14 +5199,17 @@ public class DefaultCodegen implements CodegenConfig {
         this.removeOperationIdPrefixCount = removeOperationIdPrefixCount;
     }
 
+    @Override
     public void setSkipOperationExample(boolean skipOperationExample) {
         this.skipOperationExample = skipOperationExample;
     }
 
+    @Override
     public boolean isHideGenerationTimestamp() {
         return hideGenerationTimestamp;
     }
 
+    @Override
     public void setHideGenerationTimestamp(boolean hideGenerationTimestamp) {
         this.hideGenerationTimestamp = hideGenerationTimestamp;
     }
@@ -5129,6 +5220,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @return the supported libraries
      */
+    @Override
     public Map<String, String> supportedLibraries() {
         return supportedLibraries;
     }
@@ -5138,6 +5230,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @param library Library template
      */
+    @Override
     public void setLibrary(String library) {
         if (library != null && !supportedLibraries.containsKey(library)) {
             StringBuilder sb = new StringBuilder("Unknown library: " + library + "\nAvailable libraries:");
@@ -5158,6 +5251,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @return Library template
      */
+    @Override
     public String getLibrary() {
         return library;
     }
@@ -5176,6 +5270,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @param gitHost Git host
      */
+    @Override
     public void setGitHost(String gitHost) {
         this.gitHost = gitHost;
     }
@@ -5185,6 +5280,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @return Git host
      */
+    @Override
     public String getGitHost() {
         return gitHost;
     }
@@ -5194,6 +5290,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @param gitUserId Git user ID
      */
+    @Override
     public void setGitUserId(String gitUserId) {
         this.gitUserId = gitUserId;
     }
@@ -5203,6 +5300,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @return Git user ID
      */
+    @Override
     public String getGitUserId() {
         return gitUserId;
     }
@@ -5212,6 +5310,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @param gitRepoId Git repo ID
      */
+    @Override
     public void setGitRepoId(String gitRepoId) {
         this.gitRepoId = gitRepoId;
     }
@@ -5221,6 +5320,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @return Git repo ID
      */
+    @Override
     public String getGitRepoId() {
         return gitRepoId;
     }
@@ -5230,6 +5330,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @param releaseNote Release note
      */
+    @Override
     public void setReleaseNote(String releaseNote) {
         this.releaseNote = releaseNote;
     }
@@ -5239,6 +5340,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @return Release note
      */
+    @Override
     public String getReleaseNote() {
         return releaseNote;
     }
@@ -5248,6 +5350,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @return Documentation files extension
      */
+    @Override
     public String getDocExtension() {
         return docExtension;
     }
@@ -5257,6 +5360,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @param userDocExtension documentation files extension
      */
+    @Override
     public void setDocExtension(String userDocExtension) {
         this.docExtension = userDocExtension;
     }
@@ -5266,6 +5370,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @param httpUserAgent HTTP user agent
      */
+    @Override
     public void setHttpUserAgent(String httpUserAgent) {
         this.httpUserAgent = httpUserAgent;
     }
@@ -5275,6 +5380,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @return HTTP user agent
      */
+    @Override
     public String getHttpUserAgent() {
         return httpUserAgent;
     }
@@ -5294,6 +5400,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param name string to be sanitize
      * @return sanitized string
      */
+    @Override
     @SuppressWarnings("static-method")
     public String sanitizeName(String name) {
         return sanitizeName(name, "\\W");
@@ -5403,6 +5510,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param tag Tag
      * @return Sanitized tag
      */
+    @Override
     public String sanitizeTag(String tag) {
         tag = camelize(sanitizeName(tag));
 
@@ -5642,6 +5750,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @return a string of the full path to an override ignore file.
      */
+    @Override
     public String getIgnoreFilePathOverride() {
         return ignoreFilePathOverride;
     }
@@ -5651,6 +5760,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @param ignoreFileOverride The full path to an ignore file
      */
+    @Override
     public void setIgnoreFilePathOverride(final String ignoreFileOverride) {
         this.ignoreFilePathOverride = ignoreFileOverride;
     }
@@ -5831,14 +5941,17 @@ public class DefaultCodegen implements CodegenConfig {
         }
     }
 
+    @Override
     public CodegenType getTag() {
         return null;
     }
 
+    @Override
     public String getName() {
         return null;
     }
 
+    @Override
     public String getHelp() {
         return null;
     }
@@ -6427,6 +6540,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param file     file to be processed
      * @param fileType file type
      */
+    @Override
     public void postProcessFile(File file, String fileType) {
         LOGGER.debug("Post processing file {} ({})", file, fileType);
     }
@@ -6436,6 +6550,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @return true if the option is enabled
      */
+    @Override
     public boolean isEnablePostProcessFile() {
         return enablePostProcessFile;
     }
@@ -6445,6 +6560,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @param enablePostProcessFile true to enable post-processing file
      */
+    @Override
     public void setEnablePostProcessFile(boolean enablePostProcessFile) {
         this.enablePostProcessFile = enablePostProcessFile;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/TemplateManager.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/TemplateManager.java
@@ -206,6 +206,7 @@ public class TemplateManager implements TemplatingExecutor, TemplateProcessor {
      * @return File representing the written file.
      * @throws IOException If file cannot be written.
      */
+    @Override
     public File writeToFile(String filename, byte[] contents) throws IOException {
         // Use Paths.get here to normalize path (for Windows file separator, space escaping on Linux/Mac, etc)
         File outputFile = Paths.get(filename).toFile();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractAdaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractAdaCodegen.java
@@ -277,6 +277,7 @@ abstract public class AbstractAdaCodegen extends DefaultCodegen implements Codeg
      * @param name the name of the model
      * @return capitalized model name
      */
+    @Override
     public String toModelName(final String name) {
         String result = camelize(sanitizeName(name));
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractApexCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractApexCodegen.java
@@ -643,6 +643,7 @@ public abstract class AbstractApexCodegen extends DefaultCodegen implements Code
         return p.replaceAll("\"", "%22");
     }
 
+    @Override
     public String toRegularExpression(String pattern) {
         return escapeText(pattern);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
@@ -275,6 +275,7 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
      * @param name the name of the property
      * @return getter name based on naming convention
      */
+    @Override
     public String toBooleanGetter(String name) {
         return "is" + getterAndSetterCapitalize(name);
     }
@@ -284,6 +285,7 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
         return "std::shared_ptr<" + toModelName(str) + ">";
     }
 
+    @Override
     public void processOpts() {
         super.processOpts();
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGraphQLCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGraphQLCodegen.java
@@ -143,6 +143,7 @@ public abstract class AbstractGraphQLCodegen extends DefaultCodegen implements C
         return outputFolder + File.separator + packageName + File.separator + "api" + File.separator;
     }
 
+    @Override
     public String modelFileFolder() {
         return outputFolder + File.separator + packageName + File.separator + "model" + File.separator;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -305,6 +305,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         return outputFolder + "/" + output + "/" + apiPackage().replace('.', '/');
     }
 
+    @Override
     public void setUseBeanValidation(boolean useBeanValidation) {
         this.useBeanValidation = useBeanValidation;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
@@ -191,6 +191,7 @@ abstract public class AbstractRubyCodegen extends DefaultCodegen implements Code
         return varName;
     }
 
+    @Override
     public String toRegularExpression(String pattern) {
         return addRegularExpressionDelimiter(pattern);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AsciidocDocumentationCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AsciidocDocumentationCodegen.java
@@ -163,6 +163,7 @@ public class AsciidocDocumentationCodegen extends DefaultCodegen implements Code
     private IncludeMarkupLambda includeSnippetMarkupLambda;
     private LinkMarkupLambda linkSnippetMarkupLambda;
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.DOCUMENTATION;
     }
@@ -181,10 +182,12 @@ public class AsciidocDocumentationCodegen extends DefaultCodegen implements Code
         return sanitized.startsWith(File.separator) || sanitized.startsWith("/") ? sanitized.substring(1) : sanitized;
     }
 
+    @Override
     public String getName() {
         return "asciidoc";
     }
 
+    @Override
     public String getHelp() {
         return "Generates asciidoc markup based documentation.";
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/BashClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/BashClientCodegen.java
@@ -75,6 +75,7 @@ public class BashClientCodegen extends DefaultCodegen implements CodegenConfig {
      *
      * @return the CodegenType for this generator
      */
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
@@ -85,6 +86,7 @@ public class BashClientCodegen extends DefaultCodegen implements CodegenConfig {
      *
      * @return the friendly name for the generator
      */
+    @Override
     public String getName() {
         return "bash";
     }
@@ -95,6 +97,7 @@ public class BashClientCodegen extends DefaultCodegen implements CodegenConfig {
      *
      * @return A string value for the help message
      */
+    @Override
     public String getHelp() {
         return "Generates a Bash client script based on cURL.";
     }
@@ -380,6 +383,7 @@ public class BashClientCodegen extends DefaultCodegen implements CodegenConfig {
      * Location to write model files.  You can use the modelPackage() as defined
      * when the class is instantiated.
      */
+    @Override
     public String modelFileFolder() {
         return outputFolder;
     }
@@ -509,6 +513,7 @@ public class BashClientCodegen extends DefaultCodegen implements CodegenConfig {
     /**
      * Override with any special text escaping logic
      */
+    @Override
     @SuppressWarnings("static-method")
     public String escapeText(String input) {
         if (input == null) {
@@ -605,6 +610,7 @@ public class BashClientCodegen extends DefaultCodegen implements CodegenConfig {
      * @param input String to be cleaned up
      * @return string with unsafe characters removed or escaped
      */
+    @Override
     public String escapeUnsafeCharacters(String input) {
 
         /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -874,10 +874,12 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         }
     }
 
+    @Override
     public void setPackageName(String packageName) {
         this.packageName = packageName;
     }
 
+    @Override
     public void setPackageVersion(String packageVersion) {
         this.packageVersion = packageVersion;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
@@ -781,10 +781,12 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
         this.packageGuid = packageGuid;
     }
 
+    @Override
     public void setPackageName(String packageName) {
         this.packageName = packageName;
     }
 
+    @Override
     public void setPackageVersion(String packageVersion) {
         this.packageVersion = packageVersion;
     }
@@ -855,6 +857,7 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
         this.licenseId = licenseId;
     }
 
+    @Override
     public void setReleaseNote(String releaseNote) {
         this.releaseNote = releaseNote;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -423,6 +423,7 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
      * Location to write model files. You can use the modelPackage() as defined
      * when the class is instantiated
      */
+    @Override
     public String modelFileFolder() {
         return (outputFolder + "/model").replace("/", File.separator);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
@@ -52,6 +52,7 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
      * @return the CodegenType for this generator
      * @see org.openapitools.codegen.CodegenType
      */
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
@@ -62,6 +63,7 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
      *
      * @return the friendly name for the generator
      */
+    @Override
     public String getName() {
         return "cpp-restsdk";
     }
@@ -72,6 +74,7 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
      *
      * @return A string value for the help message
      */
+    @Override
     public String getHelp() {
         return "Generates a C++ API client with C++ REST SDK (https://github.com/Microsoft/cpprestsdk).";
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestbedServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestbedServerCodegen.java
@@ -175,6 +175,7 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
      *
      * @return the CodegenType for this generator
      */
+    @Override
     public CodegenType getTag() {
         return CodegenType.SERVER;
     }
@@ -185,6 +186,7 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
      *
      * @return the friendly name for the generator
      */
+    @Override
     public String getName() {
         return "cpp-restbed-server";
     }
@@ -195,6 +197,7 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
      *
      * @return A string value for the help message
      */
+    @Override
     public String getHelp() {
         return "Generates a C++ API Server with Restbed (https://github.com/Corvusoft/restbed).";
     }
@@ -228,6 +231,7 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
      * Location to write model files. You can use the modelPackage() as defined
      * when the class is instantiated
      */
+    @Override
     public String modelFileFolder() {
         return (outputFolder + "/model").replace("/", File.separator);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTinyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTinyClientCodegen.java
@@ -43,6 +43,7 @@ public class CppTinyClientCodegen extends AbstractCppCodegen implements CodegenC
     protected String controller = "esp32";
 
 
+    @Override
     public CodegenType getTag() {
         return CodegenType.CLIENT;
     }
@@ -53,6 +54,7 @@ public class CppTinyClientCodegen extends AbstractCppCodegen implements CodegenC
      *
      * @return the friendly name for the generator
      */
+    @Override
     public String getName() {
         return "cpp-tiny";
     }
@@ -63,6 +65,7 @@ public class CppTinyClientCodegen extends AbstractCppCodegen implements CodegenC
      *
      * @return A string value for the help message
      */
+    @Override
     public String getHelp() {
         return "Generates a C++ Arduino REST API client.";
     }
@@ -317,6 +320,7 @@ public class CppTinyClientCodegen extends AbstractCppCodegen implements CodegenC
         return "" + paramName;
     }
 
+    @Override
     public String toDefaultValue(Schema p) {
         if (ModelUtils.isBooleanSchema(p)) {
             return "bool(false)";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTizenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTizenClientCodegen.java
@@ -319,6 +319,7 @@ public class CppTizenClientCodegen extends AbstractCppCodegen implements Codegen
      * @param name the name of the property
      * @return getter name based on naming convention
      */
+    @Override
     public String toBooleanGetter(String name) {
         return "get" + getterAndSetterCapitalize(name);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppUE4ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppUE4ClientCodegen.java
@@ -539,14 +539,17 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
         return input.replace("*/", "*_/").replace("/*", "/_*");
     }
 
+    @Override
     public String toBooleanGetter(String name) {
         return "Is" + getterAndSetterCapitalize(name);
     }
 
+    @Override
     public String toGetter(String name) {
         return "Get" + getterAndSetterCapitalize(name);
     }
 
+    @Override
     public String toSetter(String name) {
         return "Set" + getterAndSetterCapitalize(name);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CrystalClientCodegen.java
@@ -837,6 +837,7 @@ public class CrystalClientCodegen extends DefaultCodegen {
         return varName;
     }
 
+    @Override
     public String toRegularExpression(String pattern) {
         return addRegularExpressionDelimiter(pattern);
     }


### PR DESCRIPTION
EclipseJdt cleanup 'AddMissingOverrideAnnotation' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.20/jdt.php
For erefactor see https://github.com/cal101/erefactor

--------

Dear Project Team!

This pull request is provided in the hope that it will be useful.

Changes are manually reviewed after they passed the test suite of
your project. Only successful reviews become project PRs.
Errors found are reported upstream to support the cleanup providers.

But please do a careful review of your own as usual because tools
have bugs and bugs in the changes may have been overlooked.

For scalability and out of fun and laziness, the creation of commits
and PRs and parts of the change handling are automated.

If you are not interested or want to discuss issues just comment the
PR as usual.

Have fun,
   Cal
