### PR TITLE
[Erlang] decrease memory usage

### DIFF
--- a/modules/openapi-generator/src/main/resources/erlang-server/handler.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/handler.mustache
@@ -29,9 +29,11 @@
 -spec init(Req :: cowboy_req:req(), Opts :: {{packageName}}_router:init_opts()) ->
     {cowboy_rest, Req :: cowboy_req:req(), State :: state()}.
 
-init(Req, {Operations, LogicHandler, ValidatorState}) ->
+init(Req, {Operations, LogicHandler, ValidatorMod}) ->
     Method = cowboy_req:method(Req),
     OperationID = maps:get(Method, Operations, undefined),
+
+    ValidatorState = ValidatorMod:get_validator_state(),
 
     error_logger:info_msg("Attempt to process operation: ~p", [OperationID]),
 

--- a/modules/openapi-generator/src/main/resources/erlang-server/router.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/router.mustache
@@ -1,6 +1,6 @@
 -module({{packageName}}_router).
 
--export([get_paths/1]).
+-export([get_paths/1, get_validator_state/0]).
 
 -type operations() :: #{
     Method :: binary() => {{packageName}}_api:operation_id()
@@ -62,9 +62,15 @@ get_operations() ->
         }{{^-last}},{{/-last}}{{/operation}}{{^-last}},{{/-last}}{{/operations}}{{/apis}}{{/apiInfo}}
     }.
 
+get_validator_state() ->
+    persistent_term:get({?MODULE, validator_state}).
+
+
 prepare_validator() ->
     R = jsx:decode(element(2, file:read_file(get_openapi_path()))),
-    jesse_state:new(R, [{default_schema_ver, <<"http://json-schema.org/draft-04/schema#">>}]).
+    JesseState = jesse_state:new(R, [{default_schema_ver, <<"http://json-schema.org/draft-04/schema#">>}]),
+    persistent_term:put({?MODULE, validator_state}, JesseState),
+    ?MODULE.
 
 
 get_openapi_path() ->

--- a/samples/server/petstore/erlang-server/src/openapi_pet_handler.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_pet_handler.erl
@@ -29,9 +29,11 @@
 -spec init(Req :: cowboy_req:req(), Opts :: openapi_router:init_opts()) ->
     {cowboy_rest, Req :: cowboy_req:req(), State :: state()}.
 
-init(Req, {Operations, LogicHandler, ValidatorState}) ->
+init(Req, {Operations, LogicHandler, ValidatorMod}) ->
     Method = cowboy_req:method(Req),
     OperationID = maps:get(Method, Operations, undefined),
+
+    ValidatorState = ValidatorMod:get_validator_state(),
 
     error_logger:info_msg("Attempt to process operation: ~p", [OperationID]),
 

--- a/samples/server/petstore/erlang-server/src/openapi_router.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_router.erl
@@ -1,6 +1,6 @@
 -module(openapi_router).
 
--export([get_paths/1]).
+-export([get_paths/1, get_validator_state/0]).
 
 -type operations() :: #{
     Method :: binary() => openapi_api:operation_id()
@@ -157,9 +157,15 @@ get_operations() ->
         }
     }.
 
+get_validator_state() ->
+    persistent_term:get({?MODULE, validator_state}).
+
+
 prepare_validator() ->
     R = jsx:decode(element(2, file:read_file(get_openapi_path()))),
-    jesse_state:new(R, [{default_schema_ver, <<"http://json-schema.org/draft-04/schema#">>}]).
+    JesseState = jesse_state:new(R, [{default_schema_ver, <<"http://json-schema.org/draft-04/schema#">>}]),
+    persistent_term:put({?MODULE, validator_state}, JesseState),
+    ?MODULE.
 
 
 get_openapi_path() ->

--- a/samples/server/petstore/erlang-server/src/openapi_store_handler.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_store_handler.erl
@@ -29,9 +29,11 @@
 -spec init(Req :: cowboy_req:req(), Opts :: openapi_router:init_opts()) ->
     {cowboy_rest, Req :: cowboy_req:req(), State :: state()}.
 
-init(Req, {Operations, LogicHandler, ValidatorState}) ->
+init(Req, {Operations, LogicHandler, ValidatorMod}) ->
     Method = cowboy_req:method(Req),
     OperationID = maps:get(Method, Operations, undefined),
+
+    ValidatorState = ValidatorMod:get_validator_state(),
 
     error_logger:info_msg("Attempt to process operation: ~p", [OperationID]),
 

--- a/samples/server/petstore/erlang-server/src/openapi_user_handler.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_user_handler.erl
@@ -29,9 +29,11 @@
 -spec init(Req :: cowboy_req:req(), Opts :: openapi_router:init_opts()) ->
     {cowboy_rest, Req :: cowboy_req:req(), State :: state()}.
 
-init(Req, {Operations, LogicHandler, ValidatorState}) ->
+init(Req, {Operations, LogicHandler, ValidatorMod}) ->
     Method = cowboy_req:method(Req),
     OperationID = maps:get(Method, Operations, undefined),
+
+    ValidatorState = ValidatorMod:get_validator_state(),
 
     error_logger:info_msg("Attempt to process operation: ~p", [OperationID]),
 


### PR DESCRIPTION

When using the the generated code with many paths we could sometimes end up using 50MB memory per request.
This is since the process will use the complete dispatch rule including one validator state per path. 

This removes that and instead we fetch the state after we found the match in cowboy.
This way we will only have seen one jesse ValidatorState
https://github.com/ninenines/cowboy/blob/master/src/cowboy_router.erl#L163

 @tsloughter  @jfacorro @robertoaloi 
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
