### PR TITLE
[go-server] Fix: param names clash with variables, added suffix

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -90,14 +90,14 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{#allParams}}
 	{{#isPathParam}}
 	{{#isLong}}
-	{{paramName}}, err := parseInt64Parameter({{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}}, {{required}})
+	{{paramName}}Param, err := parseInt64Parameter({{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}}, {{required}})
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 	{{/isLong}}
 	{{#isInteger}}
-	{{paramName}}, err := parseInt32Parameter({{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}}, {{required}})
+	{{paramName}}Param, err := parseInt32Parameter({{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}}, {{required}})
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
@@ -105,26 +105,26 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/isInteger}}
 	{{^isLong}}
 	{{^isInteger}}
-	{{paramName}} := {{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}}
+	{{paramName}}Param := {{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}}
 	{{/isInteger}}{{/isLong}}
 	{{/isPathParam}}
 	{{#isQueryParam}}
 	{{#isLong}}
-	{{paramName}}, err := parseInt64Parameter(query.Get("{{baseName}}"), {{required}})
+	{{paramName}}Param, err := parseInt64Parameter(query.Get("{{baseName}}"), {{required}})
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 	{{/isLong}}
 	{{#isInteger}}
-	{{paramName}}, err := parseInt32Parameter(query.Get("{{baseName}}"), {{required}})
+	{{paramName}}Param, err := parseInt32Parameter(query.Get("{{baseName}}"), {{required}})
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 	{{/isInteger}}
 	{{#isBoolean}}
-	{{paramName}}, err := parseBoolParameter(query.Get("{{baseName}}"))
+	{{paramName}}Param, err := parseBoolParameter(query.Get("{{baseName}}"))
 	if err != nil {
 		w.WriteHeader(500)
 		return
@@ -133,15 +133,15 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{^isLong}}
 	{{^isInteger}}
 	{{^isBoolean}}
-	{{paramName}} := {{#isArray}}strings.Split({{/isArray}}query.Get("{{baseName}}"){{#isArray}}, ","){{/isArray}}
+	{{paramName}}Param := {{#isArray}}strings.Split({{/isArray}}query.Get("{{baseName}}"){{#isArray}}, ","){{/isArray}}
 	{{/isBoolean}}
 	{{/isInteger}}
 	{{/isLong}}
 	{{/isQueryParam}}
 	{{#isFormParam}}
 	{{#isFile}}{{#isArray}}
-	{{paramName}}, err := ReadFormFilesToTempFiles(r, "{{baseName}}"){{/isArray}}{{^isArray}}
-	{{paramName}}, err := ReadFormFileToTempFile(r, "{{baseName}}")
+	{{paramName}}Param, err := ReadFormFilesToTempFiles(r, "{{baseName}}"){{/isArray}}{{^isArray}}
+	{{paramName}}Param, err := ReadFormFileToTempFile(r, "{{baseName}}")
 	{{/isArray}}
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -149,16 +149,16 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	}
 	{{/isFile}}
 	{{#isLong}}{{#isArray}}
-	{{paramName}}, err := parseInt64ArrayParameter(r.FormValue("{{baseName}}"), ",", {{required}}){{/isArray}}{{^isArray}}
-	{{paramName}}, err := parseInt64Parameter(r.FormValue("{{baseName}}"), {{required}}){{/isArray}}
+	{{paramName}}Param, err := parseInt64ArrayParameter(r.FormValue("{{baseName}}"), ",", {{required}}){{/isArray}}{{^isArray}}
+	{{paramName}}Param, err := parseInt64Parameter(r.FormValue("{{baseName}}"), {{required}}){{/isArray}}
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 	{{/isLong}}
 	{{#isInteger}}{{#isArray}}
-	{{paramName}}, err := parseInt32ArrayParameter(r.FormValue("{{baseName}}"), ",", {{required}}){{/isArray}}{{^isArray}}
-	{{paramName}}, err := parseInt32Parameter(r.FormValue("{{baseName}}"), {{required}}){{/isArray}}
+	{{paramName}}Param, err := parseInt32ArrayParameter(r.FormValue("{{baseName}}"), ",", {{required}}){{/isArray}}{{^isArray}}
+	{{paramName}}Param, err := parseInt32Parameter(r.FormValue("{{baseName}}"), {{required}}){{/isArray}}
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
@@ -166,26 +166,26 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/isInteger}}
 	{{^isFile}}
 	{{^isLong}}
-	{{paramName}} := r.FormValue("{{baseName}}")
+	{{paramName}}Param := r.FormValue("{{baseName}}")
 	{{/isLong}}
 	{{/isFile}}
 	{{/isFormParam}}
 	{{#isHeaderParam}}
-	{{paramName}} := r.Header.Get("{{baseName}}")
+	{{paramName}}Param := r.Header.Get("{{baseName}}")
 	{{/isHeaderParam}}
 	{{#isBodyParam}}
-	{{paramName}} := {{dataType}}{}
+	{{paramName}}Param := {{dataType}}{}
 	d := json.NewDecoder(r.Body)
 	{{^isAdditionalPropertiesTrue}}
 	d.DisallowUnknownFields()
 	{{/isAdditionalPropertiesTrue}}
-	if err := d.Decode(&{{paramName}}); err != nil {
+	if err := d.Decode(&{{paramName}}Param); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 	{{#isArray}}
 		{{#items.isModel}}
-	for _, el := range {{paramName}} {
+	for _, el := range {{paramName}}Param {
 		if err := Assert{{baseType}}Required(el); err != nil {
 			c.errorHandler(w, r, err, nil)
 			return
@@ -195,7 +195,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/isArray}}
 	{{^isArray}}
 		{{#isModel}}
-	if err := Assert{{baseType}}Required({{paramName}}); err != nil {
+	if err := Assert{{baseType}}Required({{paramName}}Param); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
@@ -203,7 +203,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/isArray}}
 	{{/isBodyParam}}
 	{{/allParams}}
-	result, err := c.service.{{nickname}}(r.Context(){{#allParams}}, {{paramName}}{{/allParams}})
+	result, err := c.service.{{nickname}}(r.Context(){{#allParams}}, {{paramName}}Param{{/allParams}})
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -103,18 +103,18 @@ func (c *PetApiController) Routes() Routes {
 
 // AddPet - Add a new pet to the store
 func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
-	pet := Pet{}
+	petParam := Pet{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&pet); err != nil {
+	if err := d.Decode(&petParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertPetRequired(pet); err != nil {
+	if err := AssertPetRequired(petParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.AddPet(r.Context(), pet)
+	result, err := c.service.AddPet(r.Context(), petParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -128,14 +128,14 @@ func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
 // DeletePet - Deletes a pet
 func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	petId, err := parseInt64Parameter(params["petId"], true)
+	petIdParam, err := parseInt64Parameter(params["petId"], true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-	apiKey := r.Header.Get("api_key")
-	result, err := c.service.DeletePet(r.Context(), petId, apiKey)
+	apiKeyParam := r.Header.Get("api_key")
+	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -149,8 +149,8 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 // FindPetsByStatus - Finds Pets by status
 func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
-	status := strings.Split(query.Get("status"), ",")
-	result, err := c.service.FindPetsByStatus(r.Context(), status)
+	statusParam := strings.Split(query.Get("status"), ",")
+	result, err := c.service.FindPetsByStatus(r.Context(), statusParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -165,8 +165,8 @@ func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 // Deprecated
 func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
-	tags := strings.Split(query.Get("tags"), ",")
-	result, err := c.service.FindPetsByTags(r.Context(), tags)
+	tagsParam := strings.Split(query.Get("tags"), ",")
+	result, err := c.service.FindPetsByTags(r.Context(), tagsParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -180,13 +180,13 @@ func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 // GetPetById - Find pet by ID
 func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	petId, err := parseInt64Parameter(params["petId"], true)
+	petIdParam, err := parseInt64Parameter(params["petId"], true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-	result, err := c.service.GetPetById(r.Context(), petId)
+	result, err := c.service.GetPetById(r.Context(), petIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -199,18 +199,18 @@ func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
 
 // UpdatePet - Update an existing pet
 func (c *PetApiController) UpdatePet(w http.ResponseWriter, r *http.Request) {
-	pet := Pet{}
+	petParam := Pet{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&pet); err != nil {
+	if err := d.Decode(&petParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertPetRequired(pet); err != nil {
+	if err := AssertPetRequired(petParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.UpdatePet(r.Context(), pet)
+	result, err := c.service.UpdatePet(r.Context(), petParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -228,15 +228,15 @@ func (c *PetApiController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	params := mux.Vars(r)
-	petId, err := parseInt64Parameter(params["petId"], true)
+	petIdParam, err := parseInt64Parameter(params["petId"], true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-				name := r.FormValue("name")
-				status := r.FormValue("status")
-	result, err := c.service.UpdatePetWithForm(r.Context(), petId, name, status)
+				nameParam := r.FormValue("name")
+				statusParam := r.FormValue("status")
+	result, err := c.service.UpdatePetWithForm(r.Context(), petIdParam, nameParam, statusParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -254,20 +254,20 @@ func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	params := mux.Vars(r)
-	petId, err := parseInt64Parameter(params["petId"], true)
+	petIdParam, err := parseInt64Parameter(params["petId"], true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-				additionalMetadata := r.FormValue("additionalMetadata")
+				additionalMetadataParam := r.FormValue("additionalMetadata")
 	
-	file, err := ReadFormFileToTempFile(r, "file")
+	fileParam, err := ReadFormFileToTempFile(r, "file")
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-			result, err := c.service.UploadFile(r.Context(), petId, additionalMetadata, file)
+			result, err := c.service.UploadFile(r.Context(), petIdParam, additionalMetadataParam, fileParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -80,9 +80,9 @@ func (c *StoreApiController) Routes() Routes {
 // DeleteOrder - Delete purchase order by ID
 func (c *StoreApiController) DeleteOrder(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	orderId := params["orderId"]
+	orderIdParam := params["orderId"]
 	
-	result, err := c.service.DeleteOrder(r.Context(), orderId)
+	result, err := c.service.DeleteOrder(r.Context(), orderIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -109,13 +109,13 @@ func (c *StoreApiController) GetInventory(w http.ResponseWriter, r *http.Request
 // GetOrderById - Find purchase order by ID
 func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	orderId, err := parseInt64Parameter(params["orderId"], true)
+	orderIdParam, err := parseInt64Parameter(params["orderId"], true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-	result, err := c.service.GetOrderById(r.Context(), orderId)
+	result, err := c.service.GetOrderById(r.Context(), orderIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -128,18 +128,18 @@ func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request
 
 // PlaceOrder - Place an order for a pet
 func (c *StoreApiController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
-	order := Order{}
+	orderParam := Order{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&order); err != nil {
+	if err := d.Decode(&orderParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertOrderRequired(order); err != nil {
+	if err := AssertOrderRequired(orderParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.PlaceOrder(r.Context(), order)
+	result, err := c.service.PlaceOrder(r.Context(), orderParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -103,18 +103,18 @@ func (c *UserApiController) Routes() Routes {
 
 // CreateUser - Create user
 func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
-	user := User{}
+	userParam := User{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&user); err != nil {
+	if err := d.Decode(&userParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertUserRequired(user); err != nil {
+	if err := AssertUserRequired(userParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.CreateUser(r.Context(), user)
+	result, err := c.service.CreateUser(r.Context(), userParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -127,20 +127,20 @@ func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
 
 // CreateUsersWithArrayInput - Creates list of users with given input array
 func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *http.Request) {
-	user := []User{}
+	userParam := []User{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&user); err != nil {
+	if err := d.Decode(&userParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	for _, el := range user {
+	for _, el := range userParam {
 		if err := AssertUserRequired(el); err != nil {
 			c.errorHandler(w, r, err, nil)
 			return
 		}
 	}
-	result, err := c.service.CreateUsersWithArrayInput(r.Context(), user)
+	result, err := c.service.CreateUsersWithArrayInput(r.Context(), userParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -153,20 +153,20 @@ func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 
 // CreateUsersWithListInput - Creates list of users with given input array
 func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *http.Request) {
-	user := []User{}
+	userParam := []User{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&user); err != nil {
+	if err := d.Decode(&userParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	for _, el := range user {
+	for _, el := range userParam {
 		if err := AssertUserRequired(el); err != nil {
 			c.errorHandler(w, r, err, nil)
 			return
 		}
 	}
-	result, err := c.service.CreateUsersWithListInput(r.Context(), user)
+	result, err := c.service.CreateUsersWithListInput(r.Context(), userParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -180,9 +180,9 @@ func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 // DeleteUser - Delete user
 func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	username := params["username"]
+	usernameParam := params["username"]
 	
-	result, err := c.service.DeleteUser(r.Context(), username)
+	result, err := c.service.DeleteUser(r.Context(), usernameParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -196,9 +196,9 @@ func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 // GetUserByName - Get user by user name
 func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	username := params["username"]
+	usernameParam := params["username"]
 	
-	result, err := c.service.GetUserByName(r.Context(), username)
+	result, err := c.service.GetUserByName(r.Context(), usernameParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -212,9 +212,9 @@ func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request
 // LoginUser - Logs user into the system
 func (c *UserApiController) LoginUser(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
-	username := query.Get("username")
-	password := query.Get("password")
-	result, err := c.service.LoginUser(r.Context(), username, password)
+	usernameParam := query.Get("username")
+	passwordParam := query.Get("password")
+	result, err := c.service.LoginUser(r.Context(), usernameParam, passwordParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -241,20 +241,20 @@ func (c *UserApiController) LogoutUser(w http.ResponseWriter, r *http.Request) {
 // UpdateUser - Updated user
 func (c *UserApiController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	username := params["username"]
+	usernameParam := params["username"]
 	
-	user := User{}
+	userParam := User{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&user); err != nil {
+	if err := d.Decode(&userParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertUserRequired(user); err != nil {
+	if err := AssertUserRequired(userParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.UpdateUser(r.Context(), username, user)
+	result, err := c.service.UpdateUser(r.Context(), usernameParam, userParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-chi-server/go/api_pet.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet.go
@@ -103,18 +103,18 @@ func (c *PetApiController) Routes() Routes {
 
 // AddPet - Add a new pet to the store
 func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
-	pet := Pet{}
+	petParam := Pet{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&pet); err != nil {
+	if err := d.Decode(&petParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertPetRequired(pet); err != nil {
+	if err := AssertPetRequired(petParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.AddPet(r.Context(), pet)
+	result, err := c.service.AddPet(r.Context(), petParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -127,14 +127,14 @@ func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
 
 // DeletePet - Deletes a pet
 func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
-	petId, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
+	petIdParam, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-	apiKey := r.Header.Get("api_key")
-	result, err := c.service.DeletePet(r.Context(), petId, apiKey)
+	apiKeyParam := r.Header.Get("api_key")
+	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -148,8 +148,8 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 // FindPetsByStatus - Finds Pets by status
 func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
-	status := strings.Split(query.Get("status"), ",")
-	result, err := c.service.FindPetsByStatus(r.Context(), status)
+	statusParam := strings.Split(query.Get("status"), ",")
+	result, err := c.service.FindPetsByStatus(r.Context(), statusParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -164,8 +164,8 @@ func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 // Deprecated
 func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
-	tags := strings.Split(query.Get("tags"), ",")
-	result, err := c.service.FindPetsByTags(r.Context(), tags)
+	tagsParam := strings.Split(query.Get("tags"), ",")
+	result, err := c.service.FindPetsByTags(r.Context(), tagsParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -178,13 +178,13 @@ func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 
 // GetPetById - Find pet by ID
 func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
-	petId, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
+	petIdParam, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-	result, err := c.service.GetPetById(r.Context(), petId)
+	result, err := c.service.GetPetById(r.Context(), petIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -197,18 +197,18 @@ func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
 
 // UpdatePet - Update an existing pet
 func (c *PetApiController) UpdatePet(w http.ResponseWriter, r *http.Request) {
-	pet := Pet{}
+	petParam := Pet{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&pet); err != nil {
+	if err := d.Decode(&petParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertPetRequired(pet); err != nil {
+	if err := AssertPetRequired(petParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.UpdatePet(r.Context(), pet)
+	result, err := c.service.UpdatePet(r.Context(), petParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -225,15 +225,15 @@ func (c *PetApiController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	petId, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
+	petIdParam, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-				name := r.FormValue("name")
-				status := r.FormValue("status")
-	result, err := c.service.UpdatePetWithForm(r.Context(), petId, name, status)
+				nameParam := r.FormValue("name")
+				statusParam := r.FormValue("status")
+	result, err := c.service.UpdatePetWithForm(r.Context(), petIdParam, nameParam, statusParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -250,20 +250,20 @@ func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	petId, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
+	petIdParam, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-				additionalMetadata := r.FormValue("additionalMetadata")
+				additionalMetadataParam := r.FormValue("additionalMetadata")
 	
-	file, err := ReadFormFileToTempFile(r, "file")
+	fileParam, err := ReadFormFileToTempFile(r, "file")
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-			result, err := c.service.UploadFile(r.Context(), petId, additionalMetadata, file)
+			result, err := c.service.UploadFile(r.Context(), petIdParam, additionalMetadataParam, fileParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-chi-server/go/api_store.go
+++ b/samples/server/petstore/go-chi-server/go/api_store.go
@@ -79,9 +79,9 @@ func (c *StoreApiController) Routes() Routes {
 
 // DeleteOrder - Delete purchase order by ID
 func (c *StoreApiController) DeleteOrder(w http.ResponseWriter, r *http.Request) {
-	orderId := chi.URLParam(r, "orderId")
+	orderIdParam := chi.URLParam(r, "orderId")
 	
-	result, err := c.service.DeleteOrder(r.Context(), orderId)
+	result, err := c.service.DeleteOrder(r.Context(), orderIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -107,13 +107,13 @@ func (c *StoreApiController) GetInventory(w http.ResponseWriter, r *http.Request
 
 // GetOrderById - Find purchase order by ID
 func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request) {
-	orderId, err := parseInt64Parameter(chi.URLParam(r, "orderId"), true)
+	orderIdParam, err := parseInt64Parameter(chi.URLParam(r, "orderId"), true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-	result, err := c.service.GetOrderById(r.Context(), orderId)
+	result, err := c.service.GetOrderById(r.Context(), orderIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -126,18 +126,18 @@ func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request
 
 // PlaceOrder - Place an order for a pet
 func (c *StoreApiController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
-	order := Order{}
+	orderParam := Order{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&order); err != nil {
+	if err := d.Decode(&orderParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertOrderRequired(order); err != nil {
+	if err := AssertOrderRequired(orderParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.PlaceOrder(r.Context(), order)
+	result, err := c.service.PlaceOrder(r.Context(), orderParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-chi-server/go/api_user.go
+++ b/samples/server/petstore/go-chi-server/go/api_user.go
@@ -103,18 +103,18 @@ func (c *UserApiController) Routes() Routes {
 
 // CreateUser - Create user
 func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
-	user := User{}
+	userParam := User{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&user); err != nil {
+	if err := d.Decode(&userParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertUserRequired(user); err != nil {
+	if err := AssertUserRequired(userParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.CreateUser(r.Context(), user)
+	result, err := c.service.CreateUser(r.Context(), userParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -127,20 +127,20 @@ func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
 
 // CreateUsersWithArrayInput - Creates list of users with given input array
 func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *http.Request) {
-	user := []User{}
+	userParam := []User{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&user); err != nil {
+	if err := d.Decode(&userParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	for _, el := range user {
+	for _, el := range userParam {
 		if err := AssertUserRequired(el); err != nil {
 			c.errorHandler(w, r, err, nil)
 			return
 		}
 	}
-	result, err := c.service.CreateUsersWithArrayInput(r.Context(), user)
+	result, err := c.service.CreateUsersWithArrayInput(r.Context(), userParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -153,20 +153,20 @@ func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 
 // CreateUsersWithListInput - Creates list of users with given input array
 func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *http.Request) {
-	user := []User{}
+	userParam := []User{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&user); err != nil {
+	if err := d.Decode(&userParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	for _, el := range user {
+	for _, el := range userParam {
 		if err := AssertUserRequired(el); err != nil {
 			c.errorHandler(w, r, err, nil)
 			return
 		}
 	}
-	result, err := c.service.CreateUsersWithListInput(r.Context(), user)
+	result, err := c.service.CreateUsersWithListInput(r.Context(), userParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -179,9 +179,9 @@ func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 
 // DeleteUser - Delete user
 func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) {
-	username := chi.URLParam(r, "username")
+	usernameParam := chi.URLParam(r, "username")
 	
-	result, err := c.service.DeleteUser(r.Context(), username)
+	result, err := c.service.DeleteUser(r.Context(), usernameParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -194,9 +194,9 @@ func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 
 // GetUserByName - Get user by user name
 func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request) {
-	username := chi.URLParam(r, "username")
+	usernameParam := chi.URLParam(r, "username")
 	
-	result, err := c.service.GetUserByName(r.Context(), username)
+	result, err := c.service.GetUserByName(r.Context(), usernameParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -210,9 +210,9 @@ func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request
 // LoginUser - Logs user into the system
 func (c *UserApiController) LoginUser(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
-	username := query.Get("username")
-	password := query.Get("password")
-	result, err := c.service.LoginUser(r.Context(), username, password)
+	usernameParam := query.Get("username")
+	passwordParam := query.Get("password")
+	result, err := c.service.LoginUser(r.Context(), usernameParam, passwordParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -238,20 +238,20 @@ func (c *UserApiController) LogoutUser(w http.ResponseWriter, r *http.Request) {
 
 // UpdateUser - Updated user
 func (c *UserApiController) UpdateUser(w http.ResponseWriter, r *http.Request) {
-	username := chi.URLParam(r, "username")
+	usernameParam := chi.URLParam(r, "username")
 	
-	user := User{}
+	userParam := User{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&user); err != nil {
+	if err := d.Decode(&userParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertUserRequired(user); err != nil {
+	if err := AssertUserRequired(userParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.UpdateUser(r.Context(), username, user)
+	result, err := c.service.UpdateUser(r.Context(), usernameParam, userParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-server-required/go/api_pet.go
+++ b/samples/server/petstore/go-server-required/go/api_pet.go
@@ -103,18 +103,18 @@ func (c *PetApiController) Routes() Routes {
 
 // AddPet - Add a new pet to the store
 func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
-	pet := Pet{}
+	petParam := Pet{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&pet); err != nil {
+	if err := d.Decode(&petParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertPetRequired(pet); err != nil {
+	if err := AssertPetRequired(petParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.AddPet(r.Context(), pet)
+	result, err := c.service.AddPet(r.Context(), petParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -127,14 +127,14 @@ func (c *PetApiController) AddPet(w http.ResponseWriter, r *http.Request) {
 
 // DeletePet - Deletes a pet
 func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
-	petId, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
+	petIdParam, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-	apiKey := r.Header.Get("api_key")
-	result, err := c.service.DeletePet(r.Context(), petId, apiKey)
+	apiKeyParam := r.Header.Get("api_key")
+	result, err := c.service.DeletePet(r.Context(), petIdParam, apiKeyParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -148,8 +148,8 @@ func (c *PetApiController) DeletePet(w http.ResponseWriter, r *http.Request) {
 // FindPetsByStatus - Finds Pets by status
 func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
-	status := strings.Split(query.Get("status"), ",")
-	result, err := c.service.FindPetsByStatus(r.Context(), status)
+	statusParam := strings.Split(query.Get("status"), ",")
+	result, err := c.service.FindPetsByStatus(r.Context(), statusParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -164,8 +164,8 @@ func (c *PetApiController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 // Deprecated
 func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
-	tags := strings.Split(query.Get("tags"), ",")
-	result, err := c.service.FindPetsByTags(r.Context(), tags)
+	tagsParam := strings.Split(query.Get("tags"), ",")
+	result, err := c.service.FindPetsByTags(r.Context(), tagsParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -178,13 +178,13 @@ func (c *PetApiController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 
 // GetPetById - Find pet by ID
 func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
-	petId, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
+	petIdParam, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-	result, err := c.service.GetPetById(r.Context(), petId)
+	result, err := c.service.GetPetById(r.Context(), petIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -197,18 +197,18 @@ func (c *PetApiController) GetPetById(w http.ResponseWriter, r *http.Request) {
 
 // UpdatePet - Update an existing pet
 func (c *PetApiController) UpdatePet(w http.ResponseWriter, r *http.Request) {
-	pet := Pet{}
+	petParam := Pet{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&pet); err != nil {
+	if err := d.Decode(&petParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertPetRequired(pet); err != nil {
+	if err := AssertPetRequired(petParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.UpdatePet(r.Context(), pet)
+	result, err := c.service.UpdatePet(r.Context(), petParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -225,15 +225,15 @@ func (c *PetApiController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	petId, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
+	petIdParam, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-				name := r.FormValue("name")
-				status := r.FormValue("status")
-	result, err := c.service.UpdatePetWithForm(r.Context(), petId, name, status)
+				nameParam := r.FormValue("name")
+				statusParam := r.FormValue("status")
+	result, err := c.service.UpdatePetWithForm(r.Context(), petIdParam, nameParam, statusParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -250,20 +250,20 @@ func (c *PetApiController) UploadFile(w http.ResponseWriter, r *http.Request) {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	petId, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
+	petIdParam, err := parseInt64Parameter(chi.URLParam(r, "petId"), true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-				additionalMetadata := r.FormValue("additionalMetadata")
+				additionalMetadataParam := r.FormValue("additionalMetadata")
 	
-	file, err := ReadFormFileToTempFile(r, "file")
+	fileParam, err := ReadFormFileToTempFile(r, "file")
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-			result, err := c.service.UploadFile(r.Context(), petId, additionalMetadata, file)
+			result, err := c.service.UploadFile(r.Context(), petIdParam, additionalMetadataParam, fileParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-server-required/go/api_store.go
+++ b/samples/server/petstore/go-server-required/go/api_store.go
@@ -79,9 +79,9 @@ func (c *StoreApiController) Routes() Routes {
 
 // DeleteOrder - Delete purchase order by ID
 func (c *StoreApiController) DeleteOrder(w http.ResponseWriter, r *http.Request) {
-	orderId := chi.URLParam(r, "orderId")
+	orderIdParam := chi.URLParam(r, "orderId")
 	
-	result, err := c.service.DeleteOrder(r.Context(), orderId)
+	result, err := c.service.DeleteOrder(r.Context(), orderIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -107,13 +107,13 @@ func (c *StoreApiController) GetInventory(w http.ResponseWriter, r *http.Request
 
 // GetOrderById - Find purchase order by ID
 func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request) {
-	orderId, err := parseInt64Parameter(chi.URLParam(r, "orderId"), true)
+	orderIdParam, err := parseInt64Parameter(chi.URLParam(r, "orderId"), true)
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
 
-	result, err := c.service.GetOrderById(r.Context(), orderId)
+	result, err := c.service.GetOrderById(r.Context(), orderIdParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -126,18 +126,18 @@ func (c *StoreApiController) GetOrderById(w http.ResponseWriter, r *http.Request
 
 // PlaceOrder - Place an order for a pet
 func (c *StoreApiController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
-	order := Order{}
+	orderParam := Order{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&order); err != nil {
+	if err := d.Decode(&orderParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertOrderRequired(order); err != nil {
+	if err := AssertOrderRequired(orderParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.PlaceOrder(r.Context(), order)
+	result, err := c.service.PlaceOrder(r.Context(), orderParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-server-required/go/api_user.go
+++ b/samples/server/petstore/go-server-required/go/api_user.go
@@ -103,18 +103,18 @@ func (c *UserApiController) Routes() Routes {
 
 // CreateUser - Create user
 func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
-	user := User{}
+	userParam := User{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&user); err != nil {
+	if err := d.Decode(&userParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertUserRequired(user); err != nil {
+	if err := AssertUserRequired(userParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.CreateUser(r.Context(), user)
+	result, err := c.service.CreateUser(r.Context(), userParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -127,20 +127,20 @@ func (c *UserApiController) CreateUser(w http.ResponseWriter, r *http.Request) {
 
 // CreateUsersWithArrayInput - Creates list of users with given input array
 func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *http.Request) {
-	user := []User{}
+	userParam := []User{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&user); err != nil {
+	if err := d.Decode(&userParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	for _, el := range user {
+	for _, el := range userParam {
 		if err := AssertUserRequired(el); err != nil {
 			c.errorHandler(w, r, err, nil)
 			return
 		}
 	}
-	result, err := c.service.CreateUsersWithArrayInput(r.Context(), user)
+	result, err := c.service.CreateUsersWithArrayInput(r.Context(), userParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -153,20 +153,20 @@ func (c *UserApiController) CreateUsersWithArrayInput(w http.ResponseWriter, r *
 
 // CreateUsersWithListInput - Creates list of users with given input array
 func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *http.Request) {
-	user := []User{}
+	userParam := []User{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&user); err != nil {
+	if err := d.Decode(&userParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	for _, el := range user {
+	for _, el := range userParam {
 		if err := AssertUserRequired(el); err != nil {
 			c.errorHandler(w, r, err, nil)
 			return
 		}
 	}
-	result, err := c.service.CreateUsersWithListInput(r.Context(), user)
+	result, err := c.service.CreateUsersWithListInput(r.Context(), userParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -179,9 +179,9 @@ func (c *UserApiController) CreateUsersWithListInput(w http.ResponseWriter, r *h
 
 // DeleteUser - Delete user
 func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) {
-	username := chi.URLParam(r, "username")
+	usernameParam := chi.URLParam(r, "username")
 	
-	result, err := c.service.DeleteUser(r.Context(), username)
+	result, err := c.service.DeleteUser(r.Context(), usernameParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -194,9 +194,9 @@ func (c *UserApiController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 
 // GetUserByName - Get user by user name
 func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request) {
-	username := chi.URLParam(r, "username")
+	usernameParam := chi.URLParam(r, "username")
 	
-	result, err := c.service.GetUserByName(r.Context(), username)
+	result, err := c.service.GetUserByName(r.Context(), usernameParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -210,9 +210,9 @@ func (c *UserApiController) GetUserByName(w http.ResponseWriter, r *http.Request
 // LoginUser - Logs user into the system
 func (c *UserApiController) LoginUser(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
-	username := query.Get("username")
-	password := query.Get("password")
-	result, err := c.service.LoginUser(r.Context(), username, password)
+	usernameParam := query.Get("username")
+	passwordParam := query.Get("password")
+	result, err := c.service.LoginUser(r.Context(), usernameParam, passwordParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -238,20 +238,20 @@ func (c *UserApiController) LogoutUser(w http.ResponseWriter, r *http.Request) {
 
 // UpdateUser - Updated user
 func (c *UserApiController) UpdateUser(w http.ResponseWriter, r *http.Request) {
-	username := chi.URLParam(r, "username")
+	usernameParam := chi.URLParam(r, "username")
 	
-	user := User{}
+	userParam := User{}
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
-	if err := d.Decode(&user); err != nil {
+	if err := d.Decode(&userParam); err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	if err := AssertUserRequired(user); err != nil {
+	if err := AssertUserRequired(userParam); err != nil {
 		c.errorHandler(w, r, err, nil)
 		return
 	}
-	result, err := c.service.UpdateUser(r.Context(), username, user)
+	result, err := c.service.UpdateUser(r.Context(), usernameParam, userParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Controller contains variables named `query` `params` and `err`.
If the param name is any of the above, an error would occur.

Only controller is affected, so I've added `Param` suffix to all paramName in the controller

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Hi @antihax @grokify @kemokemo @jirikuncar @ph4r5h4d, please help to take a look at this PR