### PR TITLE
[Go-client] Fix the ineffectual assignment to `err` in `decode`

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -421,6 +421,9 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 			return
 		}
 		_, err = (*f).Write(b)
+		if err != nil {
+			return
+		}
 		_, err = (*f).Seek(0, io.SeekStart)
 		return
 	}


### PR DESCRIPTION
Fixes: #10064

Signed-off-by: Bo Chen <chen.bo@intel.com>

