### PR TITLE
modified tow pom.xml

### DIFF
--- a/samples/server/petstore/jaxrs-cxf-test-data/pom.xml
+++ b/samples/server/petstore/jaxrs-cxf-test-data/pom.xml
@@ -233,7 +233,8 @@
     <dependency>
       <groupId>org.openapitools</groupId>
       <artifactId>openapi-generator</artifactId>
-      <version>5.2.0-SNAPSHOT</version>
+	  <!-- <version>5.2.0-SNAPSHOT</version>-->
+      <version>5.2.0</version>
     </dependency>
   </dependencies>
   <repositories>

--- a/samples/server/petstore/kotlin/vertx/pom.xml
+++ b/samples/server/petstore/kotlin/vertx/pom.xml
@@ -63,7 +63,8 @@
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core</artifactId>
-            <version>RELEASE</version>
+			<!-- <version>RELEASE</version>-->
+            <version>1.5.1-native-mt</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
We noticed a problem with two pom.xml files in this project.
Each of them has a SNAPSHOT dependency. The  SNAPSHOT dependency will require downloading the latest component every time a build is made, which will definitely increase the build time. Therefore, we have modified the versions of the two dependency versions as follows:

①
Relative paths:  openapi-generator/samples/server/petstore/jaxrs-cxf-test-data/pom.xml
Dependency: { Name: org.openapitools/openapi-generator, Version Specifier: 5.2.0-SNAPSHOT }   ------> 5.2.0

②
Relative paths:  openapi-generator/samples/server/petstore/kotlin/vertx/pom.xml
Dependency: {Name: org.jetbrains.kotlinx/kotlinx-coroutines-core, Version Specifier: RELEASE}  ------> 1.5.1-native-mt
