### PR TITLE
[Kotlin][gradle] Issue #8255 fix (inputSpec param not accepts URL)

### DIFF
--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -154,6 +154,11 @@ apply plugin: 'org.openapi.generator'
 |None
 |The Open API 2.0/3.x specification location.
 
+|remoteSpec
+|String
+|None
+|The Open API 2.0/3.x specification location in remote source.
+
 |templateDir
 |String
 |None
@@ -414,6 +419,11 @@ openApiGenerate {
 |String
 |None
 |The input specification to validate. Supports all formats supported by the Parser.
+
+|remoteSpec
+|String
+|None
+|The input specification to validate. Should be used for remote spec location.
 
 |recommend
 |Boolean

--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -66,6 +66,8 @@ dependencies {
             "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 
     testCompile "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlin_version"
+
+    testCompile "com.github.tomakehurst:wiremock-jre8:$wiremock_version"
 }
 
 test {

--- a/modules/openapi-generator-gradle-plugin/gradle.properties
+++ b/modules/openapi-generator-gradle-plugin/gradle.properties
@@ -1,5 +1,6 @@
 # RELEASE_VERSION
 openApiGeneratorVersion=5.3.0-SNAPSHOT
+wiremock_version=2.27.2
 # /RELEASE_VERSION
 
 # BEGIN placeholders

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -84,6 +84,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     description = "Validates an Open API 2.0 or 3.x specification document."
 
                     inputSpec.set(validate.inputSpec)
+                    remoteSpec.set(validate.remoteSpec)
                     recommend.set(validate.recommend)
                 }
 
@@ -96,6 +97,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     generatorName.set(generate.generatorName)
                     outputDir.set(generate.outputDir)
                     inputSpec.set(generate.inputSpec)
+                    remoteSpec.set(generate.remoteSpec)
                     templateDir.set(generate.templateDir)
                     auth.set(generate.auth)
                     globalProperties.set(generate.globalProperties)

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -54,6 +54,11 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val inputSpec = project.objects.property<String>()
 
     /**
+     * The Open API 2.0/3.x specification location in remote source.
+     */
+    val remoteSpec = project.objects.property<String>()
+
+    /**
      * The template directory holding a custom template.
      */
     val templateDir = project.objects.property<String?>()

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorValidateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorValidateExtension.kt
@@ -31,6 +31,11 @@ open class OpenApiGeneratorValidateExtension(project: Project) {
     val inputSpec = project.objects.property<String>()
 
     /**
+     * The input specification to validate. Should be used for remote spec location.
+     */
+    val remoteSpec = project.objects.property<String>()
+
+    /**
      * Whether or not to offer recommendations related to the validated specification document.
      */
     val recommend = project.objects.property<Boolean?>()

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/service/PropertyHandler.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/service/PropertyHandler.kt
@@ -1,0 +1,24 @@
+package org.openapitools.generator.gradle.plugin.service
+
+import org.gradle.api.provider.Property
+
+class PropertyHandler {
+    companion object {
+        fun <T : Any?> Property<T>.ifNotEmpty(block: Property<T>.(T) -> Unit) {
+            if (isPresent) {
+                val item: T? = get()
+                if (item != null) {
+                    when (get()) {
+                        is String -> if ((get() as String).isNotEmpty()) {
+                            block(get())
+                        }
+                        is String? -> if (true == (get() as String?)?.isNotEmpty()) {
+                            block(get())
+                        }
+                        else -> block(get())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/service/SpecificationHandler.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/service/SpecificationHandler.kt
@@ -1,0 +1,51 @@
+package org.openapitools.generator.gradle.plugin.service
+
+import org.gradle.api.GradleException
+import org.gradle.api.provider.Property
+import org.openapitools.generator.gradle.plugin.service.PropertyHandler.Companion.ifNotEmpty
+import java.net.URI
+import java.net.URL
+
+class SpecificationHandler {
+    companion object {
+        fun getInputSpec(inputSpec : Property<String>,
+                         remoteSpec : Property<String?>): String {
+            val specificationParameters = SpecificationParameters()
+
+            inputSpec.ifNotEmpty { value ->
+                specificationParameters.localSpec = value
+            }
+
+            remoteSpec.ifNotEmpty { value ->
+                specificationParameters.remoteSpec = checkForValidUrlAndReturn(value)
+            }
+
+            return specificationParameters.getInputSpec() ?: throw GradleException("Specification path is undefined")
+        }
+
+        private fun checkForValidUrlAndReturn(value: String?): String? {
+            return if (value == null) {
+                null
+            } else {
+                toURL(value).toString()
+            }
+        }
+
+        private fun toURL(value: String): URL? {
+            try {
+                return URI(value).toURL()
+            } catch (ex: Exception) {
+                throw GradleException("Remote spec has invalid url format: $value", ex)
+            }
+        }
+    }
+
+    private class SpecificationParameters {
+        var localSpec: String? = null
+        var remoteSpec: String? = null
+
+        fun getInputSpec(): String? {
+            return localSpec ?: remoteSpec;
+        }
+    }
+}

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/ValidateTask.kt
@@ -54,9 +54,15 @@ import org.openapitools.codegen.validations.oas.RuleConfiguration
  * @author Jim Schubert
  */
 open class ValidateTask : DefaultTask() {
+
+    @Optional
     @get:InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
     val inputSpec = project.objects.property<String>()
+
+    @Optional
+    @Input
+    val remoteSpec = project.objects.property<String?>()
 
     @Optional
     @Input
@@ -75,7 +81,7 @@ open class ValidateTask : DefaultTask() {
     fun doWork() {
         val logger = Logging.getLogger(javaClass)
 
-        val spec = inputSpec.get()
+        val spec = SpecificationHandler.getInputSpec(inputSpec = inputSpec, remoteSpec = remoteSpec)
         val recommendations = recommend.get()
 
         logger.quiet("Validating spec $spec")

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
@@ -8,10 +8,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class GenerateTaskDslTest : TestBase() {
+class GenerateTaskDslTest : WiremockTestBase() {
     override var temp: File = createTempDir(javaClass.simpleName)
 
-    private val defaultBuildGradle = """
+    private val buildGradleLocalSpecExt = """
         plugins {
           id 'org.openapi.generator'
         }
@@ -28,18 +28,83 @@ class GenerateTaskDslTest : TestBase() {
         }
     """.trimIndent()
 
-    @Test
-    fun `openApiGenerate should create an expected file structure from DSL config`() {
+    private val buildGradleRemoteSpecExt = """
+        plugins {
+          id 'org.openapi.generator'
+        }
+        openApiGenerate {
+            generatorName = "kotlin"
+            remoteSpec = "http://127.0.0.1:${port}/spec.yaml"
+            outputDir = file("build/kotlin").absolutePath
+            apiPackage = "org.openapitools.example.api"
+            invokerPackage = "org.openapitools.example.invoker"
+            modelPackage = "org.openapitools.example.model"
+            configOptions = [
+                    dateLibrary: "java8"
+            ]
+        }
+    """.trimIndent()
+
+    private val buildGradleLocalSpecTask = """
+        plugins {
+          id 'org.openapi.generator'
+        }
+        
+        tasks.register('myTask', org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+            generatorName = "kotlin"
+            inputSpec = file("spec.yaml").absolutePath
+            outputDir = file("build/kotlin").absolutePath
+            apiPackage = "org.openapitools.example.api"
+            invokerPackage = "org.openapitools.example.invoker"
+            modelPackage = "org.openapitools.example.model"
+            configOptions = [
+                    dateLibrary: "java8"
+            ]
+        }
+    """.trimIndent()
+
+    private val buildGradleRemoteSpecTask = """
+        plugins {
+          id 'org.openapi.generator'
+        }
+        
+        tasks.register('myTask', org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+            generatorName = "kotlin"
+            remoteSpec = "http://127.0.0.1:${port}/spec.yaml"
+            outputDir = file("build/kotlin").absolutePath
+            apiPackage = "org.openapitools.example.api"
+            invokerPackage = "org.openapitools.example.invoker"
+            modelPackage = "org.openapitools.example.model"
+            configOptions = [
+                    dateLibrary: "java8"
+            ]
+        }
+    """.trimIndent()
+
+    @DataProvider(name = "buildGradle")
+    fun buildScripts(): MutableIterator<Array<String>> {
+        val testData: ArrayList<Array<String>> = arrayListOf()
+        testData.add(arrayOf(buildGradleLocalSpecExt, "openApiGenerate"))
+        testData.add(arrayOf(buildGradleLocalSpecTask, "myTask"))
+        testData.add(arrayOf(buildGradleRemoteSpecExt, "openApiGenerate"))
+        testData.add(arrayOf(buildGradleRemoteSpecTask, "myTask"))
+        return testData.iterator()
+    }
+
+    @Test(dataProvider = "buildGradle")
+    fun `openApiGenerate should create an expected file structure from DSL config`(buildScript: String,
+                                                                                   taskName: String) {
+        mockSpecRemoteRequest()
         // Arrange
         val projectFiles = mapOf(
                 "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0.yaml")
         )
-        withProject(defaultBuildGradle, projectFiles)
+        withProject(buildScript, projectFiles)
 
         // Act
         val result = GradleRunner.create()
                 .withProjectDir(temp)
-                .withArguments("openApiGenerate")
+                .withArguments(taskName)
                 .withPluginClasspath()
                 .build()
 
@@ -64,160 +129,141 @@ class GenerateTaskDslTest : TestBase() {
             assertTrue(f.exists() && f.isFile, "An expected file was not generated when invoking the generation.")
         }
 
-        assertEquals(TaskOutcome.SUCCESS, result.task(":openApiGenerate")?.outcome,
-                "Expected a successful run, but found ${result.task(":openApiGenerate")?.outcome}")
+        assertEquals(TaskOutcome.SUCCESS, result.task(":${taskName}")?.outcome,
+            "Expected a successful run, but found ${result.task(":${taskName}")?.outcome}")
     }
 
-    @Test
-    fun `openApiGenerate should used up-to-date instead of regenerate`() {
+    @Test(dataProvider = "buildGradle")
+    fun `openApiGenerate should used up-to-date instead of regenerate`(buildScript: String,
+                                                                       taskName: String) {
+        mockSpecRemoteRequest()
         // Arrange
         val projectFiles = mapOf(
                 "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0.yaml")
         )
-        withProject(defaultBuildGradle, projectFiles)
+        withProject(buildScript, projectFiles)
 
         // Act
         val resultFirstRun = GradleRunner.create()
                 .withProjectDir(temp)
-                .withArguments("openApiGenerate", "--info")
+                .withArguments(taskName, "--info")
                 .withPluginClasspath()
                 .build()
         val resultSecondRun = GradleRunner.create()
                 .withProjectDir(temp)
-                .withArguments("openApiGenerate", "--info")
+                .withArguments(taskName, "--info")
                 .withPluginClasspath()
                 .build()
 
         // Assert
-        assertFalse(resultFirstRun.output.contains("Task :openApiGenerate UP-TO-DATE"), "First run should not be up-to-date")
-        assertTrue(resultSecondRun.output.contains("Task :openApiGenerate UP-TO-DATE"), "Task of second run should be up-to-date")
+        assertFalse(resultFirstRun.output.contains("Task :${taskName} UP-TO-DATE"), "First run should not be up-to-date")
+        assertTrue(resultSecondRun.output.contains("Task :${taskName} UP-TO-DATE"), "Task of second run should be up-to-date")
     }
 
-    @Test
-    fun `openApiGenerate should use cache instead of regenerate`() {
+    @Test(dataProvider = "buildGradle")
+    fun `openApiGenerate should use cache instead of regenerate`(buildScript: String,
+                                                                 taskName: String) {
+        mockSpecRemoteRequest()
         // Arrange
         val projectFiles = mapOf(
                 "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0.yaml")
         )
-        withProject(defaultBuildGradle, projectFiles)
+        withProject(buildScript, projectFiles)
 
         // Act
         val resultFirstRun = GradleRunner.create()
                 .withProjectDir(temp)
-                .withArguments("openApiGenerate", "--build-cache", "--info")
-                .withPluginClasspath()
-                .build()
-
-        // delete the build directory from the last run
-        File(temp, "build/kotlin").deleteRecursively()
-
-        // re-run
-        val resultSecondRun = GradleRunner.create()
-                .withProjectDir(temp)
-                .withArguments("openApiGenerate", "--build-cache", "--info")
+                .withArguments(taskName, "--build-cache", "--info")
                 .withPluginClasspath()
                 .build()
 
         // re-run without deletes
         val resultThirdRun = GradleRunner.create()
-            .withProjectDir(temp)
-            .withArguments("openApiGenerate", "--build-cache", "--info")
-            .withPluginClasspath()
-            .build()
+                .withProjectDir(temp)
+                .withArguments(taskName, "--build-cache", "--info")
+                .withPluginClasspath()
+                .build()
 
         // Assert
         assertTrue(resultFirstRun.output.contains("No history is available."), "First run should not be up-to-date")
         assertFalse(resultSecondRun.output.contains("No history is available."), "Task of second run should be from cache")
         assertTrue(resultSecondRun.output.contains("has been removed."), "Task of second run should detect cache changes for untracked files")
-        assertTrue(resultThirdRun.output.contains("Skipping task ':openApiGenerate' as it is up-to-date."), "Task of third run should not require rebuild")
+        assertTrue(resultThirdRun.output.contains("Skipping task ':${taskName}' as it is up-to-date."), "Task of third run should not require rebuild")
     }
 
-    @Test
-    fun `openApiValidate should fail on invalid spec`() {
+    @Test(dataProvider = "buildGradle")
+    fun `openApiValidate should fail on invalid spec`(buildScript: String,
+                                                      taskName: String) {
+        mockSpecRemoteRequest("specs/petstore-v3.0-invalid.yaml")
         // Arrange
         val projectFiles = mapOf(
                 "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0-invalid.yaml")
         )
 
-        withProject(defaultBuildGradle, projectFiles)
+        withProject(buildScript, projectFiles)
 
         // Act
         val result = GradleRunner.create()
                 .withProjectDir(temp)
-                .withArguments("openApiGenerate")
+                .withArguments(taskName)
                 .withPluginClasspath()
                 .buildAndFail()
 
         // Assert
         assertTrue(result.output.contains("issues with the specification"), "Unexpected/no message presented to the user for an invalid spec.")
-        assertEquals(TaskOutcome.FAILED, result.task(":openApiGenerate")?.outcome,
+        assertEquals(TaskOutcome.FAILED, result.task(":${taskName}")?.outcome,
                 "Expected a failed run, but found ${result.task(":openApiValidate")?.outcome}")
     }
 
-    @Test
-    fun `openApiValidate should ok skip spec validation`() {
+    @Test(dataProvider = "buildGradle")
+    fun `openApiValidate should ok skip spec validation`(buildScript: String,
+                                                         taskName: String) {
+        mockSpecRemoteRequest("specs/petstore-v3.0-invalid.yaml")
+
+        val buildScriptWithHandlebars = buildScript.replace("""generatorName = "kotlin"""", """
+            generatorName = "kotlin"
+                skipValidateSpec = true
+        """.trimIndent())
         // Arrange
         val projectFiles = mapOf(
                 "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0-invalid.yaml")
         )
 
-        withProject("""
-        plugins {
-          id 'org.openapi.generator'
-        }
-        openApiGenerate {
-            generatorName = "kotlin"
-            inputSpec = file("spec.yaml").absolutePath
-            outputDir = file("build/kotlin").absolutePath
-            apiPackage = "org.openapitools.example.api"
-            invokerPackage = "org.openapitools.example.invoker"
-            modelPackage = "org.openapitools.example.model"
-            skipValidateSpec = true
-            configOptions = [
-                    dateLibrary: "java8"
-            ]
-        }
-    """.trimIndent(), projectFiles)
+        withProject(buildScriptWithHandlebars, projectFiles)
 
         // Act
         val result = GradleRunner.create()
                 .withProjectDir(temp)
-                .withArguments("openApiGenerate")
+                .withArguments(taskName)
                 .withPluginClasspath()
                 .build()
 
         // Assert
         assertTrue(result.output.contains("validation has been explicitly disabled"), "Unexpected/no message presented to the user for an invalid spec.")
-        assertEquals(TaskOutcome.SUCCESS, result.task(":openApiGenerate")?.outcome,
-                "Expected a successful run, but found ${result.task(":openApiGenerate")?.outcome}")
+        assertEquals(TaskOutcome.SUCCESS, result.task(":${taskName}")?.outcome,
+            "Expected a successful run, but found ${result.task(":${taskName}")?.outcome}")
     }
 
-    @Test
-    fun `openapiGenerate should attempt to set handlebars when specified as engine`() {
+    @Test(dataProvider = "buildGradle")
+    fun `openapiGenerate should attempt to set handlebars when specified as engine`(buildScript: String,
+                                                                                    taskName: String) {
+        mockSpecRemoteRequest()
+
+        val buildScriptWithHandlebars = buildScript.replace("""generatorName = "kotlin"""", """
+            generatorName = "kotlin"
+                engine = "handlebars"
+        """.trimIndent())
         // Arrange
         val projectFiles = mapOf(
                 "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0.yaml")
         )
 
-        withProject("""
-        plugins {
-          id 'org.openapi.generator'
-        }
-        openApiGenerate {
-            generatorName = "kotlin"
-            inputSpec = file("spec.yaml").absolutePath
-            outputDir = file("build/kotlin").absolutePath
-            apiPackage = "org.openapitools.example.api"
-            invokerPackage = "org.openapitools.example.invoker"
-            modelPackage = "org.openapitools.example.model"
-            engine = "handlebars"
-        }
-    """.trimIndent(), projectFiles)
+        withProject(buildScriptWithHandlebars, projectFiles)
 
         // Act
         val result = GradleRunner.create()
                 .withProjectDir(temp)
-                .withArguments("openApiGenerate", "--stacktrace")
+                .withArguments(taskName, "--stacktrace")
                 .withPluginClasspath()
                 .buildAndFail()
 
@@ -225,7 +271,7 @@ class GenerateTaskDslTest : TestBase() {
         // rather than write out full handlebars generator templates, we'll just test that the configurator has set handlebars as the engine.
         assertTrue(result.output.contains("HandlebarsException"), "Stack should expose an exception for missing templates.")
         assertTrue(result.output.contains("handlebars"), "Build should have attempted to use handlebars.")
-        assertEquals(TaskOutcome.FAILED, result.task(":openApiGenerate")?.outcome,
-                "Expected a failed run, but found ${result.task(":openApiGenerate")?.outcome}")
+        assertEquals(TaskOutcome.FAILED, result.task(":${taskName}")?.outcome,
+            "Expected a failed run, but found ${result.task(":${taskName}")?.outcome}")
     }
 }

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/WiremockTestBase.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/WiremockTestBase.kt
@@ -1,0 +1,37 @@
+package org.openapitools.generator.gradle.plugin
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import org.testng.annotations.AfterClass
+import org.testng.annotations.BeforeClass
+import java.io.InputStreamReader
+
+abstract class WiremockTestBase : TestBase() {
+    protected val port: Int = 9697
+    private val wireMockServer: WireMockServer = WireMockServer(port)
+
+    @BeforeClass
+    fun startWireMockServer() {
+        wireMockServer.start()
+    }
+
+    @AfterClass
+    fun stopWireMockServer() {
+        wireMockServer.stop()
+    }
+
+    fun mockSpecRemoteRequest(specPath: String = "specs/petstore-v3.0.yaml") {
+        wireMockServer.stubFor(get(urlEqualTo("/spec.yaml"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withBody(readFileContent(specPath)))
+        )
+    }
+
+    fun readFileContent(path: String): String {
+        return javaClass.classLoader.getResourceAsStream(path)
+            .use { inputStream -> InputStreamReader(inputStream).readText() };
+    }
+}

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/org/openapitools/generator/gradle/plugin/service/SpecificationHandlerTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/org/openapitools/generator/gradle/plugin/service/SpecificationHandlerTest.kt
@@ -1,0 +1,116 @@
+package org.openapitools.generator.gradle.plugin.service
+
+import org.gradle.api.GradleException
+import org.gradle.api.internal.provider.DefaultProperty
+import org.testng.annotations.DataProvider
+import org.testng.annotations.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class SpecificationHandlerTest {
+
+    @Test
+    fun `check for result if only inputSpec set`() {
+        val inputSpec = DefaultProperty(String::class.java)
+
+        val filePath = "src/main/spec.yaml"
+        inputSpec.set(filePath)
+
+        val remoteSpec = DefaultProperty(String::class.java)
+
+        val spec = SpecificationHandler.getInputSpec(inputSpec, remoteSpec)
+        assertEquals(filePath, spec)
+    }
+
+    @Test
+    fun `check for result if only remoteSpec set`() {
+        val inputSpec = DefaultProperty(String::class.java)
+
+        val remoteSpec = DefaultProperty(String::class.java)
+        val fileLocation = "http://some-location/files/spec.yaml"
+        remoteSpec.set(fileLocation)
+
+        val spec = SpecificationHandler.getInputSpec(inputSpec, remoteSpec)
+        assertEquals(fileLocation, spec)
+    }
+
+    @Test
+    fun `check for result if both set`() {
+        val inputSpec = DefaultProperty(String::class.java)
+        val filePath = "src/main/spec.yaml"
+        inputSpec.set(filePath)
+
+        val remoteSpec = DefaultProperty(String::class.java)
+        val fileLocation = "http://some-location/files/spec.yaml"
+        remoteSpec.set(fileLocation)
+
+        val spec = SpecificationHandler.getInputSpec(inputSpec, remoteSpec)
+        assertEquals(filePath, spec)
+    }
+
+    @Test
+    fun `check for result if both non set`() {
+        val inputSpec = DefaultProperty(String::class.java)
+        val remoteSpec = DefaultProperty(String::class.java)
+
+        assertFailsWith<GradleException> { SpecificationHandler.getInputSpec(inputSpec, remoteSpec) }
+    }
+
+    @Test
+    fun `check for result if both set null`() {
+        val inputSpec = DefaultProperty(String::class.java)
+        inputSpec.set(null)
+        val remoteSpec = DefaultProperty(String::class.java)
+        inputSpec.set(null)
+
+        assertFailsWith<GradleException> { SpecificationHandler.getInputSpec(inputSpec, remoteSpec) }
+    }
+
+    @DataProvider(name = "validUrls")
+    fun validUrls(): MutableIterator<Array<String>> {
+        val testData: ArrayList<Array<String>> = arrayListOf()
+        testData.add(arrayOf("http://www.asd.ss"))
+        testData.add(arrayOf("https://petstore.swagger.io/v2/swagger.json"))
+        testData.add(arrayOf("http://255.255.255.255"))
+        testData.add(arrayOf("http://www.example.com/products?id=1&page=2"))
+        testData.add(arrayOf("http://www.example.com:443"))
+        testData.add(arrayOf("http://invalid.com/as%20ss"))
+        return testData.iterator()
+    }
+
+    @Test(dataProvider = "validUrls")
+    fun `check for result if remoteSpec is valid URL`(url: String) {
+        val inputSpec = DefaultProperty(String::class.java)
+
+        val remoteSpec = DefaultProperty(String::class.java)
+        remoteSpec.set(url)
+
+        val spec = SpecificationHandler.getInputSpec(inputSpec, remoteSpec)
+
+        assertEquals(url, spec)
+    }
+
+    @DataProvider(name = "badUrls")
+    fun badUrls(): MutableIterator<Array<String>> {
+        val testData: ArrayList<Array<String>> = arrayListOf()
+        testData.add(arrayOf("www.asd.ss"))
+        testData.add(arrayOf("c://appData/test.txt"))
+        testData.add(arrayOf("C:/Users/rguluev/AppData/Local/Temp/test_projects/gradle-customer-search/build/telekom-customer-search.openapi.yaml"))
+        testData.add(arrayOf("C:\\WINDOWS\\system32\\file.txt"))
+        testData.add(arrayOf("255.255.255.255"))
+        testData.add(arrayOf("src/main/java/test.txt"))
+        testData.add(arrayOf("folder"))
+        testData.add(arrayOf("dir/subDir"))
+        return testData.iterator()
+    }
+
+    @Test(dataProvider = "badUrls")
+    fun `check for result if remoteSpec is invalid URL`(url: String) {
+        val inputSpec = DefaultProperty(String::class.java)
+
+        val remoteSpec = DefaultProperty(String::class.java)
+        remoteSpec.set(url)
+
+        assertFailsWith<GradleException> { SpecificationHandler.getInputSpec(inputSpec, remoteSpec) }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/OpenAPITools/openapi-generator/issues/8255

Implemented @joschi recommendation with the additional parameter

> Maybe splitting the input specification location into local specs and remote specs would make sense?

Related PR: https://github.com/OpenAPITools/openapi-generator/pull/9192

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
