### PR TITLE
Fix php enum default value initialization

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -195,7 +195,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         if (additionalProperties.containsKey(CodegenConstants.GIT_USER_ID)) {
             this.setGitUserId((String) additionalProperties.get(CodegenConstants.GIT_USER_ID));
         }
-        
+
         if (additionalProperties.containsKey(CodegenConstants.GIT_REPO_ID)) {
             this.setGitRepoId((String) additionalProperties.get(CodegenConstants.GIT_REPO_ID));
         }
@@ -631,7 +631,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
     @Override
     public String toEnumDefaultValue(String value, String datatype) {
-        return datatype + "_" + value;
+        return "self::" + datatype + "_" + value;
     }
 
     @Override

--- a/modules/openapi-generator/src/test/resources/3_0/php/issue_10244.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/php/issue_10244.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: 'Issue 10224 Enum default value'
+  version: latest
+paths:
+  '/':
+    get:
+      operationId: operation
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelWithEnumPropertyHavingDefault'
+components:
+  schemas:
+    ModelWithEnumPropertyHavingDefault:
+      required:
+        - propertyName
+      properties:
+        propertyName:
+          type: string
+          default: VALUE
+          enum:
+            - VALUE


### PR DESCRIPTION
Fix https://github.com/OpenAPITools/openapi-generator/issues/10244

I manually tested the output of generation but was'nt able to validate it against the petstore sample. I did not find any enum with a default value used as a model property in the petstore.

generate-samples.sh and export_docs_generators.sh did not produce any code diff. 