### PR TITLE
Typescript-angular: Added missing semi colon to interface file

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/apis.mustache
@@ -5,7 +5,7 @@ export * from './{{ classFilename }}';
 import { {{ classname }} } from './{{ classFilename }}';
 {{/operations}}
 {{#withInterfaces}}
-export * from './{{ classFilename }}Interface'
+export * from './{{ classFilename }}Interface';
 {{/withInterfaces}}
 {{/apis}}
 export const APIS = [{{#apis}}{{#operations}}{{ classname }}{{/operations}}{{^-last}}, {{/-last}}{{/apis}}];


### PR DESCRIPTION
Fixes https://github.com/OpenAPITools/openapi-generator/issues/10120
Added missing semi colon to interface export in api.ts template file (typescript-angular).

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov
