### PR TITLE
[markdown] Add primitive types to Markdown generator (#5449)

### DIFF
--- a/docs/generators/markdown.md
+++ b/docs/generators/markdown.md
@@ -30,6 +30,24 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## LANGUAGE PRIMITIVES
 
 <ul class="column-ul">
+<li>ByteArray</li>
+<li>DateTime</li>
+<li>URI</li>
+<li>UUID</li>
+<li>boolean</li>
+<li>char</li>
+<li>date</li>
+<li>decimal</li>
+<li>double</li>
+<li>file</li>
+<li>float</li>
+<li>int</li>
+<li>integer</li>
+<li>long</li>
+<li>number</li>
+<li>object</li>
+<li>short</li>
+<li>string</li>
 </ul>
 
 ## RESERVED WORDS

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MarkdownDocumentationCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MarkdownDocumentationCodegen.java
@@ -1,6 +1,8 @@
 package org.openapitools.codegen.languages;
 
 import org.openapitools.codegen.CodegenConfig;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.DefaultCodegen;
 import org.openapitools.codegen.SupportingFile;
@@ -44,6 +46,27 @@ public class MarkdownDocumentationCodegen extends DefaultCodegen implements Code
         apiPackage = File.separator + "Apis";
         modelPackage = "Models";
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
+
+        languageSpecificPrimitives.clear();
+        languageSpecificPrimitives.add("ByteArray");
+        languageSpecificPrimitives.add("DateTime");
+        languageSpecificPrimitives.add("URI");
+        languageSpecificPrimitives.add("UUID");
+        languageSpecificPrimitives.add("boolean");
+        languageSpecificPrimitives.add("char");
+        languageSpecificPrimitives.add("date");
+        languageSpecificPrimitives.add("decimal");
+        languageSpecificPrimitives.add("double");
+        languageSpecificPrimitives.add("file");
+        languageSpecificPrimitives.add("float");
+        languageSpecificPrimitives.add("int");
+        languageSpecificPrimitives.add("integer");
+        languageSpecificPrimitives.add("long");
+        languageSpecificPrimitives.add("number");
+        languageSpecificPrimitives.add("object");
+        languageSpecificPrimitives.add("short");
+        languageSpecificPrimitives.add("string");
+
         // TODO: Fill this out.
     }
 
@@ -77,6 +100,16 @@ public class MarkdownDocumentationCodegen extends DefaultCodegen implements Code
         } else if (((CharSequence) name).chars().anyMatch(character -> specialCharReplacements.keySet().contains("" + ((char) character)))) {
             return escape(name, specialCharReplacements, null, null);
         }
+        return name;
+    }
+
+    @Override
+    public String toModelName(final String name) {
+        return name;
+    }
+
+    @Override
+    public String toModelFilename(String name) {
         return name;
     }
 }

