### PR TITLE
Specify templateDir in all sample configs

### DIFF
--- a/bin/configs/csharp-OpenAPIClient.yaml
+++ b/bin/configs/csharp-OpenAPIClient.yaml
@@ -1,5 +1,6 @@
 generatorName: csharp
 outputDir: samples/client/petstore/csharp/OpenAPIClient
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/csharp
 additionalProperties:
   packageGuid: '{321C8C3F-0156-40C1-AE42-D59761FB9B6C}'

--- a/bin/configs/java-jersey2-8-oas2.yaml
+++ b/bin/configs/java-jersey2-8-oas2.yaml
@@ -2,6 +2,7 @@ generatorName: java
 outputDir: samples/client/petstore/java/jersey2-java8
 library: jersey2
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/Java
 additionalProperties:
   artifactId: petstore-jersey2-java8
   hideGenerationTimestamp: true

--- a/bin/configs/java-jersey2-extensions-x-auth-id-alias.yaml
+++ b/bin/configs/java-jersey2-extensions-x-auth-id-alias.yaml
@@ -2,6 +2,7 @@ generatorName: java
 outputDir: samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8
 library: jersey2
 inputSpec: modules/openapi-generator/src/test/resources/3_0/extensions/x-auth-id-alias.yaml
+templateDir: modules/openapi-generator/src/main/resources/Java
 additionalProperties:
   artifactId: openapi3-extensions-x-auth-id-alias-jersey2-java8
   hideGenerationTimestamp: true

--- a/bin/configs/java-microprofile-rest-client.yaml
+++ b/bin/configs/java-microprofile-rest-client.yaml
@@ -2,5 +2,6 @@ generatorName: java
 outputDir: samples/client/petstore/java/microprofile-rest-client
 library: microprofile
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/Java
 additionalProperties:
   artifactId: microprofile-rest-client

--- a/bin/configs/java-resteasy.yaml
+++ b/bin/configs/java-resteasy.yaml
@@ -2,6 +2,7 @@ generatorName: java
 outputDir: samples/client/petstore/java/resteasy
 library: resteasy
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/Java
 additionalProperties:
   artifactId: petstore-resteasy
   hideGenerationTimestamp: "true"

--- a/bin/configs/java-resttemplate-withXml.yaml
+++ b/bin/configs/java-resttemplate-withXml.yaml
@@ -2,6 +2,7 @@ generatorName: java
 outputDir: samples/client/petstore/java/resttemplate-withXml
 library: resttemplate
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/Java
 additionalProperties:
   java8: true
   withXml: "true"

--- a/bin/configs/java-resttemplate.yaml
+++ b/bin/configs/java-resttemplate.yaml
@@ -2,6 +2,7 @@ generatorName: java
 outputDir: samples/client/petstore/java/resttemplate
 library: resttemplate
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/Java
 additionalProperties:
   artifactId: petstore-resttemplate
   hideGenerationTimestamp: "true"

--- a/bin/configs/java-retrofit2-play26.yaml
+++ b/bin/configs/java-retrofit2-play26.yaml
@@ -2,6 +2,7 @@ generatorName: java
 outputDir: samples/client/petstore/java/retrofit2-play26
 library: retrofit2
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/Java
 additionalProperties:
   usePlayWS: "true"
   enableBuilderSupport: "true"

--- a/bin/configs/java-webclient-nullable-array.yaml
+++ b/bin/configs/java-webclient-nullable-array.yaml
@@ -2,6 +2,7 @@ generatorName: java
 outputDir: samples/client/petstore/java/webclient-nulable-arrays
 library: webclient
 inputSpec: modules/openapi-generator/src/test/resources/3_0/schema-with-nullable-arrays.yaml
+templateDir: modules/openapi-generator/src/main/resources/Java
 additionalProperties:
   artifactId: petstore-webclient-nullable-arrays
   hideGenerationTimestamp: "true"

--- a/bin/configs/java-webclient.yaml
+++ b/bin/configs/java-webclient.yaml
@@ -2,6 +2,7 @@ generatorName: java
 outputDir: samples/client/petstore/java/webclient
 library: webclient
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/Java
 additionalProperties:
   artifactId: petstore-webclient
   hideGenerationTimestamp: "true"

--- a/bin/configs/jaxrs-spec-interface.yaml
+++ b/bin/configs/jaxrs-spec-interface.yaml
@@ -1,6 +1,7 @@
 generatorName: jaxrs-spec
 outputDir: samples/server/petstore/jaxrs-spec-interface
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/JavaJaxRS/spec
 additionalProperties:
   artifactId: jaxrs-spec-interface-petstore-server
   interfaceOnly: "true"

--- a/bin/configs/jaxrs-spec.yaml
+++ b/bin/configs/jaxrs-spec.yaml
@@ -1,6 +1,7 @@
 generatorName: jaxrs-spec
 outputDir: samples/server/petstore/jaxrs-spec
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/JavaJaxRS/spec
 additionalProperties:
   artifactId: jaxrs-spec-petstore-server
   serializableModel: "true"

--- a/bin/configs/kotlin-spring-boot-delegate.yaml
+++ b/bin/configs/kotlin-spring-boot-delegate.yaml
@@ -1,9 +1,9 @@
 generatorName: kotlin-spring
 outputDir: samples/server/petstore/kotlin-springboot-delegate
+library: spring-boot
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/kotlin-spring
 additionalProperties:
-  library: spring-boot
   delegatePattern: "true"
   swaggerAnnotations: "true"
   beanValidations: "true"

