### PR TITLE
[python-flask] Fix NoneType when deserialize optional date (See #5813)

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-flask/util.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/util.mustache
@@ -67,6 +67,9 @@ def deserialize_date(string):
     :return: date.
     :rtype: date
     """
+    if string is None:
+      return None
+    
     try:
         from dateutil.parser import parse
         return parse(string).date()
@@ -84,6 +87,9 @@ def deserialize_datetime(string):
     :return: datetime.
     :rtype: datetime
     """
+    if string is None:
+      return None
+    
     try:
         from dateutil.parser import parse
         return parse(string)

--- a/samples/server/petstore/python-flask/openapi_server/util.py
+++ b/samples/server/petstore/python-flask/openapi_server/util.py
@@ -67,6 +67,9 @@ def deserialize_date(string):
     :return: date.
     :rtype: date
     """
+    if string is None:
+      return None
+    
     try:
         from dateutil.parser import parse
         return parse(string).date()
@@ -84,6 +87,9 @@ def deserialize_datetime(string):
     :return: datetime.
     :rtype: datetime
     """
+    if string is None:
+      return None
+    
     try:
         from dateutil.parser import parse
         return parse(string)


### PR DESCRIPTION
### What have been done
As "deserialize_date" and "deserialize_datetime" are used outside of "deserialize_model", we should check 'None' value before parsing string.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

### Verify that it works
1. Generate a server : (Yaml file below)
`java -jar openapi-generator-cli/target/openapi-generator-cli.jar generate -i openapi.yaml -g python-flask -o ./server/generated/`

2. Run : 
`python3 -m openapi_server`

3. Go to URL : 
Use Postman to "GET /events"

Without this fix : 
```
[2021-08-02 17:41:35,566] ERROR in app: Exception on /events [GET]
[...]
TypeError: Parser must be a string or character stream, not NoneType
```

With this fix : 
`127.0.0.1 - - [02/Aug/2021 17:41:13] "GET /events HTTP/1.1" 200 -`


```
openapi: "3.0.0"
info:
  version: 1.0.0
  title: OpenApi Petstore
  license:
    name: MIT
paths:
  /events:
    get:
      summary: "Get a list of all events"
      operationId: listEvents
      parameters:
        - $ref: '#/components/parameters/startDateParam'
      responses:
        '200':
          description: A paged array of pets
        
components:
  parameters:
    startDateParam:
      name: startDate
      in: query
      description: Optional start date when querying date based items
      required: false
      schema:
        type: string
        format: date
```

@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @arun-nalla (2019/11) @spacether (2019/11)