### PR TITLE
[php] Deprecated annotation on operations and fields

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-laravel/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/api.mustache
@@ -21,9 +21,12 @@ use Illuminate\Support\Facades\Request;
      *
      * {{{summary}}}.
      *
-  {{#pathParams}}   * @param {{dataType}} ${{paramName}} {{description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+  {{#pathParams}}   * @param {{dataType}} ${{paramName}} {{description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
   {{/pathParams}}   *
      * @return Http response
+  {{#isDeprecated}}
+     * @deprecated
+  {{/isDeprecated}}
      */
     public function {{operationId}}({{#pathParams}}${{paramName}}{{^-last}}, {{/-last}}{{/pathParams}})
     {

--- a/modules/openapi-generator/src/main/resources/php-laravel/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/model.mustache
@@ -11,6 +11,9 @@ class {{classname}} {
 
     {{#vars}}
     /** @var {{{dataType}}} ${{name}} {{#description}}{{description}}{{/description}}*/
+{{#deprecated}}
+    /** @deprecated */
+{{/deprecated}}
     private ${{name}};
 
     {{/vars}}

--- a/modules/openapi-generator/src/main/resources/php-lumen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-lumen/api.mustache
@@ -21,9 +21,12 @@ use Illuminate\Support\Facades\Request;
      *
      * {{{summary}}}.
      *
-  {{#pathParams}}   * @param {{dataType}} ${{paramName}} {{description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+  {{#pathParams}}   * @param {{dataType}} ${{paramName}} {{description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
   {{/pathParams}}   *
      * @return Http response
+  {{#isDeprecated}}
+     * @deprecated
+  {{/isDeprecated}}
      */
     public function {{operationId}}({{#pathParams}}${{paramName}}{{^-last}}, {{/-last}}{{/pathParams}})
     {

--- a/modules/openapi-generator/src/main/resources/php-mezzio-ph/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-mezzio-ph/api.mustache
@@ -57,6 +57,9 @@ class {{classname}}
      *
      * @return {{returnType}}
 {{/returnType}}
+{{#isDeprecated}}
+     * @deprecated
+{{/isDeprecated}}
      */
     public function {{operationId}}(ServerRequestInterface $request){{#returnType}}: {{returnType}}{{/returnType}}
     {

--- a/modules/openapi-generator/src/main/resources/php-slim-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/api.mustache
@@ -84,6 +84,9 @@ abstract class {{classname}}
      *
      * @return ResponseInterface
      * @throws Exception to force implementation class to override this method
+    {{#isDeprecated}}
+     * @deprecated
+    {{/isDeprecated}}
      */
     public function {{operationId}}(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {

--- a/modules/openapi-generator/src/main/resources/php-slim-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/model.mustache
@@ -27,6 +27,9 @@ class {{classname}}
     {{#vars}}
     
     /** @var {{dataType}} ${{name}} {{#description}}{{description}}{{/description}}*/
+{{#deprecated}}
+    /** @deprecated */
+{{/deprecated}}
     private ${{name}};
     {{/vars}}
 }

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/api.mustache
@@ -60,6 +60,9 @@ abstract class {{classname}}
      *
      * @return ResponseInterface
      * @throws HttpNotImplementedException to force implementation class to override this method
+    {{#isDeprecated}}
+     * @deprecated
+    {{/isDeprecated}}
      */
     public function {{operationId}}(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {

--- a/modules/openapi-generator/src/main/resources/php-symfony/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/api.mustache
@@ -57,13 +57,15 @@ interface {{classname}}
      *
     {{/description}}
     {{#allParams}}
-     * @param  {{vendorExtensions.x-comment-type}} ${{paramName}}  {{description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     * @param  {{vendorExtensions.x-comment-type}} ${{paramName}}  {{description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
     {{/allParams}}
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return {{{vendorExtensions.x-comment-type}}}
-     *
+    {{#isDeprecated}}
+     * @deprecated
+    {{/isDeprecated}}
      */
     public function {{operationId}}({{#allParams}}{{#vendorExtensions.x-parameter-type}}{{vendorExtensions.x-parameter-type}} {{/vendorExtensions.x-parameter-type}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}, {{/allParams}}&$responseCode, array &$responseHeaders);
 {{/operation}}

--- a/modules/openapi-generator/src/main/resources/php-symfony/api_controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/api_controller.mustache
@@ -54,6 +54,9 @@ class {{controllerName}} extends Controller
 {{/description}}
      * @param Request $request The Symfony request to handle.
      * @return Response The Symfony response.
+{{#isDeprecated}}
+     * @deprecated
+{{/isDeprecated}}
      */
     public function {{operationId}}Action(Request $request{{#hasPathParams}}{{#pathParams}}, ${{paramName}}{{/pathParams}}{{/hasPathParams}})
     {

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -131,12 +131,15 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}}{{^description}} {{paramName}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}}{{^description}} {{paramName}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
 {{/allParams}}
      *
      * @throws \{{invokerPackage}}\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return {{#returnType}}{{#responses}}{{#dataType}}{{^-first}}|{{/-first}}{{/dataType}}{{{dataType}}}{{/responses}}{{/returnType}}{{^returnType}}void{{/returnType}}
+    {{#isDeprecated}}
+     * @deprecated
+    {{/isDeprecated}}
      */
     public function {{operationId}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {
@@ -169,12 +172,15 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
 {{/allParams}}
      *
      * @throws \{{invokerPackage}}\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of {{#returnType}}{{#responses}}{{#dataType}}{{^-first}}|{{/-first}}{{/dataType}}{{{dataType}}}{{/responses}}{{/returnType}}{{^returnType}}null{{/returnType}}, HTTP status code, HTTP response headers (array of strings)
+    {{#isDeprecated}}
+     * @deprecated
+    {{/isDeprecated}}
      */
     public function {{operationId}}WithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {
@@ -294,11 +300,14 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
 {{/allParams}}
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
+    {{#isDeprecated}}
+     * @deprecated
+    {{/isDeprecated}}
      */
     public function {{operationId}}Async({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {
@@ -335,11 +344,14 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
 {{/allParams}}
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
+    {{#isDeprecated}}
+     * @deprecated
+    {{/isDeprecated}}
      */
     public function {{operationId}}AsyncWithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {
@@ -401,11 +413,14 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
 {{/allParams}}
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
+    {{#isDeprecated}}
+     * @deprecated
+    {{/isDeprecated}}
      */
     public function {{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -279,6 +279,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * Gets {{name}}
      *
      * @return {{{dataType}}}{{^required}}|null{{/required}}
+    {{#deprecated}}
+     * @deprecated
+    {{/deprecated}}
      */
     public function {{getter}}()
     {
@@ -291,6 +294,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * @param {{{dataType}}}{{^required}}|null{{/required}} ${{name}}{{#description}} {{{description}}}{{/description}}{{^description}} {{{name}}}{{/description}}
      *
      * @return self
+    {{#deprecated}}
+     * @deprecated
+    {{/deprecated}}
      */
     public function {{setter}}(${{name}})
     {

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -85,6 +85,7 @@ paths:
           required: true
           style: form
           explode: false
+          deprecated: true
           schema:
             type: array
             items:

--- a/samples/client/petstore/java/feign/api/openapi.yaml
+++ b/samples/client/petstore/java/feign/api/openapi.yaml
@@ -100,7 +100,8 @@ paths:
       description: Multiple status values can be provided with comma separated strings
       operationId: findPetsByStatus
       parameters:
-      - description: Status values that need to be considered for filter
+      - deprecated: true
+        description: Status values that need to be considered for filter
         explode: false
         in: query
         name: status

--- a/samples/client/petstore/java/webclient/api/openapi.yaml
+++ b/samples/client/petstore/java/webclient/api/openapi.yaml
@@ -100,7 +100,8 @@ paths:
       description: Multiple status values can be provided with comma separated strings
       operationId: findPetsByStatus
       parameters:
-      - description: Status values that need to be considered for filter
+      - deprecated: true
+        description: Status values that need to be considered for filter
         explode: false
         in: query
         name: status

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -598,7 +598,7 @@ class PetApi
      *
      * Finds Pets by status
      *
-     * @param  string[] $status Status values that need to be considered for filter (required)
+     * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -615,7 +615,7 @@ class PetApi
      *
      * Finds Pets by status
      *
-     * @param  string[] $status Status values that need to be considered for filter (required)
+     * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -701,7 +701,7 @@ class PetApi
      *
      * Finds Pets by status
      *
-     * @param  string[] $status Status values that need to be considered for filter (required)
+     * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -721,7 +721,7 @@ class PetApi
      *
      * Finds Pets by status
      *
-     * @param  string[] $status Status values that need to be considered for filter (required)
+     * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -767,7 +767,7 @@ class PetApi
     /**
      * Create request for operation 'findPetsByStatus'
      *
-     * @param  string[] $status Status values that need to be considered for filter (required)
+     * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
@@ -870,6 +870,7 @@ class PetApi
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Pet[]
+     * @deprecated
      */
     public function findPetsByTags($tags)
     {
@@ -887,6 +888,7 @@ class PetApi
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Pet[], HTTP status code, HTTP response headers (array of strings)
+     * @deprecated
      */
     public function findPetsByTagsWithHttpInfo($tags)
     {
@@ -972,6 +974,7 @@ class PetApi
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
      */
     public function findPetsByTagsAsync($tags)
     {
@@ -992,6 +995,7 @@ class PetApi
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
+     * @deprecated
      */
     public function findPetsByTagsAsyncWithHttpInfo($tags)
     {
@@ -1038,6 +1042,7 @@ class PetApi
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
+     * @deprecated
      */
     public function findPetsByTagsRequest($tags)
     {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
@@ -251,6 +251,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * Gets id
      *
      * @return float|null
+     * @deprecated
      */
     public function getId()
     {
@@ -263,6 +264,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * @param float|null $id id
      *
      * @return self
+     * @deprecated
      */
     public function setId($id)
     {
@@ -275,6 +277,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * Gets deprecated_ref
      *
      * @return \OpenAPI\Client\Model\DeprecatedObject|null
+     * @deprecated
      */
     public function getDeprecatedRef()
     {
@@ -287,6 +290,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * @param \OpenAPI\Client\Model\DeprecatedObject|null $deprecated_ref deprecated_ref
      *
      * @return self
+     * @deprecated
      */
     public function setDeprecatedRef($deprecated_ref)
     {
@@ -299,6 +303,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * Gets bars
      *
      * @return string[]|null
+     * @deprecated
      */
     public function getBars()
     {
@@ -311,6 +316,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * @param string[]|null $bars bars
      *
      * @return self
+     * @deprecated
      */
     public function setBars($bars)
     {

--- a/samples/server/petstore/php-laravel/lib/app/Http/Controllers/PetController.php
+++ b/samples/server/petstore/php-laravel/lib/app/Http/Controllers/PetController.php
@@ -130,6 +130,7 @@ class PetController extends Controller
      *
      *
      * @return Http response
+     * @deprecated
      */
     public function findPetsByTags()
     {

--- a/samples/server/petstore/php-laravel/lib/app/Models/ObjectWithDeprecatedFields.php
+++ b/samples/server/petstore/php-laravel/lib/app/Models/ObjectWithDeprecatedFields.php
@@ -13,12 +13,15 @@ class ObjectWithDeprecatedFields {
     private $uuid;
 
     /** @var float $id */
+    /** @deprecated */
     private $id;
 
     /** @var \app\Models\DeprecatedObject $deprecatedRef */
+    /** @deprecated */
     private $deprecatedRef;
 
     /** @var string[] $bars */
+    /** @deprecated */
     private $bars;
 
 }

--- a/samples/server/petstore/php-lumen/lib/app/Http/Controllers/PetApi.php
+++ b/samples/server/petstore/php-lumen/lib/app/Http/Controllers/PetApi.php
@@ -126,6 +126,7 @@ class PetApi extends Controller
      *
      *
      * @return Http response
+     * @deprecated
      */
     public function findPetsByTags()
     {

--- a/samples/server/petstore/php-mezzio-ph/src/App/Handler/PetFindByTags.php
+++ b/samples/server/petstore/php-mezzio-ph/src/App/Handler/PetFindByTags.php
@@ -32,6 +32,7 @@ class PetFindByTags
      * @throws PHException\HttpCode 501 if the method is not implemented
      *
      * @return \App\DTO\Collection26
+     * @deprecated
      */
     public function findPetsByTags(ServerRequestInterface $request): \App\DTO\Collection26
     {

--- a/samples/server/petstore/php-slim4/lib/Api/AbstractPetApi.php
+++ b/samples/server/petstore/php-slim4/lib/Api/AbstractPetApi.php
@@ -125,6 +125,7 @@ abstract class AbstractPetApi
      *
      * @return ResponseInterface
      * @throws HttpNotImplementedException to force implementation class to override this method
+     * @deprecated
      */
     public function findPetsByTags(ServerRequestInterface $request, ResponseInterface $response, array $args)
     {

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
@@ -80,7 +80,6 @@ interface PetApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return \OpenAPI\Server\Model\Pet
-     *
      */
     public function addPet(Pet $pet, &$responseCode, array &$responseHeaders);
 
@@ -95,7 +94,6 @@ interface PetApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return void
-     *
      */
     public function deletePet($petId, $apiKey = null, &$responseCode, array &$responseHeaders);
 
@@ -104,12 +102,11 @@ interface PetApiInterface
      *
      * Finds Pets by status
      *
-     * @param  \string[] $status  Status values that need to be considered for filter (required)
+     * @param  \string[] $status  Status values that need to be considered for filter (required) (deprecated)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return \OpenAPI\Server\Model\Pet[]
-     *
      */
     public function findPetsByStatus(array $status, &$responseCode, array &$responseHeaders);
 
@@ -123,7 +120,7 @@ interface PetApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return \OpenAPI\Server\Model\Pet[]
-     *
+     * @deprecated
      */
     public function findPetsByTags(array $tags, &$responseCode, array &$responseHeaders);
 
@@ -137,7 +134,6 @@ interface PetApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return \OpenAPI\Server\Model\Pet
-     *
      */
     public function getPetById($petId, &$responseCode, array &$responseHeaders);
 
@@ -151,7 +147,6 @@ interface PetApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return \OpenAPI\Server\Model\Pet
-     *
      */
     public function updatePet(Pet $pet, &$responseCode, array &$responseHeaders);
 
@@ -167,7 +162,6 @@ interface PetApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return void
-     *
      */
     public function updatePetWithForm($petId, $name = null, $status = null, &$responseCode, array &$responseHeaders);
 
@@ -183,7 +177,6 @@ interface PetApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return \OpenAPI\Server\Model\ApiResponse
-     *
      */
     public function uploadFile($petId, $additionalMetadata = null, UploadedFile $file = null, &$responseCode, array &$responseHeaders);
 }

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/StoreApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/StoreApiInterface.php
@@ -61,7 +61,6 @@ interface StoreApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return void
-     *
      */
     public function deleteOrder($orderId, &$responseCode, array &$responseHeaders);
 
@@ -74,7 +73,6 @@ interface StoreApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return \int
-     *
      */
     public function getInventory(&$responseCode, array &$responseHeaders);
 
@@ -88,7 +86,6 @@ interface StoreApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return \OpenAPI\Server\Model\Order
-     *
      */
     public function getOrderById($orderId, &$responseCode, array &$responseHeaders);
 
@@ -102,7 +99,6 @@ interface StoreApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return \OpenAPI\Server\Model\Order
-     *
      */
     public function placeOrder(Order $order, &$responseCode, array &$responseHeaders);
 }

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/UserApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/UserApiInterface.php
@@ -61,7 +61,6 @@ interface UserApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return void
-     *
      */
     public function createUser(User $user, &$responseCode, array &$responseHeaders);
 
@@ -75,7 +74,6 @@ interface UserApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return void
-     *
      */
     public function createUsersWithArrayInput(array $user, &$responseCode, array &$responseHeaders);
 
@@ -89,7 +87,6 @@ interface UserApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return void
-     *
      */
     public function createUsersWithListInput(array $user, &$responseCode, array &$responseHeaders);
 
@@ -103,7 +100,6 @@ interface UserApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return void
-     *
      */
     public function deleteUser($username, &$responseCode, array &$responseHeaders);
 
@@ -117,7 +113,6 @@ interface UserApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return \OpenAPI\Server\Model\User
-     *
      */
     public function getUserByName($username, &$responseCode, array &$responseHeaders);
 
@@ -132,7 +127,6 @@ interface UserApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return \string
-     *
      */
     public function loginUser($username, $password, &$responseCode, array &$responseHeaders);
 
@@ -145,7 +139,6 @@ interface UserApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return void
-     *
      */
     public function logoutUser(&$responseCode, array &$responseHeaders);
 
@@ -160,7 +153,6 @@ interface UserApiInterface
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
      * @return void
-     *
      */
     public function updateUser($username, User $user, &$responseCode, array &$responseHeaders);
 }

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
@@ -324,6 +324,7 @@ class PetController extends Controller
      *
      * @param Request $request The Symfony request to handle.
      * @return Response The Symfony response.
+     * @deprecated
      */
     public function findPetsByTagsAction(Request $request)
     {


### PR DESCRIPTION
Apply the `@deprecated` annotation to deprecated functions and properties.

@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ackintosh, @ybelenko, @renepardon

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
