### PR TITLE
[cpp-ue4] fix for generating formParams in json requests

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
@@ -170,28 +170,28 @@ void {{classname}}::{{operationIdCamelCase}}Request::SetupHttpRequest(const FHtt
 		HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
 		HttpRequest->SetContentAsString(JsonBody);
 		{{/bodyParams.0}}
-        {{^bodyParams.0}}
-            // Form parameters
-            FString JsonBody;
-            JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
-            Writer->WriteObjectStart();
-            {{#formParams}}
-                {{#required}}
-            Writer->WriteIdentifierPrefix(TEXT("{{baseName}}"));
-            WriteJsonValue(Writer, {{paramName}});
-                {{/required}}
-                {{^required}}
-            if ({{paramName}}.IsSet()){
-                Writer->WriteIdentifierPrefix(TEXT("{{baseName}}"));
-                WriteJsonValue(Writer, {{paramName}}.GetValue());
-            }
-                {{/required}}
-            {{/formParams}}
-            Writer->WriteObjectEnd();
-            Writer->Close();
-            HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
-            HttpRequest->SetContentAsString(JsonBody);
-        {{/bodyParams.0}}
+		{{^bodyParams.0}}
+			// Form parameters
+			FString JsonBody;
+			JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
+			Writer->WriteObjectStart();
+			{{#formParams}}
+				{{#required}}
+			Writer->WriteIdentifierPrefix(TEXT("{{baseName}}"));
+			WriteJsonValue(Writer, {{paramName}});
+				{{/required}}
+				{{^required}}
+			if ({{paramName}}.IsSet()){
+				Writer->WriteIdentifierPrefix(TEXT("{{baseName}}"));
+				WriteJsonValue(Writer, {{paramName}}.GetValue());
+			}
+				{{/required}}
+			{{/formParams}}
+			Writer->WriteObjectEnd();
+			Writer->Close();
+			HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
+			HttpRequest->SetContentAsString(JsonBody);
+		{{/bodyParams.0}}
 	}
 	else if (Consumes.Contains(TEXT("multipart/form-data")))
 	{

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
@@ -171,26 +171,26 @@ void {{classname}}::{{operationIdCamelCase}}Request::SetupHttpRequest(const FHtt
 		HttpRequest->SetContentAsString(JsonBody);
 		{{/bodyParams.0}}
 		{{^bodyParams.0}}
-			// Form parameters
-			FString JsonBody;
-			JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
-			Writer->WriteObjectStart();
-			{{#formParams}}
-				{{#required}}
+		// Form parameters
+		FString JsonBody;
+		JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
+		Writer->WriteObjectStart();
+		{{#formParams}}
+		{{#required}}
+		Writer->WriteIdentifierPrefix(TEXT("{{baseName}}"));
+		WriteJsonValue(Writer, {{paramName}});
+		{{/required}}
+		{{^required}}
+		if ({{paramName}}.IsSet()){
 			Writer->WriteIdentifierPrefix(TEXT("{{baseName}}"));
-			WriteJsonValue(Writer, {{paramName}});
-				{{/required}}
-				{{^required}}
-			if ({{paramName}}.IsSet()){
-				Writer->WriteIdentifierPrefix(TEXT("{{baseName}}"));
-				WriteJsonValue(Writer, {{paramName}}.GetValue());
-			}
-				{{/required}}
-			{{/formParams}}
-			Writer->WriteObjectEnd();
-			Writer->Close();
-			HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
-			HttpRequest->SetContentAsString(JsonBody);
+			WriteJsonValue(Writer, {{paramName}}.GetValue());
+		}
+		{{/required}}
+		{{/formParams}}
+		Writer->WriteObjectEnd();
+		Writer->Close();
+		HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
+		HttpRequest->SetContentAsString(JsonBody);
 		{{/bodyParams.0}}
 	}
 	else if (Consumes.Contains(TEXT("multipart/form-data")))

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
@@ -170,11 +170,28 @@ void {{classname}}::{{operationIdCamelCase}}Request::SetupHttpRequest(const FHtt
 		HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
 		HttpRequest->SetContentAsString(JsonBody);
 		{{/bodyParams.0}}
-		{{#formParams.0}}
-		{{#formParams}}
-		UE_LOG(Log{{unrealModuleName}}, Error, TEXT("Form parameter ({{baseName}}) was ignored, cannot be used in JsonBody"));
-		{{/formParams}}
-		{{/formParams.0}}
+        {{^bodyParams.0}}
+            // Form parameters
+            FString JsonBody;
+            JsonWriter Writer = TJsonWriterFactory<>::Create(&JsonBody);
+            Writer->WriteObjectStart();
+            {{#formParams}}
+                {{#required}}
+            Writer->WriteIdentifierPrefix(TEXT("{{baseName}}"));
+            WriteJsonValue(Writer, {{paramName}});
+                {{/required}}
+                {{^required}}
+            if ({{paramName}}.IsSet()){
+                Writer->WriteIdentifierPrefix(TEXT("{{baseName}}"));
+                WriteJsonValue(Writer, {{paramName}}.GetValue());
+            }
+                {{/required}}
+            {{/formParams}}
+            Writer->WriteObjectEnd();
+            Writer->Close();
+            HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json; charset=utf-8"));
+            HttpRequest->SetContentAsString(JsonBody);
+        {{/bodyParams.0}}
 	}
 	else if (Consumes.Contains(TEXT("multipart/form-data")))
 	{


### PR DESCRIPTION
Issue 10175 describes a potential bug and potential remedy.  This pull request is the basic fix I referenced in the issue.

https://github.com/OpenAPITools/openapi-generator/issues/10175

Simply put:  if there is no body parameter defined, it tries to generate a json body from formParams.  If a formParam isn't required, it uses IsSet from TOptional<> before writing the parameter.

See the referenced issue for the example schema that seems to require this template fix.

To be clear, this isn't really tested against a wide array of OpenAPI schemas.  And there are further issues with the generator.  But as a first pass, this at least gets a standard Django api-token-auth to be accepted by a Django server, and doesn't ruin other end points in my sample schema.

tagging @Kahncode as requested.

I'd want some more eyes on this at the very least.  And my conceptual question from the issue still stands.  I presume this to be a template problem, rather than a generator problem.  But that might not be correct.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
