### PR TITLE
Handle nullable items in Go arrays

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -350,6 +350,9 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             } else {
                 typDecl = "interface{}";
             }
+	    if (Boolean.TRUE.equals(inner.getNullable())) {
+		typDecl = "*" + typDecl;
+	    }
             return "[]" + typDecl;
         } else if (ModelUtils.isMapSchema(p)) {
             Schema inner = getAdditionalProperties(p);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -544,6 +544,10 @@ public class GoClientCodegen extends AbstractGoCodegen {
             if (modelMaps.containsKey(dataType)) {
                 prefix = "[]" + goImportAlias + "." + dataType;
             }
+            if (codegenProperty.items.isNullable) {
+                // We can't easily generate a pointer inline, so just use nil in that case
+                return prefix + "{nil}";
+            }
             return prefix + "{" + constructExampleCode(codegenProperty.items, modelMaps, processedModelMap) + "}";
         } else if (codegenProperty.isMap) { // map
             String prefix = codegenProperty.dataType;

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/NullableClass.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/NullableClass.md
@@ -283,20 +283,20 @@ HasArrayNullableProp returns a boolean if a field has been set.
 UnsetArrayNullableProp ensures that no value is present for ArrayNullableProp, not even an explicit nil
 ### GetArrayAndItemsNullableProp
 
-`func (o *NullableClass) GetArrayAndItemsNullableProp() []map[string]interface{}`
+`func (o *NullableClass) GetArrayAndItemsNullableProp() []*map[string]interface{}`
 
 GetArrayAndItemsNullableProp returns the ArrayAndItemsNullableProp field if non-nil, zero value otherwise.
 
 ### GetArrayAndItemsNullablePropOk
 
-`func (o *NullableClass) GetArrayAndItemsNullablePropOk() (*[]map[string]interface{}, bool)`
+`func (o *NullableClass) GetArrayAndItemsNullablePropOk() (*[]*map[string]interface{}, bool)`
 
 GetArrayAndItemsNullablePropOk returns a tuple with the ArrayAndItemsNullableProp field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetArrayAndItemsNullableProp
 
-`func (o *NullableClass) SetArrayAndItemsNullableProp(v []map[string]interface{})`
+`func (o *NullableClass) SetArrayAndItemsNullableProp(v []*map[string]interface{})`
 
 SetArrayAndItemsNullableProp sets ArrayAndItemsNullableProp field to given value.
 
@@ -318,20 +318,20 @@ HasArrayAndItemsNullableProp returns a boolean if a field has been set.
 UnsetArrayAndItemsNullableProp ensures that no value is present for ArrayAndItemsNullableProp, not even an explicit nil
 ### GetArrayItemsNullable
 
-`func (o *NullableClass) GetArrayItemsNullable() []map[string]interface{}`
+`func (o *NullableClass) GetArrayItemsNullable() []*map[string]interface{}`
 
 GetArrayItemsNullable returns the ArrayItemsNullable field if non-nil, zero value otherwise.
 
 ### GetArrayItemsNullableOk
 
-`func (o *NullableClass) GetArrayItemsNullableOk() (*[]map[string]interface{}, bool)`
+`func (o *NullableClass) GetArrayItemsNullableOk() (*[]*map[string]interface{}, bool)`
 
 GetArrayItemsNullableOk returns a tuple with the ArrayItemsNullable field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetArrayItemsNullable
 
-`func (o *NullableClass) SetArrayItemsNullable(v []map[string]interface{})`
+`func (o *NullableClass) SetArrayItemsNullable(v []*map[string]interface{})`
 
 SetArrayItemsNullable sets ArrayItemsNullable field to given value.
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_class.go
@@ -24,8 +24,8 @@ type NullableClass struct {
 	DateProp NullableString `json:"date_prop,omitempty"`
 	DatetimeProp NullableTime `json:"datetime_prop,omitempty"`
 	ArrayNullableProp []map[string]interface{} `json:"array_nullable_prop,omitempty"`
-	ArrayAndItemsNullableProp []map[string]interface{} `json:"array_and_items_nullable_prop,omitempty"`
-	ArrayItemsNullable *[]map[string]interface{} `json:"array_items_nullable,omitempty"`
+	ArrayAndItemsNullableProp []*map[string]interface{} `json:"array_and_items_nullable_prop,omitempty"`
+	ArrayItemsNullable *[]*map[string]interface{} `json:"array_items_nullable,omitempty"`
 	ObjectNullableProp map[string]map[string]interface{} `json:"object_nullable_prop,omitempty"`
 	ObjectAndItemsNullableProp map[string]map[string]interface{} `json:"object_and_items_nullable_prop,omitempty"`
 	ObjectItemsNullable *map[string]map[string]interface{} `json:"object_items_nullable,omitempty"`
@@ -338,9 +338,9 @@ func (o *NullableClass) SetArrayNullableProp(v []map[string]interface{}) {
 }
 
 // GetArrayAndItemsNullableProp returns the ArrayAndItemsNullableProp field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *NullableClass) GetArrayAndItemsNullableProp() []map[string]interface{} {
+func (o *NullableClass) GetArrayAndItemsNullableProp() []*map[string]interface{} {
 	if o == nil  {
-		var ret []map[string]interface{}
+		var ret []*map[string]interface{}
 		return ret
 	}
 	return o.ArrayAndItemsNullableProp
@@ -349,7 +349,7 @@ func (o *NullableClass) GetArrayAndItemsNullableProp() []map[string]interface{} 
 // GetArrayAndItemsNullablePropOk returns a tuple with the ArrayAndItemsNullableProp field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *NullableClass) GetArrayAndItemsNullablePropOk() (*[]map[string]interface{}, bool) {
+func (o *NullableClass) GetArrayAndItemsNullablePropOk() (*[]*map[string]interface{}, bool) {
 	if o == nil || o.ArrayAndItemsNullableProp == nil {
 		return nil, false
 	}
@@ -365,15 +365,15 @@ func (o *NullableClass) HasArrayAndItemsNullableProp() bool {
 	return false
 }
 
-// SetArrayAndItemsNullableProp gets a reference to the given []map[string]interface{} and assigns it to the ArrayAndItemsNullableProp field.
-func (o *NullableClass) SetArrayAndItemsNullableProp(v []map[string]interface{}) {
+// SetArrayAndItemsNullableProp gets a reference to the given []*map[string]interface{} and assigns it to the ArrayAndItemsNullableProp field.
+func (o *NullableClass) SetArrayAndItemsNullableProp(v []*map[string]interface{}) {
 	o.ArrayAndItemsNullableProp = v
 }
 
 // GetArrayItemsNullable returns the ArrayItemsNullable field value if set, zero value otherwise.
-func (o *NullableClass) GetArrayItemsNullable() []map[string]interface{} {
+func (o *NullableClass) GetArrayItemsNullable() []*map[string]interface{} {
 	if o == nil || o.ArrayItemsNullable == nil {
-		var ret []map[string]interface{}
+		var ret []*map[string]interface{}
 		return ret
 	}
 	return *o.ArrayItemsNullable
@@ -381,7 +381,7 @@ func (o *NullableClass) GetArrayItemsNullable() []map[string]interface{} {
 
 // GetArrayItemsNullableOk returns a tuple with the ArrayItemsNullable field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *NullableClass) GetArrayItemsNullableOk() (*[]map[string]interface{}, bool) {
+func (o *NullableClass) GetArrayItemsNullableOk() (*[]*map[string]interface{}, bool) {
 	if o == nil || o.ArrayItemsNullable == nil {
 		return nil, false
 	}
@@ -397,8 +397,8 @@ func (o *NullableClass) HasArrayItemsNullable() bool {
 	return false
 }
 
-// SetArrayItemsNullable gets a reference to the given []map[string]interface{} and assigns it to the ArrayItemsNullable field.
-func (o *NullableClass) SetArrayItemsNullable(v []map[string]interface{}) {
+// SetArrayItemsNullable gets a reference to the given []*map[string]interface{} and assigns it to the ArrayItemsNullable field.
+func (o *NullableClass) SetArrayItemsNullable(v []*map[string]interface{}) {
 	o.ArrayItemsNullable = &v
 }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

If an item in a go array is nullable, we want to represent it as a pointer,
otherwise it will be deserialized with a default value and it will be
impossible to differentiate it from null.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.