### PR TITLE
Fix typescript inner array examples

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -1214,7 +1214,7 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
             ArraySchema arrayschema = (ArraySchema) schema;
             Schema itemSchema = arrayschema.getItems();
             String itemModelName = getModelName(itemSchema);
-            if (objExample instanceof Iterable && itemModelName == null) {
+            if (objExample instanceof Iterable && itemSchema.get$ref() == null) {
                 // If the example is already a list, return it directly instead of wrongly wrap it in another list
                 return fullPrefix + objExample.toString() + closeChars;
             }

--- a/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
@@ -631,8 +631,19 @@ components:
         complete:
           type: boolean
           default: false
+        outerArray:
+          type: array
+          title: outer1
+          items:
+            $ref: '#/components/schemas/InnerArray'
       xml:
         name: Order
+    InnerArray:
+      title: inner1
+      type: array
+      items:
+        type: string
+      example: ["item1", "item2"]
     Category:
       title: Pet category
       description: A category for a pet

--- a/samples/openapi3/client/petstore/typescript/builds/default/StoreApi.md
+++ b/samples/openapi3/client/petstore/typescript/builds/default/StoreApi.md
@@ -192,6 +192,9 @@ let body:petstore.StoreApiPlaceOrderRequest = {
     shipDate: new Date('1970-01-01T00:00:00.00Z'),
     status: "placed",
     complete: false,
+    outerArray: [
+      ["item1","item2"],
+    ],
   },
 };
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -7,7 +7,7 @@ export * from './User';
 
 import { ApiResponse } from './ApiResponse';
 import { Category } from './Category';
-import { Order    , OrderStatusEnum    } from './Order';
+import { Order    , OrderStatusEnum     } from './Order';
 import { Pet     , PetStatusEnum   } from './Pet';
 import { Tag } from './Tag';
 import { User } from './User';

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/Order.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/Order.ts
@@ -25,6 +25,7 @@ export class Order {
     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
+    'outerArray'?: Array<Array<string>>;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -63,6 +64,12 @@ export class Order {
             "name": "complete",
             "baseName": "complete",
             "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "outerArray",
+            "baseName": "outerArray",
+            "type": "Array<Array<string>>",
             "format": ""
         }    ];
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Arrays of arrays can lose a level of nesting in Typescript as we check
for model and not references when building the example. This fixes it.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.