### PR TITLE
[scala-sttp] Fix Compilation failure - not found type ByteArray

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
@@ -143,6 +143,8 @@ public class ScalaSttpClientCodegen extends AbstractScalaCodegen implements Code
         typeMapping.put("binary", "File");
         typeMapping.put("number", "Double");
         typeMapping.put("decimal", "BigDecimal");
+        typeMapping.put("ByteArray", "Array[Byte]");
+        typeMapping.put("ArrayByte", "Array[Byte]");
 
         instantiationTypes.put("array", "ListBuffer");
         instantiationTypes.put("map", "Map");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/SttpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/SttpCodegenTest.java
@@ -1,8 +1,10 @@
 package org.openapitools.codegen.scala;
 
 import org.openapitools.codegen.languages.ScalaSttpClientCodegen;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.swagger.v3.oas.models.media.Schema;
 
 public class SttpCodegenTest {
 
@@ -15,6 +17,16 @@ public class SttpCodegenTest {
         Assert.assertEquals(codegen.encodePath("{UserName}"), "${userName}");
         Assert.assertEquals(codegen.encodePath("user_name"), "user_name");
         Assert.assertEquals(codegen.encodePath("before/{UserName}/after"), "before/${userName}/after");
+    }
+
+    @Test
+    public void typeByteArray() {
+      final Schema<?> schema = new Schema<Object>()
+          .description("Schema with byte string");
+      schema.setType("string");
+      schema.setFormat("byte");
+      String type = codegen.getTypeDeclaration(schema);
+      Assert.assertEquals(type, "Array[Byte]");
     }
 
 }


### PR DESCRIPTION
This PR fixes the compilation error for a property which is defined as `format = byte` and `type = string`. 
- Fixed by typeMapping ByteArray -> Array([Byte])
- Test case added.
- Fixed [issue #10150](https://github.com/OpenAPITools/openapi-generator/issues/10150)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.3.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@chameleon82 @clasnake @jimschubert @shijinkui @ramzimaalej @Bouillie @wing328 @jfeltesse-mdsol @jcarres-mdsol