--- a/modules/openapi-generator/src/main/resources/markdown-documentation/README.mustache
+++ b/modules/openapi-generator/src/main/resources/markdown-documentation/README.mustache
@@ -17,7 +17,7 @@ Class | Method | HTTP request | Description
 ## Documentation for Models
 
 {{#modelPackage}}
-{{#models}}{{#model}} - [{{{classname}}}](./{{{modelPackage}}}/{{modelDocPath}}{{{classname}}}.md)
+{{#models}}{{#model}} - [{{{classname}}}](./{{{modelPackage}}}/{{modelDocPath}}{{{classFilename}}}.md)
 {{/model}}{{/models}}
 {{/modelPackage}}
 {{^modelPackage}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/markdown/MarkdownSampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/markdown/MarkdownSampleGeneratorTest.java
@@ -1,0 +1,52 @@
+package org.openapitools.codegen.markdown;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class MarkdownSampleGeneratorTest {
+	private File outputTempDirectory;
+	private List<File> generatedFiles;
+
+	@BeforeClass
+	public void beforeClassGenerateTestMarkup() throws Exception {
+
+		this.outputTempDirectory = Files.createTempDirectory("test-markdown-sample-generator.").toFile();
+
+		final CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("markdown")
+				.setInputSpec("src/test/resources/3_0/markdown/issue_6096.yaml")
+				.setOutputDir(outputTempDirectory.getAbsolutePath());
+
+		DefaultGenerator generator = new DefaultGenerator();
+		this.generatedFiles = generator.opts(configurator.toClientOptInput()).generate();
+	}
+
+	@Test
+	public void testSampleMarkdownGeneration() throws IOException {
+		Path expectedFiles = new File("src/test/resources/3_0/markdown/expected/").toPath();
+		for (File generated : this.generatedFiles) {
+			if (!generated.toString().endsWith(".md")) {
+				continue;
+			}
+			Path expectedPath = this.outputTempDirectory.toPath().relativize(generated.toPath());
+			File expected = expectedFiles.resolve(expectedPath).toFile();
+
+			Assert.assertTrue(expected.exists(), "Could not find " + expected.toString());
+
+			Assert.assertEquals(FileUtils.readFileToString(generated),
+					FileUtils.readFileToString(expected, StandardCharsets.UTF_8));
+		}
+	}
+
+}

--- a/modules/openapi-generator/src/test/resources/3_0/markdown/expected/Models/Object.md
+++ b/modules/openapi-generator/src/test/resources/3_0/markdown/expected/Models/Object.md
@@ -1,0 +1,38 @@
+# Object
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**Number** | **BigDecimal** |  | [optional] [default to null]
+**Integer** | **Integer** |  | [optional] [default to null]
+**Boolean** | **Boolean** |  | [optional] [default to null]
+**String** | **String** |  | [optional] [default to null]
+**CharFormat** | **String** |  | [optional] [default to null]
+**DateFormat** | **date** |  | [optional] [default to null]
+**DateTimeFormat** | **Date** |  | [optional] [default to null]
+**ByteFormat** | **byte[]** |  | [optional] [default to null]
+**BinaryFormat** | **File** |  | [optional] [default to null]
+**EmailFormat** | **String** |  | [optional] [default to null]
+**UuidFormat** | **UUID** |  | [optional] [default to null]
+**PasswordFormat** | **String** |  | [optional] [default to null]
+**IntegerFormat** | **Integer** |  | [optional] [default to null]
+**IntFormat** | **Integer** |  | [optional] [default to null]
+**Int32Format** | **String** |  | [optional] [default to null]
+**Int64Format** | **String** |  | [optional] [default to null]
+**ShortFormat** | **Short** |  | [optional] [default to null]
+**LongFormat** | **Long** |  | [optional] [default to null]
+**DecimalFormat** | **BigDecimal** |  | [optional] [default to null]
+**FloatFormat** | **Float** |  | [optional] [default to null]
+**DoubleFormat** | **Double** |  | [optional] [default to null]
+**HostnameFormat** | **String** |  | [optional] [default to null]
+**Ipv4Format** | **String** |  | [optional] [default to null]
+**Ipv6Format** | **String** |  | [optional] [default to null]
+**UriFormat** | **URI** |  | [optional] [default to null]
+**Map** | **Map** |  | [optional] [default to null]
+**InlinedObject** | [**Object_InlinedObject**](Object_InlinedObject.md) |  | [optional] [default to null]
+**ReferencedObject** | [**ReferencedObject**](ReferencedObject.md) |  | [optional] [default to null]
+**ArrayOfStrings** | **List** |  | [optional] [default to null]
+**StringObject** | [**String**](String.md) |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/modules/openapi-generator/src/test/resources/3_0/markdown/expected/Models/Object_InlinedObject.md
+++ b/modules/openapi-generator/src/test/resources/3_0/markdown/expected/Models/Object_InlinedObject.md
@@ -1,0 +1,9 @@
+# Object_InlinedObject
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**String** | **String** |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/modules/openapi-generator/src/test/resources/3_0/markdown/expected/Models/ReferencedObject.md
+++ b/modules/openapi-generator/src/test/resources/3_0/markdown/expected/Models/ReferencedObject.md
@@ -1,0 +1,9 @@
+# ReferencedObject
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**String** | **String** |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/modules/openapi-generator/src/test/resources/3_0/markdown/expected/Models/String.md
+++ b/modules/openapi-generator/src/test/resources/3_0/markdown/expected/Models/String.md
@@ -1,0 +1,9 @@
+# String
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**String** | **String** |  | [optional] [default to null]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/modules/openapi-generator/src/test/resources/3_0/markdown/expected/README.md
+++ b/modules/openapi-generator/src/test/resources/3_0/markdown/expected/README.md
@@ -1,0 +1,24 @@
+# Documentation for Example
+
+<a name="documentation-for-api-endpoints"></a>
+## Documentation for API Endpoints
+
+All URIs are relative to *http://localhost:8080*
+
+Class | Method | HTTP request | Description
+------------ | ------------- | ------------- | -------------
+
+
+<a name="documentation-for-models"></a>
+## Documentation for Models
+
+ - [Object](./Models/Object.md)
+ - [Object_InlinedObject](./Models/Object_InlinedObject.md)
+ - [ReferencedObject](./Models/ReferencedObject.md)
+ - [String](./Models/String.md)
+
+
+<a name="documentation-for-authorization"></a>
+## Documentation for Authorization
+
+All endpoints do not require authorization.

--- a/modules/openapi-generator/src/test/resources/3_0/markdown/issue_6096.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/markdown/issue_6096.yaml
@@ -1,0 +1,146 @@
+
+openapi: 3.0.0
+servers:
+  - url: 'localhost:8080'
+info:
+  version: 1.0.0
+  title: Example
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+paths: {}
+components:
+  schemas:
+    Object:
+      type: object
+      additionalProperties: false
+      properties:
+        Number:
+          type: number
+          example: 3.14159
+        Integer:
+          type: integer
+          example: 123
+        Boolean:
+          type: boolean
+          example: true
+        String:
+          type: string
+          example: "A string"
+        # String formats
+        CharFormat:
+          type: string
+          format: char
+        DateFormat:
+          type: string
+          format: date
+          example: "2021-06-10"
+        DateTimeFormat:
+          type: string
+          format: date-time
+          example: "2021-06-10T12:47:27"
+        ByteFormat:
+          type: string
+          format: byte
+          example: QG1pY2hhZWxncmFoYW1ldmFucw==
+        BinaryFormat:
+          type: string
+          format: binary
+        EmailFormat:
+          type: string
+          format: email
+          example: "user@example.com"
+        UuidFormat:
+          type: string
+          format: uuid
+          example: "7db1c07f-8f63-41ff-8f94-056b4a9ce96d"
+        PasswordFormat:
+          type: string
+          format: password
+          example: hunter2
+        IntegerFormat:
+          type: string
+          format: integer
+          example: "123"
+        IntFormat:
+          type: string
+          format: int
+          example: "123"
+        Int32Format:
+          type: string
+          format: int32
+          example: "123"
+        Int64Format:
+          type: string
+          format: int64
+          example: "123"
+        ShortFormat:
+          type: string
+          format: short
+          example: "123"
+        LongFormat:
+          type: string
+          format: long
+          example: "123"
+        DecimalFormat:
+          type: string
+          format: decimal
+          example: "3.14159"
+        FloatFormat:
+          type: string
+          format: float
+          example: "3.14159"
+        DoubleFormat:
+          type: string
+          format: double
+          example: "3.14159"
+        HostnameFormat:
+          type: string
+          format: hostname
+          example: "example.com"
+        Ipv4Format:
+          type: string
+          format: ipv4
+          example: "127.0.0.1"
+        Ipv6Format:
+          type: string
+          format: ipv4
+          example: "::1"
+        UriFormat:
+          type: string
+          format: uri
+          example: "https://example.com"
+        # Compound types
+        Map:
+          type: object
+          additionalProperties: true
+        InlinedObject:
+          type: object
+          additionalProperties: false
+          properties:
+            String:
+              type: string
+              example: "A string"
+        ReferencedObject:
+          $ref:  "#/components/schemas/ReferencedObject"
+        ArrayOfStrings:
+          type: array
+          items:
+            type: string
+            example: string
+        StringObject:
+          $ref: "#/components/schemas/String"
+    ReferencedObject:
+      type: object
+      additionalProperties: false
+      properties:
+        String:
+          type: string
+          example: "A string"
+    String:
+      type: object
+      additionalProperties: false
+      properties:
+        String:
+          type: string
+          example: "A string"


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Adds primitive types to the Markdown generator to resolve #5449, which also resolves #6096. Adds a new OpenAPI spec (`issue_6096.yaml`) with many primitive types and tests that show that the primitive types are no longer linked to in the generated Markdown.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
