### PR TITLE
Add oneOfProps, allOfProps, anyOfProps to Codegen model

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -49,6 +49,11 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
     public Set<String> oneOf = new TreeSet<String>();
     public Set<String> allOf = new TreeSet<String>();
 
+    // anyOf, oneOf, allOf with full properties/tags (e.g. isString, etc)
+    public List<CodegenProperty> anyOfProps = new ArrayList<>();
+    public List<CodegenProperty> allOfProps = new ArrayList<>();
+    public List<CodegenProperty> oneOfProps = new ArrayList<>();
+
     // The schema name as written in the OpenAPI document.
     public String name;
     // The language-specific name of the class that implements this schema.
@@ -825,6 +830,9 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 Objects.equals(parentModel, that.parentModel) &&
                 Objects.equals(interfaceModels, that.interfaceModels) &&
                 Objects.equals(children, that.children) &&
+                Objects.equals(anyOf, that.anyOfProps) &&
+                Objects.equals(oneOf, that.oneOfProps) &&
+                Objects.equals(allOf, that.allOfProps) &&
                 Objects.equals(anyOf, that.anyOf) &&
                 Objects.equals(oneOf, that.oneOf) &&
                 Objects.equals(allOf, that.allOf) &&
@@ -887,7 +895,7 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
                 getAdditionalPropertiesType(), getMaxProperties(), getMinProperties(), getUniqueItems(), getMaxItems(),
                 getMinItems(), getMaxLength(), getMinLength(), getExclusiveMinimum(), getExclusiveMaximum(), getMinimum(),
                 getMaximum(), getPattern(), getMultipleOf(), getItems(), getAdditionalProperties(), getIsModel(),
-                getAdditionalPropertiesIsAnyType(), hasDiscriminatorWithNonEmptyMapping);
+                getAdditionalPropertiesIsAnyType(), hasDiscriminatorWithNonEmptyMapping, anyOfProps, oneOfProps, allOfProps);
     }
 
     @Override
@@ -903,6 +911,9 @@ public class CodegenModel implements IJsonSchemaValidationProperties {
         sb.append(", anyOf=").append(anyOf);
         sb.append(", oneOf=").append(oneOf);
         sb.append(", allOf=").append(allOf);
+        sb.append(", anyOf=").append(anyOfProps);
+        sb.append(", oneOf=").append(oneOfProps);
+        sb.append(", allOf=").append(allOfProps);
         sb.append(", name='").append(name).append('\'');
         sb.append(", classname='").append(classname).append('\'');
         sb.append(", title='").append(title).append('\'');

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2572,9 +2572,14 @@ public class DefaultCodegen implements CodegenConfig {
                 }
             }
 
+            m.oneOfProps = oneOfProps;
+            m.allOfProps = allOfProps;
+            m.anyOfProps = anyOfProps;
+/*
             m.vendorExtensions.put("x-oneOf-as-properties", oneOfProps);
             m.vendorExtensions.put("x-allOf-as-properties", allOfProps);
             m.vendorExtensions.put("x-anyOf-as-properties", anyOfProps);
+*/
 
             if (parent != null && composed.getAllOf() != null) { // set parent for allOf only
                 m.parentSchema = parentName;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2575,11 +2575,6 @@ public class DefaultCodegen implements CodegenConfig {
             m.oneOfProps = oneOfProps;
             m.allOfProps = allOfProps;
             m.anyOfProps = anyOfProps;
-/*
-            m.vendorExtensions.put("x-oneOf-as-properties", oneOfProps);
-            m.vendorExtensions.put("x-allOf-as-properties", allOfProps);
-            m.vendorExtensions.put("x-anyOf-as-properties", anyOfProps);
-*/
 
             if (parent != null && composed.getAllOf() != null) { // set parent for allOf only
                 m.parentSchema = parentName;


### PR DESCRIPTION
Add oneOfProps, allOfProps, anyOfProps to Codegen model instead of using vendor extensions. 

A follow-up PR to https://github.com/OpenAPITools/openapi-generator/pull/9977

cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