--- a/bin/configs/kotlin-spring-boot-reactive.yaml
+++ b/bin/configs/kotlin-spring-boot-reactive.yaml
@@ -1,10 +1,10 @@
 generatorName: kotlin-spring
 outputDir: samples/server/petstore/kotlin-springboot-reactive
+library: spring-boot
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/kotlin-spring
 additionalProperties:
   serviceImplementation: "true"
-  library: spring-boot
   reactive: "true"
   swaggerAnnotations: "true"
   beanValidations: "true"

--- a/bin/configs/kotlin-spring-boot.yaml
+++ b/bin/configs/kotlin-spring-boot.yaml
@@ -1,10 +1,10 @@
 generatorName: kotlin-spring
 outputDir: samples/server/petstore/kotlin-springboot
+library: spring-boot
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/kotlin-spring
 additionalProperties:
   serviceImplementation: "true"
-  library: spring-boot
   serializableModel: "true"
   swaggerAnnotations: "true"
   beanValidations: "true"

--- a/bin/configs/other/android-httpclient.yaml
+++ b/bin/configs/other/android-httpclient.yaml
@@ -1,6 +1,5 @@
 generatorName: android
 outputDir: samples/client/petstore/android/httpclient
+library: httpclient
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/android
-additionalProperties:
-  library: httpclient

--- a/bin/configs/other/android-volley.yaml
+++ b/bin/configs/other/android-volley.yaml
@@ -2,5 +2,6 @@ generatorName: android
 outputDir: samples/client/petstore/android/volley
 library: volley
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/android
 additionalProperties:
   artifactId: petstore-android-volley

--- a/bin/configs/other/clojure.yaml
+++ b/bin/configs/other/clojure.yaml
@@ -1,3 +1,4 @@
 generatorName: clojure
 outputDir: samples/client/petstore/clojure
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.json
+templateDir: modules/openapi-generator/src/main/resources/clojure

--- a/bin/configs/other/cpp-restbed-server-cpp-restbed.yaml
+++ b/bin/configs/other/cpp-restbed-server-cpp-restbed.yaml
@@ -1,3 +1,4 @@
 generatorName: cpp-restbed-server
 outputDir: samples/server/petstore/cpp-restbed
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/cpp-restbed-server

--- a/bin/configs/other/csharp-OpenAPIClientNet35.yaml
+++ b/bin/configs/other/csharp-OpenAPIClientNet35.yaml
@@ -1,6 +1,7 @@
 generatorName: csharp
 outputDir: samples/client/petstore/csharp/OpenAPIClientNet35
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/csharp
 additionalProperties:
   targetFramework: v3.5
   packageGuid: '{321C8C3F-0156-40C1-AE42-D59761FB9B6C}'

--- a/bin/configs/other/csharp-OpenAPIClientNet40.yaml
+++ b/bin/configs/other/csharp-OpenAPIClientNet40.yaml
@@ -1,6 +1,7 @@
 generatorName: csharp
 outputDir: samples/client/petstore/csharp/OpenAPIClientNet40
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/csharp
 additionalProperties:
   targetFramework: v4.0
   packageGuid: '{321C8C3F-0156-40C1-AE42-D59761FB9B6C}'

--- a/bin/configs/other/csharp-OpenAPIClientNetCoreProject.yaml
+++ b/bin/configs/other/csharp-OpenAPIClientNetCoreProject.yaml
@@ -1,6 +1,7 @@
 generatorName: csharp
 outputDir: samples/client/petstore/csharp/OpenAPIClientNetCoreProject
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/csharp
 additionalProperties:
   targetFramework: netstandard1.3
   packageGuid: '{67035b31-f8e5-41a4-9673-954035084f7d}'

--- a/bin/configs/other/csharp-OpenAPIClientNetStandard.yaml
+++ b/bin/configs/other/csharp-OpenAPIClientNetStandard.yaml
@@ -1,6 +1,7 @@
 generatorName: csharp
 outputDir: samples/client/petstore/csharp/OpenAPIClientNetStandard
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/csharp
 additionalProperties:
   targetFramework: netstandard1.3
   packageGuid: '{321C8C3F-0156-40C1-AE42-D59761FB9B6C}'

--- a/bin/configs/other/csharp-OpenAPIClientWithPropertyChanged.yaml
+++ b/bin/configs/other/csharp-OpenAPIClientWithPropertyChanged.yaml
@@ -1,6 +1,7 @@
 generatorName: csharp
 outputDir: samples/client/petstore/csharp/OpenAPIClientWithPropertyChanged
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/csharp
 additionalProperties:
   packageGuid: '{5CD900DE-8266-412F-A758-28E1F9C623D5}'
   generatePropertyChanged: "true"

--- a/bin/configs/other/dynamic-html.yaml
+++ b/bin/configs/other/dynamic-html.yaml
@@ -1,3 +1,4 @@
 generatorName: dynamic-html
 outputDir: samples/documentation/dynamic-html
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/openapi-static

--- a/bin/configs/other/eiffel.yaml
+++ b/bin/configs/other/eiffel.yaml
@@ -1,3 +1,4 @@
 generatorName: eiffel
 outputDir: samples/client/petstore/eiffel
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/Eiffel

--- a/bin/configs/other/fsharp-functions.yaml
+++ b/bin/configs/other/fsharp-functions.yaml
@@ -1,3 +1,4 @@
 generatorName: fsharp-functions
 outputDir: samples/server/petstore/fsharp-functions
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/fsharp-functions-server

