### PR TITLE
[erlang-server] Dialyzer spec

### DIFF
--- a/modules/openapi-generator/src/main/resources/erlang-server/router.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/router.mustache
@@ -9,7 +9,7 @@
 -type init_opts()  :: {
     Operations :: operations(),
     LogicHandler :: atom(),
-    ValidatorState :: jesse_state:state()
+    ValidatorMod :: module()
 }.
 
 -export_type([init_opts/0]).

--- a/samples/server/petstore/erlang-server/src/openapi_router.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_router.erl
@@ -9,7 +9,7 @@
 -type init_opts()  :: {
     Operations :: operations(),
     LogicHandler :: atom(),
-    ValidatorState :: jesse_state:state()
+    ValidatorMod :: module()
 }.
 
 -export_type([init_opts/0]).


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Dialyzer fails with success typing after #9946 
`Line 29 Column 2: Invalid type specification for function .._handler:init/2. The success typing is ...`

@tsloughter @jfacorro @robertoaloi

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
