### PR TITLE
Add map property in url params

### DIFF
--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1089,6 +1089,14 @@ paths:
             type: array
             items:
               type: string
+        - name: language
+          in: query
+          required: false
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+              format: string
       responses:
         "200":
           description: Success

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/FakeApi.md
@@ -1279,7 +1279,7 @@ No authorization required
 
 ## TestQueryParameterCollectionFormat
 
-> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = null)
 
 
 
@@ -1307,10 +1307,11 @@ namespace Example
             var http = new List<string>(); // List<string> | 
             var url = new List<string>(); // List<string> | 
             var context = new List<string>(); // List<string> | 
+            var language = new Dictionary<string, string>(); // Dictionary<string, string> |  (optional) 
 
             try
             {
-                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language);
             }
             catch (ApiException e)
             {
@@ -1333,6 +1334,7 @@ Name | Type | Description  | Notes
  **http** | [**List&lt;string&gt;**](string.md)|  | 
  **url** | [**List&lt;string&gt;**](string.md)|  | 
  **context** | [**List&lt;string&gt;**](string.md)|  | 
+ **language** | [**Dictionary&lt;string, string&gt;**](string.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -429,8 +429,9 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="language"> (optional)</param>
         /// <returns></returns>
-        void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
+        void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>));
 
         /// <summary>
         /// 
@@ -444,8 +445,9 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="language"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
+        ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>));
         #endregion Synchronous Operations
         #region Asynchronous Operations
         /// <summary>
@@ -884,9 +886,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="language"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of void</returns>
-        System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, CancellationToken cancellationToken = default(CancellationToken));
+        System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>), CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// 
@@ -900,9 +903,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="language"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse<Object>> TestQueryParameterCollectionFormatWithHttpInfoAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, CancellationToken cancellationToken = default(CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<Object>> TestQueryParameterCollectionFormatWithHttpInfoAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>), CancellationToken cancellationToken = default(CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -3531,10 +3535,11 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="language"> (optional)</param>
         /// <returns></returns>
-        public void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        public void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>))
         {
-             TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+             TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, language);
         }
 
         /// <summary>
@@ -3546,8 +3551,9 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="language"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        public ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        public ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>))
         {
             // verify the required parameter 'pipe' is set
             if (pipe == null)
@@ -3590,6 +3596,7 @@ namespace Org.OpenAPITools.Api
             if (http != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("ssv", "http", http)); // query parameter
             if (url != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("csv", "url", url)); // query parameter
             if (context != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("multi", "context", context)); // query parameter
+            if (language != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("", "language", language)); // query parameter
 
 
             // make the HTTP request
@@ -3619,11 +3626,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="language"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, CancellationToken cancellationToken = default(CancellationToken))
+        public async System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>), CancellationToken cancellationToken = default(CancellationToken))
         {
-             await TestQueryParameterCollectionFormatWithHttpInfoAsync(pipe, ioutil, http, url, context, cancellationToken);
+             await TestQueryParameterCollectionFormatWithHttpInfoAsync(pipe, ioutil, http, url, context, language, cancellationToken);
 
         }
 