--- a/bin/configs/other/html.md.yaml
+++ b/bin/configs/other/html.md.yaml
@@ -1,3 +1,4 @@
 generatorName: html
 outputDir: samples/documentation/html.md
 inputSpec: modules/openapi-generator/src/test/resources/2_0/markdown.yaml
+templateDir: modules/openapi-generator/src/main/resources/htmlDocs

--- a/bin/configs/other/java-vertx-async.yaml
+++ b/bin/configs/other/java-vertx-async.yaml
@@ -1,6 +1,7 @@
 generatorName: java-vertx
 outputDir: samples/server/petstore/java-vertx/async
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/JavaVertXServer
 additionalProperties:
   hideGenerationTimestamp: "true"
   vertxSwaggerRouterVersion: 1.4.0

--- a/bin/configs/other/java-vertx-rx.yaml
+++ b/bin/configs/other/java-vertx-rx.yaml
@@ -1,6 +1,7 @@
 generatorName: java-vertx
 outputDir: samples/server/petstore/java-vertx/rx
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/JavaVertXServer
 additionalProperties:
   artifactId: java-vertx-rx-server
   hideGenerationTimestamp: "true"

--- a/bin/configs/other/javascript-closure-angular.yaml
+++ b/bin/configs/other/javascript-closure-angular.yaml
@@ -1,3 +1,4 @@
 generatorName: javascript-closure-angular
 outputDir: samples/client/petstore/javascript-closure-angular
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/Javascript-Closure-Angular

--- a/bin/configs/other/jaxrs-spec-interface-response.yaml
+++ b/bin/configs/other/jaxrs-spec-interface-response.yaml
@@ -1,6 +1,7 @@
 generatorName: jaxrs-spec
 outputDir: samples/server/petstore/jaxrs-spec-interface-response
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/JavaJaxRS/spec
 additionalProperties:
   artifactId: jaxrs-spec-interface-response-petstore-server
   interfaceOnly: "true"

--- a/bin/configs/other/jmeter.yaml
+++ b/bin/configs/other/jmeter.yaml
@@ -1,3 +1,4 @@
 generatorName: jmeter
 outputDir: samples/client/petstore/jmeter
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/jmeter-client

--- a/bin/configs/other/k6.yaml
+++ b/bin/configs/other/k6.yaml
@@ -1,3 +1,4 @@
 generatorName: k6
 outputDir: samples/client/petstore/k6
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/k6

--- a/bin/configs/other/kotlin-spring-boot-modelMutable.yaml
+++ b/bin/configs/other/kotlin-spring-boot-modelMutable.yaml
@@ -1,9 +1,9 @@
 generatorName: kotlin-spring
 outputDir: samples/server/petstore/kotlin-springboot-modelMutable
+library: spring-boot
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/kotlin-spring
 additionalProperties:
-  library: spring-boot
   serializableModel: "true"
   swaggerAnnotations: "true"
   serviceImplementation: "true"

--- a/bin/configs/other/kotlin-vertx-vertx.yaml
+++ b/bin/configs/other/kotlin-vertx-vertx.yaml
@@ -1,5 +1,6 @@
 generatorName: kotlin-vertx
 outputDir: samples/server/petstore/kotlin/vertx
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/kotlin-vertx-server
 additionalProperties:
   modelMutable: "false"

--- a/bin/configs/other/openapi3/android-httpclient.yaml
+++ b/bin/configs/other/openapi3/android-httpclient.yaml
@@ -1,6 +1,5 @@
 generatorName: android
 outputDir: samples/client/petstore/android/httpclient
+library: httpclient
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/android
-additionalProperties:
-  library: httpclient

--- a/bin/configs/other/openapi3/android-volley.yaml
+++ b/bin/configs/other/openapi3/android-volley.yaml
@@ -2,5 +2,6 @@ generatorName: android
 outputDir: samples/client/petstore/android/volley
 library: volley
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/android
 additionalProperties:
   artifactId: petstore-android-volley

--- a/bin/configs/other/openapi3/clojure.yaml
+++ b/bin/configs/other/openapi3/clojure.yaml
@@ -1,3 +1,4 @@
 generatorName: clojure
 outputDir: samples/client/petstore/clojure
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.json
+templateDir: modules/openapi-generator/src/main/resources/clojure

--- a/bin/configs/other/openapi3/cpp-restbed-server-cpp-restbed.yaml
+++ b/bin/configs/other/openapi3/cpp-restbed-server-cpp-restbed.yaml
@@ -1,3 +1,4 @@
 generatorName: cpp-restbed-server
 outputDir: samples/server/petstore/cpp-restbed
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/cpp-restbed-server

--- a/bin/configs/other/openapi3/csharp-OpenAPIClient.yaml
+++ b/bin/configs/other/openapi3/csharp-OpenAPIClient.yaml
@@ -1,5 +1,6 @@
 generatorName: csharp
 outputDir: samples/openapi3/client/petstore/csharp/OpenAPIClient
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/csharp
 additionalProperties:
   packageGuid: '{321C8C3F-0156-40C1-AE42-D59761FB9B6C}'

--- a/bin/configs/other/openapi3/csharp-OpenAPIClientNetStandard.yaml
+++ b/bin/configs/other/openapi3/csharp-OpenAPIClientNetStandard.yaml
@@ -1,6 +1,7 @@
 generatorName: csharp
 outputDir: samples/client/petstore/csharp/OpenAPIClientNetStandard
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/csharp
 additionalProperties:
   targetFramework: netstandard1.3
   packageGuid: '{321C8C3F-0156-40C1-AE42-D59761FB9B6C}'

