### PR TITLE
Update kotlin-spring auto-generated test to avoid NPE

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/api_test.mustache
@@ -3,7 +3,6 @@ package {{package}}
 {{#imports}}import {{import}}
 {{/imports}}
 import org.junit.jupiter.api.Test
-
 {{#reactive}}
 import kotlinx.coroutines.flow.Flow;
 import kotlinx.coroutines.test.runBlockingTest
@@ -12,26 +11,29 @@ import org.springframework.http.ResponseEntity
 
 class {{classname}}Test {
 
-    {{#serviceInterface}}private val service: {{classname}}Service = {{classname}}ServiceImpl(){{/serviceInterface}}
+    {{#serviceInterface}}
+    private val service: {{classname}}Service = {{classname}}ServiceImpl()
+    {{/serviceInterface}}
     private val api: {{classname}}Controller = {{classname}}Controller({{#serviceInterface}}service{{/serviceInterface}})
 
-    {{#operations}}{{#operation}}
+    {{#operations}}
+    {{#operation}}
     /**
-    * {{summary}}
-    *
-    * {{notes}}
-    *
-    * @throws ApiException
-    *          if the Api call fails
-    */
+     * To test {{classname}}Controller.{{operationId}}
+     *
+     * @throws ApiException
+     *          if the Api call fails
+     */
     @Test
     fun {{operationId}}Test() {{#reactive}}= runBlockingTest {{/reactive}}{
         {{#allParams}}
         val {{paramName}}:{{{dataType}}}? = null
         {{/allParams}}
-        val response: ResponseEntity<{{>returnTypes}}> = api.{{operationId}}({{#allParams}}{{paramName}}!!{{^-last}}, {{/-last}}{{/allParams}})
+        val response: ResponseEntity<{{>returnTypes}}> = api.{{operationId}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
 
         // TODO: test validations
     }
-    {{/operation}}{{/operations}}
+
+    {{/operation}}
+    {{/operations}}
 }


### PR DESCRIPTION
The default output will result in the following when running tests:
```
[INFO] Running org.openapitools.api.TestApiTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.004 s <<< FAILURE! - in org.openapitools.api.TestApiTest
[ERROR] org.openapitools.api.TestApiTest.testTest()  Time elapsed: 0.001 s  <<< FAILURE!
kotlin.KotlinNullPointerException
	at org.openapitools.api.TestApiTest.testTest(TestApiTest.kt:25)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   org.openapitools.api.TestApiTest#testTest KotlinNullPointerException
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

This [fix](https://github.com/OpenAPITools/openapi-generator/pull/10058/files#diff-e7f2ed728494af823c8be1952a27a79db580904855d436035b7046ccbdcd1e06R32) will make the default output compiles without issues.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03)
