### PR TITLE
Make php's array primitive

### DIFF
--- a/docs/generators/php-laravel.md
+++ b/docs/generators/php-laravel.md
@@ -40,6 +40,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 
 <ul class="column-ul">
 <li>DateTime</li>
+<li>array</li>
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>

--- a/docs/generators/php-lumen.md
+++ b/docs/generators/php-lumen.md
@@ -40,6 +40,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 
 <ul class="column-ul">
 <li>DateTime</li>
+<li>array</li>
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>

--- a/docs/generators/php-mezzio-ph.md
+++ b/docs/generators/php-mezzio-ph.md
@@ -41,6 +41,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 
 <ul class="column-ul">
 <li>DateTime</li>
+<li>array</li>
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>

--- a/docs/generators/php-slim-deprecated.md
+++ b/docs/generators/php-slim-deprecated.md
@@ -40,6 +40,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 
 <ul class="column-ul">
 <li>DateTime</li>
+<li>array</li>
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>

--- a/docs/generators/php-slim4.md
+++ b/docs/generators/php-slim4.md
@@ -41,6 +41,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 
 <ul class="column-ul">
 <li>DateTime</li>
+<li>array</li>
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>

--- a/docs/generators/php.md
+++ b/docs/generators/php.md
@@ -41,6 +41,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 
 <ul class="column-ul">
 <li>DateTime</li>
+<li>array</li>
 <li>bool</li>
 <li>boolean</li>
 <li>byte</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -89,6 +89,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
                         "float",
                         "string",
                         "object",
+                        "array",
                         "DateTime",
                         "mixed",
                         "number",

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
@@ -17,10 +17,16 @@
 
 package org.openapitools.codegen.php;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+
 import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.languages.AbstractPhpCodegen;
+import org.openapitools.codegen.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -120,6 +126,24 @@ public class AbstractPhpCodegenTest {
             {"git_repo_id", "git_user_id", "git_repo_id/git_user_id"},
             {"foo", "bar", "foo/bar"},
         };
+    }
+
+    @Test(description = "Issue #8945")
+    public void testArrayOfArrays() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_8945.yaml");
+        final AbstractPhpCodegen codegen = new P_AbstractPhpCodegen();
+
+        Schema test1 = openAPI.getComponents().getSchemas().get("MyResponse");
+        CodegenModel cm1 = codegen.fromModel("MyResponse", test1);
+
+        // Make sure we got the container object.
+        Assert.assertEquals(cm1.getDataType(), "object");
+        Assert.assertEquals(codegen.getTypeDeclaration("MyResponse"), "\\php\\Model\\MyResponse");
+
+        // Assert the array type is properly detected.
+        CodegenProperty cp1 = cm1.vars.get(0);
+        cp1 = codegen.fromProperty("ArrayProp", test1);
+        Assert.assertTrue(cp1.isPrimitiveType);
     }
 
     private static class P_AbstractPhpCodegen extends AbstractPhpCodegen {

--- a/modules/openapi-generator/src/test/resources/3_0/issue_8945.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_8945.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.1
+info:
+  title: OpenAPI Petstore
+  description: "for schemas with properties and required ensure correct hasVars, hasRequired, vars, and requiredVars"
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+servers:
+  - url: http://petstore.swagger.io:80/v2
+tags: []
+paths:
+  /sut:
+    get:
+      operationId: getArrayOfArrays
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/MyResponse'
+components:
+  schemas:
+    MyResponse:
+      type: object
+      properties:
+        ArrayOfArrays:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArrayProp'
+        ArrayOfObjects:
+          type: array
+          items:
+            $ref: '#/components/schemas/ObjectProp'
+    ArrayOfArrays:
+      type: array
+      items:
+        $ref: '#/components/schemas/ArrayProp'
+    ArrayOfObjects:
+      type: array
+      items:
+        $ref: '#/components/schemas/ObjectProp'
+    ArrayProp:
+      type: array
+      items:
+        type: string
+    ObjectProp:
+      type: object
+      properties:
+        name:
+          type: string

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/AdditionalPropertiesClass.md
@@ -5,6 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **map_property** | **array<string,string>** |  | [optional]
-**map_of_map_property** | [**array<string,array<string,string>>**](array.md) |  | [optional]
+**map_of_map_property** | **array<string,array<string,string>>** |  | [optional]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/ArrayOfArrayOfNumberOnly.md
@@ -4,6 +4,6 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**array_array_number** | [**float[][]**](array.md) |  | [optional]
+**array_array_number** | **float[][]** |  | [optional]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/ArrayTest.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/ArrayTest.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **array_of_string** | **string[]** |  | [optional]
-**array_array_of_integer** | [**int[][]**](array.md) |  | [optional]
-**array_array_of_model** | [**\OpenAPI\Client\Model\ReadOnlyFirst[][]**](array.md) |  | [optional]
+**array_array_of_integer** | **int[][]** |  | [optional]
+**array_array_of_model** | **\OpenAPI\Client\Model\ReadOnlyFirst[][]** |  | [optional]
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/MapTest.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/MapTest.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**map_map_of_string** | [**array<string,array<string,string>>**](array.md) |  | [optional]
+**map_map_of_string** | **array<string,array<string,string>>** |  | [optional]
 **map_of_enum_string** | **array<string,string>** |  | [optional]
 **direct_map** | **array<string,bool>** |  | [optional]
 **indirect_map** | **array<string,bool>** |  | [optional]

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -86,7 +86,7 @@ class ObjectSerializer
                 foreach ($data::openAPITypes() as $property => $openAPIType) {
                     $getter = $data::getters()[$property];
                     $value = $data->$getter();
-                    if ($value !== null && !in_array($openAPIType, ['DateTime', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
+                    if ($value !== null && !in_array($openAPIType, ['DateTime', 'array', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
                         $callable = [$openAPIType, 'getAllowableEnumValues'];
                         if (is_callable($callable)) {
                             /** array $callable */
@@ -330,7 +330,7 @@ class ObjectSerializer
         }
 
         /** @psalm-suppress ParadoxicalCondition */
-        if (in_array($class, ['DateTime', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
+        if (in_array($class, ['DateTime', 'array', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
             settype($data, $class);
             return $data;
         }


### PR DESCRIPTION
Fixes a bug where code generation would sometimes treat arrays as objects and break serialization and code documentation.

Fixes #8945 
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