--- a/bin/configs/other/openapi3/csharp-OpenAPIClientWithPropertyChanged.yaml
+++ b/bin/configs/other/openapi3/csharp-OpenAPIClientWithPropertyChanged.yaml
@@ -1,6 +1,7 @@
 generatorName: csharp
 outputDir: samples/client/petstore/csharp/OpenAPIClientWithPropertyChanged
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/csharp
 additionalProperties:
   packageGuid: '{5CD900DE-8266-412F-A758-28E1F9C623D5}'
   generatePropertyChanged: "true"

--- a/bin/configs/other/openapi3/csharp-dotnet2-OpenAPIClient.yaml
+++ b/bin/configs/other/openapi3/csharp-dotnet2-OpenAPIClient.yaml
@@ -1,5 +1,6 @@
 generatorName: csharp-dotnet2
 outputDir: samples/client/petstore/csharp-dotnet2/OpenAPIClientTest/Lib/OpenAPIClient
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/csharp-dotnet2
 additionalProperties:
   hideGenerationTimestamp: "true"

--- a/bin/configs/other/openapi3/javascript-closure-angular.yaml
+++ b/bin/configs/other/openapi3/javascript-closure-angular.yaml
@@ -1,3 +1,4 @@
 generatorName: javascript-closure-angular
 outputDir: samples/client/petstore/javascript-closure-angular
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/Javascript-Closure-Angular

--- a/bin/configs/other/openapi3/kotlin-spring-boot-reactive.yaml
+++ b/bin/configs/other/openapi3/kotlin-spring-boot-reactive.yaml
@@ -1,10 +1,10 @@
 generatorName: kotlin-spring
 outputDir: samples/openapi3/server/petstore/kotlin-springboot-reactive
+library: spring-boot
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/kotlin-spring
 additionalProperties:
   serviceImplementation: "true"
-  library: spring-boot
   reactive: "true"
   swaggerAnnotations: "true"
   beanValidations: "true"

--- a/bin/configs/other/openapi3/kotlin-spring-boot.yaml
+++ b/bin/configs/other/openapi3/kotlin-spring-boot.yaml
@@ -1,10 +1,10 @@
 generatorName: kotlin-spring
 outputDir: samples/openapi3/server/petstore/kotlin-springboot
+library: spring-boot
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/kotlin-spring
 additionalProperties:
   serviceImplementation: "true"
-  library: spring-boot
   serializableModel: "true"
   swaggerAnnotations: "true"
   beanValidations: "true"

--- a/bin/configs/other/openapi3/typescript-angular-default.yaml
+++ b/bin/configs/other/openapi3/typescript-angular-default.yaml
@@ -1,5 +1,6 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v2/default
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: "2"

--- a/bin/configs/other/openapi3/typescript-angular-npm.yaml
+++ b/bin/configs/other/openapi3/typescript-angular-npm.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v4.3/npm
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   npmVersion: 0.0.1
   ngVersion: "4.3"

--- a/bin/configs/other/openapi3/typescript-angular-with-interfaces.yaml
+++ b/bin/configs/other/openapi3/typescript-angular-with-interfaces.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v2/with-interfaces
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   withInterfaces: "true"
   ngVersion: "2"

--- a/bin/configs/other/openapi3/typescript-aurelia-default.yaml
+++ b/bin/configs/other/openapi3/typescript-aurelia-default.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-aurelia
 outputDir: samples/client/petstore/typescript-aurelia/default
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-aurelia

--- a/bin/configs/other/openapi3/typescript-fetch-default.yaml
+++ b/bin/configs/other/openapi3/typescript-fetch-default.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch

--- a/bin/configs/other/openapi3/typescript-fetch-es6-target.yaml
+++ b/bin/configs/other/openapi3/typescript-fetch-es6-target.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/es6-target
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch
 additionalProperties:
   npmVersion: 1.0.0
   supportsES6: true

--- a/bin/configs/other/openapi3/typescript-fetch-with-interfaces.yaml
+++ b/bin/configs/other/openapi3/typescript-fetch-with-interfaces.yaml
@@ -1,5 +1,6 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/with-interfaces
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch
 additionalProperties:
   withInterfaces: "true"

--- a/bin/configs/other/openapi3/typescript-fetch-with-npm-version.yaml
+++ b/bin/configs/other/openapi3/typescript-fetch-with-npm-version.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/with-npm-version
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch
 additionalProperties:
   npmVersion: 1.0.0
   npmName: '@openapitools/typescript-fetch-petstore'

--- a/bin/configs/other/openapi3/typescript-inversify.yaml
+++ b/bin/configs/other/openapi3/typescript-inversify.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-inversify
 outputDir: samples/client/petstore/typescript-inversify
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-inversify

--- a/bin/configs/other/openapi3/typescript-jquery-default.yaml
+++ b/bin/configs/other/openapi3/typescript-jquery-default.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-jquery
 outputDir: samples/client/petstore/typescript-jquery/default
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-jquery

--- a/bin/configs/other/openapi3/typescript-jquery-npm.yaml
+++ b/bin/configs/other/openapi3/typescript-jquery-npm.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-jquery
 outputDir: samples/client/petstore/typescript-jquery/npm
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-jquery
 additionalProperties:
   npmVersion: 0.0.1
   npmName: '@openapitools/jquery-typescript-petstore'

--- a/bin/configs/other/openapi3/typescript-node-default.yaml
+++ b/bin/configs/other/openapi3/typescript-node-default.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-node
 outputDir: samples/client/petstore/typescript-node/default
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-node

