### PR TITLE
Swift5/Vapor query parameter coding keys required

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/api.mustache
@@ -251,6 +251,12 @@ extension {{projectName}} {
                 {{#queryParams}}
                 var {{paramName}}: {{#isEnum}}{{#isArray}}[{{enumName}}_{{operationId}}]{{/isArray}}{{^isArray}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}?{{/required}}
                 {{/queryParams}}
+
+                enum CodingKeys: String, CodingKey {
+                    {{#queryParams}}
+                    case {{paramName}}{{#baseName}} = "{{baseName}}"{{/baseName}}
+                    {{/queryParams}}
+                }
             }
             try localVariableRequest.query.encode(QueryParams({{#queryParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/queryParams}})){{/hasQueryParams}}
             {{#hasBodyParam}}

--- a/samples/client/petstore/swift5/vaporLibrary/Sources/PetstoreClient/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift5/vaporLibrary/Sources/PetstoreClient/APIs/FakeAPI.swift
@@ -324,6 +324,10 @@ open class FakeAPI {
             
             struct QueryParams: Content {
                 var query: String
+
+                enum CodingKeys: String, CodingKey {
+                    case query = "query"
+                }
             }
             try localVariableRequest.query.encode(QueryParams(query: query))
             try localVariableRequest.content.encode(body, using: Configuration.contentConfiguration.requireEncoder(for: User.defaultContentType))
@@ -605,6 +609,13 @@ open class FakeAPI {
                 var enumQueryString: EnumQueryString_testEnumParameters?
                 var enumQueryInteger: EnumQueryInteger_testEnumParameters?
                 var enumQueryDouble: EnumQueryDouble_testEnumParameters?
+
+                enum CodingKeys: String, CodingKey {
+                    case enumQueryStringArray = "enum_query_string_array"
+                    case enumQueryString = "enum_query_string"
+                    case enumQueryInteger = "enum_query_integer"
+                    case enumQueryDouble = "enum_query_double"
+                }
             }
             try localVariableRequest.query.encode(QueryParams(enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble))
             struct FormParams: Content {
@@ -683,6 +694,13 @@ open class FakeAPI {
                 var requiredInt64Group: Int64
                 var stringGroup: Int?
                 var int64Group: Int64?
+
+                enum CodingKeys: String, CodingKey {
+                    case requiredStringGroup = "required_string_group"
+                    case requiredInt64Group = "required_int64_group"
+                    case stringGroup = "string_group"
+                    case int64Group = "int64_group"
+                }
             }
             try localVariableRequest.query.encode(QueryParams(requiredStringGroup: requiredStringGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, int64Group: int64Group))
             
@@ -846,6 +864,14 @@ open class FakeAPI {
                 var http: [String]
                 var url: [String]
                 var context: [String]
+
+                enum CodingKeys: String, CodingKey {
+                    case pipe = "pipe"
+                    case ioutil = "ioutil"
+                    case http = "http"
+                    case url = "url"
+                    case context = "context"
+                }
             }
             try localVariableRequest.query.encode(QueryParams(pipe: pipe, ioutil: ioutil, http: http, url: url, context: context))
             

--- a/samples/client/petstore/swift5/vaporLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift5/vaporLibrary/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -163,6 +163,10 @@ open class PetAPI {
             
             struct QueryParams: Content {
                 var status: [Status_findPetsByStatus]
+
+                enum CodingKeys: String, CodingKey {
+                    case status = "status"
+                }
             }
             try localVariableRequest.query.encode(QueryParams(status: status))
             
@@ -224,6 +228,10 @@ open class PetAPI {
             
             struct QueryParams: Content {
                 var tags: Set<String>
+
+                enum CodingKeys: String, CodingKey {
+                    case tags = "tags"
+                }
             }
             try localVariableRequest.query.encode(QueryParams(tags: tags))
             

--- a/samples/client/petstore/swift5/vaporLibrary/Sources/PetstoreClient/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift5/vaporLibrary/Sources/PetstoreClient/APIs/UserAPI.swift
@@ -278,6 +278,11 @@ open class UserAPI {
             struct QueryParams: Content {
                 var username: String
                 var password: String
+
+                enum CodingKeys: String, CodingKey {
+                    case username = "username"
+                    case password = "password"
+                }
             }
             try localVariableRequest.query.encode(QueryParams(username: username, password: password))
             


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
The Swift5/Vapor generator doesn't provide a CodingKey for QueryParams, which means they aren't decoded back to their base name. The obvious case is `per_page` in the spec becoming `perPage` in the generated code. Without a coding key, it is passed back as `perPage` in the final query.

(Sorry I didn't bother opening an issue, but this a _really_ small change. Let me know if you want any other formalities followed.)

Technical committee: @jgavris @ehyche @Edubits @jaz-ah @4brunu

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
