### PR TITLE
[typescript-axios] Properly emit module as ES6 instead of commonJS when using ES6

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/tsconfig.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/tsconfig.mustache
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "{{#supportsES6}}es6{{/supportsES6}}{{^supportsES6}}es5{{/supportsES6}}",
-    "module": "commonjs",
+    "target": "{{#supportsES6}}ES6{{/supportsES6}}{{^supportsES6}}ES5{{/supportsES6}}",
+    "module": "{{#supportsES6}}ES6{{/supportsES6}}{{^supportsES6}}ES5{{/supportsES6}}",
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDir": ".",

--- a/samples/client/petstore/typescript-axios/builds/es6-target/tsconfig.json
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es6",
-    "module": "commonjs",
+    "target": "ES6",
+    "module": "ES6",
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDir": ".",

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/tsconfig.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es5",
-    "module": "commonjs",
+    "target": "ES5",
+    "module": "ES5",
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDir": ".",

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/tsconfig.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es5",
-    "module": "commonjs",
+    "target": "ES5",
+    "module": "ES5",
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDir": ".",

--- a/samples/client/petstore/typescript-axios/tests/default/tsconfig.json
+++ b/samples/client/petstore/typescript-axios/tests/default/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "compilerOptions": {
         "moduleResolution": "node",
-        "module": "commonjs",
-        "target": "es5",
+        "module": "ES5",
+        "target": "ES5",
         "noImplicitAny": true,
         "sourceMap": false,
         "outDir": "dist",


### PR DESCRIPTION
When using ES6 in the generator, the generated sources are indeed ES6. However, when building the package (and publishing to npm or other registries, as that's done automatically), TypeScript compiler builds a commonJS version of the code, which goes against the desire of the user's desire to build ES6.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)