--- a/bin/configs/other/openapi3/typescript-node-npm.yaml
+++ b/bin/configs/other/openapi3/typescript-node-npm.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-node
 outputDir: samples/client/petstore/typescript-node/npm
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-node
 additionalProperties:
   npmVersion: 0.0.1
   npmName: '@openapitools/angular2-typescript-petstore'

--- a/bin/configs/other/scala-akka-http-server.yaml
+++ b/bin/configs/other/scala-akka-http-server.yaml
@@ -1,3 +1,4 @@
 generatorName: scala-akka-http-server
 outputDir: samples/server/petstore/scala-akka-http-server
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/scala-akka-http-server

--- a/bin/configs/perl-deep_module_test.yaml
+++ b/bin/configs/perl-deep_module_test.yaml
@@ -1,6 +1,7 @@
 generatorName: perl
 outputDir: samples/client/petstore/perl/deep_module_test
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/perl
 additionalProperties:
   moduleName: Something::Deep
   hideGenerationTimestamp: "true"

--- a/bin/configs/spring-cloud-async.yaml
+++ b/bin/configs/spring-cloud-async.yaml
@@ -2,7 +2,7 @@ generatorName: spring
 outputDir: samples/client/petstore/spring-cloud-async
 library: spring-cloud
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
-templateDir: modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud
+templateDir: modules/openapi-generator/src/main/resources/JavaSpring
 additionalProperties:
   async: "true"
   java8: "true"

--- a/bin/configs/spring-cloud-no-nullable.yaml
+++ b/bin/configs/spring-cloud-no-nullable.yaml
@@ -2,7 +2,7 @@ generatorName: spring
 outputDir: samples/client/petstore/spring-cloud-no-nullable
 library: spring-cloud
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
-templateDir: modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud
+templateDir: modules/openapi-generator/src/main/resources/JavaSpring
 additionalProperties:
   artifactId: petstore-spring-cloud-no-nullable
   responseWrapper: HystrixCommand

--- a/bin/configs/spring-cloud-petstore-feign-spring-pageable.yaml
+++ b/bin/configs/spring-cloud-petstore-feign-spring-pageable.yaml
@@ -1,8 +1,8 @@
 generatorName: spring
-templateDir: modules/openapi-generator/src/main/resources/JavaSpring
-inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-spring-pageable.yaml
 outputDir: samples/client/petstore/spring-cloud-spring-pageable
-artifactId: spring-cloud-spring-pageable
 library: spring-cloud
+inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-spring-pageable.yaml
+templateDir: modules/openapi-generator/src/main/resources/JavaSpring
 additionalProperties:
+  artifactId: spring-cloud-spring-pageable
   hideGenerationTimestamp: 'true'

--- a/bin/configs/spring-cloud.yaml
+++ b/bin/configs/spring-cloud.yaml
@@ -2,7 +2,7 @@ generatorName: spring
 outputDir: samples/client/petstore/spring-cloud
 library: spring-cloud
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
-templateDir: modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud
+templateDir: modules/openapi-generator/src/main/resources/JavaSpring
 additionalProperties:
   artifactId: petstore-spring-cloud
   responseWrapper: HystrixCommand

--- a/bin/configs/spring-mvc-petstore-server-spring-pageable.yaml
+++ b/bin/configs/spring-mvc-petstore-server-spring-pageable.yaml
@@ -1,8 +1,8 @@
 generatorName: spring
-templateDir: modules/openapi-generator/src/main/resources/JavaSpring
-inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing-with-spring-pageable.yaml
 outputDir: samples/server/petstore/spring-mvc-spring-pageable
-artifactId: spring-mvc-spring-pageable
 library: spring-mvc
+inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing-with-spring-pageable.yaml
+templateDir: modules/openapi-generator/src/main/resources/JavaSpring
 additionalProperties:
+  artifactId: spring-mvc-spring-pageable
   hideGenerationTimestamp: 'true'

--- a/bin/configs/spring-stubs.yaml
+++ b/bin/configs/spring-stubs.yaml
@@ -1,6 +1,7 @@
 generatorName: spring
 outputDir: samples/client/petstore/spring-stubs
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/JavaSpring
 additionalProperties:
   artifactId: spring-stubs
   interfaceOnly: "true"

--- a/bin/configs/springboot-petstore-server-spring-pageable-delegatePattern-without-j8.yaml
+++ b/bin/configs/springboot-petstore-server-spring-pageable-delegatePattern-without-j8.yaml
@@ -1,10 +1,10 @@
 generatorName: spring
-templateDir: modules/openapi-generator/src/main/resources/JavaSpring
-inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing-with-spring-pageable.yaml
 outputDir: samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8
-artifactId: springboot-spring-pageable-delegatePattern-without-j8
 library: spring-boot
+inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing-with-spring-pageable.yaml
+templateDir: modules/openapi-generator/src/main/resources/JavaSpring
 delegatePattern: true
 java8: false
 additionalProperties:
+  artifactId: springboot-spring-pageable-delegatePattern-without-j8
   hideGenerationTimestamp: 'true'

--- a/bin/configs/springboot-petstore-server-spring-pageable-delegatePattern.yaml
+++ b/bin/configs/springboot-petstore-server-spring-pageable-delegatePattern.yaml
@@ -1,9 +1,9 @@
 generatorName: spring
-templateDir: modules/openapi-generator/src/main/resources/JavaSpring
-inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing-with-spring-pageable.yaml
 outputDir: samples/server/petstore/springboot-spring-pageable-delegatePattern
-artifactId: springboot-spring-pageable-delegatePattern
 library: spring-boot
+inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing-with-spring-pageable.yaml
+templateDir: modules/openapi-generator/src/main/resources/JavaSpring
 delegatePattern: true
 additionalProperties:
+  artifactId: springboot-spring-pageable-delegatePattern
   hideGenerationTimestamp: 'true'

--- a/bin/configs/springboot-petstore-server-spring-pageable-without-j8.yaml
+++ b/bin/configs/springboot-petstore-server-spring-pageable-without-j8.yaml
@@ -1,9 +1,9 @@
 generatorName: spring
-templateDir: modules/openapi-generator/src/main/resources/JavaSpring
-inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing-with-spring-pageable.yaml
 outputDir: samples/server/petstore/springboot-spring-pageable-without-j8
-artifactId: springboot-spring-pageable-withoutj8
 library: spring-boot
+inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing-with-spring-pageable.yaml
+templateDir: modules/openapi-generator/src/main/resources/JavaSpring
 java8: false
 additionalProperties:
+  artifactId: springboot-spring-pageable-withoutj8
   hideGenerationTimestamp: 'true'

--- a/bin/configs/springboot-petstore-server-spring-pageable.yaml
+++ b/bin/configs/springboot-petstore-server-spring-pageable.yaml
@@ -1,8 +1,8 @@
 generatorName: spring
-templateDir: modules/openapi-generator/src/main/resources/JavaSpring
-inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing-with-spring-pageable.yaml
 outputDir: samples/server/petstore/springboot-spring-pageable
-artifactId: springboot-spring-pageable
 library: spring-boot
+inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing-with-spring-pageable.yaml
+templateDir: modules/openapi-generator/src/main/resources/JavaSpring
 additionalProperties:
+  artifactId: springboot-spring-pageable
   hideGenerationTimestamp: 'true'

--- a/bin/configs/typescript-angular-default-v6.yaml
+++ b/bin/configs/typescript-angular-default-v6.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 6.0.0
   providedInRoot: "false"

--- a/bin/configs/typescript-angular-single-request-parameter-v8.yaml
+++ b/bin/configs/typescript-angular-single-request-parameter-v8.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   npmVersion: 1.0.0
   ngVersion: 8.0.0

--- a/bin/configs/typescript-angular-v10-provided-in-root-with-npm.yaml
+++ b/bin/configs/typescript-angular-v10-provided-in-root-with-npm.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v10-provided-in-root/builds/with-npm
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 10.0.0
   npmVersion: 1.0.0

--- a/bin/configs/typescript-angular-v10-provided-in-root.yaml
+++ b/bin/configs/typescript-angular-v10-provided-in-root.yaml
@@ -1,5 +1,6 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v10-provided-in-root/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 10.0.0

--- a/bin/configs/typescript-angular-v11-oneOf.yaml
+++ b/bin/configs/typescript-angular-v11-oneOf.yaml
@@ -1,5 +1,6 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v11-oneOf/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/3_0/oneOfArrayMapImport.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 11.0.0

--- a/bin/configs/typescript-angular-v11-provided-in-root-with-npm.yaml
+++ b/bin/configs/typescript-angular-v11-provided-in-root-with-npm.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v11-provided-in-root/builds/with-npm
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 11.0.0
   npmVersion: 1.0.0

--- a/bin/configs/typescript-angular-v11-provided-in-root.yaml
+++ b/bin/configs/typescript-angular-v11-provided-in-root.yaml
@@ -1,5 +1,6 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v11-provided-in-root/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 11.0.0

--- a/bin/configs/typescript-angular-v6-provided-in-root-with-npm.yaml
+++ b/bin/configs/typescript-angular-v6-provided-in-root-with-npm.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 6.0.0
   npmVersion: 1.0.0

--- a/bin/configs/typescript-angular-v6-provided-in-root.yaml
+++ b/bin/configs/typescript-angular-v6-provided-in-root.yaml
@@ -1,5 +1,6 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 6.0.0

--- a/bin/configs/typescript-angular-v7-not-provided-in-root-with-npm.yaml
+++ b/bin/configs/typescript-angular-v7-not-provided-in-root-with-npm.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 7.0.0
   npmVersion: 1.0.0

--- a/bin/configs/typescript-angular-v7-not-provided-in-root.yaml
+++ b/bin/configs/typescript-angular-v7-not-provided-in-root.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 7.0.0
   providedInRoot: "false"

--- a/bin/configs/typescript-angular-v7-provided-in-root-with-npm.yaml
+++ b/bin/configs/typescript-angular-v7-provided-in-root-with-npm.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 7.0.0
   npmVersion: 1.0.0

--- a/bin/configs/typescript-angular-v7-provided-in-root.yaml
+++ b/bin/configs/typescript-angular-v7-provided-in-root.yaml
@@ -1,5 +1,6 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 7.0.0

--- a/bin/configs/typescript-angular-v9-provided-in-any.yaml
+++ b/bin/configs/typescript-angular-v9-provided-in-any.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v9-provided-in-any/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 9.0.0
   providedIn: any

--- a/bin/configs/typescript-angular-v9-provided-in-root-with-npm.yaml
+++ b/bin/configs/typescript-angular-v9-provided-in-root-with-npm.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v9-provided-in-root/builds/with-npm
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 9.0.0
   npmVersion: 1.0.0

--- a/bin/configs/typescript-angular-v9-provided-in-root.yaml
+++ b/bin/configs/typescript-angular-v9-provided-in-root.yaml
@@ -1,5 +1,6 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v9-provided-in-root/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   ngVersion: 9.0.0

