### PR TITLE
[csharp-netcore]Fixed the utc time issue for httpSigning auth.

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/HttpSigningConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/HttpSigningConfiguration.mustache
@@ -193,7 +193,7 @@ namespace {{packageName}}.Client
                 }
                 else if (header.Equals(HEADER_DATE))
                 {
-                    var utcDateTime = dateTime.ToString("r").ToString();
+                    var utcDateTime = dateTime.ToUniversalTime().ToString("r");
                     HttpSignatureHeader.Add(header.ToLower(), utcDateTime);
                     HttpSignedRequestHeader.Add(HEADER_DATE, utcDateTime);
                 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -193,7 +193,7 @@ namespace Org.OpenAPITools.Client
                 }
                 else if (header.Equals(HEADER_DATE))
                 {
-                    var utcDateTime = dateTime.ToString("r").ToString();
+                    var utcDateTime = dateTime.ToUniversalTime().ToString("r");
                     HttpSignatureHeader.Add(header.ToLower(), utcDateTime);
                     HttpSignedRequestHeader.Add(HEADER_DATE, utcDateTime);
                 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -193,7 +193,7 @@ namespace Org.OpenAPITools.Client
                 }
                 else if (header.Equals(HEADER_DATE))
                 {
-                    var utcDateTime = dateTime.ToString("r").ToString();
+                    var utcDateTime = dateTime.ToUniversalTime().ToString("r");
                     HttpSignatureHeader.Add(header.ToLower(), utcDateTime);
                     HttpSignedRequestHeader.Add(HEADER_DATE, utcDateTime);
                 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -193,7 +193,7 @@ namespace Org.OpenAPITools.Client
                 }
                 else if (header.Equals(HEADER_DATE))
                 {
-                    var utcDateTime = dateTime.ToString("r").ToString();
+                    var utcDateTime = dateTime.ToUniversalTime().ToString("r");
                     HttpSignatureHeader.Add(header.ToLower(), utcDateTime);
                     HttpSignedRequestHeader.Add(HEADER_DATE, utcDateTime);
                 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -193,7 +193,7 @@ namespace Org.OpenAPITools.Client
                 }
                 else if (header.Equals(HEADER_DATE))
                 {
-                    var utcDateTime = dateTime.ToString("r").ToString();
+                    var utcDateTime = dateTime.ToUniversalTime().ToString("r");
                     HttpSignatureHeader.Add(header.ToLower(), utcDateTime);
                     HttpSignedRequestHeader.Add(HEADER_DATE, utcDateTime);
                 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -193,7 +193,7 @@ namespace Org.OpenAPITools.Client
                 }
                 else if (header.Equals(HEADER_DATE))
                 {
-                    var utcDateTime = dateTime.ToString("r").ToString();
+                    var utcDateTime = dateTime.ToUniversalTime().ToString("r");
                     HttpSignatureHeader.Add(header.ToLower(), utcDateTime);
                     HttpSignedRequestHeader.Add(HEADER_DATE, utcDateTime);
                 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -193,7 +193,7 @@ namespace Org.OpenAPITools.Client
                 }
                 else if (header.Equals(HEADER_DATE))
                 {
-                    var utcDateTime = dateTime.ToString("r").ToString();
+                    var utcDateTime = dateTime.ToUniversalTime().ToString("r");
                     HttpSignatureHeader.Add(header.ToLower(), utcDateTime);
                     HttpSignedRequestHeader.Add(HEADER_DATE, utcDateTime);
                 }


### PR DESCRIPTION
Fixed the utc time issue which leads to expired httpSignature. 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@wing328 