@@ -3636,9 +3644,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="language"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse<Object>> TestQueryParameterCollectionFormatWithHttpInfoAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, CancellationToken cancellationToken = default(CancellationToken))
+        public async System.Threading.Tasks.Task<ApiResponse<Object>> TestQueryParameterCollectionFormatWithHttpInfoAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>), CancellationToken cancellationToken = default(CancellationToken))
         {
             // verify the required parameter 'pipe' is set
             if (pipe == null)
@@ -3681,6 +3690,7 @@ namespace Org.OpenAPITools.Api
             if (http != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("ssv", "http", http)); // query parameter
             if (url != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("csv", "url", url)); // query parameter
             if (context != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("multi", "context", context)); // query parameter
+            if (language != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("", "language", language)); // query parameter
 
 
             // make the HTTP request

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
@@ -528,13 +528,17 @@ defmodule OpenapiPetstore.Api.Fake do
   - url ([String.t]): 
   - context ([String.t]): 
   - opts (KeywordList): [optional] Optional parameters
+    - :language (%{optional(String.t) => String.t}): 
   ## Returns
 
   {:ok, nil} on success
   {:error, Tesla.Env.t} on failure
   """
   @spec test_query_parameter_collection_format(Tesla.Env.client, list(String.t), list(String.t), list(String.t), list(String.t), list(String.t), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
-  def test_query_parameter_collection_format(connection, pipe, ioutil, http, url, context, _opts \\ []) do
+  def test_query_parameter_collection_format(connection, pipe, ioutil, http, url, context, opts \\ []) do
+    optional_params = %{
+      :"language" => :query
+    }
     %{}
     |> method(:put)
     |> url("/fake/test-query-paramters")
@@ -543,6 +547,7 @@ defmodule OpenapiPetstore.Api.Fake do
     |> add_param(:query, :"http", http)
     |> add_param(:query, :"url", url)
     |> add_param(:query, :"context", context)
+    |> add_optional_params(optional_params, opts)
     |> ensure_body()
     |> Enum.into([])
     |> (&Connection.request(connection, &1)).()

--- a/samples/client/petstore/java/feign/api/openapi.yaml
+++ b/samples/client/petstore/java/feign/api/openapi.yaml
@@ -1222,6 +1222,16 @@ paths:
             type: string
           type: array
         style: form
+      - explode: true
+        in: query
+        name: language
+        required: false
+        schema:
+          additionalProperties:
+            format: string
+            type: string
+          type: object
+        style: form
       responses:
         "200":
           description: Success

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -438,12 +438,13 @@ public interface FakeApi extends ApiClient.Api {
    * @param http  (required)
    * @param url  (required)
    * @param context  (required)
+   * @param language  (optional)
    */
-  @RequestLine("PUT /fake/test-query-paramters?pipe={pipe}&ioutil={ioutil}&http={http}&url={url}&context={context}")
+  @RequestLine("PUT /fake/test-query-paramters?pipe={pipe}&ioutil={ioutil}&http={http}&url={url}&context={context}&language={language}")
   @Headers({
     "Accept: application/json",
   })
-  void testQueryParameterCollectionFormat(@Param("pipe") List<String> pipe, @Param("ioutil") List<String> ioutil, @Param("http") List<String> http, @Param("url") List<String> url, @Param("context") List<String> context);
+  void testQueryParameterCollectionFormat(@Param("pipe") List<String> pipe, @Param("ioutil") List<String> ioutil, @Param("http") List<String> http, @Param("url") List<String> url, @Param("context") List<String> context, @Param("language") Map<String, String> language);
 
   /**
    * 
@@ -461,9 +462,10 @@ public interface FakeApi extends ApiClient.Api {
    *   <li>http -  (required)</li>
    *   <li>url -  (required)</li>
    *   <li>context -  (required)</li>
+   *   <li>language -  (optional)</li>
    *   </ul>
    */
-  @RequestLine("PUT /fake/test-query-paramters?pipe={pipe}&ioutil={ioutil}&http={http}&url={url}&context={context}")
+  @RequestLine("PUT /fake/test-query-paramters?pipe={pipe}&ioutil={ioutil}&http={http}&url={url}&context={context}&language={language}")
   @Headers({
   "Accept: application/json",
   })
@@ -492,6 +494,10 @@ public interface FakeApi extends ApiClient.Api {
     }
     public TestQueryParameterCollectionFormatQueryParams context(final List<String> value) {
       put("context", EncodingUtils.encodeCollection(value, "multi"));
+      return this;
+    }
+    public TestQueryParameterCollectionFormatQueryParams language(final Map<String, String> value) {
+      put("language", EncodingUtils.encode(value));
       return this;
     }
   }

--- a/samples/client/petstore/java/webclient/api/openapi.yaml
+++ b/samples/client/petstore/java/webclient/api/openapi.yaml
@@ -1222,6 +1222,16 @@ paths:
             type: string
           type: array
         style: form
+      - explode: true
+        in: query
+        name: language
+        required: false
+        schema:
+          additionalProperties:
+            format: string
+            type: string
+          type: object
+        style: form
       responses:
         "200":
           description: Success

--- a/samples/client/petstore/java/webclient/docs/FakeApi.md
+++ b/samples/client/petstore/java/webclient/docs/FakeApi.md
@@ -1132,7 +1132,7 @@ No authorization required
 
 ## testQueryParameterCollectionFormat
 
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language)
 
 
 
@@ -1159,8 +1159,9 @@ public class Example {
         List<String> http = Arrays.asList(); // List<String> | 
         List<String> url = Arrays.asList(); // List<String> | 
         List<String> context = Arrays.asList(); // List<String> | 
+        Map<String, String> language = new HashMap(); // Map<String, String> | 
         try {
-            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
             System.err.println("Status code: " + e.getCode());
@@ -1182,6 +1183,7 @@ Name | Type | Description  | Notes
  **http** | [**List&lt;String&gt;**](String.md)|  |
  **url** | [**List&lt;String&gt;**](String.md)|  |
  **context** | [**List&lt;String&gt;**](String.md)|  |
+ **language** | [**Map&lt;String, String&gt;**](String.md)|  | [optional]
 
 ### Return type
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -1016,9 +1016,10 @@ public class FakeApi {
      * @param http The http parameter
      * @param url The url parameter
      * @param context The context parameter
+     * @param language The language parameter
      * @throws WebClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryParameterCollectionFormatRequestCreation(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws WebClientResponseException {
+    private ResponseSpec testQueryParameterCollectionFormatRequestCreation(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> language) throws WebClientResponseException {
         Object postBody = null;
         // verify the required parameter 'pipe' is set
         if (pipe == null) {
@@ -1053,6 +1054,7 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("ssv".toUpperCase(Locale.ROOT)), "http", http));
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", url));
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1074,15 +1076,16 @@ public class FakeApi {
      * @param http The http parameter
      * @param url The url parameter
      * @param context The context parameter
+     * @param language The language parameter
      * @throws WebClientResponseException if an error occurs while attempting to invoke the API
      */
-    public Mono<Void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws WebClientResponseException {
+    public Mono<Void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> language) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
-        return testQueryParameterCollectionFormatRequestCreation(pipe, ioutil, http, url, context).bodyToMono(localVarReturnType);
+        return testQueryParameterCollectionFormatRequestCreation(pipe, ioutil, http, url, context, language).bodyToMono(localVarReturnType);
     }
 
-    public Mono<ResponseEntity<Void>> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws WebClientResponseException {
+    public Mono<ResponseEntity<Void>> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> language) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
-        return testQueryParameterCollectionFormatRequestCreation(pipe, ioutil, http, url, context).toEntity(localVarReturnType);
+        return testQueryParameterCollectionFormatRequestCreation(pipe, ioutil, http, url, context, language).toEntity(localVarReturnType);
     }
 }

--- a/samples/client/petstore/javascript-es6/docs/FakeApi.md
+++ b/samples/client/petstore/javascript-es6/docs/FakeApi.md
@@ -816,7 +816,7 @@ No authorization required
 
 ## testQueryParameterCollectionFormat
 
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, opts)
 
 
 
@@ -833,7 +833,10 @@ let ioutil = ["null"]; // [String] |
 let http = ["null"]; // [String] | 
 let url = ["null"]; // [String] | 
 let context = ["null"]; // [String] | 
-apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, (error, data, response) => {
+let opts = {
+  'language': {key: "null"} // {String: String} | 
+};
+apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, opts, (error, data, response) => {
   if (error) {
     console.error(error);
   } else {
@@ -852,6 +855,7 @@ Name | Type | Description  | Notes
  **http** | [**[String]**](String.md)|  | 
  **url** | [**[String]**](String.md)|  | 
  **context** | [**[String]**](String.md)|  | 
+ **language** | [**{String: String}**](String.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/client/petstore/javascript-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/FakeApi.js
@@ -786,9 +786,12 @@ export default class FakeApi {
      * @param {Array.<String>} http 
      * @param {Array.<String>} url 
      * @param {Array.<String>} context 
+     * @param {Object} opts Optional parameters
+     * @param {Object.<String, {String: String}>} opts.language 
      * @param {module:api/FakeApi~testQueryParameterCollectionFormatCallback} callback The callback function, accepting three arguments: error, data, response
      */
-    testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, callback) {
+    testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, opts, callback) {
+      opts = opts || {};
       let postBody = null;
       // verify the required parameter 'pipe' is set
       if (pipe === undefined || pipe === null) {
@@ -818,7 +821,8 @@ export default class FakeApi {
         'ioutil': this.apiClient.buildCollectionParam(ioutil, 'csv'),
         'http': this.apiClient.buildCollectionParam(http, 'ssv'),
         'url': this.apiClient.buildCollectionParam(url, 'csv'),
-        'context': this.apiClient.buildCollectionParam(context, 'multi')
+        'context': this.apiClient.buildCollectionParam(context, 'multi'),
+        'language': opts['language']
       };
       let headerParams = {
       };

--- a/samples/client/petstore/javascript-promise-es6/docs/FakeApi.md
+++ b/samples/client/petstore/javascript-promise-es6/docs/FakeApi.md
@@ -800,7 +800,7 @@ No authorization required
 
 ## testQueryParameterCollectionFormat
 
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, opts)
 
 
 
@@ -817,7 +817,10 @@ let ioutil = ["null"]; // [String] |
 let http = ["null"]; // [String] | 
 let url = ["null"]; // [String] | 
 let context = ["null"]; // [String] | 
-apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context).then(() => {
+let opts = {
+  'language': {key: "null"} // {String: String} | 
+};
+apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, opts).then(() => {
   console.log('API called successfully.');
 }, (error) => {
   console.error(error);
@@ -835,6 +838,7 @@ Name | Type | Description  | Notes
  **http** | [**[String]**](String.md)|  | 
  **url** | [**[String]**](String.md)|  | 
  **context** | [**[String]**](String.md)|  | 
+ **language** | [**{String: String}**](String.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/client/petstore/javascript-promise-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/FakeApi.js
@@ -891,9 +891,12 @@ export default class FakeApi {
      * @param {Array.<String>} http 
      * @param {Array.<String>} url 
      * @param {Array.<String>} context 
+     * @param {Object} opts Optional parameters
+     * @param {Object.<String, {String: String}>} opts.language 
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
-    testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context) {
+    testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, opts) {
+      opts = opts || {};
       let postBody = null;
       // verify the required parameter 'pipe' is set
       if (pipe === undefined || pipe === null) {
@@ -923,7 +926,8 @@ export default class FakeApi {
         'ioutil': this.apiClient.buildCollectionParam(ioutil, 'csv'),
         'http': this.apiClient.buildCollectionParam(http, 'ssv'),
         'url': this.apiClient.buildCollectionParam(url, 'csv'),
-        'context': this.apiClient.buildCollectionParam(context, 'multi')
+        'context': this.apiClient.buildCollectionParam(context, 'multi'),
+        'language': opts['language']
       };
       let headerParams = {
       };
@@ -948,10 +952,12 @@ export default class FakeApi {
      * @param {Array.<String>} http 
      * @param {Array.<String>} url 
      * @param {Array.<String>} context 
+     * @param {Object} opts Optional parameters
+     * @param {Object.<String, {String: String}>} opts.language 
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */
-    testQueryParameterCollectionFormat(pipe, ioutil, http, url, context) {
-      return this.testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context)
+    testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, opts) {
+      return this.testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, opts)
         .then(function(response_and_data) {
           return response_and_data.data;
         });

--- a/samples/client/petstore/perl/docs/FakeApi.md
+++ b/samples/client/petstore/perl/docs/FakeApi.md
@@ -813,7 +813,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_query_parameter_collection_format**
-> test_query_parameter_collection_format(pipe => $pipe, ioutil => $ioutil, http => $http, url => $url, context => $context)
+> test_query_parameter_collection_format(pipe => $pipe, ioutil => $ioutil, http => $http, url => $url, context => $context, language => $language)
 
 
 
@@ -831,9 +831,10 @@ my $ioutil = [("null")]; # ARRAY[string] |
 my $http = [("null")]; # ARRAY[string] | 
 my $url = [("null")]; # ARRAY[string] | 
 my $context = [("null")]; # ARRAY[string] | 
+my $language = ('key' =>  "null"}; # HASH[string,string] | 
 
 eval { 
-    $api_instance->test_query_parameter_collection_format(pipe => $pipe, ioutil => $ioutil, http => $http, url => $url, context => $context);
+    $api_instance->test_query_parameter_collection_format(pipe => $pipe, ioutil => $ioutil, http => $http, url => $url, context => $context, language => $language);
 };
 if ($@) {
     warn "Exception when calling FakeApi->test_query_parameter_collection_format: $@\n";
@@ -849,6 +850,7 @@ Name | Type | Description  | Notes
  **http** | [**ARRAY[string]**](string.md)|  | 
  **url** | [**ARRAY[string]**](string.md)|  | 
  **context** | [**ARRAY[string]**](string.md)|  | 
+ **language** | [**HASH[string,string]**](string.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeApi.pm
@@ -1371,6 +1371,7 @@ sub test_json_form_data {
 # @param ARRAY[string] $http  (required)
 # @param ARRAY[string] $url  (required)
 # @param ARRAY[string] $context  (required)
+# @param HASH[string,string] $language  (optional)
 {
     my $params = {
     'pipe' => {
@@ -1397,6 +1398,11 @@ sub test_json_form_data {
         data_type => 'ARRAY[string]',
         description => '',
         required => '1',
+    },
+    'language' => {
+        data_type => 'HASH[string,string]',
+        description => '',
+        required => '0',
     },
     };
     __PACKAGE__->method_documentation->{ 'test_query_parameter_collection_format' } = { 
@@ -1473,6 +1479,11 @@ sub test_query_parameter_collection_format {
     # query params
     if ( exists $args{'context'}) {
         $query_params->{'context'} = $self->{api_client}->to_query_value($args{'context'});
+    }
+
+    # query params
+    if ( exists $args{'language'}) {
+        $query_params->{'language'} = $self->{api_client}->to_query_value($args{'language'});
     }
 
     my $_body_data;

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -972,7 +972,7 @@ No authorization required
 ## `testQueryParameterCollectionFormat()`
 
 ```php
-testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context)
+testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $language)
 ```
 
 
@@ -997,9 +997,10 @@ $ioutil = array('ioutil_example'); // string[]
 $http = array('http_example'); // string[]
 $url = array('url_example'); // string[]
 $context = array('context_example'); // string[]
+$language = array('key' => 'language_example'); // array<string,string>
 
 try {
-    $apiInstance->testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context);
+    $apiInstance->testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $language);
 } catch (Exception $e) {
     echo 'Exception when calling FakeApi->testQueryParameterCollectionFormat: ', $e->getMessage(), PHP_EOL;
 }
@@ -1014,6 +1015,7 @@ Name | Type | Description  | Notes
  **http** | [**string[]**](../Model/string.md)|  |
  **url** | [**string[]**](../Model/string.md)|  |
  **context** | [**string[]**](../Model/string.md)|  |
+ **language** | [**array<string,string>**](../Model/string.md)|  | [optional]
 
 ### Return type
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -4247,14 +4247,15 @@ class FakeApi
      * @param  string[] $http http (required)
      * @param  string[] $url url (required)
      * @param  string[] $context context (required)
+     * @param  array<string,string> $language language (optional)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context)
+    public function testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $language = null)
     {
-        $this->testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context);
+        $this->testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context, $language);
     }
 
     /**
@@ -4265,14 +4266,15 @@ class FakeApi
      * @param  string[] $http (required)
      * @param  string[] $url (required)
      * @param  string[] $context (required)
+     * @param  array<string,string> $language (optional)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context)
+    public function testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context, $language = null)
     {
-        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context);
+        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $language);
 
         try {
             $options = $this->createHttpClientOption();
@@ -4319,13 +4321,14 @@ class FakeApi
      * @param  string[] $http (required)
      * @param  string[] $url (required)
      * @param  string[] $context (required)
+     * @param  array<string,string> $language (optional)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testQueryParameterCollectionFormatAsync($pipe, $ioutil, $http, $url, $context)
+    public function testQueryParameterCollectionFormatAsync($pipe, $ioutil, $http, $url, $context, $language = null)
     {
-        return $this->testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context)
+        return $this->testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $language)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -4341,14 +4344,15 @@ class FakeApi
      * @param  string[] $http (required)
      * @param  string[] $url (required)
      * @param  string[] $context (required)
+     * @param  array<string,string> $language (optional)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context)
+    public function testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $language = null)
     {
         $returnType = '';
-        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context);
+        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $language);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -4381,11 +4385,12 @@ class FakeApi
      * @param  string[] $http (required)
      * @param  string[] $url (required)
      * @param  string[] $context (required)
+     * @param  array<string,string> $language (optional)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context)
+    public function testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $language = null)
     {
         // verify the required parameter 'pipe' is set
         if ($pipe === null || (is_array($pipe) && count($pipe) === 0)) {
@@ -4462,6 +4467,17 @@ class FakeApi
             }
             else {
                 $queryParams['context'] = $context;
+            }
+        }
+        // query params
+        if ($language !== null) {
+            if('form' === 'form' && is_array($language)) {
+                foreach($language as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['language'] = $language;
             }
         }
 

--- a/samples/client/petstore/ruby-faraday/docs/FakeApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeApi.md
@@ -1115,7 +1115,7 @@ No authorization required
 
 ## test_query_parameter_collection_format
 
-> test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts)
 
 
 
@@ -1133,10 +1133,13 @@ ioutil = ['inner_example'] # Array<String> |
 http = ['inner_example'] # Array<String> | 
 url = ['inner_example'] # Array<String> | 
 context = ['inner_example'] # Array<String> | 
+opts = {
+  language: { key: 'inner_example'} # Hash<String, String> | 
+}
 
 begin
   
-  api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+  api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts)
 rescue Petstore::ApiError => e
   puts "Error when calling FakeApi->test_query_parameter_collection_format: #{e}"
 end
@@ -1146,12 +1149,12 @@ end
 
 This returns an Array which contains the response data (`nil` in this case), status code and headers.
 
-> <Array(nil, Integer, Hash)> test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context)
+> <Array(nil, Integer, Hash)> test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
 
 ```ruby
 begin
   
-  data, status_code, headers = api_instance.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context)
+  data, status_code, headers = api_instance.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
   p status_code # => 2xx
   p headers # => { ... }
   p data # => nil
@@ -1169,6 +1172,7 @@ end
 | **http** | [**Array&lt;String&gt;**](String.md) |  |  |
 | **url** | [**Array&lt;String&gt;**](String.md) |  |  |
 | **context** | [**Array&lt;String&gt;**](String.md) |  |  |
+| **language** | [**Hash&lt;String, String&gt;**](String.md) |  | [optional] |
 
 ### Return type
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
@@ -1193,6 +1193,7 @@ module Petstore
     # @param url [Array<String>] 
     # @param context [Array<String>] 
     # @param [Hash] opts the optional parameters
+    # @option opts [Hash<String, String>] :language 
     # @return [nil]
     def test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts = {})
       test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
@@ -1206,6 +1207,7 @@ module Petstore
     # @param url [Array<String>] 
     # @param context [Array<String>] 
     # @param [Hash] opts the optional parameters
+    # @option opts [Hash<String, String>] :language 
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts = {})
       if @api_client.config.debugging
@@ -1241,6 +1243,7 @@ module Petstore
       query_params[:'http'] = @api_client.build_collection_param(http, :ssv)
       query_params[:'url'] = @api_client.build_collection_param(url, :csv)
       query_params[:'context'] = @api_client.build_collection_param(context, :multi)
+      query_params[:'language'] = opts[:'language'] if !opts[:'language'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -1115,7 +1115,7 @@ No authorization required
 
 ## test_query_parameter_collection_format
 
-> test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts)
 
 
 
@@ -1133,10 +1133,13 @@ ioutil = ['inner_example'] # Array<String> |
 http = ['inner_example'] # Array<String> | 
 url = ['inner_example'] # Array<String> | 
 context = ['inner_example'] # Array<String> | 
+opts = {
+  language: { key: 'inner_example'} # Hash<String, String> | 
+}
 
 begin
   
-  api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+  api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts)
 rescue Petstore::ApiError => e
   puts "Error when calling FakeApi->test_query_parameter_collection_format: #{e}"
 end
@@ -1146,12 +1149,12 @@ end
 
 This returns an Array which contains the response data (`nil` in this case), status code and headers.
 
-> <Array(nil, Integer, Hash)> test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context)
+> <Array(nil, Integer, Hash)> test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
 
 ```ruby
 begin
   
-  data, status_code, headers = api_instance.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context)
+  data, status_code, headers = api_instance.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
   p status_code # => 2xx
   p headers # => { ... }
   p data # => nil
@@ -1169,6 +1172,7 @@ end
 | **http** | [**Array&lt;String&gt;**](String.md) |  |  |
 | **url** | [**Array&lt;String&gt;**](String.md) |  |  |
 | **context** | [**Array&lt;String&gt;**](String.md) |  |  |
+| **language** | [**Hash&lt;String, String&gt;**](String.md) |  | [optional] |
 
 ### Return type
 

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -1193,6 +1193,7 @@ module Petstore
     # @param url [Array<String>] 
     # @param context [Array<String>] 
     # @param [Hash] opts the optional parameters
+    # @option opts [Hash<String, String>] :language 
     # @return [nil]
     def test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts = {})
       test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
@@ -1206,6 +1207,7 @@ module Petstore
     # @param url [Array<String>] 
     # @param context [Array<String>] 
     # @param [Hash] opts the optional parameters
+    # @option opts [Hash<String, String>] :language 
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts = {})
       if @api_client.config.debugging
@@ -1241,6 +1243,7 @@ module Petstore
       query_params[:'http'] = @api_client.build_collection_param(http, :ssv)
       query_params[:'url'] = @api_client.build_collection_param(url, :csv)
       query_params[:'context'] = @api_client.build_collection_param(context, :multi)
+      query_params[:'language'] = opts[:'language'] if !opts[:'language'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -133,6 +133,7 @@ export interface TestQueryParameterCollectionFormatRequest {
     http: Array<string>;
     url: Array<string>;
     context: Array<string>;
+    language?: { [key: string]: string; };
 }
 
 /**
@@ -888,6 +889,10 @@ export class FakeApi extends runtime.BaseAPI {
 
         if (requestParameters.context) {
             queryParameters['context'] = requestParameters.context;
+        }
+
+        if (requestParameters.language !== undefined) {
+            queryParameters['language'] = requestParameters.language;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/doc/FakeApi.md
@@ -761,7 +761,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **testQueryParameterCollectionFormat**
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language)
 
 
 
@@ -777,9 +777,10 @@ final BuiltList<String> ioutil = ; // BuiltList<String> |
 final BuiltList<String> http = ; // BuiltList<String> | 
 final BuiltList<String> url = ; // BuiltList<String> | 
 final BuiltList<String> context = ; // BuiltList<String> | 
+final BuiltMap<String, String> language = ; // BuiltMap<String, String> | 
 
 try { 
-    api.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+    api.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language);
 } catch on DioError (e) {
     print('Exception when calling FakeApi->testQueryParameterCollectionFormat: $e\n');
 }
@@ -794,6 +795,7 @@ Name | Type | Description  | Notes
  **http** | [**BuiltList&lt;String&gt;**](String.md)|  | 
  **url** | [**BuiltList&lt;String&gt;**](String.md)|  | 
  **context** | [**BuiltList&lt;String&gt;**](String.md)|  | 
+ **language** | [**BuiltMap&lt;String, String&gt;**](String.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/api/fake_api.dart
@@ -1353,6 +1353,7 @@ class FakeApi {
   /// * [http] 
   /// * [url] 
   /// * [context] 
+  /// * [language] 
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
   /// * [extras] - Can be used to add flags to the request
@@ -1368,6 +1369,7 @@ class FakeApi {
     required BuiltList<String> http,
     required BuiltList<String> url,
     required BuiltList<String> context,
+    BuiltMap<String, String>? language,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
     Map<String, dynamic>? extra,
@@ -1394,6 +1396,7 @@ class FakeApi {
       r'http': encodeCollectionQueryParameter<String>(_serializers, http, const FullType(BuiltList, [FullType(String)]), format: ListFormat.ssv,),
       r'url': encodeCollectionQueryParameter<String>(_serializers, url, const FullType(BuiltList, [FullType(String)]), format: ListFormat.csv,),
       r'context': encodeCollectionQueryParameter<String>(_serializers, context, const FullType(BuiltList, [FullType(String)]), format: ListFormat.multi,),
+      if (language != null) r'language': encodeQueryParameter(_serializers, language, const FullType(BuiltMap, [FullType(String), FullType(String)]), ),
     };
 
     final _response = await _dio.request<Object>(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FakeApi.md
@@ -761,7 +761,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **testQueryParameterCollectionFormat**
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language)
 
 
 
@@ -777,9 +777,10 @@ var ioutil = []; // BuiltList<String> |
 var http = []; // BuiltList<String> | 
 var url = []; // BuiltList<String> | 
 var context = []; // BuiltList<String> | 
+var language = ; // BuiltMap<String, String> | 
 
 try { 
-    api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+    api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language);
 } catch (e) {
     print('Exception when calling FakeApi->testQueryParameterCollectionFormat: $e\n');
 }
@@ -794,6 +795,7 @@ Name | Type | Description  | Notes
  **http** | [**BuiltList<String>**](String.md)|  | 
  **url** | [**BuiltList<String>**](String.md)|  | 
  **context** | [**BuiltList<String>**](String.md)|  | 
+ **language** | [**BuiltMap<String, String>**](String.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -892,6 +892,7 @@ class FakeApi {
     BuiltList<String> http,
     BuiltList<String> url,
     BuiltList<String> context, { 
+    BuiltMap<String, String> language,
     CancelToken cancelToken,
     Map<String, dynamic> headers,
     Map<String, dynamic> extra,
@@ -911,6 +912,7 @@ class FakeApi {
         r'http': http,
         r'url': url,
         r'context': context,
+        if (language != null) r'language': language,
       },
       extra: <String, dynamic>{
         'secure': <Map<String, String>>[],

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/FakeApi.md
@@ -761,7 +761,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **testQueryParameterCollectionFormat**
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language)
 
 
 
@@ -777,9 +777,10 @@ final ioutil = []; // List<String> |
 final http = []; // List<String> | 
 final url = []; // List<String> | 
 final context = []; // List<String> | 
+final language = ; // Map<String, String> | 
 
 try { 
-    api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+    api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language);
 } catch (e) {
     print('Exception when calling FakeApi->testQueryParameterCollectionFormat: $e\n');
 }
@@ -794,6 +795,7 @@ Name | Type | Description  | Notes
  **http** | [**List<String>**](String.md)|  | [default to const []]
  **url** | [**List<String>**](String.md)|  | [default to const []]
  **context** | [**List<String>**](String.md)|  | [default to const []]
+ **language** | [**Map<String, String>**](String.md)|  | [optional] [default to const {}]
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -1176,7 +1176,9 @@ class FakeApi {
   /// * [List<String>] url (required):
   ///
   /// * [List<String>] context (required):
-  Future<Response> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) async {
+  ///
+  /// * [Map<String, String>] language:
+  Future<Response> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, { Map<String, String> language }) async {
     // Verify required params are set.
     if (pipe == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: pipe');
@@ -1207,6 +1209,9 @@ class FakeApi {
       queryParams.addAll(_convertParametersForCollectionFormat('ssv', 'http', http));
       queryParams.addAll(_convertParametersForCollectionFormat('csv', 'url', url));
       queryParams.addAll(_convertParametersForCollectionFormat('multi', 'context', context));
+    if (language != null) {
+      queryParams.addAll(_convertParametersForCollectionFormat('', 'language', language));
+    }
 
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
@@ -1238,8 +1243,10 @@ class FakeApi {
   /// * [List<String>] url (required):
   ///
   /// * [List<String>] context (required):
-  Future<void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) async {
-    final response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+  ///
+  /// * [Map<String, String>] language:
+  Future<void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, { Map<String, String> language }) async {
+    final response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context,  language: language );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/doc/FakeApi.md
@@ -761,7 +761,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **testQueryParameterCollectionFormat**
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language)
 
 
 
@@ -777,9 +777,10 @@ final ioutil = []; // List<String> |
 final http = []; // List<String> | 
 final url = []; // List<String> | 
 final context = []; // List<String> | 
+final language = ; // Map<String, String> | 
 
 try { 
-    api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+    api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language);
 } catch (e) {
     print('Exception when calling FakeApi->testQueryParameterCollectionFormat: $e\n');
 }
@@ -794,6 +795,7 @@ Name | Type | Description  | Notes
  **http** | [**List<String>**](String.md)|  | [default to const []]
  **url** | [**List<String>**](String.md)|  | [default to const []]
  **context** | [**List<String>**](String.md)|  | [default to const []]
+ **language** | [**Map<String, String>**](String.md)|  | [optional] [default to const {}]
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/lib/api/fake_api.dart
@@ -1183,7 +1183,9 @@ class FakeApi {
   /// * [List<String>] url (required):
   ///
   /// * [List<String>] context (required):
-  Future<Response> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) async {
+  ///
+  /// * [Map<String, String>] language:
+  Future<Response> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, { Map<String, String> language }) async {
     // Verify required params are set.
     if (pipe == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: pipe');
@@ -1214,6 +1216,9 @@ class FakeApi {
       queryParams.addAll(_convertParametersForCollectionFormat('ssv', 'http', http));
       queryParams.addAll(_convertParametersForCollectionFormat('csv', 'url', url));
       queryParams.addAll(_convertParametersForCollectionFormat('multi', 'context', context));
+    if (language != null) {
+      queryParams.addAll(_convertParametersForCollectionFormat('', 'language', language));
+    }
 
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
@@ -1245,8 +1250,10 @@ class FakeApi {
   /// * [List<String>] url (required):
   ///
   /// * [List<String>] context (required):
-  Future<void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) async {
-    final response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+  ///
+  /// * [Map<String, String>] language:
+  Future<void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, { Map<String, String> language }) async {
+    final response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context,  language: language );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/python-legacy/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-legacy/docs/FakeApi.md
@@ -1130,7 +1130,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_query_parameter_collection_format**
-> test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context, language=language)
 
 
 
@@ -1160,9 +1160,10 @@ ioutil = ['ioutil_example'] # list[str] |
 http = ['http_example'] # list[str] | 
 url = ['url_example'] # list[str] | 
 context = ['context_example'] # list[str] | 
+language = {'key': 'language_example'} # dict(str, str) |  (optional)
 
     try:
-        api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+        api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context, language=language)
     except ApiException as e:
         print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
 ```
@@ -1176,6 +1177,7 @@ Name | Type | Description  | Notes
  **http** | [**list[str]**](str.md)|  | 
  **url** | [**list[str]**](str.md)|  | 
  **context** | [**list[str]**](str.md)|  | 
+ **language** | [**dict(str, str)**](str.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/fake_api.py
@@ -2435,6 +2435,8 @@ class FakeApi(object):
         :type url: list[str]
         :param context: (required)
         :type context: list[str]
+        :param language:
+        :type language: dict(str, str)
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the urllib3.HTTPResponse object will
@@ -2473,6 +2475,8 @@ class FakeApi(object):
         :type url: list[str]
         :param context: (required)
         :type context: list[str]
+        :param language:
+        :type language: dict(str, str)
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _return_http_data_only: response data without head status code
@@ -2503,7 +2507,8 @@ class FakeApi(object):
             'ioutil',
             'http',
             'url',
-            'context'
+            'context',
+            'language'
         ]
         all_params.extend(
             [
@@ -2564,6 +2569,8 @@ class FakeApi(object):
         if 'context' in local_var_params and local_var_params['context'] is not None:  # noqa: E501
             query_params.append(('context', local_var_params['context']))  # noqa: E501
             collection_formats['context'] = 'multi'  # noqa: E501
+        if 'language' in local_var_params and local_var_params['language'] is not None:  # noqa: E501
+            query_params.append(('language', local_var_params['language']))  # noqa: E501
 
         header_params = {}
 

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
@@ -275,9 +275,9 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = {
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class)
     })
-    public Response testQueryParameterCollectionFormat(@ApiParam(value = "", required = true) @QueryParam("pipe") @NotNull @Valid  List<String> pipe,@ApiParam(value = "", required = true) @QueryParam("ioutil") @NotNull @Valid  List<String> ioutil,@ApiParam(value = "", required = true) @QueryParam("http") @NotNull @Valid  List<String> http,@ApiParam(value = "", required = true) @QueryParam("url") @NotNull @Valid  List<String> url,@ApiParam(value = "", required = true) @QueryParam("context") @NotNull @Valid  List<String> context,@Context SecurityContext securityContext)
+    public Response testQueryParameterCollectionFormat(@ApiParam(value = "", required = true) @QueryParam("pipe") @NotNull @Valid  List<String> pipe,@ApiParam(value = "", required = true) @QueryParam("ioutil") @NotNull @Valid  List<String> ioutil,@ApiParam(value = "", required = true) @QueryParam("http") @NotNull @Valid  List<String> http,@ApiParam(value = "", required = true) @QueryParam("url") @NotNull @Valid  List<String> url,@ApiParam(value = "", required = true) @QueryParam("context") @NotNull @Valid  List<String> context,@ApiParam(value = "") @QueryParam("language") @Valid  Map<String, String> language,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, securityContext);
+        return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language, securityContext);
     }
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApiService.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApiService.java
@@ -44,6 +44,6 @@ public abstract class FakeApiService {
     public abstract Response testGroupParameters( @NotNull Integer requiredStringGroup, @NotNull Boolean requiredBooleanGroup, @NotNull Long requiredInt64Group,Integer stringGroup,Boolean booleanGroup,Long int64Group,SecurityContext securityContext) throws NotFoundException;
     public abstract Response testInlineAdditionalProperties(Map<String, String> requestBody,SecurityContext securityContext) throws NotFoundException;
     public abstract Response testJsonFormData(String param,String param2,SecurityContext securityContext) throws NotFoundException;
-    public abstract Response testQueryParameterCollectionFormat( @NotNull List<String> pipe, @NotNull List<String> ioutil, @NotNull List<String> http, @NotNull List<String> url, @NotNull List<String> context,SecurityContext securityContext) throws NotFoundException;
+    public abstract Response testQueryParameterCollectionFormat( @NotNull List<String> pipe, @NotNull List<String> ioutil, @NotNull List<String> http, @NotNull List<String> url, @NotNull List<String> context,Map<String, String> language,SecurityContext securityContext) throws NotFoundException;
     public abstract Response uploadFileWithRequiredFile(Long petId,FormDataBodyPart requiredFileBodypart,String additionalMetadata,SecurityContext securityContext) throws NotFoundException;
 }

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
@@ -109,7 +109,7 @@ public class FakeApiServiceImpl extends FakeApiService {
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }
     @Override
-    public Response testQueryParameterCollectionFormat( @NotNull List<String> pipe,  @NotNull List<String> ioutil,  @NotNull List<String> http,  @NotNull List<String> url,  @NotNull List<String> context, SecurityContext securityContext) throws NotFoundException {
+    public Response testQueryParameterCollectionFormat( @NotNull List<String> pipe,  @NotNull List<String> ioutil,  @NotNull List<String> http,  @NotNull List<String> url,  @NotNull List<String> context, Map<String, String> language, SecurityContext securityContext) throws NotFoundException {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }

--- a/samples/server/petstore/php-laravel/lib/app/Http/Controllers/FakeController.php
+++ b/samples/server/petstore/php-laravel/lib/app/Http/Controllers/FakeController.php
@@ -554,6 +554,8 @@ class FakeController extends Controller
         }
         $context = $input['context'];
 
+        $language = $input['language'];
+
 
         return response('How about implementing testQueryParameterCollectionFormat as a put method ?');
     }

--- a/samples/server/petstore/php-lumen/lib/app/Http/Controllers/FakeApi.php
+++ b/samples/server/petstore/php-lumen/lib/app/Http/Controllers/FakeApi.php
@@ -550,6 +550,8 @@ class FakeApi extends Controller
         }
         $context = $input['context'];
 
+        $language = $input['language'];
+
 
         return response('How about implementing testQueryParameterCollectionFormat as a put method ?');
     }


### PR DESCRIPTION
Adding map property in url params to test generation of this specific case in generators as requested in https://github.com/OpenAPITools/openapi-generator/pull/10116#issuecomment-898190912

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 