### PR TITLE
[Elixir] Adding :package and :description to mix.exs template

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/mix.exs.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/mix.exs.mustache
@@ -7,6 +7,8 @@ defmodule {{moduleName}}.Mixfile do
      elixir: "~> {{supportedElixirVersion}}",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
+     package: package(),
+     description: "{{appDescription}}",
      deps: deps()]
   end
 
@@ -32,6 +34,14 @@ defmodule {{moduleName}}.Mixfile do
 {{#deps}}
       {{{this}}}{{^-last}},{{/-last}}
 {{/deps}}
+    ]
+  end
+
+   defp package() do
+    [
+      name: "{{#underscored}}{{packageName}}{{/underscored}}",
+      files: ~w(lib mix.exs README* LICENSE*),
+      licenses: ["{{licenseId}}"]
     ]
   end
 end

--- a/samples/client/petstore/elixir/mix.exs
+++ b/samples/client/petstore/elixir/mix.exs
@@ -7,6 +7,8 @@ defmodule OpenapiPetstore.Mixfile do
      elixir: "~> 1.6",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
+     package: package(),
+     description: "This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \&quot; \\",
      deps: deps()]
   end
 
@@ -31,6 +33,14 @@ defmodule OpenapiPetstore.Mixfile do
     [
       {:tesla, "~> 1.2"},
       {:poison, "~> 3.0"}
+    ]
+  end
+
+   defp package() do
+    [
+      name: "openapi_petstore",
+      files: ~w(lib mix.exs README* LICENSE*),
+      licenses: [""]
     ]
   end
 end


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Closes #9944 

Adds additional values to `mix.exs` to enable publishing generated packges to Hex.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
