### PR TITLE
[Haskell-http-client] Correct fix of no-content endpoints

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
@@ -881,6 +881,7 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
         if (returnType == null || returnType.equals("null")) {
             returnType = "NoContent";
             SetNoContent(op, VENDOR_EXTENSION_X_INLINE_ACCEPT);
+            op.hasProduces = false;
         }
         if (returnType.contains(" ")) {
             returnType = "(" + returnType + ")";


### PR DESCRIPTION
While the fix in #9916 correctly made endpoint types which did not produce content return the `NoContent` type, those endpoint still generated `Produces` instances with the wrong mime types due to not resetting the `hasProduces` variable. This corrects that fix so that the `Produces` instance for `MimeNoContent` is generated instead of any other instance.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
