### PR TITLE
[C][Client] Allocate memory for the element of array when the type is number

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -666,7 +666,13 @@ fail:
         {
             goto end;
         }
-        list_addElement({{{name}}}List , &{{{name}}}_local->valuedouble);
+        double *{{{name}}}_local_value = (double *)calloc(1, sizeof(double));
+        if(!{{{name}}}_local_value)
+        {
+            goto end;
+        }
+        *{{{name}}}_local_value = {{{name}}}_local->valuedouble;
+        list_addElement({{{name}}}List , {{{name}}}_local_value);
         {{/isNumeric}}
         {{#isBoolean}}
         if(!cJSON_IsBool({{{name}}}_local))


### PR DESCRIPTION
If the type of element of an array is number, e.g. 

```yaml
        "supplementalGroups": {
          "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.",
          "items": {
            "format": "int64",
            "type": "integer"
          },
          "type": "array"
        },
```
The current template code of CLibcurl will not allocate memory for the element before adding it to a list:

```c
    list_addElement(supplemental_groupsList , &supplemental_groups_local->valuedouble);
```

`supplemental_groups_local` is a local variable, it will be released soon. And then the pointer pointing to `supplemental_groups_local->valuedouble` will be invalid.

This PR allocates memory for the element:
```c
    double *supplemental_groups_local_value = (double *)calloc(1, sizeof(double));
    if(!supplemental_groups_local_value)
    {
        goto end;
    }
    *supplemental_groups_local_value = supplemental_groups_local->valuedouble;
    list_addElement(supplemental_groupsList , supplemental_groups_local_value);
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [master](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Hi @wing328 @zhemant @michelealbano

Could you please review this PR ? Thanks.