### PR TITLE
[Java] Add missing imports for Set in java clients

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.MediaType;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api_test.mustache
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 {{/fullJavaUtil}}
 
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 {{/fullJavaUtil}}
 {{#asyncNative}}
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api_test.mustache
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 {{/fullJavaUtil}}
 
 {{#asyncNative}}

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/PetApi.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.MediaType;

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.MediaType;

--- a/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/microprofile-rest-client/src/main/java/org/openapitools/client/api/UserApi.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.MediaType;

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import java.util.concurrent.CompletableFuture;
 

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import java.util.concurrent.CompletableFuture;
 

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import java.util.concurrent.CompletableFuture;
 

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/PetApi.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import java.util.concurrent.CompletableFuture;
 

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import java.util.concurrent.CompletableFuture;
 

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/UserApi.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import java.util.concurrent.CompletableFuture;
 

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class AnotherFakeApi {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class FakeApi {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class FakeClassnameTags123Api {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class PetApi {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class StoreApi {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/UserApi.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.StringJoiner;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class UserApi {


### PR DESCRIPTION
In case of array properties declared with uniqueItems: true, the
generated Java code uses Sets but imports are not present for them in
the Api and Test classes.

Maybe this can be considered for a bugfix release also for older releases?

CC @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @nmuesch

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
