### PR TITLE
Add tests for enum query encoding

### DIFF
--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake_tests/test/api_util_test.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake_tests/test/api_util_test.dart
@@ -7,6 +7,125 @@ import 'package:test/test.dart';
 
 void main() {
   group('api_utils', () {
+    group('encodeQueryParameter should encode', () {
+      group('String enum', () {
+        test('empty String for null', () {
+          expect(
+            encodeQueryParameter(
+              standardSerializers,
+              null,
+              const FullType(ModelEnumClass),
+            ),
+            '',
+          );
+        });
+
+        test('correct String for value', () {
+          expect(
+            encodeQueryParameter(
+              standardSerializers,
+              ModelEnumClass.leftParenthesisXyzRightParenthesis,
+              const FullType(ModelEnumClass),
+            ),
+            '(xyz)',
+          );
+        });
+      });
+
+      group('int enum', () {
+        test('empty String for null', () {
+          expect(
+            encodeQueryParameter(
+              standardSerializers,
+              null,
+              const FullType(EnumTestEnumIntegerEnum),
+            ),
+            '',
+          );
+        });
+
+        test('correct int for value', () {
+          expect(
+            encodeQueryParameter(
+              standardSerializers,
+              EnumTestEnumIntegerEnum.numberNegative1,
+              const FullType(EnumTestEnumIntegerEnum),
+            ),
+            -1,
+          );
+        });
+      });
+    });
+
+    group('encodeCollectionQueryParameter should encode', () {
+      final serializers = (standardSerializers.toBuilder()
+            ..addBuilderFactory(
+              const FullType(BuiltList, [FullType(ModelEnumClass)]),
+              () => ListBuilder<ModelEnumClass>(),
+            )
+            ..addBuilderFactory(
+              const FullType(BuiltList, [FullType(EnumTestEnumIntegerEnum)]),
+              () => ListBuilder<EnumTestEnumIntegerEnum>(),
+            ))
+          .build();
+
+      group('String enum', () {
+        test('empty ListParam for empty list', () {
+          final param = encodeCollectionQueryParameter(
+            serializers,
+            <ModelEnumClass>[].build(),
+            const FullType(BuiltList, [FullType(ModelEnumClass)]),
+          );
+
+          expect(param.value, isEmpty);
+          expect(param.format, ListFormat.multi);
+        });
+
+        test('correct ListParam for value', () {
+          final param = encodeCollectionQueryParameter(
+            serializers,
+            <ModelEnumClass>[
+              ModelEnumClass.leftParenthesisXyzRightParenthesis,
+              ModelEnumClass.efg,
+            ].build(),
+            const FullType(BuiltList, [FullType(ModelEnumClass)]),
+          );
+
+          expect(param.value, hasLength(2));
+          expect(param.value, containsAll(['-efg', '(xyz)']));
+          expect(param.format, ListFormat.multi);
+        });
+      });
+
+      group('int enum', () {
+        test('empty ListParam for empty list', () {
+          final param = encodeCollectionQueryParameter(
+            serializers,
+            <EnumTestEnumIntegerEnum>[].build(),
+            const FullType(BuiltList, [FullType(EnumTestEnumIntegerEnum)]),
+          );
+
+          expect(param.value, isEmpty);
+          expect(param.format, ListFormat.multi);
+        });
+
+        test('correct ListParam for value', () {
+          final param = encodeCollectionQueryParameter(
+            serializers,
+            <EnumTestEnumIntegerEnum>[
+              EnumTestEnumIntegerEnum.number1,
+              EnumTestEnumIntegerEnum.numberNegative1,
+            ].build(),
+            const FullType(BuiltList, [FullType(EnumTestEnumIntegerEnum)]),
+          );
+
+          expect(param.value, hasLength(2));
+          expect(param.value, containsAll([1, -1]));
+          expect(param.format, ListFormat.multi);
+        });
+      });
+    });
+
     group('encodeFormParameter should return', () {
       test('empty String for null', () {
         expect(


### PR DESCRIPTION
Added tests for enum encoding in query parameters.

Fixes #9905
Fixes #9854

@tfbsza @bmxbandita I have added new tests for encoding enum values in query parameters but I can't find anything fundamentally wrong with it. The tests succeed and seem to encode the correct values.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
