### PR TITLE
Fix minor typo in @cached_property python docstring

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_utils.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_utils.mustache
@@ -39,7 +39,7 @@ def convert_js_args_to_python_args(fn):
 
 class cached_property(object):
     # this caches the result of the function call for fn with no inputs
-    # use this as a decorator on fuction methods that you want converted
+    # use this as a decorator on function methods that you want converted
     # into cached properties
     result_key = '_results'
 

--- a/samples/client/petstore/python/petstore_api/model_utils.py
+++ b/samples/client/petstore/python/petstore_api/model_utils.py
@@ -47,7 +47,7 @@ def convert_js_args_to_python_args(fn):
 
 class cached_property(object):
     # this caches the result of the function call for fn with no inputs
-    # use this as a decorator on fuction methods that you want converted
+    # use this as a decorator on function methods that you want converted
     # into cached properties
     result_key = '_results'
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model_utils.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model_utils.py
@@ -47,7 +47,7 @@ def convert_js_args_to_python_args(fn):
 
 class cached_property(object):
     # this caches the result of the function call for fn with no inputs
-    # use this as a decorator on fuction methods that you want converted
+    # use this as a decorator on function methods that you want converted
     # into cached properties
     result_key = '_results'
 

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/model_utils.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/model_utils.py
@@ -47,7 +47,7 @@ def convert_js_args_to_python_args(fn):
 
 class cached_property(object):
     # this caches the result of the function call for fn with no inputs
-    # use this as a decorator on fuction methods that you want converted
+    # use this as a decorator on function methods that you want converted
     # into cached properties
     result_key = '_results'
 

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/model_utils.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/model_utils.py
@@ -47,7 +47,7 @@ def convert_js_args_to_python_args(fn):
 
 class cached_property(object):
     # this caches the result of the function call for fn with no inputs
-    # use this as a decorator on fuction methods that you want converted
+    # use this as a decorator on function methods that you want converted
     # into cached properties
     result_key = '_results'
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model_utils.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model_utils.py
@@ -47,7 +47,7 @@ def convert_js_args_to_python_args(fn):
 
 class cached_property(object):
     # this caches the result of the function call for fn with no inputs
-    # use this as a decorator on fuction methods that you want converted
+    # use this as a decorator on function methods that you want converted
     # into cached properties
     result_key = '_results'
 


### PR DESCRIPTION
Very minor contribution but I noticed 1 typo in the docstring of @cached_property 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@arun-nalla @spacether