### PR TITLE
vertx-web renamed HttpStatusException to HttpException 

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaVertXWebServer/apiImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXWebServer/apiImpl.mustache
@@ -7,7 +7,7 @@ import {{invokerPackage}}.ApiResponse;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.handler.impl.HttpStatusException;
+import io.vertx.ext.web.handler.HttpException;
 
 import java.util.List;
 import java.util.Map;
@@ -18,7 +18,7 @@ public class {{classname}}Impl implements {{classname}} {
 {{#operations}}
 {{#operation}}
     public Future<ApiResponse<{{{returnType}}}>> {{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) {
-        return Future.failedFuture(new HttpStatusException(501));
+        return Future.failedFuture(new HttpException(501));
     }
 
 {{/operation}}


### PR DESCRIPTION
Vertx has moved HttpStatusException (vertx internal) to HttpException (public)

https://github.com/vert-x3/wiki/wiki/4.1.0-Deprecations-and-breaking-changes#iovertxextwebhandlerimplhttpstatusexception

See #10298 