### PR TITLE
[dart-dio-next] only remove typed_data import if safe

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioNextClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioNextClientCodegen.java
@@ -322,6 +322,18 @@ public class DartDioNextClientCodegen extends AbstractDartCodegen {
                 }
             }
 
+            // the MultipartFile handling above changes the type of some parameters from
+            // `UInt8List`, the default for files, to `MultipartFile`.
+            //
+            // The following block removes the required import for Uint8List if it is no
+            // longer in use.
+            if (op.allParams.stream().noneMatch(param -> param.dataType.equals("Uint8List"))
+                    && op.responses.stream().filter(response -> response.dataType != null)
+                            .noneMatch(response -> response.dataType.equals("Uint8List"))) {
+                // Remove unused imports after processing
+                op.imports.remove("Uint8List");
+            }
+
             for (CodegenParameter param : op.bodyParams) {
                 if (param.isContainer) {
                     final Map<String, Object> serializer = new HashMap<>();
@@ -331,11 +343,6 @@ public class DartDioNextClientCodegen extends AbstractDartCodegen {
                     serializer.put("baseType", param.baseType);
                     serializers.add(serializer);
                 }
-            }
-
-            if (op.allParams.stream().noneMatch(param -> param.dataType.equals("Uint8List"))) {
-                // Remove unused imports after processing
-                op.imports.remove("Uint8List");
             }
 
             resultImports.addAll(rewriteImports(op.imports, false));


### PR DESCRIPTION
This PR closes #9955 by only removing the import for `dart:typed_data` if there are no parameters AND no responses of type `UInt8List`.

Previously only parameters were being checked, meaning invalid dart code would be generated if there was a `UInt8List` response, because the import would have been removed.

Have tested against the example I provided in the bug report, as well as our own codebase where the error was first identified.

Have run `./bin/generate-samples.sh`, but as the Petstore API does not have any file responses, there were no changes to the generated code.

@swipesight @jaumard @josh-burton @amondnet @sbu-WBT @kuhnroyal @agilob (2020/12)

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
