### PR TITLE
[php] Fix Composer 2 name error

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -301,7 +301,7 @@ public class CodegenConfigurator {
 
     public CodegenConfigurator setGitUserId(String gitUserId) {
         if (StringUtils.isNotEmpty(gitUserId)) {
-            addAdditionalProperty(CodegenConstants.GIT_HOST, gitUserId);
+            addAdditionalProperty(CodegenConstants.GIT_USER_ID, gitUserId);
         }
         generatorSettingsBuilder.withGitUserId(gitUserId);
         return this;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -191,6 +191,18 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             this.setParameterNamingConvention((String) additionalProperties.get(VARIABLE_NAMING_CONVENTION));
         }
 
+        if (additionalProperties.containsKey(CodegenConstants.GIT_USER_ID)) {
+            this.setGitUserId((String) additionalProperties.get(CodegenConstants.GIT_USER_ID));
+        }
+        
+        if (additionalProperties.containsKey(CodegenConstants.GIT_REPO_ID)) {
+            this.setGitRepoId((String) additionalProperties.get(CodegenConstants.GIT_REPO_ID));
+        }
+
+        if (!this.getComposerPackageName().isEmpty()) {
+            additionalProperties.put("composerPackageName", this.getComposerPackageName());
+        }
+
         additionalProperties.put("escapedInvokerPackage", invokerPackage.replace("\\", "\\\\"));
 
         // make api and model src path available in mustache template

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
@@ -757,5 +758,23 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
                 Thread.currentThread().interrupt();
             }
         }
+    }
+
+    /**
+     * Get Composer package name based on GIT_USER_ID and GIT_REPO_ID.
+     *
+     * @return package name or empty string on fail
+     */
+    public String getComposerPackageName() {
+        String packageName = this.getGitUserId() + "/" + this.getGitRepoId();
+        if (
+            packageName.contentEquals("/")
+            || packageName.contentEquals("null/null")
+            || !Pattern.matches("^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$", packageName)
+        ) {
+            return "";
+        }
+
+        return packageName;
     }
 }

--- a/modules/openapi-generator/src/main/resources/php/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/composer.mustache
@@ -1,5 +1,7 @@
 {
-    "name": "{{gitUserId}}/{{gitRepoId}}",
+    {{#composerPackageName}}
+    "name": "{{composerPackageName}}",
+    {{/composerPackageName}}
     {{#artifactVersion}}
     "version": "{{artifactVersion}}",
     {{/artifactVersion}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
@@ -22,6 +22,7 @@ import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.languages.AbstractPhpCodegen;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -98,6 +99,27 @@ public class AbstractPhpCodegenTest {
 
         Assert.assertEquals(codegenOperation.produces.get(0).get("mediaType"), "*_/_*");
         Assert.assertEquals(codegenOperation.produces.get(1).get("mediaType"), "application/json");
+    }
+
+    @Test(dataProvider = "composerNames", description = "Issue #9998")
+    public void testGetComposerPackageName(String gitUserId, String gitRepoId, String result) {
+        final AbstractPhpCodegen codegen = new P_AbstractPhpCodegen();
+        codegen.processOpts();
+
+        codegen.setGitUserId(gitUserId);
+        codegen.setGitRepoId(gitRepoId);
+        Assert.assertEquals(codegen.getComposerPackageName(), result);
+    }
+
+    @DataProvider(name = "composerNames")
+    public static Object[][] composerNames() {
+        return new Object[][] {
+            {"", "", ""},
+            {"null", "null", ""},
+            {"GIT_REPO_ID", "GIT_USER_ID", ""},
+            {"git_repo_id", "git_user_id", "git_repo_id/git_user_id"},
+            {"foo", "bar", "foo/bar"},
+        };
     }
 
     private static class P_AbstractPhpCodegen extends AbstractPhpCodegen {

--- a/samples/client/petstore/php/OpenAPIClient-php/composer.json
+++ b/samples/client/petstore/php/OpenAPIClient-php/composer.json
@@ -1,5 +1,4 @@
 {
-    "name": "GIT_USER_ID/GIT_REPO_ID",
     "description": "This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\",
     "keywords": [
         "openapitools",


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
I've added small method to AbstractPhpGenerator to validate Composer package name(against `^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$`).
PHP client `composer.json` template slightly changed. Now it contains package name only when it pass validation.

Closes #9998 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @jebentier, @dkarlovi, @mandrean, @jfastnacht, @ackintosh, @renepardon