### PR TITLE
Add @JsonTypeName to jax-rs pojo's in order to allow Jackson to deserialize instances of superclasses

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -5,11 +5,13 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 
 {{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{#description}}/**
  * {{description}}
  **/{{/description}}
 {{#useSwaggerAnnotations}}{{#description}}@ApiModel(description = "{{{description}}}"){{/description}}{{/useSwaggerAnnotations}}
+@JsonTypeName("{{name}}")
 {{>generatedAnnotation}}{{>additionalModelTypeAnnotations}}public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}
 


### PR DESCRIPTION
When generating models with the JavaJaxRS generator Jackson is currently unable to deserialize instances of superclasses if the class name and OpenAPI object name differs. Subclasses deserialize just fine because they are mentioned in the @JsonSubTypes annotation.

This Pull Request adds the @JsonTypeName to all pojo's in order to let Jackson recognize the OpenAPI object name as a discriminator value.