### PR TITLE
[typescript-fetch] Add initOverrides 

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -49,7 +49,7 @@ export interface {{classname}}Interface {
      * @throws {RequiredError}
      * @memberof {{classname}}Interface
      */
-    {{nickname}}Raw({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<runtime.ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>>;
+    {{nickname}}Raw({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit): Promise<runtime.ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>>;
 
     /**
      {{#notes}}
@@ -60,10 +60,10 @@ export interface {{classname}}Interface {
      {{/summary}}
      */
     {{^useSingleRequestParameter}}
-    {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}{{^-last}}, {{/-last}}{{/allParams}}): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
+    {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}{{^-last}}, {{/-last}}, {{/allParams}}initOverrides?: RequestInit): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
     {{/useSingleRequestParameter}}
     {{#useSingleRequestParameter}}
-    {{nickname}}({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
+    {{nickname}}({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
     {{/useSingleRequestParameter}}
 
 {{/operation}}
@@ -91,7 +91,7 @@ export class {{classname}} extends runtime.BaseAPI {
      * {{&summary}}
      {{/summary}}
      */
-    async {{nickname}}Raw({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<runtime.ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>> {
+    async {{nickname}}Raw({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit): Promise<runtime.ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>> {
         {{#allParams}}
         {{#required}}
         if (requestParameters.{{paramName}} === null || requestParameters.{{paramName}} === undefined) {
@@ -284,7 +284,7 @@ export class {{classname}} extends runtime.BaseAPI {
             {{#hasFormParams}}
             body: formParams,
             {{/hasFormParams}}
-        });
+        }, initOverrides);
 
         {{#returnType}}
         {{#isResponseFile}}
@@ -331,24 +331,24 @@ export class {{classname}} extends runtime.BaseAPI {
      {{/summary}}
      */
     {{^useSingleRequestParameter}}
-    async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}{{^-last}}, {{/-last}}{{/allParams}}): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+    async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}{{^-last}}, {{/-last}}, {{/allParams}}initOverrides?: RequestInit): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
         {{#returnType}}
-        const response = await this.{{nickname}}Raw({{#allParams.0}}{ {{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}} }{{/allParams.0}});
+        const response = await this.{{nickname}}Raw({{#allParams.0}}{ {{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}} }, {{/allParams.0}}initOverrides);
         return await response.value();
         {{/returnType}}
         {{^returnType}}
-        await this.{{nickname}}Raw({{#allParams.0}}{ {{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}} }{{/allParams.0}});
+        await this.{{nickname}}Raw({{#allParams.0}}{ {{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}} }{{/allParams.0}}, initOverrides);
         {{/returnType}}
     }
     {{/useSingleRequestParameter}}
     {{#useSingleRequestParameter}}
-    async {{nickname}}({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+    async {{nickname}}({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
         {{#returnType}}
-        const response = await this.{{nickname}}Raw({{#allParams.0}}requestParameters{{/allParams.0}});
+        const response = await this.{{nickname}}Raw({{#allParams.0}}requestParameters, {{/allParams.0}}initOverrides);
         return await response.value();
         {{/returnType}}
         {{^returnType}}
-        await this.{{nickname}}Raw({{#allParams.0}}requestParameters{{/allParams.0}});
+        await this.{{nickname}}Raw({{#allParams.0}}requestParameters, {{/allParams.0}}initOverrides);
         {{/returnType}}
     }
     {{/useSingleRequestParameter}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -33,8 +33,8 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
-    protected async request(context: RequestOpts): Promise<Response> {
-        const { url, init } = this.createFetchParams(context);
+    protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
+        const { url, init } = this.createFetchParams(context, initOverrides);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
             return response;
@@ -42,7 +42,7 @@ export class BaseAPI {
         throw response;
     }
 
-    private createFetchParams(context: RequestOpts) {
+    private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
             // only add the querystring to the URL if there are query parameters.
@@ -59,7 +59,8 @@ export class BaseAPI {
             method: context.method,
             headers: headers,
             body,
-            credentials: this.configuration.credentials
+            credentials: this.configuration.credentials,
+            ...initOverrides
         };
         return { url, init };
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
@@ -33,7 +33,7 @@ export class AnotherFakeApi extends runtime.BaseAPI {
      * To test special tags and operation ID starting with number
      * To test special tags
      */
-    async _123testSpecialTagsRaw(requestParameters: 123testSpecialTagsRequest): Promise<runtime.ApiResponse<Client>> {
+    async _123testSpecialTagsRaw(requestParameters: 123testSpecialTagsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Client>> {
         if (requestParameters.client === null || requestParameters.client === undefined) {
             throw new runtime.RequiredError('client','Required parameter requestParameters.client was null or undefined when calling _123testSpecialTags.');
         }
@@ -50,7 +50,7 @@ export class AnotherFakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: ClientToJSON(requestParameters.client),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ClientFromJSON(jsonValue));
     }
@@ -59,8 +59,8 @@ export class AnotherFakeApi extends runtime.BaseAPI {
      * To test special tags and operation ID starting with number
      * To test special tags
      */
-    async _123testSpecialTags(requestParameters: 123testSpecialTagsRequest): Promise<Client> {
-        const response = await this._123testSpecialTagsRaw(requestParameters);
+    async _123testSpecialTags(requestParameters: 123testSpecialTagsRequest, initOverrides?: RequestInit): Promise<Client> {
+        const response = await this._123testSpecialTagsRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/DefaultApi.ts
@@ -27,7 +27,7 @@ export class DefaultApi extends runtime.BaseAPI {
 
     /**
      */
-    async fooGetRaw(): Promise<runtime.ApiResponse<InlineResponseDefault>> {
+    async fooGetRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<InlineResponseDefault>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -37,15 +37,15 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => InlineResponseDefaultFromJSON(jsonValue));
     }
 
     /**
      */
-    async fooGet(): Promise<InlineResponseDefault> {
-        const response = await this.fooGetRaw();
+    async fooGet(initOverrides?: RequestInit): Promise<InlineResponseDefault> {
+        const response = await this.fooGetRaw(initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -143,7 +143,7 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Health check endpoint
      */
-    async fakeHealthGetRaw(): Promise<runtime.ApiResponse<HealthCheckResult>> {
+    async fakeHealthGetRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<HealthCheckResult>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -153,7 +153,7 @@ export class FakeApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => HealthCheckResultFromJSON(jsonValue));
     }
@@ -161,15 +161,15 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Health check endpoint
      */
-    async fakeHealthGet(): Promise<HealthCheckResult> {
-        const response = await this.fakeHealthGetRaw();
+    async fakeHealthGet(initOverrides?: RequestInit): Promise<HealthCheckResult> {
+        const response = await this.fakeHealthGetRaw(initOverrides);
         return await response.value();
     }
 
     /**
      * test http signature authentication
      */
-    async fakeHttpSignatureTestRaw(requestParameters: FakeHttpSignatureTestRequest): Promise<runtime.ApiResponse<void>> {
+    async fakeHttpSignatureTestRaw(requestParameters: FakeHttpSignatureTestRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.pet === null || requestParameters.pet === undefined) {
             throw new runtime.RequiredError('pet','Required parameter requestParameters.pet was null or undefined when calling fakeHttpSignatureTest.');
         }
@@ -194,7 +194,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.pet),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -202,14 +202,14 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * test http signature authentication
      */
-    async fakeHttpSignatureTest(requestParameters: FakeHttpSignatureTestRequest): Promise<void> {
-        await this.fakeHttpSignatureTestRaw(requestParameters);
+    async fakeHttpSignatureTest(requestParameters: FakeHttpSignatureTestRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.fakeHttpSignatureTestRaw(requestParameters, initOverrides);
     }
 
     /**
      * Test serialization of outer boolean types
      */
-    async fakeOuterBooleanSerializeRaw(requestParameters: FakeOuterBooleanSerializeRequest): Promise<runtime.ApiResponse<boolean>> {
+    async fakeOuterBooleanSerializeRaw(requestParameters: FakeOuterBooleanSerializeRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<boolean>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -222,7 +222,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body as any,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -230,15 +230,15 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Test serialization of outer boolean types
      */
-    async fakeOuterBooleanSerialize(requestParameters: FakeOuterBooleanSerializeRequest): Promise<boolean> {
-        const response = await this.fakeOuterBooleanSerializeRaw(requestParameters);
+    async fakeOuterBooleanSerialize(requestParameters: FakeOuterBooleanSerializeRequest, initOverrides?: RequestInit): Promise<boolean> {
+        const response = await this.fakeOuterBooleanSerializeRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Test serialization of object with outer number type
      */
-    async fakeOuterCompositeSerializeRaw(requestParameters: FakeOuterCompositeSerializeRequest): Promise<runtime.ApiResponse<OuterComposite>> {
+    async fakeOuterCompositeSerializeRaw(requestParameters: FakeOuterCompositeSerializeRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<OuterComposite>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -251,7 +251,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: OuterCompositeToJSON(requestParameters.outerComposite),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OuterCompositeFromJSON(jsonValue));
     }
@@ -259,15 +259,15 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Test serialization of object with outer number type
      */
-    async fakeOuterCompositeSerialize(requestParameters: FakeOuterCompositeSerializeRequest): Promise<OuterComposite> {
-        const response = await this.fakeOuterCompositeSerializeRaw(requestParameters);
+    async fakeOuterCompositeSerialize(requestParameters: FakeOuterCompositeSerializeRequest, initOverrides?: RequestInit): Promise<OuterComposite> {
+        const response = await this.fakeOuterCompositeSerializeRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Test serialization of outer number types
      */
-    async fakeOuterNumberSerializeRaw(requestParameters: FakeOuterNumberSerializeRequest): Promise<runtime.ApiResponse<number>> {
+    async fakeOuterNumberSerializeRaw(requestParameters: FakeOuterNumberSerializeRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<number>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -280,7 +280,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body as any,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -288,15 +288,15 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Test serialization of outer number types
      */
-    async fakeOuterNumberSerialize(requestParameters: FakeOuterNumberSerializeRequest): Promise<number> {
-        const response = await this.fakeOuterNumberSerializeRaw(requestParameters);
+    async fakeOuterNumberSerialize(requestParameters: FakeOuterNumberSerializeRequest, initOverrides?: RequestInit): Promise<number> {
+        const response = await this.fakeOuterNumberSerializeRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Test serialization of outer string types
      */
-    async fakeOuterStringSerializeRaw(requestParameters: FakeOuterStringSerializeRequest): Promise<runtime.ApiResponse<string>> {
+    async fakeOuterStringSerializeRaw(requestParameters: FakeOuterStringSerializeRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<string>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -309,7 +309,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body as any,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -317,15 +317,15 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Test serialization of outer string types
      */
-    async fakeOuterStringSerialize(requestParameters: FakeOuterStringSerializeRequest): Promise<string> {
-        const response = await this.fakeOuterStringSerializeRaw(requestParameters);
+    async fakeOuterStringSerialize(requestParameters: FakeOuterStringSerializeRequest, initOverrides?: RequestInit): Promise<string> {
+        const response = await this.fakeOuterStringSerializeRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Test serialization of enum (int) properties with examples
      */
-    async fakePropertyEnumIntegerSerializeRaw(requestParameters: FakePropertyEnumIntegerSerializeRequest): Promise<runtime.ApiResponse<OuterObjectWithEnumProperty>> {
+    async fakePropertyEnumIntegerSerializeRaw(requestParameters: FakePropertyEnumIntegerSerializeRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<OuterObjectWithEnumProperty>> {
         if (requestParameters.outerObjectWithEnumProperty === null || requestParameters.outerObjectWithEnumProperty === undefined) {
             throw new runtime.RequiredError('outerObjectWithEnumProperty','Required parameter requestParameters.outerObjectWithEnumProperty was null or undefined when calling fakePropertyEnumIntegerSerialize.');
         }
@@ -342,7 +342,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: OuterObjectWithEnumPropertyToJSON(requestParameters.outerObjectWithEnumProperty),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OuterObjectWithEnumPropertyFromJSON(jsonValue));
     }
@@ -350,15 +350,15 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * Test serialization of enum (int) properties with examples
      */
-    async fakePropertyEnumIntegerSerialize(requestParameters: FakePropertyEnumIntegerSerializeRequest): Promise<OuterObjectWithEnumProperty> {
-        const response = await this.fakePropertyEnumIntegerSerializeRaw(requestParameters);
+    async fakePropertyEnumIntegerSerialize(requestParameters: FakePropertyEnumIntegerSerializeRequest, initOverrides?: RequestInit): Promise<OuterObjectWithEnumProperty> {
+        const response = await this.fakePropertyEnumIntegerSerializeRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * For this test, the body has to be a binary file.
      */
-    async testBodyWithBinaryRaw(requestParameters: TestBodyWithBinaryRequest): Promise<runtime.ApiResponse<void>> {
+    async testBodyWithBinaryRaw(requestParameters: TestBodyWithBinaryRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling testBodyWithBinary.');
         }
@@ -375,7 +375,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body as any,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -383,14 +383,14 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * For this test, the body has to be a binary file.
      */
-    async testBodyWithBinary(requestParameters: TestBodyWithBinaryRequest): Promise<void> {
-        await this.testBodyWithBinaryRaw(requestParameters);
+    async testBodyWithBinary(requestParameters: TestBodyWithBinaryRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.testBodyWithBinaryRaw(requestParameters, initOverrides);
     }
 
     /**
      * For this test, the body for this request must reference a schema named `File`.
      */
-    async testBodyWithFileSchemaRaw(requestParameters: TestBodyWithFileSchemaRequest): Promise<runtime.ApiResponse<void>> {
+    async testBodyWithFileSchemaRaw(requestParameters: TestBodyWithFileSchemaRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.fileSchemaTestClass === null || requestParameters.fileSchemaTestClass === undefined) {
             throw new runtime.RequiredError('fileSchemaTestClass','Required parameter requestParameters.fileSchemaTestClass was null or undefined when calling testBodyWithFileSchema.');
         }
@@ -407,7 +407,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: FileSchemaTestClassToJSON(requestParameters.fileSchemaTestClass),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -415,13 +415,13 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * For this test, the body for this request must reference a schema named `File`.
      */
-    async testBodyWithFileSchema(requestParameters: TestBodyWithFileSchemaRequest): Promise<void> {
-        await this.testBodyWithFileSchemaRaw(requestParameters);
+    async testBodyWithFileSchema(requestParameters: TestBodyWithFileSchemaRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.testBodyWithFileSchemaRaw(requestParameters, initOverrides);
     }
 
     /**
      */
-    async testBodyWithQueryParamsRaw(requestParameters: TestBodyWithQueryParamsRequest): Promise<runtime.ApiResponse<void>> {
+    async testBodyWithQueryParamsRaw(requestParameters: TestBodyWithQueryParamsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.query === null || requestParameters.query === undefined) {
             throw new runtime.RequiredError('query','Required parameter requestParameters.query was null or undefined when calling testBodyWithQueryParams.');
         }
@@ -446,22 +446,22 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.user),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
 
     /**
      */
-    async testBodyWithQueryParams(requestParameters: TestBodyWithQueryParamsRequest): Promise<void> {
-        await this.testBodyWithQueryParamsRaw(requestParameters);
+    async testBodyWithQueryParams(requestParameters: TestBodyWithQueryParamsRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.testBodyWithQueryParamsRaw(requestParameters, initOverrides);
     }
 
     /**
      * To test \"client\" model
      * To test \"client\" model
      */
-    async testClientModelRaw(requestParameters: TestClientModelRequest): Promise<runtime.ApiResponse<Client>> {
+    async testClientModelRaw(requestParameters: TestClientModelRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Client>> {
         if (requestParameters.client === null || requestParameters.client === undefined) {
             throw new runtime.RequiredError('client','Required parameter requestParameters.client was null or undefined when calling testClientModel.');
         }
@@ -478,7 +478,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: ClientToJSON(requestParameters.client),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ClientFromJSON(jsonValue));
     }
@@ -487,8 +487,8 @@ export class FakeApi extends runtime.BaseAPI {
      * To test \"client\" model
      * To test \"client\" model
      */
-    async testClientModel(requestParameters: TestClientModelRequest): Promise<Client> {
-        const response = await this.testClientModelRaw(requestParameters);
+    async testClientModel(requestParameters: TestClientModelRequest, initOverrides?: RequestInit): Promise<Client> {
+        const response = await this.testClientModelRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -496,7 +496,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      */
-    async testEndpointParametersRaw(requestParameters: TestEndpointParametersRequest): Promise<runtime.ApiResponse<void>> {
+    async testEndpointParametersRaw(requestParameters: TestEndpointParametersRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.number === null || requestParameters.number === undefined) {
             throw new runtime.RequiredError('number','Required parameter requestParameters.number was null or undefined when calling testEndpointParameters.');
         }
@@ -598,7 +598,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -607,15 +607,15 @@ export class FakeApi extends runtime.BaseAPI {
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      */
-    async testEndpointParameters(requestParameters: TestEndpointParametersRequest): Promise<void> {
-        await this.testEndpointParametersRaw(requestParameters);
+    async testEndpointParameters(requestParameters: TestEndpointParametersRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.testEndpointParametersRaw(requestParameters, initOverrides);
     }
 
     /**
      * To test enum parameters
      * To test enum parameters
      */
-    async testEnumParametersRaw(requestParameters: TestEnumParametersRequest): Promise<runtime.ApiResponse<void>> {
+    async testEnumParametersRaw(requestParameters: TestEnumParametersRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
         if (requestParameters.enumQueryStringArray) {
@@ -672,7 +672,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -681,15 +681,15 @@ export class FakeApi extends runtime.BaseAPI {
      * To test enum parameters
      * To test enum parameters
      */
-    async testEnumParameters(requestParameters: TestEnumParametersRequest): Promise<void> {
-        await this.testEnumParametersRaw(requestParameters);
+    async testEnumParameters(requestParameters: TestEnumParametersRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.testEnumParametersRaw(requestParameters, initOverrides);
     }
 
     /**
      * Fake endpoint to test group parameters (optional)
      * Fake endpoint to test group parameters (optional)
      */
-    async testGroupParametersRaw(requestParameters: TestGroupParametersRequest): Promise<runtime.ApiResponse<void>> {
+    async testGroupParametersRaw(requestParameters: TestGroupParametersRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.requiredStringGroup === null || requestParameters.requiredStringGroup === undefined) {
             throw new runtime.RequiredError('requiredStringGroup','Required parameter requestParameters.requiredStringGroup was null or undefined when calling testGroupParameters.');
         }
@@ -743,7 +743,7 @@ export class FakeApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -752,14 +752,14 @@ export class FakeApi extends runtime.BaseAPI {
      * Fake endpoint to test group parameters (optional)
      * Fake endpoint to test group parameters (optional)
      */
-    async testGroupParameters(requestParameters: TestGroupParametersRequest): Promise<void> {
-        await this.testGroupParametersRaw(requestParameters);
+    async testGroupParameters(requestParameters: TestGroupParametersRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.testGroupParametersRaw(requestParameters, initOverrides);
     }
 
     /**
      * test inline additionalProperties
      */
-    async testInlineAdditionalPropertiesRaw(requestParameters: TestInlineAdditionalPropertiesRequest): Promise<runtime.ApiResponse<void>> {
+    async testInlineAdditionalPropertiesRaw(requestParameters: TestInlineAdditionalPropertiesRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.requestBody === null || requestParameters.requestBody === undefined) {
             throw new runtime.RequiredError('requestBody','Required parameter requestParameters.requestBody was null or undefined when calling testInlineAdditionalProperties.');
         }
@@ -776,7 +776,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.requestBody,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -784,14 +784,14 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * test inline additionalProperties
      */
-    async testInlineAdditionalProperties(requestParameters: TestInlineAdditionalPropertiesRequest): Promise<void> {
-        await this.testInlineAdditionalPropertiesRaw(requestParameters);
+    async testInlineAdditionalProperties(requestParameters: TestInlineAdditionalPropertiesRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.testInlineAdditionalPropertiesRaw(requestParameters, initOverrides);
     }
 
     /**
      * test json serialization of form data
      */
-    async testJsonFormDataRaw(requestParameters: TestJsonFormDataRequest): Promise<runtime.ApiResponse<void>> {
+    async testJsonFormDataRaw(requestParameters: TestJsonFormDataRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.param === null || requestParameters.param === undefined) {
             throw new runtime.RequiredError('param','Required parameter requestParameters.param was null or undefined when calling testJsonFormData.');
         }
@@ -832,7 +832,7 @@ export class FakeApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -840,14 +840,14 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * test json serialization of form data
      */
-    async testJsonFormData(requestParameters: TestJsonFormDataRequest): Promise<void> {
-        await this.testJsonFormDataRaw(requestParameters);
+    async testJsonFormData(requestParameters: TestJsonFormDataRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.testJsonFormDataRaw(requestParameters, initOverrides);
     }
 
     /**
      * To test the collection format in query parameters
      */
-    async testQueryParameterCollectionFormatRaw(requestParameters: TestQueryParameterCollectionFormatRequest): Promise<runtime.ApiResponse<void>> {
+    async testQueryParameterCollectionFormatRaw(requestParameters: TestQueryParameterCollectionFormatRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.pipe === null || requestParameters.pipe === undefined) {
             throw new runtime.RequiredError('pipe','Required parameter requestParameters.pipe was null or undefined when calling testQueryParameterCollectionFormat.');
         }
@@ -897,7 +897,7 @@ export class FakeApi extends runtime.BaseAPI {
             method: 'PUT',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -905,8 +905,8 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      * To test the collection format in query parameters
      */
-    async testQueryParameterCollectionFormat(requestParameters: TestQueryParameterCollectionFormatRequest): Promise<void> {
-        await this.testQueryParameterCollectionFormatRaw(requestParameters);
+    async testQueryParameterCollectionFormat(requestParameters: TestQueryParameterCollectionFormatRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.testQueryParameterCollectionFormatRaw(requestParameters, initOverrides);
     }
 
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeClassnameTags123Api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeClassnameTags123Api.ts
@@ -33,7 +33,7 @@ export class FakeClassnameTags123Api extends runtime.BaseAPI {
      * To test class name in snake case
      * To test class name in snake case
      */
-    async testClassnameRaw(requestParameters: TestClassnameRequest): Promise<runtime.ApiResponse<Client>> {
+    async testClassnameRaw(requestParameters: TestClassnameRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Client>> {
         if (requestParameters.client === null || requestParameters.client === undefined) {
             throw new runtime.RequiredError('client','Required parameter requestParameters.client was null or undefined when calling testClassname.');
         }
@@ -54,7 +54,7 @@ export class FakeClassnameTags123Api extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: ClientToJSON(requestParameters.client),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ClientFromJSON(jsonValue));
     }
@@ -63,8 +63,8 @@ export class FakeClassnameTags123Api extends runtime.BaseAPI {
      * To test class name in snake case
      * To test class name in snake case
      */
-    async testClassname(requestParameters: TestClassnameRequest): Promise<Client> {
-        const response = await this.testClassnameRaw(requestParameters);
+    async testClassname(requestParameters: TestClassnameRequest, initOverrides?: RequestInit): Promise<Client> {
+        const response = await this.testClassnameRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
@@ -74,7 +74,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.pet === null || requestParameters.pet === undefined) {
             throw new runtime.RequiredError('pet','Required parameter requestParameters.pet was null or undefined when calling addPet.');
         }
@@ -96,7 +96,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.pet),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -104,14 +104,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(requestParameters: AddPetRequest): Promise<void> {
-        await this.addPetRaw(requestParameters);
+    async addPet(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.addPetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -134,7 +134,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -142,15 +142,15 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(requestParameters: DeletePetRequest): Promise<void> {
-        await this.deletePetRaw(requestParameters);
+    async deletePet(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deletePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -173,7 +173,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -182,8 +182,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(requestParameters: FindPetsByStatusRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByStatusRaw(requestParameters);
+    async findPetsByStatus(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByStatusRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -191,7 +191,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Set<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Set<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -214,7 +214,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => new Set(jsonValue.map(PetFromJSON)));
     }
@@ -223,8 +223,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(requestParameters: FindPetsByTagsRequest): Promise<Set<Pet>> {
-        const response = await this.findPetsByTagsRaw(requestParameters);
+    async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<Set<Pet>> {
+        const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -232,7 +232,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -250,7 +250,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => PetFromJSON(jsonValue));
     }
@@ -259,15 +259,15 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(requestParameters: GetPetByIdRequest): Promise<Pet> {
-        const response = await this.getPetByIdRaw(requestParameters);
+    async getPetById(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<Pet> {
+        const response = await this.getPetByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.pet === null || requestParameters.pet === undefined) {
             throw new runtime.RequiredError('pet','Required parameter requestParameters.pet was null or undefined when calling updatePet.');
         }
@@ -289,7 +289,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.pet),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -297,14 +297,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(requestParameters: UpdatePetRequest): Promise<void> {
-        await this.updatePetRaw(requestParameters);
+    async updatePet(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -346,7 +346,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -354,14 +354,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Promise<void> {
-        await this.updatePetWithFormRaw(requestParameters);
+    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetWithFormRaw(requestParameters, initOverrides);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -405,7 +405,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));
     }
@@ -413,15 +413,15 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(requestParameters: UploadFileRequest): Promise<ModelApiResponse> {
-        const response = await this.uploadFileRaw(requestParameters);
+    async uploadFile(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+        const response = await this.uploadFileRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * uploads an image (required)
      */
-    async uploadFileWithRequiredFileRaw(requestParameters: UploadFileWithRequiredFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileWithRequiredFileRaw(requestParameters: UploadFileWithRequiredFileRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFileWithRequiredFile.');
         }
@@ -469,7 +469,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));
     }
@@ -477,8 +477,8 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image (required)
      */
-    async uploadFileWithRequiredFile(requestParameters: UploadFileWithRequiredFileRequest): Promise<ModelApiResponse> {
-        const response = await this.uploadFileWithRequiredFileRaw(requestParameters);
+    async uploadFileWithRequiredFile(requestParameters: UploadFileWithRequiredFileRequest, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+        const response = await this.uploadFileWithRequiredFileRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
@@ -41,7 +41,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -55,7 +55,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -64,15 +64,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(requestParameters: DeleteOrderRequest): Promise<void> {
-        await this.deleteOrderRaw(requestParameters);
+    async deleteOrder(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteOrderRaw(requestParameters, initOverrides);
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventoryRaw(): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
+    async getInventoryRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -86,7 +86,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse<any>(response);
     }
@@ -95,8 +95,8 @@ export class StoreApi extends runtime.BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventory(): Promise<{ [key: string]: number; }> {
-        const response = await this.getInventoryRaw();
+    async getInventory(initOverrides?: RequestInit): Promise<{ [key: string]: number; }> {
+        const response = await this.getInventoryRaw(initOverrides);
         return await response.value();
     }
 
@@ -104,7 +104,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -118,7 +118,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -127,15 +127,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(requestParameters: GetOrderByIdRequest): Promise<Order> {
-        const response = await this.getOrderByIdRaw(requestParameters);
+    async getOrderById(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.getOrderByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.order === null || requestParameters.order === undefined) {
             throw new runtime.RequiredError('order','Required parameter requestParameters.order was null or undefined when calling placeOrder.');
         }
@@ -152,7 +152,7 @@ export class StoreApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: OrderToJSON(requestParameters.order),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -160,8 +160,8 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(requestParameters: PlaceOrderRequest): Promise<Order> {
-        const response = await this.placeOrderRaw(requestParameters);
+    async placeOrder(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.placeOrderRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
@@ -59,7 +59,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.user === null || requestParameters.user === undefined) {
             throw new runtime.RequiredError('user','Required parameter requestParameters.user was null or undefined when calling createUser.');
         }
@@ -76,7 +76,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.user),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -85,14 +85,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(requestParameters: CreateUserRequest): Promise<void> {
-        await this.createUserRaw(requestParameters);
+    async createUser(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.user === null || requestParameters.user === undefined) {
             throw new runtime.RequiredError('user','Required parameter requestParameters.user was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -109,7 +109,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.user.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -117,14 +117,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Promise<void> {
-        await this.createUsersWithArrayInputRaw(requestParameters);
+    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithArrayInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.user === null || requestParameters.user === undefined) {
             throw new runtime.RequiredError('user','Required parameter requestParameters.user was null or undefined when calling createUsersWithListInput.');
         }
@@ -141,7 +141,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.user.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -149,15 +149,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Promise<void> {
-        await this.createUsersWithListInputRaw(requestParameters);
+    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithListInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -171,7 +171,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -180,14 +180,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(requestParameters: DeleteUserRequest): Promise<void> {
-        await this.deleteUserRaw(requestParameters);
+    async deleteUser(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -201,7 +201,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
     }
@@ -209,15 +209,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(requestParameters: GetUserByNameRequest): Promise<User> {
-        const response = await this.getUserByNameRaw(requestParameters);
+    async getUserByName(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<User> {
+        const response = await this.getUserByNameRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -243,7 +243,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -251,15 +251,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(requestParameters: LoginUserRequest): Promise<string> {
-        const response = await this.loginUserRaw(requestParameters);
+    async loginUser(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<string> {
+        const response = await this.loginUserRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs out current logged in user session
      */
-    async logoutUserRaw(): Promise<runtime.ApiResponse<void>> {
+    async logoutUserRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -269,7 +269,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -277,15 +277,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    async logoutUser(): Promise<void> {
-        await this.logoutUserRaw();
+    async logoutUser(initOverrides?: RequestInit): Promise<void> {
+        await this.logoutUserRaw(initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -306,7 +306,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.user),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -315,8 +315,8 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(requestParameters: UpdateUserRequest): Promise<void> {
-        await this.updateUserRaw(requestParameters);
+    async updateUser(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updateUserRaw(requestParameters, initOverrides);
     }
 
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -44,8 +44,8 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
-    protected async request(context: RequestOpts): Promise<Response> {
-        const { url, init } = this.createFetchParams(context);
+    protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
+        const { url, init } = this.createFetchParams(context, initOverrides);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
             return response;
@@ -53,7 +53,7 @@ export class BaseAPI {
         throw response;
     }
 
-    private createFetchParams(context: RequestOpts) {
+    private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
             // only add the querystring to the URL if there are query parameters.
@@ -70,7 +70,8 @@ export class BaseAPI {
             method: context.method,
             headers: headers,
             body,
-            credentials: this.configuration.credentials
+            credentials: this.configuration.credentials,
+            ...initOverrides
         };
         return { url, init };
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
@@ -68,7 +68,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -90,7 +90,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -98,14 +98,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(requestParameters: AddPetRequest): Promise<void> {
-        await this.addPetRaw(requestParameters);
+    async addPet(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.addPetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -128,7 +128,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -136,15 +136,15 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(requestParameters: DeletePetRequest): Promise<void> {
-        await this.deletePetRaw(requestParameters);
+    async deletePet(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deletePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -167,7 +167,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -176,8 +176,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(requestParameters: FindPetsByStatusRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByStatusRaw(requestParameters);
+    async findPetsByStatus(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByStatusRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -185,7 +185,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -208,7 +208,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -217,8 +217,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(requestParameters: FindPetsByTagsRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByTagsRaw(requestParameters);
+    async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -226,7 +226,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -244,7 +244,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => PetFromJSON(jsonValue));
     }
@@ -253,15 +253,15 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(requestParameters: GetPetByIdRequest): Promise<Pet> {
-        const response = await this.getPetByIdRaw(requestParameters);
+    async getPetById(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<Pet> {
+        const response = await this.getPetByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -283,7 +283,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -291,14 +291,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(requestParameters: UpdatePetRequest): Promise<void> {
-        await this.updatePetRaw(requestParameters);
+    async updatePet(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -340,7 +340,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -348,14 +348,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Promise<void> {
-        await this.updatePetWithFormRaw(requestParameters);
+    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetWithFormRaw(requestParameters, initOverrides);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -399,7 +399,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));
     }
@@ -407,8 +407,8 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(requestParameters: UploadFileRequest): Promise<ModelApiResponse> {
-        const response = await this.uploadFileRaw(requestParameters);
+    async uploadFile(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+        const response = await this.uploadFileRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
@@ -41,7 +41,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -55,7 +55,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -64,15 +64,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(requestParameters: DeleteOrderRequest): Promise<void> {
-        await this.deleteOrderRaw(requestParameters);
+    async deleteOrder(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteOrderRaw(requestParameters, initOverrides);
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventoryRaw(): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
+    async getInventoryRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -86,7 +86,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse<any>(response);
     }
@@ -95,8 +95,8 @@ export class StoreApi extends runtime.BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventory(): Promise<{ [key: string]: number; }> {
-        const response = await this.getInventoryRaw();
+    async getInventory(initOverrides?: RequestInit): Promise<{ [key: string]: number; }> {
+        const response = await this.getInventoryRaw(initOverrides);
         return await response.value();
     }
 
@@ -104,7 +104,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -118,7 +118,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -127,15 +127,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(requestParameters: GetOrderByIdRequest): Promise<Order> {
-        const response = await this.getOrderByIdRaw(requestParameters);
+    async getOrderById(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.getOrderByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -152,7 +152,7 @@ export class StoreApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: OrderToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -160,8 +160,8 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(requestParameters: PlaceOrderRequest): Promise<Order> {
-        const response = await this.placeOrderRaw(requestParameters);
+    async placeOrder(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.placeOrderRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
@@ -59,7 +59,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -76,7 +76,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -85,14 +85,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(requestParameters: CreateUserRequest): Promise<void> {
-        await this.createUserRaw(requestParameters);
+    async createUser(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -109,7 +109,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -117,14 +117,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Promise<void> {
-        await this.createUsersWithArrayInputRaw(requestParameters);
+    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithArrayInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -141,7 +141,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -149,15 +149,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Promise<void> {
-        await this.createUsersWithListInputRaw(requestParameters);
+    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithListInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -171,7 +171,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -180,14 +180,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(requestParameters: DeleteUserRequest): Promise<void> {
-        await this.deleteUserRaw(requestParameters);
+    async deleteUser(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -201,7 +201,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
     }
@@ -209,15 +209,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(requestParameters: GetUserByNameRequest): Promise<User> {
-        const response = await this.getUserByNameRaw(requestParameters);
+    async getUserByName(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<User> {
+        const response = await this.getUserByNameRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -243,7 +243,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -251,15 +251,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(requestParameters: LoginUserRequest): Promise<string> {
-        const response = await this.loginUserRaw(requestParameters);
+    async loginUser(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<string> {
+        const response = await this.loginUserRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs out current logged in user session
      */
-    async logoutUserRaw(): Promise<runtime.ApiResponse<void>> {
+    async logoutUserRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -269,7 +269,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -277,15 +277,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    async logoutUser(): Promise<void> {
-        await this.logoutUserRaw();
+    async logoutUser(initOverrides?: RequestInit): Promise<void> {
+        await this.logoutUserRaw(initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -306,7 +306,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -315,8 +315,8 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(requestParameters: UpdateUserRequest): Promise<void> {
-        await this.updateUserRaw(requestParameters);
+    async updateUser(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updateUserRaw(requestParameters, initOverrides);
     }
 
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -44,8 +44,8 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
-    protected async request(context: RequestOpts): Promise<Response> {
-        const { url, init } = this.createFetchParams(context);
+    protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
+        const { url, init } = this.createFetchParams(context, initOverrides);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
             return response;
@@ -53,7 +53,7 @@ export class BaseAPI {
         throw response;
     }
 
-    private createFetchParams(context: RequestOpts) {
+    private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
             // only add the querystring to the URL if there are query parameters.
@@ -70,7 +70,8 @@ export class BaseAPI {
             method: context.method,
             headers: headers,
             body,
-            credentials: this.configuration.credentials
+            credentials: this.configuration.credentials,
+            ...initOverrides
         };
         return { url, init };
     }

--- a/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
@@ -61,7 +61,7 @@ export class DefaultApi extends runtime.BaseAPI {
 
     /**
      */
-    async fakeEnumRequestGetInlineRaw(requestParameters: FakeEnumRequestGetInlineRequest): Promise<runtime.ApiResponse<InlineResponse200>> {
+    async fakeEnumRequestGetInlineRaw(requestParameters: FakeEnumRequestGetInlineRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<InlineResponse200>> {
         const queryParameters: any = {};
 
         if (requestParameters.stringEnum !== undefined) {
@@ -87,21 +87,21 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => InlineResponse200FromJSON(jsonValue));
     }
 
     /**
      */
-    async fakeEnumRequestGetInline(requestParameters: FakeEnumRequestGetInlineRequest): Promise<InlineResponse200> {
-        const response = await this.fakeEnumRequestGetInlineRaw(requestParameters);
+    async fakeEnumRequestGetInline(requestParameters: FakeEnumRequestGetInlineRequest, initOverrides?: RequestInit): Promise<InlineResponse200> {
+        const response = await this.fakeEnumRequestGetInlineRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      */
-    async fakeEnumRequestGetRefRaw(requestParameters: FakeEnumRequestGetRefRequest): Promise<runtime.ApiResponse<EnumPatternObject>> {
+    async fakeEnumRequestGetRefRaw(requestParameters: FakeEnumRequestGetRefRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<EnumPatternObject>> {
         const queryParameters: any = {};
 
         if (requestParameters.stringEnum !== undefined) {
@@ -127,21 +127,21 @@ export class DefaultApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => EnumPatternObjectFromJSON(jsonValue));
     }
 
     /**
      */
-    async fakeEnumRequestGetRef(requestParameters: FakeEnumRequestGetRefRequest): Promise<EnumPatternObject> {
-        const response = await this.fakeEnumRequestGetRefRaw(requestParameters);
+    async fakeEnumRequestGetRef(requestParameters: FakeEnumRequestGetRefRequest, initOverrides?: RequestInit): Promise<EnumPatternObject> {
+        const response = await this.fakeEnumRequestGetRefRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      */
-    async fakeEnumRequestPostInlineRaw(requestParameters: FakeEnumRequestPostInlineRequest): Promise<runtime.ApiResponse<InlineObject>> {
+    async fakeEnumRequestPostInlineRaw(requestParameters: FakeEnumRequestPostInlineRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<InlineObject>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -154,21 +154,21 @@ export class DefaultApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: InlineObjectToJSON(requestParameters.inlineObject),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => InlineObjectFromJSON(jsonValue));
     }
 
     /**
      */
-    async fakeEnumRequestPostInline(requestParameters: FakeEnumRequestPostInlineRequest): Promise<InlineObject> {
-        const response = await this.fakeEnumRequestPostInlineRaw(requestParameters);
+    async fakeEnumRequestPostInline(requestParameters: FakeEnumRequestPostInlineRequest, initOverrides?: RequestInit): Promise<InlineObject> {
+        const response = await this.fakeEnumRequestPostInlineRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      */
-    async fakeEnumRequestPostRefRaw(requestParameters: FakeEnumRequestPostRefRequest): Promise<runtime.ApiResponse<EnumPatternObject>> {
+    async fakeEnumRequestPostRefRaw(requestParameters: FakeEnumRequestPostRefRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<EnumPatternObject>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -181,15 +181,15 @@ export class DefaultApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: EnumPatternObjectToJSON(requestParameters.enumPatternObject),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => EnumPatternObjectFromJSON(jsonValue));
     }
 
     /**
      */
-    async fakeEnumRequestPostRef(requestParameters: FakeEnumRequestPostRefRequest): Promise<EnumPatternObject> {
-        const response = await this.fakeEnumRequestPostRefRaw(requestParameters);
+    async fakeEnumRequestPostRef(requestParameters: FakeEnumRequestPostRefRequest, initOverrides?: RequestInit): Promise<EnumPatternObject> {
+        const response = await this.fakeEnumRequestPostRefRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -44,8 +44,8 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
-    protected async request(context: RequestOpts): Promise<Response> {
-        const { url, init } = this.createFetchParams(context);
+    protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
+        const { url, init } = this.createFetchParams(context, initOverrides);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
             return response;
@@ -53,7 +53,7 @@ export class BaseAPI {
         throw response;
     }
 
-    private createFetchParams(context: RequestOpts) {
+    private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
             // only add the querystring to the URL if there are query parameters.
@@ -70,7 +70,8 @@ export class BaseAPI {
             method: context.method,
             headers: headers,
             body,
-            credentials: this.configuration.credentials
+            credentials: this.configuration.credentials,
+            ...initOverrides
         };
         return { url, init };
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
@@ -68,7 +68,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -90,7 +90,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -98,14 +98,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(requestParameters: AddPetRequest): Promise<void> {
-        await this.addPetRaw(requestParameters);
+    async addPet(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.addPetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -128,7 +128,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -136,15 +136,15 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(requestParameters: DeletePetRequest): Promise<void> {
-        await this.deletePetRaw(requestParameters);
+    async deletePet(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deletePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -167,7 +167,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -176,8 +176,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(requestParameters: FindPetsByStatusRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByStatusRaw(requestParameters);
+    async findPetsByStatus(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByStatusRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -185,7 +185,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -208,7 +208,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -217,8 +217,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(requestParameters: FindPetsByTagsRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByTagsRaw(requestParameters);
+    async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -226,7 +226,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -244,7 +244,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => PetFromJSON(jsonValue));
     }
@@ -253,15 +253,15 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(requestParameters: GetPetByIdRequest): Promise<Pet> {
-        const response = await this.getPetByIdRaw(requestParameters);
+    async getPetById(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<Pet> {
+        const response = await this.getPetByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -283,7 +283,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -291,14 +291,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(requestParameters: UpdatePetRequest): Promise<void> {
-        await this.updatePetRaw(requestParameters);
+    async updatePet(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -340,7 +340,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -348,14 +348,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Promise<void> {
-        await this.updatePetWithFormRaw(requestParameters);
+    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetWithFormRaw(requestParameters, initOverrides);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -399,7 +399,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));
     }
@@ -407,8 +407,8 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(requestParameters: UploadFileRequest): Promise<ModelApiResponse> {
-        const response = await this.uploadFileRaw(requestParameters);
+    async uploadFile(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+        const response = await this.uploadFileRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
@@ -41,7 +41,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -55,7 +55,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -64,15 +64,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(requestParameters: DeleteOrderRequest): Promise<void> {
-        await this.deleteOrderRaw(requestParameters);
+    async deleteOrder(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteOrderRaw(requestParameters, initOverrides);
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventoryRaw(): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
+    async getInventoryRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -86,7 +86,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse<any>(response);
     }
@@ -95,8 +95,8 @@ export class StoreApi extends runtime.BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventory(): Promise<{ [key: string]: number; }> {
-        const response = await this.getInventoryRaw();
+    async getInventory(initOverrides?: RequestInit): Promise<{ [key: string]: number; }> {
+        const response = await this.getInventoryRaw(initOverrides);
         return await response.value();
     }
 
@@ -104,7 +104,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -118,7 +118,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -127,15 +127,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(requestParameters: GetOrderByIdRequest): Promise<Order> {
-        const response = await this.getOrderByIdRaw(requestParameters);
+    async getOrderById(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.getOrderByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -152,7 +152,7 @@ export class StoreApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: OrderToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -160,8 +160,8 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(requestParameters: PlaceOrderRequest): Promise<Order> {
-        const response = await this.placeOrderRaw(requestParameters);
+    async placeOrder(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.placeOrderRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
@@ -59,7 +59,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -76,7 +76,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -85,14 +85,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(requestParameters: CreateUserRequest): Promise<void> {
-        await this.createUserRaw(requestParameters);
+    async createUser(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -109,7 +109,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -117,14 +117,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Promise<void> {
-        await this.createUsersWithArrayInputRaw(requestParameters);
+    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithArrayInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -141,7 +141,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -149,15 +149,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Promise<void> {
-        await this.createUsersWithListInputRaw(requestParameters);
+    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithListInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -171,7 +171,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -180,14 +180,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(requestParameters: DeleteUserRequest): Promise<void> {
-        await this.deleteUserRaw(requestParameters);
+    async deleteUser(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -201,7 +201,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
     }
@@ -209,15 +209,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(requestParameters: GetUserByNameRequest): Promise<User> {
-        const response = await this.getUserByNameRaw(requestParameters);
+    async getUserByName(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<User> {
+        const response = await this.getUserByNameRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -243,7 +243,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -251,15 +251,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(requestParameters: LoginUserRequest): Promise<string> {
-        const response = await this.loginUserRaw(requestParameters);
+    async loginUser(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<string> {
+        const response = await this.loginUserRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs out current logged in user session
      */
-    async logoutUserRaw(): Promise<runtime.ApiResponse<void>> {
+    async logoutUserRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -269,7 +269,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -277,15 +277,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    async logoutUser(): Promise<void> {
-        await this.logoutUserRaw();
+    async logoutUser(initOverrides?: RequestInit): Promise<void> {
+        await this.logoutUserRaw(initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -306,7 +306,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -315,8 +315,8 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(requestParameters: UpdateUserRequest): Promise<void> {
-        await this.updateUserRaw(requestParameters);
+    async updateUser(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updateUserRaw(requestParameters, initOverrides);
     }
 
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -44,8 +44,8 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
-    protected async request(context: RequestOpts): Promise<Response> {
-        const { url, init } = this.createFetchParams(context);
+    protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
+        const { url, init } = this.createFetchParams(context, initOverrides);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
             return response;
@@ -53,7 +53,7 @@ export class BaseAPI {
         throw response;
     }
 
-    private createFetchParams(context: RequestOpts) {
+    private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
             // only add the querystring to the URL if there are query parameters.
@@ -70,7 +70,8 @@ export class BaseAPI {
             method: context.method,
             headers: headers,
             body,
-            credentials: this.configuration.credentials
+            credentials: this.configuration.credentials,
+            ...initOverrides
         };
         return { url, init };
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
@@ -68,7 +68,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -90,7 +90,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -98,14 +98,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(body: Pet): Promise<void> {
-        await this.addPetRaw({ body: body });
+    async addPet(body: Pet, initOverrides?: RequestInit): Promise<void> {
+        await this.addPetRaw({ body: body }, initOverrides);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -128,7 +128,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -136,15 +136,15 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(petId: number, apiKey?: string): Promise<void> {
-        await this.deletePetRaw({ petId: petId, apiKey: apiKey });
+    async deletePet(petId: number, , apiKey?: string, initOverrides?: RequestInit): Promise<void> {
+        await this.deletePetRaw({ petId: petId, apiKey: apiKey }, initOverrides);
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -167,7 +167,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -176,8 +176,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(status: Array<FindPetsByStatusStatusEnum>): Promise<Array<Pet>> {
-        const response = await this.findPetsByStatusRaw({ status: status });
+    async findPetsByStatus(status: Array<FindPetsByStatusStatusEnum>, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByStatusRaw({ status: status }, initOverrides);
         return await response.value();
     }
 
@@ -185,7 +185,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -208,7 +208,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -217,8 +217,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(tags: Array<string>): Promise<Array<Pet>> {
-        const response = await this.findPetsByTagsRaw({ tags: tags });
+    async findPetsByTags(tags: Array<string>, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByTagsRaw({ tags: tags }, initOverrides);
         return await response.value();
     }
 
@@ -226,7 +226,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -244,7 +244,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => PetFromJSON(jsonValue));
     }
@@ -253,15 +253,15 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(petId: number): Promise<Pet> {
-        const response = await this.getPetByIdRaw({ petId: petId });
+    async getPetById(petId: number, initOverrides?: RequestInit): Promise<Pet> {
+        const response = await this.getPetByIdRaw({ petId: petId }, initOverrides);
         return await response.value();
     }
 
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -283,7 +283,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -291,14 +291,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(body: Pet): Promise<void> {
-        await this.updatePetRaw({ body: body });
+    async updatePet(body: Pet, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetRaw({ body: body }, initOverrides);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -340,7 +340,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -348,14 +348,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(petId: number, name?: string, status?: string): Promise<void> {
-        await this.updatePetWithFormRaw({ petId: petId, name: name, status: status });
+    async updatePetWithForm(petId: number, , name?: string, , status?: string, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetWithFormRaw({ petId: petId, name: name, status: status }, initOverrides);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -399,7 +399,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));
     }
@@ -407,8 +407,8 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(petId: number, additionalMetadata?: string, file?: Blob): Promise<ModelApiResponse> {
-        const response = await this.uploadFileRaw({ petId: petId, additionalMetadata: additionalMetadata, file: file });
+    async uploadFile(petId: number, , additionalMetadata?: string, , file?: Blob, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+        const response = await this.uploadFileRaw({ petId: petId, additionalMetadata: additionalMetadata, file: file }, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
@@ -41,7 +41,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -55,7 +55,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -64,15 +64,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(orderId: string): Promise<void> {
-        await this.deleteOrderRaw({ orderId: orderId });
+    async deleteOrder(orderId: string, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteOrderRaw({ orderId: orderId }, initOverrides);
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventoryRaw(): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
+    async getInventoryRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -86,7 +86,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse<any>(response);
     }
@@ -95,8 +95,8 @@ export class StoreApi extends runtime.BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventory(): Promise<{ [key: string]: number; }> {
-        const response = await this.getInventoryRaw();
+    async getInventory(initOverrides?: RequestInit): Promise<{ [key: string]: number; }> {
+        const response = await this.getInventoryRaw(initOverrides);
         return await response.value();
     }
 
@@ -104,7 +104,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -118,7 +118,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -127,15 +127,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(orderId: number): Promise<Order> {
-        const response = await this.getOrderByIdRaw({ orderId: orderId });
+    async getOrderById(orderId: number, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.getOrderByIdRaw({ orderId: orderId }, initOverrides);
         return await response.value();
     }
 
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -152,7 +152,7 @@ export class StoreApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: OrderToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -160,8 +160,8 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(body: Order): Promise<Order> {
-        const response = await this.placeOrderRaw({ body: body });
+    async placeOrder(body: Order, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.placeOrderRaw({ body: body }, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
@@ -59,7 +59,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -76,7 +76,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -85,14 +85,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(body: User): Promise<void> {
-        await this.createUserRaw({ body: body });
+    async createUser(body: User, initOverrides?: RequestInit): Promise<void> {
+        await this.createUserRaw({ body: body }, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -109,7 +109,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -117,14 +117,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(body: Array<User>): Promise<void> {
-        await this.createUsersWithArrayInputRaw({ body: body });
+    async createUsersWithArrayInput(body: Array<User>, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithArrayInputRaw({ body: body }, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -141,7 +141,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -149,15 +149,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(body: Array<User>): Promise<void> {
-        await this.createUsersWithListInputRaw({ body: body });
+    async createUsersWithListInput(body: Array<User>, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithListInputRaw({ body: body }, initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -171,7 +171,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -180,14 +180,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(username: string): Promise<void> {
-        await this.deleteUserRaw({ username: username });
+    async deleteUser(username: string, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteUserRaw({ username: username }, initOverrides);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -201,7 +201,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
     }
@@ -209,15 +209,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(username: string): Promise<User> {
-        const response = await this.getUserByNameRaw({ username: username });
+    async getUserByName(username: string, initOverrides?: RequestInit): Promise<User> {
+        const response = await this.getUserByNameRaw({ username: username }, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -243,7 +243,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -251,15 +251,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(username: string, password: string): Promise<string> {
-        const response = await this.loginUserRaw({ username: username, password: password });
+    async loginUser(username: string, , password: string, initOverrides?: RequestInit): Promise<string> {
+        const response = await this.loginUserRaw({ username: username, password: password }, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs out current logged in user session
      */
-    async logoutUserRaw(): Promise<runtime.ApiResponse<void>> {
+    async logoutUserRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -269,7 +269,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -277,15 +277,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    async logoutUser(): Promise<void> {
-        await this.logoutUserRaw();
+    async logoutUser(initOverrides?: RequestInit): Promise<void> {
+        await this.logoutUserRaw(, initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -306,7 +306,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -315,8 +315,8 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(username: string, body: User): Promise<void> {
-        await this.updateUserRaw({ username: username, body: body });
+    async updateUser(username: string, , body: User, initOverrides?: RequestInit): Promise<void> {
+        await this.updateUserRaw({ username: username, body: body }, initOverrides);
     }
 
 }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -44,8 +44,8 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
-    protected async request(context: RequestOpts): Promise<Response> {
-        const { url, init } = this.createFetchParams(context);
+    protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
+        const { url, init } = this.createFetchParams(context, initOverrides);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
             return response;
@@ -53,7 +53,7 @@ export class BaseAPI {
         throw response;
     }
 
-    private createFetchParams(context: RequestOpts) {
+    private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
             // only add the querystring to the URL if there are query parameters.
@@ -70,7 +70,8 @@ export class BaseAPI {
             method: context.method,
             headers: headers,
             body,
-            credentials: this.configuration.credentials
+            credentials: this.configuration.credentials,
+            ...initOverrides
         };
         return { url, init };
     }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
@@ -68,7 +68,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: PetApiAddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: PetApiAddPetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -90,7 +90,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -98,14 +98,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(requestParameters: PetApiAddPetRequest): Promise<void> {
-        await this.addPetRaw(requestParameters);
+    async addPet(requestParameters: PetApiAddPetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.addPetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: PetApiDeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: PetApiDeletePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -128,7 +128,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -136,15 +136,15 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(requestParameters: PetApiDeletePetRequest): Promise<void> {
-        await this.deletePetRaw(requestParameters);
+    async deletePet(requestParameters: PetApiDeletePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deletePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: PetApiFindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: PetApiFindPetsByStatusRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -167,7 +167,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -176,8 +176,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(requestParameters: PetApiFindPetsByStatusRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByStatusRaw(requestParameters);
+    async findPetsByStatus(requestParameters: PetApiFindPetsByStatusRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByStatusRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -185,7 +185,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: PetApiFindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: PetApiFindPetsByTagsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -208,7 +208,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -217,8 +217,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(requestParameters: PetApiFindPetsByTagsRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByTagsRaw(requestParameters);
+    async findPetsByTags(requestParameters: PetApiFindPetsByTagsRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -226,7 +226,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: PetApiGetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: PetApiGetPetByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -244,7 +244,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => PetFromJSON(jsonValue));
     }
@@ -253,15 +253,15 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(requestParameters: PetApiGetPetByIdRequest): Promise<Pet> {
-        const response = await this.getPetByIdRaw(requestParameters);
+    async getPetById(requestParameters: PetApiGetPetByIdRequest, initOverrides?: RequestInit): Promise<Pet> {
+        const response = await this.getPetByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: PetApiUpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: PetApiUpdatePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -283,7 +283,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -291,14 +291,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(requestParameters: PetApiUpdatePetRequest): Promise<void> {
-        await this.updatePetRaw(requestParameters);
+    async updatePet(requestParameters: PetApiUpdatePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: PetApiUpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: PetApiUpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -340,7 +340,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -348,14 +348,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(requestParameters: PetApiUpdatePetWithFormRequest): Promise<void> {
-        await this.updatePetWithFormRaw(requestParameters);
+    async updatePetWithForm(requestParameters: PetApiUpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetWithFormRaw(requestParameters, initOverrides);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: PetApiUploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: PetApiUploadFileRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -399,7 +399,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));
     }
@@ -407,8 +407,8 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(requestParameters: PetApiUploadFileRequest): Promise<ModelApiResponse> {
-        const response = await this.uploadFileRaw(requestParameters);
+    async uploadFile(requestParameters: PetApiUploadFileRequest, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+        const response = await this.uploadFileRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
@@ -41,7 +41,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: StoreApiDeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: StoreApiDeleteOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -55,7 +55,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -64,15 +64,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(requestParameters: StoreApiDeleteOrderRequest): Promise<void> {
-        await this.deleteOrderRaw(requestParameters);
+    async deleteOrder(requestParameters: StoreApiDeleteOrderRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteOrderRaw(requestParameters, initOverrides);
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventoryRaw(): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
+    async getInventoryRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -86,7 +86,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse<any>(response);
     }
@@ -95,8 +95,8 @@ export class StoreApi extends runtime.BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventory(): Promise<{ [key: string]: number; }> {
-        const response = await this.getInventoryRaw();
+    async getInventory(initOverrides?: RequestInit): Promise<{ [key: string]: number; }> {
+        const response = await this.getInventoryRaw(initOverrides);
         return await response.value();
     }
 
@@ -104,7 +104,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: StoreApiGetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: StoreApiGetOrderByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -118,7 +118,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -127,15 +127,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(requestParameters: StoreApiGetOrderByIdRequest): Promise<Order> {
-        const response = await this.getOrderByIdRaw(requestParameters);
+    async getOrderById(requestParameters: StoreApiGetOrderByIdRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.getOrderByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: StoreApiPlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: StoreApiPlaceOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -152,7 +152,7 @@ export class StoreApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: OrderToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -160,8 +160,8 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(requestParameters: StoreApiPlaceOrderRequest): Promise<Order> {
-        const response = await this.placeOrderRaw(requestParameters);
+    async placeOrder(requestParameters: StoreApiPlaceOrderRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.placeOrderRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
@@ -59,7 +59,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: UserApiCreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: UserApiCreateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -76,7 +76,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -85,14 +85,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(requestParameters: UserApiCreateUserRequest): Promise<void> {
-        await this.createUserRaw(requestParameters);
+    async createUser(requestParameters: UserApiCreateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: UserApiCreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: UserApiCreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -109,7 +109,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -117,14 +117,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(requestParameters: UserApiCreateUsersWithArrayInputRequest): Promise<void> {
-        await this.createUsersWithArrayInputRaw(requestParameters);
+    async createUsersWithArrayInput(requestParameters: UserApiCreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithArrayInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: UserApiCreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: UserApiCreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -141,7 +141,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -149,15 +149,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(requestParameters: UserApiCreateUsersWithListInputRequest): Promise<void> {
-        await this.createUsersWithListInputRaw(requestParameters);
+    async createUsersWithListInput(requestParameters: UserApiCreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithListInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: UserApiDeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: UserApiDeleteUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -171,7 +171,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -180,14 +180,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(requestParameters: UserApiDeleteUserRequest): Promise<void> {
-        await this.deleteUserRaw(requestParameters);
+    async deleteUser(requestParameters: UserApiDeleteUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: UserApiGetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: UserApiGetUserByNameRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -201,7 +201,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
     }
@@ -209,15 +209,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(requestParameters: UserApiGetUserByNameRequest): Promise<User> {
-        const response = await this.getUserByNameRaw(requestParameters);
+    async getUserByName(requestParameters: UserApiGetUserByNameRequest, initOverrides?: RequestInit): Promise<User> {
+        const response = await this.getUserByNameRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: UserApiLoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: UserApiLoginUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -243,7 +243,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -251,15 +251,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(requestParameters: UserApiLoginUserRequest): Promise<string> {
-        const response = await this.loginUserRaw(requestParameters);
+    async loginUser(requestParameters: UserApiLoginUserRequest, initOverrides?: RequestInit): Promise<string> {
+        const response = await this.loginUserRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs out current logged in user session
      */
-    async logoutUserRaw(): Promise<runtime.ApiResponse<void>> {
+    async logoutUserRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -269,7 +269,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -277,15 +277,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    async logoutUser(): Promise<void> {
-        await this.logoutUserRaw();
+    async logoutUser(initOverrides?: RequestInit): Promise<void> {
+        await this.logoutUserRaw(initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UserApiUpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UserApiUpdateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -306,7 +306,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -315,8 +315,8 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(requestParameters: UserApiUpdateUserRequest): Promise<void> {
-        await this.updateUserRaw(requestParameters);
+    async updateUser(requestParameters: UserApiUpdateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updateUserRaw(requestParameters, initOverrides);
     }
 
 }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -44,8 +44,8 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
-    protected async request(context: RequestOpts): Promise<Response> {
-        const { url, init } = this.createFetchParams(context);
+    protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
+        const { url, init } = this.createFetchParams(context, initOverrides);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
             return response;
@@ -53,7 +53,7 @@ export class BaseAPI {
         throw response;
     }
 
-    private createFetchParams(context: RequestOpts) {
+    private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
             // only add the querystring to the URL if there are query parameters.
@@ -70,7 +70,8 @@ export class BaseAPI {
             method: context.method,
             headers: headers,
             body,
-            credentials: this.configuration.credentials
+            credentials: this.configuration.credentials,
+            ...initOverrides
         };
         return { url, init };
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
@@ -39,7 +39,7 @@ export class BehaviorApi extends runtime.BaseAPI {
     /**
      * Get permissions for the behavior
      */
-    async getBehaviorPermissionsRaw(requestParameters: GetBehaviorPermissionsRequest): Promise<runtime.ApiResponse<GetBehaviorPermissionsResponse>> {
+    async getBehaviorPermissionsRaw(requestParameters: GetBehaviorPermissionsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<GetBehaviorPermissionsResponse>> {
         if (requestParameters.behaviorId === null || requestParameters.behaviorId === undefined) {
             throw new runtime.RequiredError('behaviorId','Required parameter requestParameters.behaviorId was null or undefined when calling getBehaviorPermissions.');
         }
@@ -53,7 +53,7 @@ export class BehaviorApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => GetBehaviorPermissionsResponseFromJSON(jsonValue));
     }
@@ -61,15 +61,15 @@ export class BehaviorApi extends runtime.BaseAPI {
     /**
      * Get permissions for the behavior
      */
-    async getBehaviorPermissions(behaviorId: number): Promise<GetBehaviorPermissionsResponse> {
-        const response = await this.getBehaviorPermissionsRaw({ behaviorId: behaviorId });
+    async getBehaviorPermissions(behaviorId: number, initOverrides?: RequestInit): Promise<GetBehaviorPermissionsResponse> {
+        const response = await this.getBehaviorPermissionsRaw({ behaviorId: behaviorId }, initOverrides);
         return await response.value();
     }
 
     /**
      * Get the type of behavior
      */
-    async getBehaviorTypeRaw(requestParameters: GetBehaviorTypeRequest): Promise<runtime.ApiResponse<GetBehaviorTypeResponse>> {
+    async getBehaviorTypeRaw(requestParameters: GetBehaviorTypeRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<GetBehaviorTypeResponse>> {
         if (requestParameters.behaviorId === null || requestParameters.behaviorId === undefined) {
             throw new runtime.RequiredError('behaviorId','Required parameter requestParameters.behaviorId was null or undefined when calling getBehaviorType.');
         }
@@ -83,7 +83,7 @@ export class BehaviorApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => GetBehaviorTypeResponseFromJSON(jsonValue));
     }
@@ -91,8 +91,8 @@ export class BehaviorApi extends runtime.BaseAPI {
     /**
      * Get the type of behavior
      */
-    async getBehaviorType(behaviorId: number): Promise<GetBehaviorTypeResponse> {
-        const response = await this.getBehaviorTypeRaw({ behaviorId: behaviorId });
+    async getBehaviorType(behaviorId: number, initOverrides?: RequestInit): Promise<GetBehaviorTypeResponse> {
+        const response = await this.getBehaviorTypeRaw({ behaviorId: behaviorId }, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
@@ -85,7 +85,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.dummyCat === null || requestParameters.dummyCat === undefined) {
             throw new runtime.RequiredError('dummyCat','Required parameter requestParameters.dummyCat was null or undefined when calling addPet.');
         }
@@ -107,7 +107,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: CategoryToJSON(requestParameters.dummyCat),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -115,14 +115,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(dummyCat: Category): Promise<void> {
-        await this.addPetRaw({ dummyCat: dummyCat });
+    async addPet(dummyCat: Category, initOverrides?: RequestInit): Promise<void> {
+        await this.addPetRaw({ dummyCat: dummyCat }, initOverrides);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -145,7 +145,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -153,15 +153,15 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(petId: number, apiKey?: string): Promise<void> {
-        await this.deletePetRaw({ petId: petId, apiKey: apiKey });
+    async deletePet(petId: number, , apiKey?: string, initOverrides?: RequestInit): Promise<void> {
+        await this.deletePetRaw({ petId: petId, apiKey: apiKey }, initOverrides);
     }
 
     /**
      * Multiple ids can be provided with comma separated strings.
      * Finds Pets by ids
      */
-    async findPetsByIdsRaw(requestParameters: FindPetsByIdsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByIdsRaw(requestParameters: FindPetsByIdsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.ids === null || requestParameters.ids === undefined) {
             throw new runtime.RequiredError('ids','Required parameter requestParameters.ids was null or undefined when calling findPetsByIds.');
         }
@@ -184,7 +184,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -193,8 +193,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple ids can be provided with comma separated strings.
      * Finds Pets by ids
      */
-    async findPetsByIds(ids: Array<number>): Promise<Array<Pet>> {
-        const response = await this.findPetsByIdsRaw({ ids: ids });
+    async findPetsByIds(ids: Array<number>, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByIdsRaw({ ids: ids }, initOverrides);
         return await response.value();
     }
 
@@ -202,7 +202,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<FindPetsByStatusResponse>> {
+    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<FindPetsByStatusResponse>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -225,7 +225,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => FindPetsByStatusResponseFromJSON(jsonValue));
     }
@@ -234,8 +234,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(status: Array<FindPetsByStatusStatusEnum>): Promise<FindPetsByStatusResponse> {
-        const response = await this.findPetsByStatusRaw({ status: status });
+    async findPetsByStatus(status: Array<FindPetsByStatusStatusEnum>, initOverrides?: RequestInit): Promise<FindPetsByStatusResponse> {
+        const response = await this.findPetsByStatusRaw({ status: status }, initOverrides);
         return await response.value();
     }
 
@@ -243,7 +243,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -266,7 +266,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -275,8 +275,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(tags: Array<string>): Promise<Array<Pet>> {
-        const response = await this.findPetsByTagsRaw({ tags: tags });
+    async findPetsByTags(tags: Array<string>, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByTagsRaw({ tags: tags }, initOverrides);
         return await response.value();
     }
 
@@ -284,7 +284,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple ids can be provided with comma separated strings.
      * Finds Pets by user ids
      */
-    async findPetsByUserIdsRaw(requestParameters: FindPetsByUserIdsRequest): Promise<runtime.ApiResponse<FindPetsByUserResponse>> {
+    async findPetsByUserIdsRaw(requestParameters: FindPetsByUserIdsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<FindPetsByUserResponse>> {
         if (requestParameters.ids === null || requestParameters.ids === undefined) {
             throw new runtime.RequiredError('ids','Required parameter requestParameters.ids was null or undefined when calling findPetsByUserIds.');
         }
@@ -307,7 +307,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => FindPetsByUserResponseFromJSON(jsonValue));
     }
@@ -316,8 +316,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple ids can be provided with comma separated strings.
      * Finds Pets by user ids
      */
-    async findPetsByUserIds(ids: Array<number>): Promise<FindPetsByUserResponse> {
-        const response = await this.findPetsByUserIdsRaw({ ids: ids });
+    async findPetsByUserIds(ids: Array<number>, initOverrides?: RequestInit): Promise<FindPetsByUserResponse> {
+        const response = await this.findPetsByUserIdsRaw({ ids: ids }, initOverrides);
         return await response.value();
     }
 
@@ -325,7 +325,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -343,7 +343,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => PetFromJSON(jsonValue));
     }
@@ -352,15 +352,15 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(petId: number): Promise<Pet> {
-        const response = await this.getPetByIdRaw({ petId: petId });
+    async getPetById(petId: number, initOverrides?: RequestInit): Promise<Pet> {
+        const response = await this.getPetByIdRaw({ petId: petId }, initOverrides);
         return await response.value();
     }
 
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -382,7 +382,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -390,14 +390,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(body: Pet): Promise<void> {
-        await this.updatePetRaw({ body: body });
+    async updatePet(body: Pet, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetRaw({ body: body }, initOverrides);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -439,7 +439,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -447,14 +447,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(petId: number, name?: string, status?: string): Promise<void> {
-        await this.updatePetWithFormRaw({ petId: petId, name: name, status: status });
+    async updatePetWithForm(petId: number, , name?: string, , status?: string, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetWithFormRaw({ petId: petId, name: name, status: status }, initOverrides);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -498,7 +498,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));
     }
@@ -506,8 +506,8 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(petId: number, additionalMetadata?: string, file?: Blob): Promise<ModelApiResponse> {
-        const response = await this.uploadFileRaw({ petId: petId, additionalMetadata: additionalMetadata, file: file });
+    async uploadFile(petId: number, , additionalMetadata?: string, , file?: Blob, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+        const response = await this.uploadFileRaw({ petId: petId, additionalMetadata: additionalMetadata, file: file }, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
@@ -44,7 +44,7 @@ export class PetPartApi extends runtime.BaseAPI {
     /**
      * Returns single pet part type for the petPart id.
      */
-    async getFakePetPartTypeRaw(requestParameters: GetFakePetPartTypeRequest): Promise<runtime.ApiResponse<GetPetPartTypeResponse>> {
+    async getFakePetPartTypeRaw(requestParameters: GetFakePetPartTypeRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<GetPetPartTypeResponse>> {
         if (requestParameters.fakePetPartId === null || requestParameters.fakePetPartId === undefined) {
             throw new runtime.RequiredError('fakePetPartId','Required parameter requestParameters.fakePetPartId was null or undefined when calling getFakePetPartType.');
         }
@@ -58,7 +58,7 @@ export class PetPartApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => GetPetPartTypeResponseFromJSON(jsonValue));
     }
@@ -66,15 +66,15 @@ export class PetPartApi extends runtime.BaseAPI {
     /**
      * Returns single pet part type for the petPart id.
      */
-    async getFakePetPartType(fakePetPartId: number): Promise<GetPetPartTypeResponse> {
-        const response = await this.getFakePetPartTypeRaw({ fakePetPartId: fakePetPartId });
+    async getFakePetPartType(fakePetPartId: number, initOverrides?: RequestInit): Promise<GetPetPartTypeResponse> {
+        const response = await this.getFakePetPartTypeRaw({ fakePetPartId: fakePetPartId }, initOverrides);
         return await response.value();
     }
 
     /**
      * Get the matching parts for the given pet part.
      */
-    async getMatchingPartsRaw(requestParameters: GetMatchingPartsRequest): Promise<runtime.ApiResponse<GetMatchingPartsResponse>> {
+    async getMatchingPartsRaw(requestParameters: GetMatchingPartsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<GetMatchingPartsResponse>> {
         if (requestParameters.fakePetPartId === null || requestParameters.fakePetPartId === undefined) {
             throw new runtime.RequiredError('fakePetPartId','Required parameter requestParameters.fakePetPartId was null or undefined when calling getMatchingParts.');
         }
@@ -120,7 +120,7 @@ export class PetPartApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => GetMatchingPartsResponseFromJSON(jsonValue));
     }
@@ -128,8 +128,8 @@ export class PetPartApi extends runtime.BaseAPI {
     /**
      * Get the matching parts for the given pet part.
      */
-    async getMatchingParts(fakePetPartId: number, _long: boolean, smooth: boolean, _short: boolean, name?: string, connectedPart?: string): Promise<GetMatchingPartsResponse> {
-        const response = await this.getMatchingPartsRaw({ fakePetPartId: fakePetPartId, _long: _long, smooth: smooth, _short: _short, name: name, connectedPart: connectedPart });
+    async getMatchingParts(fakePetPartId: number, , _long: boolean, , smooth: boolean, , _short: boolean, , name?: string, , connectedPart?: string, initOverrides?: RequestInit): Promise<GetMatchingPartsResponse> {
+        const response = await this.getMatchingPartsRaw({ fakePetPartId: fakePetPartId, _long: _long, smooth: smooth, _short: _short, name: name, connectedPart: connectedPart }, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
@@ -41,7 +41,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -55,7 +55,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -64,15 +64,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(orderId: string): Promise<void> {
-        await this.deleteOrderRaw({ orderId: orderId });
+    async deleteOrder(orderId: string, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteOrderRaw({ orderId: orderId }, initOverrides);
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventoryRaw(): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
+    async getInventoryRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -86,7 +86,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse<any>(response);
     }
@@ -95,8 +95,8 @@ export class StoreApi extends runtime.BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventory(): Promise<{ [key: string]: number; }> {
-        const response = await this.getInventoryRaw();
+    async getInventory(initOverrides?: RequestInit): Promise<{ [key: string]: number; }> {
+        const response = await this.getInventoryRaw(initOverrides);
         return await response.value();
     }
 
@@ -104,7 +104,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -118,7 +118,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -127,15 +127,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(orderId: number): Promise<Order> {
-        const response = await this.getOrderByIdRaw({ orderId: orderId });
+    async getOrderById(orderId: number, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.getOrderByIdRaw({ orderId: orderId }, initOverrides);
         return await response.value();
     }
 
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -152,7 +152,7 @@ export class StoreApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: OrderToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -160,8 +160,8 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(body: Order): Promise<Order> {
-        const response = await this.placeOrderRaw({ body: body });
+    async placeOrder(body: Order, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.placeOrderRaw({ body: body }, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
@@ -62,7 +62,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -79,7 +79,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -88,14 +88,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(body: User): Promise<void> {
-        await this.createUserRaw({ body: body });
+    async createUser(body: User, initOverrides?: RequestInit): Promise<void> {
+        await this.createUserRaw({ body: body }, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -112,7 +112,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -120,14 +120,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(body: Array<User>): Promise<void> {
-        await this.createUsersWithArrayInputRaw({ body: body });
+    async createUsersWithArrayInput(body: Array<User>, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithArrayInputRaw({ body: body }, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -144,7 +144,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -152,15 +152,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(body: Array<User>): Promise<void> {
-        await this.createUsersWithListInputRaw({ body: body });
+    async createUsersWithListInput(body: Array<User>, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithListInputRaw({ body: body }, initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -174,7 +174,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -183,14 +183,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(username: string): Promise<void> {
-        await this.deleteUserRaw({ username: username });
+    async deleteUser(username: string, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteUserRaw({ username: username }, initOverrides);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -204,7 +204,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
     }
@@ -212,15 +212,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(username: string): Promise<User> {
-        const response = await this.getUserByNameRaw({ username: username });
+    async getUserByName(username: string, initOverrides?: RequestInit): Promise<User> {
+        const response = await this.getUserByNameRaw({ username: username }, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -246,7 +246,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -254,15 +254,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(username: string, password: string): Promise<string> {
-        const response = await this.loginUserRaw({ username: username, password: password });
+    async loginUser(username: string, , password: string, initOverrides?: RequestInit): Promise<string> {
+        const response = await this.loginUserRaw({ username: username, password: password }, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs out current logged in user session
      */
-    async logoutUserRaw(): Promise<runtime.ApiResponse<void>> {
+    async logoutUserRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -272,7 +272,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -280,15 +280,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    async logoutUser(): Promise<void> {
-        await this.logoutUserRaw();
+    async logoutUser(initOverrides?: RequestInit): Promise<void> {
+        await this.logoutUserRaw(, initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<DefaultMetaOnlyResponse>> {
+    async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<DefaultMetaOnlyResponse>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -309,7 +309,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => DefaultMetaOnlyResponseFromJSON(jsonValue));
     }
@@ -318,8 +318,8 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(username: string, body: User): Promise<DefaultMetaOnlyResponse> {
-        const response = await this.updateUserRaw({ username: username, body: body });
+    async updateUser(username: string, , body: User, initOverrides?: RequestInit): Promise<DefaultMetaOnlyResponse> {
+        const response = await this.updateUserRaw({ username: username, body: body }, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -44,8 +44,8 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
-    protected async request(context: RequestOpts): Promise<Response> {
-        const { url, init } = this.createFetchParams(context);
+    protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
+        const { url, init } = this.createFetchParams(context, initOverrides);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
             return response;
@@ -53,7 +53,7 @@ export class BaseAPI {
         throw response;
     }
 
-    private createFetchParams(context: RequestOpts) {
+    private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
             // only add the querystring to the URL if there are query parameters.
@@ -70,7 +70,8 @@ export class BaseAPI {
             method: context.method,
             headers: headers,
             body,
-            credentials: this.configuration.credentials
+            credentials: this.configuration.credentials,
+            ...initOverrides
         };
         return { url, init };
     }

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/PetApi.ts
@@ -68,7 +68,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -90,7 +90,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -98,14 +98,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(requestParameters: AddPetRequest): Promise<void> {
-        await this.addPetRaw(requestParameters);
+    async addPet(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.addPetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -128,7 +128,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -136,15 +136,15 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(requestParameters: DeletePetRequest): Promise<void> {
-        await this.deletePetRaw(requestParameters);
+    async deletePet(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deletePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -167,7 +167,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -176,8 +176,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(requestParameters: FindPetsByStatusRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByStatusRaw(requestParameters);
+    async findPetsByStatus(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByStatusRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -185,7 +185,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -208,7 +208,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -217,8 +217,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(requestParameters: FindPetsByTagsRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByTagsRaw(requestParameters);
+    async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -226,7 +226,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -244,7 +244,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => PetFromJSON(jsonValue));
     }
@@ -253,15 +253,15 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(requestParameters: GetPetByIdRequest): Promise<Pet> {
-        const response = await this.getPetByIdRaw(requestParameters);
+    async getPetById(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<Pet> {
+        const response = await this.getPetByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -283,7 +283,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -291,14 +291,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(requestParameters: UpdatePetRequest): Promise<void> {
-        await this.updatePetRaw(requestParameters);
+    async updatePet(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -340,7 +340,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -348,14 +348,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Promise<void> {
-        await this.updatePetWithFormRaw(requestParameters);
+    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetWithFormRaw(requestParameters, initOverrides);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -399,7 +399,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));
     }
@@ -407,8 +407,8 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(requestParameters: UploadFileRequest): Promise<ModelApiResponse> {
-        const response = await this.uploadFileRaw(requestParameters);
+    async uploadFile(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+        const response = await this.uploadFileRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/StoreApi.ts
@@ -41,7 +41,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -55,7 +55,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -64,15 +64,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(requestParameters: DeleteOrderRequest): Promise<void> {
-        await this.deleteOrderRaw(requestParameters);
+    async deleteOrder(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteOrderRaw(requestParameters, initOverrides);
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventoryRaw(): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
+    async getInventoryRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -86,7 +86,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse<any>(response);
     }
@@ -95,8 +95,8 @@ export class StoreApi extends runtime.BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventory(): Promise<{ [key: string]: number; }> {
-        const response = await this.getInventoryRaw();
+    async getInventory(initOverrides?: RequestInit): Promise<{ [key: string]: number; }> {
+        const response = await this.getInventoryRaw(initOverrides);
         return await response.value();
     }
 
@@ -104,7 +104,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -118,7 +118,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -127,15 +127,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(requestParameters: GetOrderByIdRequest): Promise<Order> {
-        const response = await this.getOrderByIdRaw(requestParameters);
+    async getOrderById(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.getOrderByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -152,7 +152,7 @@ export class StoreApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: OrderToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -160,8 +160,8 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(requestParameters: PlaceOrderRequest): Promise<Order> {
-        const response = await this.placeOrderRaw(requestParameters);
+    async placeOrder(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.placeOrderRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/UserApi.ts
@@ -59,7 +59,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -76,7 +76,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -85,14 +85,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(requestParameters: CreateUserRequest): Promise<void> {
-        await this.createUserRaw(requestParameters);
+    async createUser(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -109,7 +109,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -117,14 +117,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Promise<void> {
-        await this.createUsersWithArrayInputRaw(requestParameters);
+    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithArrayInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -141,7 +141,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -149,15 +149,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Promise<void> {
-        await this.createUsersWithListInputRaw(requestParameters);
+    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithListInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -171,7 +171,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -180,14 +180,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(requestParameters: DeleteUserRequest): Promise<void> {
-        await this.deleteUserRaw(requestParameters);
+    async deleteUser(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -201,7 +201,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
     }
@@ -209,15 +209,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(requestParameters: GetUserByNameRequest): Promise<User> {
-        const response = await this.getUserByNameRaw(requestParameters);
+    async getUserByName(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<User> {
+        const response = await this.getUserByNameRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -243,7 +243,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -251,15 +251,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(requestParameters: LoginUserRequest): Promise<string> {
-        const response = await this.loginUserRaw(requestParameters);
+    async loginUser(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<string> {
+        const response = await this.loginUserRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs out current logged in user session
      */
-    async logoutUserRaw(): Promise<runtime.ApiResponse<void>> {
+    async logoutUserRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -269,7 +269,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -277,15 +277,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    async logoutUser(): Promise<void> {
-        await this.logoutUserRaw();
+    async logoutUser(initOverrides?: RequestInit): Promise<void> {
+        await this.logoutUserRaw(initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -306,7 +306,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -315,8 +315,8 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(requestParameters: UpdateUserRequest): Promise<void> {
-        await this.updateUserRaw(requestParameters);
+    async updateUser(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updateUserRaw(requestParameters, initOverrides);
     }
 
 }

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
@@ -44,8 +44,8 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
-    protected async request(context: RequestOpts): Promise<Response> {
-        const { url, init } = this.createFetchParams(context);
+    protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
+        const { url, init } = this.createFetchParams(context, initOverrides);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
             return response;
@@ -53,7 +53,7 @@ export class BaseAPI {
         throw response;
     }
 
-    private createFetchParams(context: RequestOpts) {
+    private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
             // only add the querystring to the URL if there are query parameters.
@@ -70,7 +70,8 @@ export class BaseAPI {
             method: context.method,
             headers: headers,
             body,
-            credentials: this.configuration.credentials
+            credentials: this.configuration.credentials,
+            ...initOverrides
         };
         return { url, init };
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
@@ -75,12 +75,12 @@ export interface PetApiInterface {
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>>;
+    addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>>;
 
     /**
      * Add a new pet to the store
      */
-    addPet(requestParameters: AddPetRequest): Promise<void>;
+    addPet(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<void>;
 
     /**
      * 
@@ -91,12 +91,12 @@ export interface PetApiInterface {
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>>;
+    deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>>;
 
     /**
      * Deletes a pet
      */
-    deletePet(requestParameters: DeletePetRequest): Promise<void>;
+    deletePet(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<void>;
 
     /**
      * Multiple status values can be provided with comma separated strings
@@ -106,13 +106,13 @@ export interface PetApiInterface {
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>>;
+    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>>;
 
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Promise<Array<Pet>>;
+    findPetsByStatus(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<Array<Pet>>;
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -122,13 +122,13 @@ export interface PetApiInterface {
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>>;
+    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>>;
 
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTags(requestParameters: FindPetsByTagsRequest): Promise<Array<Pet>>;
+    findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<Array<Pet>>;
 
     /**
      * Returns a single pet
@@ -138,13 +138,13 @@ export interface PetApiInterface {
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>>;
+    getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Pet>>;
 
     /**
      * Returns a single pet
      * Find pet by ID
      */
-    getPetById(requestParameters: GetPetByIdRequest): Promise<Pet>;
+    getPetById(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<Pet>;
 
     /**
      * 
@@ -154,12 +154,12 @@ export interface PetApiInterface {
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>>;
+    updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>>;
 
     /**
      * Update an existing pet
      */
-    updatePet(requestParameters: UpdatePetRequest): Promise<void>;
+    updatePet(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<void>;
 
     /**
      * 
@@ -171,12 +171,12 @@ export interface PetApiInterface {
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>>;
+    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>>;
 
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Promise<void>;
+    updatePetWithForm(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<void>;
 
     /**
      * 
@@ -188,12 +188,12 @@ export interface PetApiInterface {
      * @throws {RequiredError}
      * @memberof PetApiInterface
      */
-    uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>>;
+    uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<ModelApiResponse>>;
 
     /**
      * uploads an image
      */
-    uploadFile(requestParameters: UploadFileRequest): Promise<ModelApiResponse>;
+    uploadFile(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<ModelApiResponse>;
 
 }
 
@@ -205,7 +205,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -227,7 +227,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -235,14 +235,14 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
     /**
      * Add a new pet to the store
      */
-    async addPet(requestParameters: AddPetRequest): Promise<void> {
-        await this.addPetRaw(requestParameters);
+    async addPet(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.addPetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -265,7 +265,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -273,15 +273,15 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
     /**
      * Deletes a pet
      */
-    async deletePet(requestParameters: DeletePetRequest): Promise<void> {
-        await this.deletePetRaw(requestParameters);
+    async deletePet(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deletePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -304,7 +304,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -313,8 +313,8 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(requestParameters: FindPetsByStatusRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByStatusRaw(requestParameters);
+    async findPetsByStatus(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByStatusRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -322,7 +322,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -345,7 +345,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -354,8 +354,8 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(requestParameters: FindPetsByTagsRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByTagsRaw(requestParameters);
+    async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -363,7 +363,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -381,7 +381,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => PetFromJSON(jsonValue));
     }
@@ -390,15 +390,15 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(requestParameters: GetPetByIdRequest): Promise<Pet> {
-        const response = await this.getPetByIdRaw(requestParameters);
+    async getPetById(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<Pet> {
+        const response = await this.getPetByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -420,7 +420,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -428,14 +428,14 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
     /**
      * Update an existing pet
      */
-    async updatePet(requestParameters: UpdatePetRequest): Promise<void> {
-        await this.updatePetRaw(requestParameters);
+    async updatePet(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -477,7 +477,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -485,14 +485,14 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Promise<void> {
-        await this.updatePetWithFormRaw(requestParameters);
+    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetWithFormRaw(requestParameters, initOverrides);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -536,7 +536,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));
     }
@@ -544,8 +544,8 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
     /**
      * uploads an image
      */
-    async uploadFile(requestParameters: UploadFileRequest): Promise<ModelApiResponse> {
-        const response = await this.uploadFileRaw(requestParameters);
+    async uploadFile(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+        const response = await this.uploadFileRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
@@ -47,13 +47,13 @@ export interface StoreApiInterface {
      * @throws {RequiredError}
      * @memberof StoreApiInterface
      */
-    deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>>;
+    deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>>;
 
     /**
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrder(requestParameters: DeleteOrderRequest): Promise<void>;
+    deleteOrder(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<void>;
 
     /**
      * Returns a map of status codes to quantities
@@ -62,13 +62,13 @@ export interface StoreApiInterface {
      * @throws {RequiredError}
      * @memberof StoreApiInterface
      */
-    getInventoryRaw(): Promise<runtime.ApiResponse<{ [key: string]: number; }>>;
+    getInventoryRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<{ [key: string]: number; }>>;
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventory(): Promise<{ [key: string]: number; }>;
+    getInventory(initOverrides?: RequestInit): Promise<{ [key: string]: number; }>;
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -78,13 +78,13 @@ export interface StoreApiInterface {
      * @throws {RequiredError}
      * @memberof StoreApiInterface
      */
-    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>>;
+    getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>>;
 
     /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderById(requestParameters: GetOrderByIdRequest): Promise<Order>;
+    getOrderById(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<Order>;
 
     /**
      * 
@@ -94,12 +94,12 @@ export interface StoreApiInterface {
      * @throws {RequiredError}
      * @memberof StoreApiInterface
      */
-    placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>>;
+    placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>>;
 
     /**
      * Place an order for a pet
      */
-    placeOrder(requestParameters: PlaceOrderRequest): Promise<Order>;
+    placeOrder(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<Order>;
 
 }
 
@@ -112,7 +112,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -126,7 +126,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -135,15 +135,15 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(requestParameters: DeleteOrderRequest): Promise<void> {
-        await this.deleteOrderRaw(requestParameters);
+    async deleteOrder(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteOrderRaw(requestParameters, initOverrides);
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventoryRaw(): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
+    async getInventoryRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -157,7 +157,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse<any>(response);
     }
@@ -166,8 +166,8 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventory(): Promise<{ [key: string]: number; }> {
-        const response = await this.getInventoryRaw();
+    async getInventory(initOverrides?: RequestInit): Promise<{ [key: string]: number; }> {
+        const response = await this.getInventoryRaw(initOverrides);
         return await response.value();
     }
 
@@ -175,7 +175,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -189,7 +189,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -198,15 +198,15 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(requestParameters: GetOrderByIdRequest): Promise<Order> {
-        const response = await this.getOrderByIdRaw(requestParameters);
+    async getOrderById(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.getOrderByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -223,7 +223,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
             headers: headerParameters,
             query: queryParameters,
             body: OrderToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -231,8 +231,8 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
     /**
      * Place an order for a pet
      */
-    async placeOrder(requestParameters: PlaceOrderRequest): Promise<Order> {
-        const response = await this.placeOrderRaw(requestParameters);
+    async placeOrder(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.placeOrderRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
@@ -65,13 +65,13 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>>;
+    createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>>;
 
     /**
      * This can only be done by the logged in user.
      * Create user
      */
-    createUser(requestParameters: CreateUserRequest): Promise<void>;
+    createUser(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<void>;
 
     /**
      * 
@@ -81,12 +81,12 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>>;
+    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>>;
 
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Promise<void>;
+    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<void>;
 
     /**
      * 
@@ -96,12 +96,12 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>>;
+    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>>;
 
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Promise<void>;
+    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<void>;
 
     /**
      * This can only be done by the logged in user.
@@ -111,13 +111,13 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>>;
+    deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>>;
 
     /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUser(requestParameters: DeleteUserRequest): Promise<void>;
+    deleteUser(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<void>;
 
     /**
      * 
@@ -127,12 +127,12 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>>;
+    getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<User>>;
 
     /**
      * Get user by user name
      */
-    getUserByName(requestParameters: GetUserByNameRequest): Promise<User>;
+    getUserByName(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<User>;
 
     /**
      * 
@@ -143,12 +143,12 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>>;
+    loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<string>>;
 
     /**
      * Logs user into the system
      */
-    loginUser(requestParameters: LoginUserRequest): Promise<string>;
+    loginUser(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<string>;
 
     /**
      * 
@@ -157,12 +157,12 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    logoutUserRaw(): Promise<runtime.ApiResponse<void>>;
+    logoutUserRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>>;
 
     /**
      * Logs out current logged in user session
      */
-    logoutUser(): Promise<void>;
+    logoutUser(initOverrides?: RequestInit): Promise<void>;
 
     /**
      * This can only be done by the logged in user.
@@ -173,13 +173,13 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>>;
+    updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>>;
 
     /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUser(requestParameters: UpdateUserRequest): Promise<void>;
+    updateUser(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<void>;
 
 }
 
@@ -192,7 +192,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -209,7 +209,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -218,14 +218,14 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(requestParameters: CreateUserRequest): Promise<void> {
-        await this.createUserRaw(requestParameters);
+    async createUser(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -242,7 +242,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -250,14 +250,14 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Promise<void> {
-        await this.createUsersWithArrayInputRaw(requestParameters);
+    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithArrayInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -274,7 +274,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -282,15 +282,15 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Promise<void> {
-        await this.createUsersWithListInputRaw(requestParameters);
+    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithListInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -304,7 +304,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -313,14 +313,14 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(requestParameters: DeleteUserRequest): Promise<void> {
-        await this.deleteUserRaw(requestParameters);
+    async deleteUser(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -334,7 +334,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
     }
@@ -342,15 +342,15 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Get user by user name
      */
-    async getUserByName(requestParameters: GetUserByNameRequest): Promise<User> {
-        const response = await this.getUserByNameRaw(requestParameters);
+    async getUserByName(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<User> {
+        const response = await this.getUserByNameRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -376,7 +376,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -384,15 +384,15 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Logs user into the system
      */
-    async loginUser(requestParameters: LoginUserRequest): Promise<string> {
-        const response = await this.loginUserRaw(requestParameters);
+    async loginUser(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<string> {
+        const response = await this.loginUserRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs out current logged in user session
      */
-    async logoutUserRaw(): Promise<runtime.ApiResponse<void>> {
+    async logoutUserRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -402,7 +402,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -410,15 +410,15 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
     /**
      * Logs out current logged in user session
      */
-    async logoutUser(): Promise<void> {
-        await this.logoutUserRaw();
+    async logoutUser(initOverrides?: RequestInit): Promise<void> {
+        await this.logoutUserRaw(initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -439,7 +439,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -448,8 +448,8 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(requestParameters: UpdateUserRequest): Promise<void> {
-        await this.updateUserRaw(requestParameters);
+    async updateUser(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updateUserRaw(requestParameters, initOverrides);
     }
 
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -44,8 +44,8 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
-    protected async request(context: RequestOpts): Promise<Response> {
-        const { url, init } = this.createFetchParams(context);
+    protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
+        const { url, init } = this.createFetchParams(context, initOverrides);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
             return response;
@@ -53,7 +53,7 @@ export class BaseAPI {
         throw response;
     }
 
-    private createFetchParams(context: RequestOpts) {
+    private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
             // only add the querystring to the URL if there are query parameters.
@@ -70,7 +70,8 @@ export class BaseAPI {
             method: context.method,
             headers: headers,
             body,
-            credentials: this.configuration.credentials
+            credentials: this.configuration.credentials,
+            ...initOverrides
         };
         return { url, init };
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
@@ -68,7 +68,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -90,7 +90,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -98,14 +98,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(requestParameters: AddPetRequest): Promise<void> {
-        await this.addPetRaw(requestParameters);
+    async addPet(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.addPetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -128,7 +128,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -136,15 +136,15 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(requestParameters: DeletePetRequest): Promise<void> {
-        await this.deletePetRaw(requestParameters);
+    async deletePet(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deletePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -167,7 +167,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -176,8 +176,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(requestParameters: FindPetsByStatusRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByStatusRaw(requestParameters);
+    async findPetsByStatus(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByStatusRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -185,7 +185,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -208,7 +208,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(PetFromJSON));
     }
@@ -217,8 +217,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(requestParameters: FindPetsByTagsRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByTagsRaw(requestParameters);
+    async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -226,7 +226,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -244,7 +244,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => PetFromJSON(jsonValue));
     }
@@ -253,15 +253,15 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(requestParameters: GetPetByIdRequest): Promise<Pet> {
-        const response = await this.getPetByIdRaw(requestParameters);
+    async getPetById(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<Pet> {
+        const response = await this.getPetByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -283,7 +283,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: PetToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -291,14 +291,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(requestParameters: UpdatePetRequest): Promise<void> {
-        await this.updatePetRaw(requestParameters);
+    async updatePet(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -340,7 +340,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -348,14 +348,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Promise<void> {
-        await this.updatePetWithFormRaw(requestParameters);
+    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetWithFormRaw(requestParameters, initOverrides);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -399,7 +399,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));
     }
@@ -407,8 +407,8 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(requestParameters: UploadFileRequest): Promise<ModelApiResponse> {
-        const response = await this.uploadFileRaw(requestParameters);
+    async uploadFile(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+        const response = await this.uploadFileRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
@@ -41,7 +41,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -55,7 +55,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -64,15 +64,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(requestParameters: DeleteOrderRequest): Promise<void> {
-        await this.deleteOrderRaw(requestParameters);
+    async deleteOrder(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteOrderRaw(requestParameters, initOverrides);
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventoryRaw(): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
+    async getInventoryRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -86,7 +86,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse<any>(response);
     }
@@ -95,8 +95,8 @@ export class StoreApi extends runtime.BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventory(): Promise<{ [key: string]: number; }> {
-        const response = await this.getInventoryRaw();
+    async getInventory(initOverrides?: RequestInit): Promise<{ [key: string]: number; }> {
+        const response = await this.getInventoryRaw(initOverrides);
         return await response.value();
     }
 
@@ -104,7 +104,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -118,7 +118,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -127,15 +127,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(requestParameters: GetOrderByIdRequest): Promise<Order> {
-        const response = await this.getOrderByIdRaw(requestParameters);
+    async getOrderById(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.getOrderByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -152,7 +152,7 @@ export class StoreApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: OrderToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrderFromJSON(jsonValue));
     }
@@ -160,8 +160,8 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(requestParameters: PlaceOrderRequest): Promise<Order> {
-        const response = await this.placeOrderRaw(requestParameters);
+    async placeOrder(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.placeOrderRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
@@ -59,7 +59,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -76,7 +76,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -85,14 +85,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(requestParameters: CreateUserRequest): Promise<void> {
-        await this.createUserRaw(requestParameters);
+    async createUser(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -109,7 +109,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -117,14 +117,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Promise<void> {
-        await this.createUsersWithArrayInputRaw(requestParameters);
+    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithArrayInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -141,7 +141,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body.map(UserToJSON),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -149,15 +149,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Promise<void> {
-        await this.createUsersWithListInputRaw(requestParameters);
+    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithListInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -171,7 +171,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -180,14 +180,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(requestParameters: DeleteUserRequest): Promise<void> {
-        await this.deleteUserRaw(requestParameters);
+    async deleteUser(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -201,7 +201,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => UserFromJSON(jsonValue));
     }
@@ -209,15 +209,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(requestParameters: GetUserByNameRequest): Promise<User> {
-        const response = await this.getUserByNameRaw(requestParameters);
+    async getUserByName(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<User> {
+        const response = await this.getUserByNameRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -243,7 +243,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -251,15 +251,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(requestParameters: LoginUserRequest): Promise<string> {
-        const response = await this.loginUserRaw(requestParameters);
+    async loginUser(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<string> {
+        const response = await this.loginUserRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs out current logged in user session
      */
-    async logoutUserRaw(): Promise<runtime.ApiResponse<void>> {
+    async logoutUserRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -269,7 +269,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -277,15 +277,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    async logoutUser(): Promise<void> {
-        await this.logoutUserRaw();
+    async logoutUser(initOverrides?: RequestInit): Promise<void> {
+        await this.logoutUserRaw(initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -306,7 +306,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: UserToJSON(requestParameters.body),
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -315,8 +315,8 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(requestParameters: UpdateUserRequest): Promise<void> {
-        await this.updateUserRaw(requestParameters);
+    async updateUser(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updateUserRaw(requestParameters, initOverrides);
     }
 
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -44,8 +44,8 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
-    protected async request(context: RequestOpts): Promise<Response> {
-        const { url, init } = this.createFetchParams(context);
+    protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
+        const { url, init } = this.createFetchParams(context, initOverrides);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
             return response;
@@ -53,7 +53,7 @@ export class BaseAPI {
         throw response;
     }
 
-    private createFetchParams(context: RequestOpts) {
+    private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
             // only add the querystring to the URL if there are query parameters.
@@ -70,7 +70,8 @@ export class BaseAPI {
             method: context.method,
             headers: headers,
             body,
-            credentials: this.configuration.credentials
+            credentials: this.configuration.credentials,
+            ...initOverrides
         };
         return { url, init };
     }

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
@@ -64,7 +64,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -86,7 +86,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -94,14 +94,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(requestParameters: AddPetRequest): Promise<void> {
-        await this.addPetRaw(requestParameters);
+    async addPet(requestParameters: AddPetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.addPetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -124,7 +124,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -132,15 +132,15 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(requestParameters: DeletePetRequest): Promise<void> {
-        await this.deletePetRaw(requestParameters);
+    async deletePet(requestParameters: DeletePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deletePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -163,7 +163,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response);
     }
@@ -172,8 +172,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(requestParameters: FindPetsByStatusRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByStatusRaw(requestParameters);
+    async findPetsByStatus(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByStatusRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -181,7 +181,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -204,7 +204,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response);
     }
@@ -213,8 +213,8 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(requestParameters: FindPetsByTagsRequest): Promise<Array<Pet>> {
-        const response = await this.findPetsByTagsRaw(requestParameters);
+    async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit): Promise<Array<Pet>> {
+        const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
@@ -222,7 +222,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -240,7 +240,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response);
     }
@@ -249,15 +249,15 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(requestParameters: GetPetByIdRequest): Promise<Pet> {
-        const response = await this.getPetByIdRaw(requestParameters);
+    async getPetById(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit): Promise<Pet> {
+        const response = await this.getPetByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -279,7 +279,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -287,14 +287,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(requestParameters: UpdatePetRequest): Promise<void> {
-        await this.updatePetRaw(requestParameters);
+    async updatePet(requestParameters: UpdatePetRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetRaw(requestParameters, initOverrides);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -336,7 +336,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -344,14 +344,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Promise<void> {
-        await this.updatePetWithFormRaw(requestParameters);
+    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updatePetWithFormRaw(requestParameters, initOverrides);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -395,7 +395,7 @@ export class PetApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: formParams,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response);
     }
@@ -403,8 +403,8 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(requestParameters: UploadFileRequest): Promise<ModelApiResponse> {
-        const response = await this.uploadFileRaw(requestParameters);
+    async uploadFile(requestParameters: UploadFileRequest, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+        const response = await this.uploadFileRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
@@ -39,7 +39,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -53,7 +53,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -62,15 +62,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(requestParameters: DeleteOrderRequest): Promise<void> {
-        await this.deleteOrderRaw(requestParameters);
+    async deleteOrder(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteOrderRaw(requestParameters, initOverrides);
     }
 
     /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventoryRaw(): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
+    async getInventoryRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<{ [key: string]: number; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -84,7 +84,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse<any>(response);
     }
@@ -93,8 +93,8 @@ export class StoreApi extends runtime.BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    async getInventory(): Promise<{ [key: string]: number; }> {
-        const response = await this.getInventoryRaw();
+    async getInventory(initOverrides?: RequestInit): Promise<{ [key: string]: number; }> {
+        const response = await this.getInventoryRaw(initOverrides);
         return await response.value();
     }
 
@@ -102,7 +102,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -116,7 +116,7 @@ export class StoreApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response);
     }
@@ -125,15 +125,15 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(requestParameters: GetOrderByIdRequest): Promise<Order> {
-        const response = await this.getOrderByIdRaw(requestParameters);
+    async getOrderById(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.getOrderByIdRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -150,7 +150,7 @@ export class StoreApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response);
     }
@@ -158,8 +158,8 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(requestParameters: PlaceOrderRequest): Promise<Order> {
-        const response = await this.placeOrderRaw(requestParameters);
+    async placeOrder(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit): Promise<Order> {
+        const response = await this.placeOrderRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
@@ -57,7 +57,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -74,7 +74,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -83,14 +83,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(requestParameters: CreateUserRequest): Promise<void> {
-        await this.createUserRaw(requestParameters);
+    async createUser(requestParameters: CreateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -107,7 +107,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -115,14 +115,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Promise<void> {
-        await this.createUsersWithArrayInputRaw(requestParameters);
+    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithArrayInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -139,7 +139,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -147,15 +147,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Promise<void> {
-        await this.createUsersWithListInputRaw(requestParameters);
+    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.createUsersWithListInputRaw(requestParameters, initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -169,7 +169,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'DELETE',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -178,14 +178,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(requestParameters: DeleteUserRequest): Promise<void> {
-        await this.deleteUserRaw(requestParameters);
+    async deleteUser(requestParameters: DeleteUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.deleteUserRaw(requestParameters, initOverrides);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -199,7 +199,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.JSONApiResponse(response);
     }
@@ -207,15 +207,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(requestParameters: GetUserByNameRequest): Promise<User> {
-        const response = await this.getUserByNameRaw(requestParameters);
+    async getUserByName(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit): Promise<User> {
+        const response = await this.getUserByNameRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -241,7 +241,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.TextApiResponse(response) as any;
     }
@@ -249,15 +249,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(requestParameters: LoginUserRequest): Promise<string> {
-        const response = await this.loginUserRaw(requestParameters);
+    async loginUser(requestParameters: LoginUserRequest, initOverrides?: RequestInit): Promise<string> {
+        const response = await this.loginUserRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Logs out current logged in user session
      */
-    async logoutUserRaw(): Promise<runtime.ApiResponse<void>> {
+    async logoutUserRaw(initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -267,7 +267,7 @@ export class UserApi extends runtime.BaseAPI {
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -275,15 +275,15 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    async logoutUser(): Promise<void> {
-        await this.logoutUserRaw();
+    async logoutUser(initOverrides?: RequestInit): Promise<void> {
+        await this.logoutUserRaw(initOverrides);
     }
 
     /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -304,7 +304,7 @@ export class UserApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
             body: requestParameters.body,
-        });
+        }, initOverrides);
 
         return new runtime.VoidApiResponse(response);
     }
@@ -313,8 +313,8 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(requestParameters: UpdateUserRequest): Promise<void> {
-        await this.updateUserRaw(requestParameters);
+    async updateUser(requestParameters: UpdateUserRequest, initOverrides?: RequestInit): Promise<void> {
+        await this.updateUserRaw(requestParameters, initOverrides);
     }
 
 }

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -44,8 +44,8 @@ export class BaseAPI {
         return this.withMiddleware<T>(...middlewares);
     }
 
-    protected async request(context: RequestOpts): Promise<Response> {
-        const { url, init } = this.createFetchParams(context);
+    protected async request(context: RequestOpts, initOverrides?: RequestInit): Promise<Response> {
+        const { url, init } = this.createFetchParams(context, initOverrides);
         const response = await this.fetchApi(url, init);
         if (response.status >= 200 && response.status < 300) {
             return response;
@@ -53,7 +53,7 @@ export class BaseAPI {
         throw response;
     }
 
-    private createFetchParams(context: RequestOpts) {
+    private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
             // only add the querystring to the URL if there are query parameters.
@@ -70,7 +70,8 @@ export class BaseAPI {
             method: context.method,
             headers: headers,
             body,
-            credentials: this.configuration.credentials
+            credentials: this.configuration.credentials,
+            ...initOverrides
         };
         return { url, init };
     }


### PR DESCRIPTION
Fixes #4851

You can now pass in fetch initOverrides per request.

This change is mainly to add support for request cancellation (via AbortSignal), for example:

```js
const controller = new AbortController();
const signal = controller.signal;

usersApi.getUser({ id: userId }, { signal });
```

About the target branch, it's not clear to me if i should be targeting master, but I guess this change can be released as a patch release as it's non-breaking. 

@TiFu  @taxpon  @sebastianhaas  @kenisteward @Vrolijkx  @macjohnny  @topce @akehir @petejohansonxo @amakhrov 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
