### PR TITLE
[Ruby][Faraday] Fix request options and add params_encoder

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -11,7 +11,7 @@
         :client_key => @config.ssl_client_key
       }
 
-      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options) do |conn|
+      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options, :request => {:params_encoder => @config.params_encoder}) do |conn|
         conn.basic_auth(config.username, config.password)
         if opts[:header_params]["Content-Type"] == "multipart/form-data"
           conn.request :multipart
@@ -73,7 +73,7 @@
       update_params_for_auth! header_params, query_params, opts[:auth_names]
 
       req_opts = {
-        :params_encoding => @config.params_encoding,
+        :params_encoder => @config.params_encoder,
         :timeout => @config.timeout,
         :verbose => @config.debugging
       }

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -73,9 +73,6 @@
       update_params_for_auth! header_params, query_params, opts[:auth_names]
 
       req_opts = {
-        :method => http_method,
-        :headers => header_params,
-        :params => query_params,
         :params_encoding => @config.params_encoding,
         :timeout => @config.timeout,
         :verbose => @config.debugging
@@ -83,7 +80,6 @@
 
       if [:post, :patch, :put, :delete].include?(http_method)
         req_body = build_request_body(header_params, form_params, opts[:body])
-        req_opts.update :body => req_body
         if @config.debugging
           @config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
         end
@@ -92,6 +88,7 @@
       request.body = req_body
       request.url url
       request.params = query_params
+      request.options = OpenStruct.new(req_opts)
       download_file(request) if opts[:return_type] == 'File'
       request
     end

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -83,11 +83,18 @@ module {{moduleName}}
     # @return [true, false]
     attr_accessor :client_side_validation
 
+    # Set this to customize parameters encoder of array parameter.
+    # Default to nil. Faraday uses NestedParamsEncoder when nil.
+    #
+    # @see The params_encoder option of Faraday. Related source code:
+    # https://github.com/lostisland/faraday/tree/main/lib/faraday/encoders
+    attr_accessor :params_encoder
+
 {{^isFaraday}}
-{{> configuration_tls_typhoeus_partial}}
+{{> configuration_typhoeus_partial}}
 {{/isFaraday}}
 {{#isFaraday}}
-{{> configuration_tls_faraday_partial}}
+{{> configuration_faraday_partial}}
 {{/isFaraday}}
     # Set this to customize parameters encoding of array parameter with multi collectionFormat.
     # Default to nil.
@@ -118,6 +125,7 @@ module {{moduleName}}
       @ssl_ca_file = nil
       @ssl_client_cert = nil
       @ssl_client_key = nil
+      @params_encoder = nil
       {{/isFaraday}}
       {{^isFaraday}}
       @verify_ssl = true

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -117,7 +117,6 @@ module {{moduleName}}
       @server_operation_variables = {}
       @api_key = {}
       @api_key_prefix = {}
-      @timeout = 0
       @client_side_validation = true
       {{#isFaraday}}
       @ssl_verify = true
@@ -126,6 +125,7 @@ module {{moduleName}}
       @ssl_client_cert = nil
       @ssl_client_key = nil
       @params_encoder = nil
+      @timeout = 60
       {{/isFaraday}}
       {{^isFaraday}}
       @verify_ssl = true
@@ -133,6 +133,7 @@ module {{moduleName}}
       @params_encoding = nil
       @cert_file = nil
       @key_file = nil
+      @timeout = 0
       {{/isFaraday}}
       @debugging = false
       @inject_format = false

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration_faraday_partial.mustache
@@ -27,3 +27,11 @@
     ### TLS/SSL setting
     # Client private key file (for client certificate)
     attr_accessor :ssl_client_key
+
+    # Set this to customize parameters encoder of array parameter.
+    # Default to nil. Faraday uses NestedParamsEncoder when nil.
+    #
+    # @see The params_encoder option of Faraday. Related source code:
+    # https://github.com/lostisland/faraday/tree/main/lib/faraday/encoders
+    attr_accessor :params_encoder
+

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -117,9 +117,6 @@ module Petstore
       update_params_for_auth! header_params, query_params, opts[:auth_names]
 
       req_opts = {
-        :method => http_method,
-        :headers => header_params,
-        :params => query_params,
         :params_encoding => @config.params_encoding,
         :timeout => @config.timeout,
         :verbose => @config.debugging
@@ -127,7 +124,6 @@ module Petstore
 
       if [:post, :patch, :put, :delete].include?(http_method)
         req_body = build_request_body(header_params, form_params, opts[:body])
-        req_opts.update :body => req_body
         if @config.debugging
           @config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
         end
@@ -136,6 +132,7 @@ module Petstore
       request.body = req_body
       request.url url
       request.params = query_params
+      request.options = OpenStruct.new(req_opts)
       download_file(request) if opts[:return_type] == 'File'
       request
     end

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -55,7 +55,7 @@ module Petstore
         :client_key => @config.ssl_client_key
       }
 
-      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options) do |conn|
+      connection = Faraday.new(:url => config.base_url, :ssl => ssl_options, :request => {:params_encoder => @config.params_encoder}) do |conn|
         conn.basic_auth(config.username, config.password)
         if opts[:header_params]["Content-Type"] == "multipart/form-data"
           conn.request :multipart
@@ -117,7 +117,7 @@ module Petstore
       update_params_for_auth! header_params, query_params, opts[:auth_names]
 
       req_opts = {
-        :params_encoding => @config.params_encoding,
+        :params_encoder => @config.params_encoder,
         :timeout => @config.timeout,
         :verbose => @config.debugging
       }

--- a/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -91,6 +91,13 @@ module Petstore
     # @return [true, false]
     attr_accessor :client_side_validation
 
+    # Set this to customize parameters encoder of array parameter.
+    # Default to nil. Faraday uses NestedParamsEncoder when nil.
+    #
+    # @see The params_encoder option of Faraday. Related source code:
+    # https://github.com/lostisland/faraday/tree/main/lib/faraday/encoders
+    attr_accessor :params_encoder
+
     ### TLS/SSL setting
     # Set this to false to skip verifying SSL certificate when calling API from https server.
     # Default to true.
@@ -121,6 +128,14 @@ module Petstore
     # Client private key file (for client certificate)
     attr_accessor :ssl_client_key
 
+    # Set this to customize parameters encoder of array parameter.
+    # Default to nil. Faraday uses NestedParamsEncoder when nil.
+    #
+    # @see The params_encoder option of Faraday. Related source code:
+    # https://github.com/lostisland/faraday/tree/main/lib/faraday/encoders
+    attr_accessor :params_encoder
+
+
     # Set this to customize parameters encoding of array parameter with multi collectionFormat.
     # Default to nil.
     #
@@ -149,6 +164,7 @@ module Petstore
       @ssl_ca_file = nil
       @ssl_client_cert = nil
       @ssl_client_key = nil
+      @params_encoder = nil
       @debugging = false
       @inject_format = false
       @force_ending_format = false

--- a/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -157,7 +157,6 @@ module Petstore
       @server_operation_variables = {}
       @api_key = {}
       @api_key_prefix = {}
-      @timeout = 0
       @client_side_validation = true
       @ssl_verify = true
       @ssl_verify_mode = nil
@@ -165,6 +164,7 @@ module Petstore
       @ssl_client_cert = nil
       @ssl_client_key = nil
       @params_encoder = nil
+      @timeout = 60
       @debugging = false
       @inject_format = false
       @force_ending_format = false


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
