### PR TITLE
[typescript-fetch] Fix double comma arguments due to initOverrides

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -60,7 +60,7 @@ export interface {{classname}}Interface {
      {{/summary}}
      */
     {{^useSingleRequestParameter}}
-    {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}{{^-last}}, {{/-last}}, {{/allParams}}initOverrides?: RequestInit): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
+    {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}, {{/allParams}}initOverrides?: RequestInit): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
     {{/useSingleRequestParameter}}
     {{#useSingleRequestParameter}}
     {{nickname}}({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
@@ -331,7 +331,7 @@ export class {{classname}} extends runtime.BaseAPI {
      {{/summary}}
      */
     {{^useSingleRequestParameter}}
-    async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}{{^-last}}, {{/-last}}, {{/allParams}}initOverrides?: RequestInit): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+    async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}, {{/allParams}}initOverrides?: RequestInit): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
         {{#returnType}}
         const response = await this.{{nickname}}Raw({{#allParams.0}}{ {{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}} }, {{/allParams.0}}initOverrides);
         return await response.value();

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
@@ -136,7 +136,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(petId: number, , apiKey?: string, initOverrides?: RequestInit): Promise<void> {
+    async deletePet(petId: number, apiKey?: string, initOverrides?: RequestInit): Promise<void> {
         await this.deletePetRaw({ petId: petId, apiKey: apiKey }, initOverrides);
     }
 
@@ -348,7 +348,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(petId: number, , name?: string, , status?: string, initOverrides?: RequestInit): Promise<void> {
+    async updatePetWithForm(petId: number, name?: string, status?: string, initOverrides?: RequestInit): Promise<void> {
         await this.updatePetWithFormRaw({ petId: petId, name: name, status: status }, initOverrides);
     }
 
@@ -407,7 +407,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(petId: number, , additionalMetadata?: string, , file?: Blob, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+    async uploadFile(petId: number, additionalMetadata?: string, file?: Blob, initOverrides?: RequestInit): Promise<ModelApiResponse> {
         const response = await this.uploadFileRaw({ petId: petId, additionalMetadata: additionalMetadata, file: file }, initOverrides);
         return await response.value();
     }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
@@ -251,7 +251,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(username: string, , password: string, initOverrides?: RequestInit): Promise<string> {
+    async loginUser(username: string, password: string, initOverrides?: RequestInit): Promise<string> {
         const response = await this.loginUserRaw({ username: username, password: password }, initOverrides);
         return await response.value();
     }
@@ -315,7 +315,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(username: string, , body: User, initOverrides?: RequestInit): Promise<void> {
+    async updateUser(username: string, body: User, initOverrides?: RequestInit): Promise<void> {
         await this.updateUserRaw({ username: username, body: body }, initOverrides);
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
@@ -153,7 +153,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(petId: number, , apiKey?: string, initOverrides?: RequestInit): Promise<void> {
+    async deletePet(petId: number, apiKey?: string, initOverrides?: RequestInit): Promise<void> {
         await this.deletePetRaw({ petId: petId, apiKey: apiKey }, initOverrides);
     }
 
@@ -447,7 +447,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(petId: number, , name?: string, , status?: string, initOverrides?: RequestInit): Promise<void> {
+    async updatePetWithForm(petId: number, name?: string, status?: string, initOverrides?: RequestInit): Promise<void> {
         await this.updatePetWithFormRaw({ petId: petId, name: name, status: status }, initOverrides);
     }
 
@@ -506,7 +506,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(petId: number, , additionalMetadata?: string, , file?: Blob, initOverrides?: RequestInit): Promise<ModelApiResponse> {
+    async uploadFile(petId: number, additionalMetadata?: string, file?: Blob, initOverrides?: RequestInit): Promise<ModelApiResponse> {
         const response = await this.uploadFileRaw({ petId: petId, additionalMetadata: additionalMetadata, file: file }, initOverrides);
         return await response.value();
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
@@ -128,7 +128,7 @@ export class PetPartApi extends runtime.BaseAPI {
     /**
      * Get the matching parts for the given pet part.
      */
-    async getMatchingParts(fakePetPartId: number, , _long: boolean, , smooth: boolean, , _short: boolean, , name?: string, , connectedPart?: string, initOverrides?: RequestInit): Promise<GetMatchingPartsResponse> {
+    async getMatchingParts(fakePetPartId: number, _long: boolean, smooth: boolean, _short: boolean, name?: string, connectedPart?: string, initOverrides?: RequestInit): Promise<GetMatchingPartsResponse> {
         const response = await this.getMatchingPartsRaw({ fakePetPartId: fakePetPartId, _long: _long, smooth: smooth, _short: _short, name: name, connectedPart: connectedPart }, initOverrides);
         return await response.value();
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
@@ -254,7 +254,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(username: string, , password: string, initOverrides?: RequestInit): Promise<string> {
+    async loginUser(username: string, password: string, initOverrides?: RequestInit): Promise<string> {
         const response = await this.loginUserRaw({ username: username, password: password }, initOverrides);
         return await response.value();
     }
@@ -318,7 +318,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(username: string, , body: User, initOverrides?: RequestInit): Promise<DefaultMetaOnlyResponse> {
+    async updateUser(username: string, body: User, initOverrides?: RequestInit): Promise<DefaultMetaOnlyResponse> {
         const response = await this.updateUserRaw({ username: username, body: body }, initOverrides);
         return await response.value();
     }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/index.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/index.ts
@@ -1,3 +1,5 @@
+/* tslint:disable */
+/* eslint-disable */
 export * from './SagaApiManager'
 export * from './allSagas'
 export * from './BehaviorApi';

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/index.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/index.ts
@@ -1,3 +1,5 @@
+/* tslint:disable */
+/* eslint-disable */
 export * from './runtime';
 export * from './runtimeSagasAndRecords';
 export * from './ApiEntitiesRecord';

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/index.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/index.ts
@@ -1,3 +1,5 @@
+/* tslint:disable */
+/* eslint-disable */
 export * from './BehaviorType';
 export * from './Category';
 export * from './CategoryRecord';

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/package-lock.json
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openapitools/typescript-fetch-petstore",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "typescript": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "dev": true
+    }
+  }
+}


### PR DESCRIPTION
Refs #10050

This is a follow up PR for #10050 to fix incorrect arguments names.

I've removed `{{^-last}}, {{/-last}}` and replaced it with `,` as there will always be another argument (the initOverrides argument). 

I've done a global search for `, ,` and can't find this issue anywhere so i think this fix is good.

Note after generating the samples i see the following files have changed but I have not commited them:

```console
	modified:   samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/PetApi.cs
	modified:   samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/PetApi.cs
	modified:   samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Api/PetApi.cs
	modified:   samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/PetApi.cs
	modified:   samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
	modified:   samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/PetApi.cs
	modified:   samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/PetApi.cs
	modified:   samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
	modified:   samples/client/petstore/go/go-petstore/api_pet.go
	modified:   samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
	modified:   samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/serializers.dart
	modified:   samples/openapi3/client/petstore/go/go-petstore/api_pet.go
	modified:   samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/InlineObject.ts
	modified:   samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/PetApi.cs
	modified:   samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/PetApi.cs
	modified:   samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs
	modified:   samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/PetApi.cs
	modified:   samples/server/petstore/go-api-server/.openapi-generator/FILES
	modified:   samples/server/petstore/go-chi-server/.openapi-generator/FILES
	modified:   samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
	modified:   samples/server/petstore/php-symfony/SymfonyBundle-php/Api/StoreApiInterface.php
	modified:   samples/server/petstore/php-symfony/SymfonyBundle-php/Api/UserApiInterface.php
```

<details><summary>Click to view diff</summary>

```diff
diff --git a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/PetApi.cs b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/PetApi.cs
index d73282dfca..cde6290d76 100644
--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/PetApi.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         List<Pet> FindPetsByStatus(List<string> status);

@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status);
         /// <summary>
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         List<Pet> FindPetsByTags(List<string> tags);
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags);
@@ -277,7 +277,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -289,7 +289,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -300,7 +300,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -313,7 +313,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
@@ -855,7 +855,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         public List<Pet> FindPetsByStatus(List<string> status)
         {
@@ -867,7 +867,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status)
         {
@@ -933,7 +933,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         public async System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -946,7 +946,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -1016,7 +1016,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         public List<Pet> FindPetsByTags(List<string> tags)
@@ -1029,7 +1029,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags)
@@ -1096,7 +1096,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -1110,7 +1110,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
diff --git a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/PetApi.cs b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/PetApi.cs
index 0aba26f224..23dd719cad 100644
--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/PetApi.cs
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         List<Pet> FindPetsByStatus(List<string> status);

@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status);
         /// <summary>
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         List<Pet> FindPetsByTags(List<string> tags);
@@ -105,7 +105,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags);
@@ -278,7 +278,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -290,7 +290,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -301,7 +301,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -314,7 +314,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
@@ -949,7 +949,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         public List<Pet> FindPetsByStatus(List<string> status)
         {
@@ -961,7 +961,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status)
         {
@@ -1027,7 +1027,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         public async System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -1040,7 +1040,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -1110,7 +1110,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         public List<Pet> FindPetsByTags(List<string> tags)
@@ -1123,7 +1123,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags)
@@ -1190,7 +1190,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -1204,7 +1204,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
diff --git a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Api/PetApi.cs b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Api/PetApi.cs
index d73282dfca..cde6290d76 100644
--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Api/PetApi.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         List<Pet> FindPetsByStatus(List<string> status);

@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status);
         /// <summary>
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         List<Pet> FindPetsByTags(List<string> tags);
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags);
@@ -277,7 +277,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -289,7 +289,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -300,7 +300,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -313,7 +313,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
@@ -855,7 +855,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         public List<Pet> FindPetsByStatus(List<string> status)
         {
@@ -867,7 +867,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status)
         {
@@ -933,7 +933,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         public async System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -946,7 +946,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -1016,7 +1016,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         public List<Pet> FindPetsByTags(List<string> tags)
@@ -1029,7 +1029,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags)
@@ -1096,7 +1096,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -1110,7 +1110,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
diff --git a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/PetApi.cs b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/PetApi.cs
index d73282dfca..cde6290d76 100644
--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/PetApi.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         List<Pet> FindPetsByStatus(List<string> status);

@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status);
         /// <summary>
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         List<Pet> FindPetsByTags(List<string> tags);
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags);
@@ -277,7 +277,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -289,7 +289,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -300,7 +300,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -313,7 +313,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
@@ -855,7 +855,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         public List<Pet> FindPetsByStatus(List<string> status)
         {
@@ -867,7 +867,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status)
         {
@@ -933,7 +933,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         public async System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -946,7 +946,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -1016,7 +1016,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         public List<Pet> FindPetsByTags(List<string> tags)
@@ -1029,7 +1029,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags)
@@ -1096,7 +1096,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -1110,7 +1110,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
diff --git a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
index d73282dfca..cde6290d76 100644
--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         List<Pet> FindPetsByStatus(List<string> status);

@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status);
         /// <summary>
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         List<Pet> FindPetsByTags(List<string> tags);
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags);
@@ -277,7 +277,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -289,7 +289,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -300,7 +300,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -313,7 +313,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
@@ -855,7 +855,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         public List<Pet> FindPetsByStatus(List<string> status)
         {
@@ -867,7 +867,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status)
         {
@@ -933,7 +933,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         public async System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -946,7 +946,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -1016,7 +1016,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         public List<Pet> FindPetsByTags(List<string> tags)
@@ -1029,7 +1029,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags)
@@ -1096,7 +1096,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -1110,7 +1110,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
diff --git a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/PetApi.cs b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/PetApi.cs
index d73282dfca..cde6290d76 100644
--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/PetApi.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         List<Pet> FindPetsByStatus(List<string> status);

@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status);
         /// <summary>
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         List<Pet> FindPetsByTags(List<string> tags);
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags);
@@ -277,7 +277,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -289,7 +289,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -300,7 +300,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -313,7 +313,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
@@ -855,7 +855,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         public List<Pet> FindPetsByStatus(List<string> status)
         {
@@ -867,7 +867,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status)
         {
@@ -933,7 +933,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         public async System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -946,7 +946,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -1016,7 +1016,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         public List<Pet> FindPetsByTags(List<string> tags)
@@ -1029,7 +1029,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags)
@@ -1096,7 +1096,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -1110,7 +1110,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
diff --git a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/PetApi.cs b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/PetApi.cs
index 6f8809911e..83b9932d32 100644
--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/PetApi.cs
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         List<Pet> FindPetsByStatus(List<string> status);

@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status);
         /// <summary>
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         List<Pet> FindPetsByTags(List<string> tags);
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags);
@@ -255,7 +255,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -267,7 +267,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -278,7 +278,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -291,7 +291,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
@@ -780,7 +780,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         public List<Pet> FindPetsByStatus(List<string> status)
         {
@@ -792,7 +792,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo(List<string> status)
         {
@@ -842,7 +842,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         public async System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -855,7 +855,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync(List<string> status, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -909,7 +909,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         public List<Pet> FindPetsByTags(List<string> tags)
@@ -922,7 +922,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         public Org.OpenAPITools.Client.ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo(List<string> tags)
@@ -973,7 +973,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -987,7 +987,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
diff --git a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
index af3d41b729..2bed8136ff 100644
--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         List<Pet> FindPetsByStatus (List<string> status);

@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo (List<string> status);
         /// <summary>
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         List<Pet> FindPetsByTags (List<string> tags);
@@ -109,7 +109,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo (List<string> tags);
@@ -287,7 +287,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync (List<string> status, CancellationToken cancellationToken = default(CancellationToken));
@@ -299,7 +299,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple status values can be provided with comma separated strings
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync (List<string> status, CancellationToken cancellationToken = default(CancellationToken));
@@ -310,7 +310,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -323,7 +323,7 @@ namespace Org.OpenAPITools.Api
         /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
@@ -880,7 +880,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>List&lt;Pet&gt;</returns>
         public List<Pet> FindPetsByStatus (List<string> status)
         {
@@ -892,7 +892,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         public ApiResponse<List<Pet>> FindPetsByStatusWithHttpInfo (List<string> status)
         {
@@ -953,7 +953,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         public async System.Threading.Tasks.Task<List<Pet>> FindPetsByStatusAsync (List<string> status, CancellationToken cancellationToken = default(CancellationToken))
@@ -967,7 +967,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by status Multiple status values can be provided with comma separated strings
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         public async System.Threading.Tasks.Task<ApiResponse<List<Pet>>> FindPetsByStatusWithHttpInfoAsync (List<string> status, CancellationToken cancellationToken = default(CancellationToken))
@@ -1029,7 +1029,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>List&lt;Pet&gt;</returns>
         [Obsolete]
         public List<Pet> FindPetsByTags (List<string> tags)
@@ -1042,7 +1042,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <returns>ApiResponse of List&lt;Pet&gt;</returns>
         [Obsolete]
         public ApiResponse<List<Pet>> FindPetsByTagsWithHttpInfo (List<string> tags)
@@ -1104,7 +1104,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of List&lt;Pet&gt;</returns>
         [Obsolete]
@@ -1119,7 +1119,7 @@ namespace Org.OpenAPITools.Api
         /// Finds Pets by tags Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of ApiResponse (List&lt;Pet&gt;)</returns>
         [Obsolete]
diff --git a/samples/client/petstore/go/go-petstore/api_pet.go b/samples/client/petstore/go/go-petstore/api_pet.go
index 9e806f501e..2c0e36b43e 100644
--- a/samples/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/client/petstore/go/go-petstore/api_pet.go
@@ -469,6 +469,7 @@ type ApiFindPetsByTagsRequest struct {
 }

 // Tags to filter by
+// Deprecated
 func (r ApiFindPetsByTagsRequest) Tags(tags []string) ApiFindPetsByTagsRequest {
        r.tags = &tags
        return r
diff --git a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
index d7c0658ce9..857b70aefc 100644
--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -598,7 +598,7 @@ class PetApi
      *
      * Finds Pets by status
      *
-     * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
+     * @param  string[] $status Status values that need to be considered for filter (required)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -615,7 +615,7 @@ class PetApi
      *
      * Finds Pets by status
      *
-     * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
+     * @param  string[] $status Status values that need to be considered for filter (required)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -701,7 +701,7 @@ class PetApi
      *
      * Finds Pets by status
      *
-     * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
+     * @param  string[] $status Status values that need to be considered for filter (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -721,7 +721,7 @@ class PetApi
      *
      * Finds Pets by status
      *
-     * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
+     * @param  string[] $status Status values that need to be considered for filter (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -767,7 +767,7 @@ class PetApi
     /**
      * Create request for operation 'findPetsByStatus'
      *
-     * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
+     * @param  string[] $status Status values that need to be considered for filter (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
@@ -865,7 +865,7 @@ class PetApi
      *
      * Finds Pets by tags
      *
-     * @param  string[] $tags Tags to filter by (required)
+     * @param  string[] $tags Tags to filter by (required) (deprecated)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -883,7 +883,7 @@ class PetApi
      *
      * Finds Pets by tags
      *
-     * @param  string[] $tags Tags to filter by (required)
+     * @param  string[] $tags Tags to filter by (required) (deprecated)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
@@ -970,7 +970,7 @@ class PetApi
      *
      * Finds Pets by tags
      *
-     * @param  string[] $tags Tags to filter by (required)
+     * @param  string[] $tags Tags to filter by (required) (deprecated)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -991,7 +991,7 @@ class PetApi
      *
      * Finds Pets by tags
      *
-     * @param  string[] $tags Tags to filter by (required)
+     * @param  string[] $tags Tags to filter by (required) (deprecated)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
@@ -1038,7 +1038,7 @@ class PetApi
     /**
      * Create request for operation 'findPetsByTags'
      *
-     * @param  string[] $tags Tags to filter by (required)
+     * @param  string[] $tags Tags to filter by (required) (deprecated)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
diff --git a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/serializers.dart b/samples/openapi3/client/petstor
e/dart-dio-next/petstore_client_lib_fake/lib/src/serializers.dart
index 1b807addf9..52ea4eb7a1 100644
--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/serializers.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/serializers.dart
@@ -110,26 +110,14 @@ part 'serializers.g.dart';
   User,
 ])
 Serializers serializers = (_$serializers.toBuilder()
-      ..addBuilderFactory(
-        const FullType(BuiltList, [FullType(String)]),
-        () => ListBuilder<String>(),
-      )
       ..addBuilderFactory(
         const FullType(BuiltMap, [FullType(String), FullType(String)]),
         () => MapBuilder<String, String>(),
       )
-      ..addBuilderFactory(
-        const FullType(BuiltList, [FullType(String)]),
-        () => ListBuilder<String>(),
-      )
       ..addBuilderFactory(
         const FullType(BuiltSet, [FullType(Pet)]),
         () => SetBuilder<Pet>(),
       )
-      ..addBuilderFactory(
-        const FullType(BuiltSet, [FullType(String)]),
-        () => SetBuilder<String>(),
-      )
       ..addBuilderFactory(
         const FullType(BuiltList, [FullType(Pet)]),
         () => ListBuilder<Pet>(),
diff --git a/samples/openapi3/client/petstore/go/go-petstore/api_pet.go b/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
index 9f172c3cd3..31daf0920d 100644
--- a/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
@@ -357,7 +357,6 @@ type ApiFindPetsByStatusRequest struct {
 }

 // Status values that need to be considered for filter
-// Deprecated
 func (r ApiFindPetsByStatusRequest) Status(status []string) ApiFindPetsByStatusRequest {
        r.status = &status
        return r
@@ -470,6 +469,7 @@ type ApiFindPetsByTagsRequest struct {
 }

 // Tags to filter by
+// Deprecated
 func (r ApiFindPetsByTagsRequest) Tags(tags []string) ApiFindPetsByTagsRequest {
        r.tags = &tags
        return r
diff --git a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/InlineObject.ts b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/InlineObject.ts
index d6ffd66e69..d087f929aa 100644
--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/InlineObject.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/InlineObject.ts
@@ -10,6 +10,7 @@
  * Do not edit the class manually.
  */

+import { file } from './ModelFile';
 import { HttpFile } from '../http/http';

 export class InlineObject {
diff --git a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/PetApi.cs b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/PetApi.cs
index e23c800b82..920319edb0 100644
--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools.Controllers
         /// Finds Pets by tags
         /// </summary>
         /// <remarks>Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</remarks>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <response code="200">successful operation</response>
         /// <response code="400">Invalid tag value</response>
         [HttpGet]
diff --git a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/PetApi.cs b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/PetApi.cs
index e23c800b82..920319edb0 100644
--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools.Controllers
         /// Finds Pets by tags
         /// </summary>
         /// <remarks>Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</remarks>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <response code="200">successful operation</response>
         /// <response code="400">Invalid tag value</response>
         [HttpGet]
diff --git a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs
index 68541eb890..59852f41f3 100644
--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -81,7 +81,7 @@ namespace Org.OpenAPITools.Controllers
         /// Finds Pets by status
         /// </summary>
         /// <remarks>Multiple status values can be provided with comma separated strings</remarks>
-        /// <param name="status">Status values that need to be considered for filter (deprecated)</param>
+        /// <param name="status">Status values that need to be considered for filter</param>
         /// <response code="200">successful operation</response>
         /// <response code="400">Invalid status value</response>
         [HttpGet]
@@ -111,7 +111,7 @@ namespace Org.OpenAPITools.Controllers
         /// Finds Pets by tags
         /// </summary>
         /// <remarks>Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</remarks>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <response code="200">successful operation</response>
         /// <response code="400">Invalid tag value</response>
         [HttpGet]
diff --git a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/PetApi.cs b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/PetApi.cs
index 733404e0bd..93f8d23c48 100644
--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -100,7 +100,7 @@ namespace Org.OpenAPITools.Controllers
         /// Finds Pets by tags
         /// </summary>
         /// <remarks>Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</remarks>
-        /// <param name="tags">Tags to filter by</param>
+        /// <param name="tags">Tags to filter by (deprecated)</param>
         /// <response code="200">successful operation</response>
         /// <response code="400">Invalid tag value</response>
         [HttpGet]
diff --git a/samples/server/petstore/go-api-server/.openapi-generator/FILES b/samples/server/petstore/go-api-server/.openapi-generator/FILES
index 59b4003ddc..9135763258 100644
--- a/samples/server/petstore/go-api-server/.openapi-generator/FILES
+++ b/samples/server/petstore/go-api-server/.openapi-generator/FILES
@@ -9,7 +9,6 @@ go/api_store.go
 go/api_store_service.go
 go/api_user.go
 go/api_user_service.go
-go/error.go
 go/helpers.go
 go/impl.go
 go/logger.go
diff --git a/samples/server/petstore/go-chi-server/.openapi-generator/FILES b/samples/server/petstore/go-chi-server/.openapi-generator/FILES
index 59b4003ddc..9135763258 100644
--- a/samples/server/petstore/go-chi-server/.openapi-generator/FILES
+++ b/samples/server/petstore/go-chi-server/.openapi-generator/FILES
@@ -9,7 +9,6 @@ go/api_store.go
 go/api_store_service.go
 go/api_user.go
 go/api_user_service.go
-go/error.go
 go/helpers.go
 go/impl.go
 go/logger.go
diff --git a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
index f324381b81..532e360578 100644
--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
@@ -75,11 +75,11 @@ interface PetApiInterface
      *
      * Add a new pet to the store
      *
-     * @param  \OpenAPI\Server\Model\Pet $pet  Pet object that needs to be added to the store (required)
+     * @param  OpenAPI\Server\Model\Pet $pet  Pet object that needs to be added to the store (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return \OpenAPI\Server\Model\Pet
+     * @return OpenAPI\Server\Model\Pet
      */
     public function addPet(Pet $pet, &$responseCode, array &$responseHeaders);

@@ -88,8 +88,8 @@ interface PetApiInterface
      *
      * Deletes a pet
      *
-     * @param  \int $petId  Pet id to delete (required)
-     * @param  \string $apiKey   (optional)
+     * @param  int $petId  Pet id to delete (required)
+     * @param  string $apiKey   (optional)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
@@ -102,11 +102,11 @@ interface PetApiInterface
      *
      * Finds Pets by status
      *
-     * @param  \string[] $status  Status values that need to be considered for filter (required) (deprecated)
+     * @param  string[] $status  Status values that need to be considered for filter (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return \OpenAPI\Server\Model\Pet[]
+     * @return OpenAPI\Server\Model\Pet[]
      */
     public function findPetsByStatus(array $status, &$responseCode, array &$responseHeaders);

@@ -115,11 +115,11 @@ interface PetApiInterface
      *
      * Finds Pets by tags
      *
-     * @param  \string[] $tags  Tags to filter by (required)
+     * @param  string[] $tags  Tags to filter by (required) (deprecated)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return \OpenAPI\Server\Model\Pet[]
+     * @return OpenAPI\Server\Model\Pet[]
      * @deprecated
      */
     public function findPetsByTags(array $tags, &$responseCode, array &$responseHeaders);
@@ -129,11 +129,11 @@ interface PetApiInterface
      *
      * Find pet by ID
      *
-     * @param  \int $petId  ID of pet to return (required)
+     * @param  int $petId  ID of pet to return (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return \OpenAPI\Server\Model\Pet
+     * @return OpenAPI\Server\Model\Pet
      */
     public function getPetById($petId, &$responseCode, array &$responseHeaders);

@@ -142,11 +142,11 @@ interface PetApiInterface
      *
      * Update an existing pet
      *
-     * @param  \OpenAPI\Server\Model\Pet $pet  Pet object that needs to be added to the store (required)
+     * @param  OpenAPI\Server\Model\Pet $pet  Pet object that needs to be added to the store (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return \OpenAPI\Server\Model\Pet
+     * @return OpenAPI\Server\Model\Pet
      */
     public function updatePet(Pet $pet, &$responseCode, array &$responseHeaders);

@@ -155,9 +155,9 @@ interface PetApiInterface
      *
      * Updates a pet in the store with form data
      *
-     * @param  \int $petId  ID of pet that needs to be updated (required)
-     * @param  \string $name  Updated name of the pet (optional)
-     * @param  \string $status  Updated status of the pet (optional)
+     * @param  int $petId  ID of pet that needs to be updated (required)
+     * @param  string $name  Updated name of the pet (optional)
+     * @param  string $status  Updated status of the pet (optional)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
@@ -170,13 +170,13 @@ interface PetApiInterface
      *
      * uploads an image
      *
-     * @param  \int $petId  ID of pet to update (required)
-     * @param  \string $additionalMetadata  Additional data to pass to server (optional)
-     * @param  \UploadedFile $file  file to upload (optional)
+     * @param  int $petId  ID of pet to update (required)
+     * @param  string $additionalMetadata  Additional data to pass to server (optional)
+     * @param  UploadedFile $file  file to upload (optional)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return \OpenAPI\Server\Model\ApiResponse
+     * @return OpenAPI\Server\Model\ApiResponse
      */
     public function uploadFile($petId, $additionalMetadata = null, UploadedFile $file = null, &$responseCode, array &$responseHeaders);
 }
diff --git a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/StoreApiInterface.php b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/StoreApiInterface.php
index d70e7bb92a..a8474923c8 100644
--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/StoreApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/StoreApiInterface.php
@@ -56,7 +56,7 @@ interface StoreApiInterface
      *
      * Delete purchase order by ID
      *
-     * @param  \string $orderId  ID of the order that needs to be deleted (required)
+     * @param  string $orderId  ID of the order that needs to be deleted (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
@@ -72,7 +72,7 @@ interface StoreApiInterface
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return \int
+     * @return int
      */
     public function getInventory(&$responseCode, array &$responseHeaders);

@@ -81,11 +81,11 @@ interface StoreApiInterface
      *
      * Find purchase order by ID
      *
-     * @param  \int $orderId  ID of pet that needs to be fetched (required)
+     * @param  int $orderId  ID of pet that needs to be fetched (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return \OpenAPI\Server\Model\Order
+     * @return OpenAPI\Server\Model\Order
      */
     public function getOrderById($orderId, &$responseCode, array &$responseHeaders);

@@ -94,11 +94,11 @@ interface StoreApiInterface
      *
      * Place an order for a pet
      *
-     * @param  \OpenAPI\Server\Model\Order $order  order placed for purchasing the pet (required)
+     * @param  OpenAPI\Server\Model\Order $order  order placed for purchasing the pet (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return \OpenAPI\Server\Model\Order
+     * @return OpenAPI\Server\Model\Order
      */
     public function placeOrder(Order $order, &$responseCode, array &$responseHeaders);
 }
diff --git a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/UserApiInterface.php b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/UserApiInterface.php
index 9b8489e78f..ee1e3ee197 100644
--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/UserApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/UserApiInterface.php
@@ -56,7 +56,7 @@ interface UserApiInterface
      *
      * Create user
      *
-     * @param  \OpenAPI\Server\Model\User $user  Created user object (required)
+     * @param  OpenAPI\Server\Model\User $user  Created user object (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
@@ -69,7 +69,7 @@ interface UserApiInterface
      *
      * Creates list of users with given input array
      *
-     * @param  \OpenAPI\Server\Model\User[] $user  List of user object (required)
+     * @param  OpenAPI\Server\Model\User[] $user  List of user object (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
@@ -82,7 +82,7 @@ interface UserApiInterface
      *
      * Creates list of users with given input array
      *
-     * @param  \OpenAPI\Server\Model\User[] $user  List of user object (required)
+     * @param  OpenAPI\Server\Model\User[] $user  List of user object (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
@@ -95,7 +95,7 @@ interface UserApiInterface
      *
      * Delete user
      *
-     * @param  \string $username  The name that needs to be deleted (required)
+     * @param  string $username  The name that needs to be deleted (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
@@ -108,11 +108,11 @@ interface UserApiInterface
      *
      * Get user by user name
      *
-     * @param  \string $username  The name that needs to be fetched. Use user1 for testing. (required)
+     * @param  string $username  The name that needs to be fetched. Use user1 for testing. (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return \OpenAPI\Server\Model\User
+     * @return OpenAPI\Server\Model\User
      */
     public function getUserByName($username, &$responseCode, array &$responseHeaders);

@@ -121,12 +121,12 @@ interface UserApiInterface
      *
      * Logs user into the system
      *
-     * @param  \string $username  The user name for login (required)
-     * @param  \string $password  The password for login in clear text (required)
+     * @param  string $username  The user name for login (required)
+     * @param  string $password  The password for login in clear text (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return \string
+     * @return string
      */
     public function loginUser($username, $password, &$responseCode, array &$responseHeaders);

@@ -147,8 +147,8 @@ interface UserApiInterface
      *
      * Updated user
      *
-     * @param  \string $username  name that need to be deleted (required)
-     * @param  \OpenAPI\Server\Model\User $user  Updated user object (required)
+     * @param  string $username  name that need to be deleted (required)
+     * @param  OpenAPI\Server\Model\User $user  Updated user object (required)
      * @param  \int $responseCode     The HTTP response code to return
      * @param  \array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
```

</details>

Do you want me to commit these changes are part of this PR?

---

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
