### PR TITLE
[C#][netcore] fix path and query parameters encoding

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/WebRequestPathBuilder.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/WebRequestPathBuilder.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 using System.Collections.Generic;
+using System.Web;
 
 namespace {{packageName}}.Client
 {
@@ -21,7 +22,7 @@ namespace {{packageName}}.Client
             {
                 foreach (var parameter in parameters)
                 {
-                    _path = _path.Replace("{" + parameter.Key + "}", parameter.Value);
+                    _path = _path.Replace("{" + parameter.Key + "}", HttpUtility.UrlEncode(parameter.Value));
                 }
             }
 
@@ -31,7 +32,7 @@ namespace {{packageName}}.Client
                 {
                     foreach (var value in parameter.Value)
                     {
-                        _query = _query + parameter.Key + "=" + value + "&";
+                        _query = _query + parameter.Key + "=" + HttpUtility.UrlEncode(value) + "&";
                     }
                 }
             }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/WebRequestPathBuilder.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/WebRequestPathBuilder.cs
@@ -8,6 +8,7 @@
  */
 
 using System.Collections.Generic;
+using System.Web;
 
 namespace Org.OpenAPITools.Client
 {
@@ -29,7 +30,7 @@ namespace Org.OpenAPITools.Client
             {
                 foreach (var parameter in parameters)
                 {
-                    _path = _path.Replace("{" + parameter.Key + "}", parameter.Value);
+                    _path = _path.Replace("{" + parameter.Key + "}", HttpUtility.UrlEncode(parameter.Value));
                 }
             }
 
@@ -39,7 +40,7 @@ namespace Org.OpenAPITools.Client
                 {
                     foreach (var value in parameter.Value)
                     {
-                        _query = _query + parameter.Key + "=" + value + "&";
+                        _query = _query + parameter.Key + "=" + HttpUtility.UrlEncode(value) + "&";
                     }
                 }
             }


### PR DESCRIPTION
To fix https://github.com/OpenAPITools/openapi-generator/issues/10018

Local test result is good:
```
/v2/pet/34?test_query=%3chello%26world%3e&test_query3=12
```
as `<hello&world>` is encoded correctly above.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