--- a/bin/configs/typescript-angular-with-npm-v6.yaml
+++ b/bin/configs/typescript-angular-with-npm-v6.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   npmVersion: 1.0.0
   ngVersion: 6.0.0

--- a/bin/configs/typescript-angular-with-npm-v8.yaml
+++ b/bin/configs/typescript-angular-with-npm-v8.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   npmVersion: 1.0.0
   ngVersion: 8.0.0

--- a/bin/configs/typescript-angular-with-prefixed-module-name-v8.yaml
+++ b/bin/configs/typescript-angular-with-prefixed-module-name-v8.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-angular
 outputDir: samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-angular
 additionalProperties:
   npmVersion: 1.0.0
   ngVersion: 8.0.0

--- a/bin/configs/typescript-aurelia-default.yaml
+++ b/bin/configs/typescript-aurelia-default.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-aurelia
 outputDir: samples/client/petstore/typescript-aurelia/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-aurelia

--- a/bin/configs/typescript-axios-composed-schemas.yaml
+++ b/bin/configs/typescript-axios-composed-schemas.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-axios
 outputDir: samples/client/petstore/typescript-axios/builds/composed-schemas
 inputSpec: modules/openapi-generator/src/test/resources/3_0/composed-schemas.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-axios

--- a/bin/configs/typescript-axios-default.yaml
+++ b/bin/configs/typescript-axios-default.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-axios
 outputDir: samples/client/petstore/typescript-axios/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-axios

--- a/bin/configs/typescript-axios-es6-target.yaml
+++ b/bin/configs/typescript-axios-es6-target.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-axios
 outputDir: samples/client/petstore/typescript-axios/builds/es6-target
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-axios
 additionalProperties:
   npmVersion: 1.0.0
   supportsES6: true

--- a/bin/configs/typescript-axios-with-complex-headers.yaml
+++ b/bin/configs/typescript-axios-with-complex-headers.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-axios
 outputDir: samples/client/petstore/typescript-axios/builds/with-complex-headers
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore-with-complex-headers.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-axios

--- a/bin/configs/typescript-axios-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+++ b/bin/configs/typescript-axios-with-fake-endpoints-models-for-testing-with-http-signature.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-axios
 outputDir: samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-axios

--- a/bin/configs/typescript-axios-with-interfaces.yaml
+++ b/bin/configs/typescript-axios-with-interfaces.yaml
@@ -1,5 +1,6 @@
 generatorName: typescript-axios
 outputDir: samples/client/petstore/typescript-axios/builds/with-interfaces
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-axios
 additionalProperties:
   withInterfaces: "true"

--- a/bin/configs/typescript-axios-with-npm-version-and-separate-models-and-api.yaml
+++ b/bin/configs/typescript-axios-with-npm-version-and-separate-models-and-api.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-axios
 outputDir: samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-axios
 additionalProperties:
   npmVersion: 1.0.0
   apiPackage: api.another.level

--- a/bin/configs/typescript-axios-with-npm-version.yaml
+++ b/bin/configs/typescript-axios-with-npm-version.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-axios
 outputDir: samples/client/petstore/typescript-axios/builds/with-npm-version
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-axios
 additionalProperties:
   npmVersion: 1.0.0
   npmName: '@openapitools/typescript-axios-petstore'

--- a/bin/configs/typescript-axios-with-single-request-parameters.yaml
+++ b/bin/configs/typescript-axios-with-single-request-parameters.yaml
@@ -1,5 +1,6 @@
 generatorName: typescript-axios
 outputDir: samples/client/petstore/typescript-axios/builds/with-single-request-parameters
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-operations-without-required-params.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-axios
 additionalProperties:
   useSingleRequestParameter: "true"

--- a/bin/configs/typescript-consolidated-deno.yaml
+++ b/bin/configs/typescript-consolidated-deno.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript
 outputDir: samples/openapi3/client/petstore/typescript/builds/deno
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript
 additionalProperties:
   platform: deno
   npmName: ts-petstore-client

--- a/bin/configs/typescript-consolidated-inversify.yaml
+++ b/bin/configs/typescript-consolidated-inversify.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript
 outputDir: samples/openapi3/client/petstore/typescript/builds/inversify
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript
 additionalProperties:
   platform: node
   npmName: ts-petstore-client

--- a/bin/configs/typescript-consolidated-jquery.yaml
+++ b/bin/configs/typescript-consolidated-jquery.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript
 outputDir: samples/openapi3/client/petstore/typescript/builds/jquery
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript
 additionalProperties:
   framework: jquery
   npmName: ts-petstore-client

--- a/bin/configs/typescript-consolidated-node-object-parameters.yaml
+++ b/bin/configs/typescript-consolidated-node-object-parameters.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript
 outputDir: samples/openapi3/client/petstore/typescript/builds/object_params
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript
 additionalProperties:
   platform: node
   npmName: ts-petstore-client

--- a/bin/configs/typescript-consolidated-node.yaml
+++ b/bin/configs/typescript-consolidated-node.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript
 outputDir: samples/openapi3/client/petstore/typescript/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript
 additionalProperties:
   platform: node
   npmName: ts-petstore-client

--- a/bin/configs/typescript-fetch-default-v3.0.yaml
+++ b/bin/configs/typescript-fetch-default-v3.0.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/default-v3.0
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch

--- a/bin/configs/typescript-fetch-default.yaml
+++ b/bin/configs/typescript-fetch-default.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch

--- a/bin/configs/typescript-fetch-enum.yaml
+++ b/bin/configs/typescript-fetch-enum.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/enum
 inputSpec: modules/openapi-generator/src/test/resources/3_0/typescript-fetch/enum.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch

--- a/bin/configs/typescript-fetch-es6-target.yaml
+++ b/bin/configs/typescript-fetch-es6-target.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/es6-target
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch
 additionalProperties:
   npmVersion: 1.0.0
   supportsES6: true

--- a/bin/configs/typescript-fetch-multiple-parameters.yaml
+++ b/bin/configs/typescript-fetch-multiple-parameters.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/multiple-parameters
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch
 additionalProperties:
   useSingleRequestParameter: false
   snapshot: false

--- a/bin/configs/typescript-fetch-prefix-parameter-interfaces.yaml
+++ b/bin/configs/typescript-fetch-prefix-parameter-interfaces.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch
 additionalProperties:
   npmVersion: 1.0.0
   npmName: '@openapitools/typescript-fetch-petstore'

--- a/bin/configs/typescript-fetch-sagas-and-records.yaml
+++ b/bin/configs/typescript-fetch-sagas-and-records.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/sagas-and-records
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing-saga-and-records.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch
 additionalProperties:
   npmVersion: 1.0.0
   npmName: '@openapitools/typescript-fetch-petstore'

--- a/bin/configs/typescript-fetch-typescript-three-plus.yaml
+++ b/bin/configs/typescript-fetch-typescript-three-plus.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/typescript-three-plus
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch
 additionalProperties:
   npmVersion: 1.0.0
   npmName: '@openapitools/typescript-fetch-petstore'

--- a/bin/configs/typescript-fetch-with-interfaces.yaml
+++ b/bin/configs/typescript-fetch-with-interfaces.yaml
@@ -1,5 +1,6 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/with-interfaces
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch
 additionalProperties:
   withInterfaces: "true"

--- a/bin/configs/typescript-fetch-with-npm-version.yaml
+++ b/bin/configs/typescript-fetch-with-npm-version.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/with-npm-version
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch
 additionalProperties:
   npmVersion: 1.0.0
   npmName: '@openapitools/typescript-fetch-petstore'

--- a/bin/configs/typescript-fetch-without-runtime-checks.yaml
+++ b/bin/configs/typescript-fetch-without-runtime-checks.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-fetch
 outputDir: samples/client/petstore/typescript-fetch/builds/without-runtime-checks
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-fetch
 additionalProperties:
   npmVersion: 1.0.0
   npmName: '@openapitools/typescript-fetch-petstore'

--- a/bin/configs/typescript-inversify.yaml
+++ b/bin/configs/typescript-inversify.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-inversify
 outputDir: samples/client/petstore/typescript-inversify
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-inversify

--- a/bin/configs/typescript-jquery-default.yaml
+++ b/bin/configs/typescript-jquery-default.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-jquery
 outputDir: samples/client/petstore/typescript-jquery/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-jquery

--- a/bin/configs/typescript-jquery-npm.yaml
+++ b/bin/configs/typescript-jquery-npm.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-jquery
 outputDir: samples/client/petstore/typescript-jquery/npm
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-jquery
 additionalProperties:
   npmVersion: 0.0.1
   npmName: '@openapitools/jquery-typescript-petstore'

--- a/bin/configs/typescript-node-default.yaml
+++ b/bin/configs/typescript-node-default.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-node
 outputDir: samples/client/petstore/typescript-node/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-node

--- a/bin/configs/typescript-node-npm.yaml
+++ b/bin/configs/typescript-node-npm.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-node
 outputDir: samples/client/petstore/typescript-node/npm
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-node
 additionalProperties:
   npmVersion: 0.0.1
   npmName: '@openapitools/node-typescript-petstore'

--- a/bin/configs/typescript-rxjs-default.yaml
+++ b/bin/configs/typescript-rxjs-default.yaml
@@ -1,3 +1,4 @@
 generatorName: typescript-rxjs
 outputDir: samples/client/petstore/typescript-rxjs/builds/default
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-rxjs

--- a/bin/configs/typescript-rxjs-es6-target.yaml
+++ b/bin/configs/typescript-rxjs-es6-target.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-rxjs
 outputDir: samples/client/petstore/typescript-rxjs/builds/es6-target
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-rxjs
 additionalProperties:
   npmVersion: 1.0.0
   supportsES6: true

--- a/bin/configs/typescript-rxjs-with-npm-version.yaml
+++ b/bin/configs/typescript-rxjs-with-npm-version.yaml
@@ -1,6 +1,7 @@
 generatorName: typescript-rxjs
 outputDir: samples/client/petstore/typescript-rxjs/builds/with-npm-version
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-rxjs
 additionalProperties:
   npmVersion: 1.0.0
   npmName: '@openapitools/typescript-rxjs-petstore'

--- a/bin/configs/typescript-rxjs-with-progress-subscriber.yaml
+++ b/bin/configs/typescript-rxjs-with-progress-subscriber.yaml
@@ -1,5 +1,6 @@
 generatorName: typescript-rxjs
 outputDir: samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber
 inputSpec: modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+templateDir: modules/openapi-generator/src/main/resources/typescript-rxjs
 additionalProperties:
   withProgressSubscriber: "true"


### PR DESCRIPTION
I noticed that many sample configs don't have `templateDir` explicitly defined, meaning you have to rebuild the generator binary (quite slow) each time a template change is made. So I went ahead and added this attribute to all configs where missing.

These changes do not result in any generated sample code changes, as expected.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.