### PR TITLE
Add OAS3 allowEmptyValue for query params

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -27,7 +27,7 @@ import java.util.*;
 public class CodegenParameter implements IJsonSchemaValidationProperties {
     public boolean isFormParam, isQueryParam, isPathParam, isHeaderParam,
             isCookieParam, isBodyParam, isContainer,
-            isCollectionFormatMulti, isPrimitiveType, isModel, isExplode, isDeepObject;
+            isCollectionFormatMulti, isPrimitiveType, isModel, isExplode, isDeepObject, isAllowEmptyValue;
     public String baseName, paramName, dataType, datatypeWithEnum, dataFormat, contentType,
             collectionFormat, description, unescapedDescription, baseType, defaultValue, enumName, style;
 
@@ -208,6 +208,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
         output.isExplode = this.isExplode;
         output.style = this.style;
         output.isDeepObject = this.isDeepObject;
+        output.isAllowEmptyValue = this.isAllowEmptyValue;
         output.contentType = this.contentType;
 
         return output;
@@ -215,7 +216,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
 
     @Override
     public int hashCode() {
-        return Objects.hash(isFormParam, isQueryParam, isPathParam, isHeaderParam, isCookieParam, isBodyParam, isContainer, isCollectionFormatMulti, isPrimitiveType, isModel, isExplode, baseName, paramName, dataType, datatypeWithEnum, dataFormat, collectionFormat, description, unescapedDescription, baseType, defaultValue, enumName, style, isDeepObject, example, jsonSchema, isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isDecimal, isByteArray, isBinary, isBoolean, isDate, isDateTime, isUuid, isUri, isEmail, isFreeFormObject, isAnyType, isArray, isMap, isFile, isEnum, _enum, allowableValues, items, mostInnerItems, additionalProperties, vars, requiredVars, vendorExtensions, hasValidation, getMaxProperties(), getMinProperties(), isNullable, isDeprecated, required, getMaximum(), getExclusiveMaximum(), getMinimum(), getExclusiveMinimum(), getMaxLength(), getMinLength(), getPattern(), getMaxItems(), getMinItems(), getUniqueItems(), contentType, multipleOf, isNull, additionalPropertiesIsAnyType, hasVars, hasRequired, isShort, isUnboundedInteger, hasDiscriminatorWithNonEmptyMapping);
+        return Objects.hash(isFormParam, isQueryParam, isPathParam, isHeaderParam, isCookieParam, isBodyParam, isContainer, isCollectionFormatMulti, isPrimitiveType, isModel, isExplode, baseName, paramName, dataType, datatypeWithEnum, dataFormat, collectionFormat, description, unescapedDescription, baseType, defaultValue, enumName, style, isDeepObject, isAllowEmptyValue, example, jsonSchema, isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isDecimal, isByteArray, isBinary, isBoolean, isDate, isDateTime, isUuid, isUri, isEmail, isFreeFormObject, isAnyType, isArray, isMap, isFile, isEnum, _enum, allowableValues, items, mostInnerItems, additionalProperties, vars, requiredVars, vendorExtensions, hasValidation, getMaxProperties(), getMinProperties(), isNullable, isDeprecated, required, getMaximum(), getExclusiveMaximum(), getMinimum(), getExclusiveMinimum(), getMaxLength(), getMinLength(), getPattern(), getMaxItems(), getMinItems(), getUniqueItems(), contentType, multipleOf, isNull, additionalPropertiesIsAnyType, hasVars, hasRequired, isShort, isUnboundedInteger, hasDiscriminatorWithNonEmptyMapping);
     }
 
     @Override
@@ -283,6 +284,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
                 Objects.equals(enumName, that.enumName) &&
                 Objects.equals(style, that.style) &&
                 Objects.equals(isDeepObject, that.isDeepObject) &&
+                Objects.equals(isAllowEmptyValue, that.isAllowEmptyValue) &&
                 Objects.equals(example, that.example) &&
                 Objects.equals(jsonSchema, that.jsonSchema) &&
                 Objects.equals(_enum, that._enum) &&
@@ -333,6 +335,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
         sb.append(", enumName='").append(enumName).append('\'');
         sb.append(", style='").append(style).append('\'');
         sb.append(", deepObject='").append(isDeepObject).append('\'');
+        sb.append(", allowEmptyValue='").append(isAllowEmptyValue).append('\'');
         sb.append(", example='").append(example).append('\'');
         sb.append(", jsonSchema='").append(jsonSchema).append('\'');
         sb.append(", isString=").append(isString);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4547,6 +4547,7 @@ public class DefaultCodegen implements CodegenConfig {
 
         if (parameter instanceof QueryParameter || "query".equalsIgnoreCase(parameter.getIn())) {
             codegenParameter.isQueryParam = true;
+            codegenParameter.isAllowEmptyValue = parameter.getAllowEmptyValue() != null && parameter.getAllowEmptyValue();
         } else if (parameter instanceof PathParameter || "path".equalsIgnoreCase(parameter.getIn())) {
             codegenParameter.required = true;
             codegenParameter.isPathParam = true;

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1097,6 +1097,12 @@ paths:
             additionalProperties:
               type: string
               format: string
+        - name: allowEmpty
+          in: query
+          required: true
+          allowEmptyValue: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/FakeApi.md
@@ -1279,7 +1279,7 @@ No authorization required
 
 ## TestQueryParameterCollectionFormat
 
-> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = null)
+> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string allowEmpty, Dictionary<string, string> language = null)
 
 
 
@@ -1307,11 +1307,12 @@ namespace Example
             var http = new List<string>(); // List<string> | 
             var url = new List<string>(); // List<string> | 
             var context = new List<string>(); // List<string> | 
+            var allowEmpty = allowEmpty_example;  // string | 
             var language = new Dictionary<string, string>(); // Dictionary<string, string> |  (optional) 
 
             try
             {
-                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language);
+                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language);
             }
             catch (ApiException e)
             {
@@ -1334,6 +1335,7 @@ Name | Type | Description  | Notes
  **http** | [**List&lt;string&gt;**](string.md)|  | 
  **url** | [**List&lt;string&gt;**](string.md)|  | 
  **context** | [**List&lt;string&gt;**](string.md)|  | 
+ **allowEmpty** | **string**|  | 
  **language** | [**Dictionary&lt;string, string&gt;**](string.md)|  | [optional] 
 
 ### Return type

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -429,9 +429,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="allowEmpty"></param>
         /// <param name="language"> (optional)</param>
         /// <returns></returns>
-        void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>));
+        void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string allowEmpty, Dictionary<string, string> language = default(Dictionary<string, string>));
 
         /// <summary>
         /// 
@@ -445,9 +446,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="allowEmpty"></param>
         /// <param name="language"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>));
+        ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string allowEmpty, Dictionary<string, string> language = default(Dictionary<string, string>));
         #endregion Synchronous Operations
         #region Asynchronous Operations
         /// <summary>
@@ -886,10 +888,11 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="allowEmpty"></param>
         /// <param name="language"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of void</returns>
-        System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>), CancellationToken cancellationToken = default(CancellationToken));
+        System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string allowEmpty, Dictionary<string, string> language = default(Dictionary<string, string>), CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// 
@@ -903,10 +906,11 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="allowEmpty"></param>
         /// <param name="language"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse<Object>> TestQueryParameterCollectionFormatWithHttpInfoAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>), CancellationToken cancellationToken = default(CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<Object>> TestQueryParameterCollectionFormatWithHttpInfoAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string allowEmpty, Dictionary<string, string> language = default(Dictionary<string, string>), CancellationToken cancellationToken = default(CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -3535,11 +3539,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="allowEmpty"></param>
         /// <param name="language"> (optional)</param>
         /// <returns></returns>
-        public void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>))
+        public void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string allowEmpty, Dictionary<string, string> language = default(Dictionary<string, string>))
         {
-             TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, language);
+             TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, allowEmpty, language);
         }
 
         /// <summary>
@@ -3551,9 +3556,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="allowEmpty"></param>
         /// <param name="language"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        public ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>))
+        public ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string allowEmpty, Dictionary<string, string> language = default(Dictionary<string, string>))
         {
             // verify the required parameter 'pipe' is set
             if (pipe == null)
@@ -3570,6 +3576,9 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'context' is set
             if (context == null)
                 throw new ApiException(400, "Missing required parameter 'context' when calling FakeApi->TestQueryParameterCollectionFormat");
+            // verify the required parameter 'allowEmpty' is set
+            if (allowEmpty == null)
+                throw new ApiException(400, "Missing required parameter 'allowEmpty' when calling FakeApi->TestQueryParameterCollectionFormat");
 
             var localVarPath = "/fake/test-query-parameters";
             var localVarPathParams = new Dictionary<String, String>();
@@ -3597,6 +3606,7 @@ namespace Org.OpenAPITools.Api
             if (url != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("csv", "url", url)); // query parameter
             if (context != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("multi", "context", context)); // query parameter
             if (language != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("", "language", language)); // query parameter
+            if (allowEmpty != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("", "allowEmpty", allowEmpty)); // query parameter
 
 
             // make the HTTP request
@@ -3626,12 +3636,13 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="allowEmpty"></param>
         /// <param name="language"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>), CancellationToken cancellationToken = default(CancellationToken))
+        public async System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string allowEmpty, Dictionary<string, string> language = default(Dictionary<string, string>), CancellationToken cancellationToken = default(CancellationToken))
         {
-             await TestQueryParameterCollectionFormatWithHttpInfoAsync(pipe, ioutil, http, url, context, language, cancellationToken);
+             await TestQueryParameterCollectionFormatWithHttpInfoAsync(pipe, ioutil, http, url, context, allowEmpty, language, cancellationToken);
 
         }
 
@@ -3644,10 +3655,11 @@ namespace Org.OpenAPITools.Api
         /// <param name="http"></param>
         /// <param name="url"></param>
         /// <param name="context"></param>
+        /// <param name="allowEmpty"></param>
         /// <param name="language"> (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel request (optional) </param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse<Object>> TestQueryParameterCollectionFormatWithHttpInfoAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, Dictionary<string, string> language = default(Dictionary<string, string>), CancellationToken cancellationToken = default(CancellationToken))
+        public async System.Threading.Tasks.Task<ApiResponse<Object>> TestQueryParameterCollectionFormatWithHttpInfoAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context, string allowEmpty, Dictionary<string, string> language = default(Dictionary<string, string>), CancellationToken cancellationToken = default(CancellationToken))
         {
             // verify the required parameter 'pipe' is set
             if (pipe == null)
@@ -3664,6 +3676,9 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'context' is set
             if (context == null)
                 throw new ApiException(400, "Missing required parameter 'context' when calling FakeApi->TestQueryParameterCollectionFormat");
+            // verify the required parameter 'allowEmpty' is set
+            if (allowEmpty == null)
+                throw new ApiException(400, "Missing required parameter 'allowEmpty' when calling FakeApi->TestQueryParameterCollectionFormat");
 
             var localVarPath = "/fake/test-query-parameters";
             var localVarPathParams = new Dictionary<String, String>();
@@ -3691,6 +3706,7 @@ namespace Org.OpenAPITools.Api
             if (url != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("csv", "url", url)); // query parameter
             if (context != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("multi", "context", context)); // query parameter
             if (language != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("", "language", language)); // query parameter
+            if (allowEmpty != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("", "allowEmpty", allowEmpty)); // query parameter
 
 
             // make the HTTP request

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
@@ -527,6 +527,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - http ([String.t]): 
   - url ([String.t]): 
   - context ([String.t]): 
+  - allow_empty (String.t): 
   - opts (KeywordList): [optional] Optional parameters
     - :language (%{optional(String.t) => String.t}): 
   ## Returns
@@ -534,8 +535,8 @@ defmodule OpenapiPetstore.Api.Fake do
   {:ok, nil} on success
   {:error, Tesla.Env.t} on failure
   """
-  @spec test_query_parameter_collection_format(Tesla.Env.client, list(String.t), list(String.t), list(String.t), list(String.t), list(String.t), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
-  def test_query_parameter_collection_format(connection, pipe, ioutil, http, url, context, opts \\ []) do
+  @spec test_query_parameter_collection_format(Tesla.Env.client, list(String.t), list(String.t), list(String.t), list(String.t), list(String.t), String.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  def test_query_parameter_collection_format(connection, pipe, ioutil, http, url, context, allow_empty, opts \\ []) do
     optional_params = %{
       :"language" => :query
     }
@@ -547,6 +548,7 @@ defmodule OpenapiPetstore.Api.Fake do
     |> add_param(:query, :"http", http)
     |> add_param(:query, :"url", url)
     |> add_param(:query, :"context", context)
+    |> add_param(:query, :"allowEmpty", allow_empty)
     |> add_optional_params(optional_params, opts)
     |> ensure_body()
     |> Enum.into([])

--- a/samples/client/petstore/java/feign/api/openapi.yaml
+++ b/samples/client/petstore/java/feign/api/openapi.yaml
@@ -1232,6 +1232,14 @@ paths:
             type: string
           type: object
         style: form
+      - allowEmptyValue: true
+        explode: true
+        in: query
+        name: allowEmpty
+        required: true
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           description: Success

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -438,13 +438,14 @@ public interface FakeApi extends ApiClient.Api {
    * @param http  (required)
    * @param url  (required)
    * @param context  (required)
+   * @param allowEmpty  (required)
    * @param language  (optional)
    */
-  @RequestLine("PUT /fake/test-query-parameters?pipe={pipe}&ioutil={ioutil}&http={http}&url={url}&context={context}&language={language}")
+  @RequestLine("PUT /fake/test-query-parameters?pipe={pipe}&ioutil={ioutil}&http={http}&url={url}&context={context}&language={language}&allowEmpty={allowEmpty}")
   @Headers({
     "Accept: application/json",
   })
-  void testQueryParameterCollectionFormat(@Param("pipe") List<String> pipe, @Param("ioutil") List<String> ioutil, @Param("http") List<String> http, @Param("url") List<String> url, @Param("context") List<String> context, @Param("language") Map<String, String> language);
+  void testQueryParameterCollectionFormat(@Param("pipe") List<String> pipe, @Param("ioutil") List<String> ioutil, @Param("http") List<String> http, @Param("url") List<String> url, @Param("context") List<String> context, @Param("allowEmpty") String allowEmpty, @Param("language") Map<String, String> language);
 
   /**
    * 
@@ -463,9 +464,10 @@ public interface FakeApi extends ApiClient.Api {
    *   <li>url -  (required)</li>
    *   <li>context -  (required)</li>
    *   <li>language -  (optional)</li>
+   *   <li>allowEmpty -  (required)</li>
    *   </ul>
    */
-  @RequestLine("PUT /fake/test-query-parameters?pipe={pipe}&ioutil={ioutil}&http={http}&url={url}&context={context}&language={language}")
+  @RequestLine("PUT /fake/test-query-parameters?pipe={pipe}&ioutil={ioutil}&http={http}&url={url}&context={context}&language={language}&allowEmpty={allowEmpty}")
   @Headers({
   "Accept: application/json",
   })
@@ -498,6 +500,10 @@ public interface FakeApi extends ApiClient.Api {
     }
     public TestQueryParameterCollectionFormatQueryParams language(final Map<String, String> value) {
       put("language", EncodingUtils.encode(value));
+      return this;
+    }
+    public TestQueryParameterCollectionFormatQueryParams allowEmpty(final String value) {
+      put("allowEmpty", EncodingUtils.encode(value));
       return this;
     }
   }

--- a/samples/client/petstore/java/webclient/api/openapi.yaml
+++ b/samples/client/petstore/java/webclient/api/openapi.yaml
@@ -1232,6 +1232,14 @@ paths:
             type: string
           type: object
         style: form
+      - allowEmptyValue: true
+        explode: true
+        in: query
+        name: allowEmpty
+        required: true
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           description: Success

--- a/samples/client/petstore/java/webclient/docs/FakeApi.md
+++ b/samples/client/petstore/java/webclient/docs/FakeApi.md
@@ -1132,7 +1132,7 @@ No authorization required
 
 ## testQueryParameterCollectionFormat
 
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language)
 
 
 
@@ -1159,9 +1159,10 @@ public class Example {
         List<String> http = Arrays.asList(); // List<String> | 
         List<String> url = Arrays.asList(); // List<String> | 
         List<String> context = Arrays.asList(); // List<String> | 
+        String allowEmpty = "allowEmpty_example"; // String | 
         Map<String, String> language = new HashMap(); // Map<String, String> | 
         try {
-            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language);
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language);
         } catch (ApiException e) {
             System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
             System.err.println("Status code: " + e.getCode());
@@ -1183,6 +1184,7 @@ Name | Type | Description  | Notes
  **http** | [**List&lt;String&gt;**](String.md)|  |
  **url** | [**List&lt;String&gt;**](String.md)|  |
  **context** | [**List&lt;String&gt;**](String.md)|  |
+ **allowEmpty** | **String**|  |
  **language** | [**Map&lt;String, String&gt;**](String.md)|  | [optional]
 
 ### Return type

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -1016,10 +1016,11 @@ public class FakeApi {
      * @param http The http parameter
      * @param url The url parameter
      * @param context The context parameter
+     * @param allowEmpty The allowEmpty parameter
      * @param language The language parameter
      * @throws WebClientResponseException if an error occurs while attempting to invoke the API
      */
-    private ResponseSpec testQueryParameterCollectionFormatRequestCreation(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> language) throws WebClientResponseException {
+    private ResponseSpec testQueryParameterCollectionFormatRequestCreation(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, Map<String, String> language) throws WebClientResponseException {
         Object postBody = null;
         // verify the required parameter 'pipe' is set
         if (pipe == null) {
@@ -1041,6 +1042,10 @@ public class FakeApi {
         if (context == null) {
             throw new WebClientResponseException("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
         }
+        // verify the required parameter 'allowEmpty' is set
+        if (allowEmpty == null) {
+            throw new WebClientResponseException("Missing the required parameter 'allowEmpty' when calling testQueryParameterCollectionFormat", HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(), null, null, null);
+        }
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
@@ -1055,6 +1060,7 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", url));
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
 
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
@@ -1076,16 +1082,17 @@ public class FakeApi {
      * @param http The http parameter
      * @param url The url parameter
      * @param context The context parameter
+     * @param allowEmpty The allowEmpty parameter
      * @param language The language parameter
      * @throws WebClientResponseException if an error occurs while attempting to invoke the API
      */
-    public Mono<Void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> language) throws WebClientResponseException {
+    public Mono<Void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, Map<String, String> language) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
-        return testQueryParameterCollectionFormatRequestCreation(pipe, ioutil, http, url, context, language).bodyToMono(localVarReturnType);
+        return testQueryParameterCollectionFormatRequestCreation(pipe, ioutil, http, url, context, allowEmpty, language).bodyToMono(localVarReturnType);
     }
 
-    public Mono<ResponseEntity<Void>> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> language) throws WebClientResponseException {
+    public Mono<ResponseEntity<Void>> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, Map<String, String> language) throws WebClientResponseException {
         ParameterizedTypeReference<Void> localVarReturnType = new ParameterizedTypeReference<Void>() {};
-        return testQueryParameterCollectionFormatRequestCreation(pipe, ioutil, http, url, context, language).toEntity(localVarReturnType);
+        return testQueryParameterCollectionFormatRequestCreation(pipe, ioutil, http, url, context, allowEmpty, language).toEntity(localVarReturnType);
     }
 }

--- a/samples/client/petstore/javascript-es6/docs/FakeApi.md
+++ b/samples/client/petstore/javascript-es6/docs/FakeApi.md
@@ -816,7 +816,7 @@ No authorization required
 
 ## testQueryParameterCollectionFormat
 
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, opts)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, opts)
 
 
 
@@ -833,10 +833,11 @@ let ioutil = ["null"]; // [String] |
 let http = ["null"]; // [String] | 
 let url = ["null"]; // [String] | 
 let context = ["null"]; // [String] | 
+let allowEmpty = "allowEmpty_example"; // String | 
 let opts = {
   'language': {key: "null"} // {String: String} | 
 };
-apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, opts, (error, data, response) => {
+apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, opts, (error, data, response) => {
   if (error) {
     console.error(error);
   } else {
@@ -855,6 +856,7 @@ Name | Type | Description  | Notes
  **http** | [**[String]**](String.md)|  | 
  **url** | [**[String]**](String.md)|  | 
  **context** | [**[String]**](String.md)|  | 
+ **allowEmpty** | **String**|  | 
  **language** | [**{String: String}**](String.md)|  | [optional] 
 
 ### Return type

--- a/samples/client/petstore/javascript-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/FakeApi.js
@@ -786,11 +786,12 @@ export default class FakeApi {
      * @param {Array.<String>} http 
      * @param {Array.<String>} url 
      * @param {Array.<String>} context 
+     * @param {String} allowEmpty 
      * @param {Object} opts Optional parameters
      * @param {Object.<String, {String: String}>} opts.language 
      * @param {module:api/FakeApi~testQueryParameterCollectionFormatCallback} callback The callback function, accepting three arguments: error, data, response
      */
-    testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, opts, callback) {
+    testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, opts, callback) {
       opts = opts || {};
       let postBody = null;
       // verify the required parameter 'pipe' is set
@@ -813,6 +814,10 @@ export default class FakeApi {
       if (context === undefined || context === null) {
         throw new Error("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
       }
+      // verify the required parameter 'allowEmpty' is set
+      if (allowEmpty === undefined || allowEmpty === null) {
+        throw new Error("Missing the required parameter 'allowEmpty' when calling testQueryParameterCollectionFormat");
+      }
 
       let pathParams = {
       };
@@ -822,7 +827,8 @@ export default class FakeApi {
         'http': this.apiClient.buildCollectionParam(http, 'ssv'),
         'url': this.apiClient.buildCollectionParam(url, 'csv'),
         'context': this.apiClient.buildCollectionParam(context, 'multi'),
-        'language': opts['language']
+        'language': opts['language'],
+        'allowEmpty': allowEmpty
       };
       let headerParams = {
       };

--- a/samples/client/petstore/javascript-promise-es6/docs/FakeApi.md
+++ b/samples/client/petstore/javascript-promise-es6/docs/FakeApi.md
@@ -800,7 +800,7 @@ No authorization required
 
 ## testQueryParameterCollectionFormat
 
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, opts)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, opts)
 
 
 
@@ -817,10 +817,11 @@ let ioutil = ["null"]; // [String] |
 let http = ["null"]; // [String] | 
 let url = ["null"]; // [String] | 
 let context = ["null"]; // [String] | 
+let allowEmpty = "allowEmpty_example"; // String | 
 let opts = {
   'language': {key: "null"} // {String: String} | 
 };
-apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, opts).then(() => {
+apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, opts).then(() => {
   console.log('API called successfully.');
 }, (error) => {
   console.error(error);
@@ -838,6 +839,7 @@ Name | Type | Description  | Notes
  **http** | [**[String]**](String.md)|  | 
  **url** | [**[String]**](String.md)|  | 
  **context** | [**[String]**](String.md)|  | 
+ **allowEmpty** | **String**|  | 
  **language** | [**{String: String}**](String.md)|  | [optional] 
 
 ### Return type

--- a/samples/client/petstore/javascript-promise-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/FakeApi.js
@@ -891,11 +891,12 @@ export default class FakeApi {
      * @param {Array.<String>} http 
      * @param {Array.<String>} url 
      * @param {Array.<String>} context 
+     * @param {String} allowEmpty 
      * @param {Object} opts Optional parameters
      * @param {Object.<String, {String: String}>} opts.language 
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
      */
-    testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, opts) {
+    testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, allowEmpty, opts) {
       opts = opts || {};
       let postBody = null;
       // verify the required parameter 'pipe' is set
@@ -918,6 +919,10 @@ export default class FakeApi {
       if (context === undefined || context === null) {
         throw new Error("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
       }
+      // verify the required parameter 'allowEmpty' is set
+      if (allowEmpty === undefined || allowEmpty === null) {
+        throw new Error("Missing the required parameter 'allowEmpty' when calling testQueryParameterCollectionFormat");
+      }
 
       let pathParams = {
       };
@@ -927,7 +932,8 @@ export default class FakeApi {
         'http': this.apiClient.buildCollectionParam(http, 'ssv'),
         'url': this.apiClient.buildCollectionParam(url, 'csv'),
         'context': this.apiClient.buildCollectionParam(context, 'multi'),
-        'language': opts['language']
+        'language': opts['language'],
+        'allowEmpty': allowEmpty
       };
       let headerParams = {
       };
@@ -952,12 +958,13 @@ export default class FakeApi {
      * @param {Array.<String>} http 
      * @param {Array.<String>} url 
      * @param {Array.<String>} context 
+     * @param {String} allowEmpty 
      * @param {Object} opts Optional parameters
      * @param {Object.<String, {String: String}>} opts.language 
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}
      */
-    testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, opts) {
-      return this.testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, opts)
+    testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, opts) {
+      return this.testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, allowEmpty, opts)
         .then(function(response_and_data) {
           return response_and_data.data;
         });

--- a/samples/client/petstore/perl/docs/FakeApi.md
+++ b/samples/client/petstore/perl/docs/FakeApi.md
@@ -813,7 +813,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_query_parameter_collection_format**
-> test_query_parameter_collection_format(pipe => $pipe, ioutil => $ioutil, http => $http, url => $url, context => $context, language => $language)
+> test_query_parameter_collection_format(pipe => $pipe, ioutil => $ioutil, http => $http, url => $url, context => $context, allow_empty => $allow_empty, language => $language)
 
 
 
@@ -831,10 +831,11 @@ my $ioutil = [("null")]; # ARRAY[string] |
 my $http = [("null")]; # ARRAY[string] | 
 my $url = [("null")]; # ARRAY[string] | 
 my $context = [("null")]; # ARRAY[string] | 
+my $allow_empty = "allow_empty_example"; # string | 
 my $language = ('key' =>  "null"}; # HASH[string,string] | 
 
 eval {
-    $api_instance->test_query_parameter_collection_format(pipe => $pipe, ioutil => $ioutil, http => $http, url => $url, context => $context, language => $language);
+    $api_instance->test_query_parameter_collection_format(pipe => $pipe, ioutil => $ioutil, http => $http, url => $url, context => $context, allow_empty => $allow_empty, language => $language);
 };
 if ($@) {
     warn "Exception when calling FakeApi->test_query_parameter_collection_format: $@\n";
@@ -850,6 +851,7 @@ Name | Type | Description  | Notes
  **http** | [**ARRAY[string]**](string.md)|  | 
  **url** | [**ARRAY[string]**](string.md)|  | 
  **context** | [**ARRAY[string]**](string.md)|  | 
+ **allow_empty** | **string**|  | 
  **language** | [**HASH[string,string]**](string.md)|  | [optional] 
 
 ### Return type

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeApi.pm
@@ -1371,6 +1371,7 @@ sub test_json_form_data {
 # @param ARRAY[string] $http  (required)
 # @param ARRAY[string] $url  (required)
 # @param ARRAY[string] $context  (required)
+# @param string $allow_empty  (required)
 # @param HASH[string,string] $language  (optional)
 {
     my $params = {
@@ -1396,6 +1397,11 @@ sub test_json_form_data {
     },
     'context' => {
         data_type => 'ARRAY[string]',
+        description => '',
+        required => '1',
+    },
+    'allow_empty' => {
+        data_type => 'string',
         description => '',
         required => '1',
     },
@@ -1441,6 +1447,11 @@ sub test_query_parameter_collection_format {
       croak("Missing the required parameter 'context' when calling test_query_parameter_collection_format");
     }
 
+    # verify the required parameter 'allow_empty' is set
+    unless (exists $args{'allow_empty'}) {
+      croak("Missing the required parameter 'allow_empty' when calling test_query_parameter_collection_format");
+    }
+
     # parse inputs
     my $_resource_path = '/fake/test-query-parameters';
 
@@ -1484,6 +1495,11 @@ sub test_query_parameter_collection_format {
     # query params
     if ( exists $args{'language'}) {
         $query_params->{'language'} = $self->{api_client}->to_query_value($args{'language'});
+    }
+
+    # query params
+    if ( exists $args{'allow_empty'}) {
+        $query_params->{'allowEmpty'} = $self->{api_client}->to_query_value($args{'allow_empty'});
     }
 
     my $_body_data;

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -972,7 +972,7 @@ No authorization required
 ## `testQueryParameterCollectionFormat()`
 
 ```php
-testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $language)
+testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $allow_empty, $language)
 ```
 
 
@@ -997,10 +997,11 @@ $ioutil = array('ioutil_example'); // string[]
 $http = array('http_example'); // string[]
 $url = array('url_example'); // string[]
 $context = array('context_example'); // string[]
+$allow_empty = 'allow_empty_example'; // string
 $language = array('key' => 'language_example'); // array<string,string>
 
 try {
-    $apiInstance->testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $language);
+    $apiInstance->testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $allow_empty, $language);
 } catch (Exception $e) {
     echo 'Exception when calling FakeApi->testQueryParameterCollectionFormat: ', $e->getMessage(), PHP_EOL;
 }
@@ -1015,6 +1016,7 @@ Name | Type | Description  | Notes
  **http** | [**string[]**](../Model/string.md)|  |
  **url** | [**string[]**](../Model/string.md)|  |
  **context** | [**string[]**](../Model/string.md)|  |
+ **allow_empty** | **string**|  |
  **language** | [**array<string,string>**](../Model/string.md)|  | [optional]
 
 ### Return type

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -4247,15 +4247,16 @@ class FakeApi
      * @param  string[] $http http (required)
      * @param  string[] $url url (required)
      * @param  string[] $context context (required)
+     * @param  string $allow_empty allow_empty (required)
      * @param  array<string,string> $language language (optional)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $language = null)
+    public function testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null)
     {
-        $this->testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context, $language);
+        $this->testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language);
     }
 
     /**
@@ -4266,15 +4267,16 @@ class FakeApi
      * @param  string[] $http (required)
      * @param  string[] $url (required)
      * @param  string[] $context (required)
+     * @param  string $allow_empty (required)
      * @param  array<string,string> $language (optional)
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context, $language = null)
+    public function testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null)
     {
-        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $language);
+        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language);
 
         try {
             $options = $this->createHttpClientOption();
@@ -4321,14 +4323,15 @@ class FakeApi
      * @param  string[] $http (required)
      * @param  string[] $url (required)
      * @param  string[] $context (required)
+     * @param  string $allow_empty (required)
      * @param  array<string,string> $language (optional)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testQueryParameterCollectionFormatAsync($pipe, $ioutil, $http, $url, $context, $language = null)
+    public function testQueryParameterCollectionFormatAsync($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null)
     {
-        return $this->testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $language)
+        return $this->testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -4344,15 +4347,16 @@ class FakeApi
      * @param  string[] $http (required)
      * @param  string[] $url (required)
      * @param  string[] $context (required)
+     * @param  string $allow_empty (required)
      * @param  array<string,string> $language (optional)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $language = null)
+    public function testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null)
     {
         $returnType = '';
-        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $language);
+        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -4385,12 +4389,13 @@ class FakeApi
      * @param  string[] $http (required)
      * @param  string[] $url (required)
      * @param  string[] $context (required)
+     * @param  string $allow_empty (required)
      * @param  array<string,string> $language (optional)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $language = null)
+    public function testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null)
     {
         // verify the required parameter 'pipe' is set
         if ($pipe === null || (is_array($pipe) && count($pipe) === 0)) {
@@ -4420,6 +4425,12 @@ class FakeApi
         if ($context === null || (is_array($context) && count($context) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $context when calling testQueryParameterCollectionFormat'
+            );
+        }
+        // verify the required parameter 'allow_empty' is set
+        if ($allow_empty === null || (is_array($allow_empty) && count($allow_empty) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $allow_empty when calling testQueryParameterCollectionFormat'
             );
         }
 
@@ -4478,6 +4489,17 @@ class FakeApi
             }
             else {
                 $queryParams['language'] = $language;
+            }
+        }
+        // query params
+        if ($allow_empty !== null) {
+            if('form' === 'form' && is_array($allow_empty)) {
+                foreach($allow_empty as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            }
+            else {
+                $queryParams['allowEmpty'] = $allow_empty;
             }
         }
 

--- a/samples/client/petstore/ruby-faraday/docs/FakeApi.md
+++ b/samples/client/petstore/ruby-faraday/docs/FakeApi.md
@@ -1115,7 +1115,7 @@ No authorization required
 
 ## test_query_parameter_collection_format
 
-> test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts)
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context, allow_empty, opts)
 
 
 
@@ -1133,13 +1133,14 @@ ioutil = ['inner_example'] # Array<String> |
 http = ['inner_example'] # Array<String> | 
 url = ['inner_example'] # Array<String> | 
 context = ['inner_example'] # Array<String> | 
+allow_empty = 'allow_empty_example' # String | 
 opts = {
   language: { key: 'inner_example'} # Hash<String, String> | 
 }
 
 begin
   
-  api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts)
+  api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context, allow_empty, opts)
 rescue Petstore::ApiError => e
   puts "Error when calling FakeApi->test_query_parameter_collection_format: #{e}"
 end
@@ -1149,12 +1150,12 @@ end
 
 This returns an Array which contains the response data (`nil` in this case), status code and headers.
 
-> <Array(nil, Integer, Hash)> test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
+> <Array(nil, Integer, Hash)> test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, opts)
 
 ```ruby
 begin
   
-  data, status_code, headers = api_instance.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
+  data, status_code, headers = api_instance.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, opts)
   p status_code # => 2xx
   p headers # => { ... }
   p data # => nil
@@ -1172,6 +1173,7 @@ end
 | **http** | [**Array&lt;String&gt;**](String.md) |  |  |
 | **url** | [**Array&lt;String&gt;**](String.md) |  |  |
 | **context** | [**Array&lt;String&gt;**](String.md) |  |  |
+| **allow_empty** | **String** |  |  |
 | **language** | [**Hash&lt;String, String&gt;**](String.md) |  | [optional] |
 
 ### Return type

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
@@ -1192,11 +1192,12 @@ module Petstore
     # @param http [Array<String>] 
     # @param url [Array<String>] 
     # @param context [Array<String>] 
+    # @param allow_empty [String] 
     # @param [Hash] opts the optional parameters
     # @option opts [Hash<String, String>] :language 
     # @return [nil]
-    def test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts = {})
-      test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
+    def test_query_parameter_collection_format(pipe, ioutil, http, url, context, allow_empty, opts = {})
+      test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, opts)
       nil
     end
 
@@ -1206,10 +1207,11 @@ module Petstore
     # @param http [Array<String>] 
     # @param url [Array<String>] 
     # @param context [Array<String>] 
+    # @param allow_empty [String] 
     # @param [Hash] opts the optional parameters
     # @option opts [Hash<String, String>] :language 
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts = {})
+    def test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_query_parameter_collection_format ...'
       end
@@ -1233,6 +1235,10 @@ module Petstore
       if @api_client.config.client_side_validation && context.nil?
         fail ArgumentError, "Missing the required parameter 'context' when calling FakeApi.test_query_parameter_collection_format"
       end
+      # verify the required parameter 'allow_empty' is set
+      if @api_client.config.client_side_validation && allow_empty.nil?
+        fail ArgumentError, "Missing the required parameter 'allow_empty' when calling FakeApi.test_query_parameter_collection_format"
+      end
       # resource path
       local_var_path = '/fake/test-query-parameters'
 
@@ -1243,6 +1249,7 @@ module Petstore
       query_params[:'http'] = @api_client.build_collection_param(http, :ssv)
       query_params[:'url'] = @api_client.build_collection_param(url, :csv)
       query_params[:'context'] = @api_client.build_collection_param(context, :multi)
+      query_params[:'allowEmpty'] = allow_empty
       query_params[:'language'] = opts[:'language'] if !opts[:'language'].nil?
 
       # header parameters

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -1115,7 +1115,7 @@ No authorization required
 
 ## test_query_parameter_collection_format
 
-> test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts)
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context, allow_empty, opts)
 
 
 
@@ -1133,13 +1133,14 @@ ioutil = ['inner_example'] # Array<String> |
 http = ['inner_example'] # Array<String> | 
 url = ['inner_example'] # Array<String> | 
 context = ['inner_example'] # Array<String> | 
+allow_empty = 'allow_empty_example' # String | 
 opts = {
   language: { key: 'inner_example'} # Hash<String, String> | 
 }
 
 begin
   
-  api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts)
+  api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context, allow_empty, opts)
 rescue Petstore::ApiError => e
   puts "Error when calling FakeApi->test_query_parameter_collection_format: #{e}"
 end
@@ -1149,12 +1150,12 @@ end
 
 This returns an Array which contains the response data (`nil` in this case), status code and headers.
 
-> <Array(nil, Integer, Hash)> test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
+> <Array(nil, Integer, Hash)> test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, opts)
 
 ```ruby
 begin
   
-  data, status_code, headers = api_instance.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
+  data, status_code, headers = api_instance.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, opts)
   p status_code # => 2xx
   p headers # => { ... }
   p data # => nil
@@ -1172,6 +1173,7 @@ end
 | **http** | [**Array&lt;String&gt;**](String.md) |  |  |
 | **url** | [**Array&lt;String&gt;**](String.md) |  |  |
 | **context** | [**Array&lt;String&gt;**](String.md) |  |  |
+| **allow_empty** | **String** |  |  |
 | **language** | [**Hash&lt;String, String&gt;**](String.md) |  | [optional] |
 
 ### Return type

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -1192,11 +1192,12 @@ module Petstore
     # @param http [Array<String>] 
     # @param url [Array<String>] 
     # @param context [Array<String>] 
+    # @param allow_empty [String] 
     # @param [Hash] opts the optional parameters
     # @option opts [Hash<String, String>] :language 
     # @return [nil]
-    def test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts = {})
-      test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
+    def test_query_parameter_collection_format(pipe, ioutil, http, url, context, allow_empty, opts = {})
+      test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, opts)
       nil
     end
 
@@ -1206,10 +1207,11 @@ module Petstore
     # @param http [Array<String>] 
     # @param url [Array<String>] 
     # @param context [Array<String>] 
+    # @param allow_empty [String] 
     # @param [Hash] opts the optional parameters
     # @option opts [Hash<String, String>] :language 
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts = {})
+    def test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_query_parameter_collection_format ...'
       end
@@ -1233,6 +1235,10 @@ module Petstore
       if @api_client.config.client_side_validation && context.nil?
         fail ArgumentError, "Missing the required parameter 'context' when calling FakeApi.test_query_parameter_collection_format"
       end
+      # verify the required parameter 'allow_empty' is set
+      if @api_client.config.client_side_validation && allow_empty.nil?
+        fail ArgumentError, "Missing the required parameter 'allow_empty' when calling FakeApi.test_query_parameter_collection_format"
+      end
       # resource path
       local_var_path = '/fake/test-query-parameters'
 
@@ -1243,6 +1249,7 @@ module Petstore
       query_params[:'http'] = @api_client.build_collection_param(http, :ssv)
       query_params[:'url'] = @api_client.build_collection_param(url, :csv)
       query_params[:'context'] = @api_client.build_collection_param(context, :multi)
+      query_params[:'allowEmpty'] = allow_empty
       query_params[:'language'] = opts[:'language'] if !opts[:'language'].nil?
 
       # header parameters

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -133,6 +133,7 @@ export interface TestQueryParameterCollectionFormatRequest {
     http: Array<string>;
     url: Array<string>;
     context: Array<string>;
+    allowEmpty: string;
     language?: { [key: string]: string; };
 }
 
@@ -869,6 +870,10 @@ export class FakeApi extends runtime.BaseAPI {
             throw new runtime.RequiredError('context','Required parameter requestParameters.context was null or undefined when calling testQueryParameterCollectionFormat.');
         }
 
+        if (requestParameters.allowEmpty === null || requestParameters.allowEmpty === undefined) {
+            throw new runtime.RequiredError('allowEmpty','Required parameter requestParameters.allowEmpty was null or undefined when calling testQueryParameterCollectionFormat.');
+        }
+
         const queryParameters: any = {};
 
         if (requestParameters.pipe) {
@@ -893,6 +898,10 @@ export class FakeApi extends runtime.BaseAPI {
 
         if (requestParameters.language !== undefined) {
             queryParameters['language'] = requestParameters.language;
+        }
+
+        if (requestParameters.allowEmpty !== undefined) {
+            queryParameters['allowEmpty'] = requestParameters.allowEmpty;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/doc/FakeApi.md
@@ -761,7 +761,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **testQueryParameterCollectionFormat**
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language)
 
 
 
@@ -777,10 +777,11 @@ final BuiltList<String> ioutil = ; // BuiltList<String> |
 final BuiltList<String> http = ; // BuiltList<String> | 
 final BuiltList<String> url = ; // BuiltList<String> | 
 final BuiltList<String> context = ; // BuiltList<String> | 
+final String allowEmpty = allowEmpty_example; // String | 
 final BuiltMap<String, String> language = ; // BuiltMap<String, String> | 
 
 try {
-    api.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language);
+    api.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language);
 } catch on DioError (e) {
     print('Exception when calling FakeApi->testQueryParameterCollectionFormat: $e\n');
 }
@@ -795,6 +796,7 @@ Name | Type | Description  | Notes
  **http** | [**BuiltList&lt;String&gt;**](String.md)|  | 
  **url** | [**BuiltList&lt;String&gt;**](String.md)|  | 
  **context** | [**BuiltList&lt;String&gt;**](String.md)|  | 
+ **allowEmpty** | **String**|  | 
  **language** | [**BuiltMap&lt;String, String&gt;**](String.md)|  | [optional] 
 
 ### Return type

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/lib/src/api/fake_api.dart
@@ -1353,6 +1353,7 @@ class FakeApi {
   /// * [http] 
   /// * [url] 
   /// * [context] 
+  /// * [allowEmpty] 
   /// * [language] 
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
@@ -1369,6 +1370,7 @@ class FakeApi {
     required BuiltList<String> http,
     required BuiltList<String> url,
     required BuiltList<String> context,
+    required String allowEmpty,
     BuiltMap<String, String>? language,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -1397,6 +1399,7 @@ class FakeApi {
       r'url': encodeCollectionQueryParameter<String>(_serializers, url, const FullType(BuiltList, [FullType(String)]), format: ListFormat.csv,),
       r'context': encodeCollectionQueryParameter<String>(_serializers, context, const FullType(BuiltList, [FullType(String)]), format: ListFormat.multi,),
       if (language != null) r'language': encodeQueryParameter(_serializers, language, const FullType(BuiltMap, [FullType(String), FullType(String)]), ),
+      r'allowEmpty': encodeQueryParameter(_serializers, allowEmpty, const FullType(String)),
     };
 
     final _response = await _dio.request<Object>(

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/doc/FakeApi.md
@@ -761,7 +761,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **testQueryParameterCollectionFormat**
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language)
 
 
 
@@ -777,10 +777,11 @@ var ioutil = []; // BuiltList<String> |
 var http = []; // BuiltList<String> | 
 var url = []; // BuiltList<String> | 
 var context = []; // BuiltList<String> | 
+var allowEmpty = allowEmpty_example; // String | 
 var language = ; // BuiltMap<String, String> | 
 
 try {
-    api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language);
+    api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language);
 } catch (e) {
     print('Exception when calling FakeApi->testQueryParameterCollectionFormat: $e\n');
 }
@@ -795,6 +796,7 @@ Name | Type | Description  | Notes
  **http** | [**BuiltList<String>**](String.md)|  | 
  **url** | [**BuiltList<String>**](String.md)|  | 
  **context** | [**BuiltList<String>**](String.md)|  | 
+ **allowEmpty** | **String**|  | 
  **language** | [**BuiltMap<String, String>**](String.md)|  | [optional] 
 
 ### Return type

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -891,7 +891,8 @@ class FakeApi {
     BuiltList<String> ioutil,
     BuiltList<String> http,
     BuiltList<String> url,
-    BuiltList<String> context, { 
+    BuiltList<String> context,
+    String allowEmpty, { 
     BuiltMap<String, String> language,
     CancelToken cancelToken,
     Map<String, dynamic> headers,
@@ -913,6 +914,7 @@ class FakeApi {
         r'url': url,
         r'context': context,
         if (language != null) r'language': language,
+        r'allowEmpty': allowEmpty,
       },
       extra: <String, dynamic>{
         'secure': <Map<String, String>>[],

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/FakeApi.md
@@ -761,7 +761,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **testQueryParameterCollectionFormat**
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language)
 
 
 
@@ -777,10 +777,11 @@ final ioutil = []; // List<String> |
 final http = []; // List<String> | 
 final url = []; // List<String> | 
 final context = []; // List<String> | 
+final allowEmpty = allowEmpty_example; // String | 
 final language = ; // Map<String, String> | 
 
 try {
-    api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language);
+    api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language);
 } catch (e) {
     print('Exception when calling FakeApi->testQueryParameterCollectionFormat: $e\n');
 }
@@ -795,6 +796,7 @@ Name | Type | Description  | Notes
  **http** | [**List<String>**](String.md)|  | [default to const []]
  **url** | [**List<String>**](String.md)|  | [default to const []]
  **context** | [**List<String>**](String.md)|  | [default to const []]
+ **allowEmpty** | **String**|  | 
  **language** | [**Map<String, String>**](String.md)|  | [optional] [default to const {}]
 
 ### Return type

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -1177,8 +1177,10 @@ class FakeApi {
   ///
   /// * [List<String>] context (required):
   ///
+  /// * [String] allowEmpty (required):
+  ///
   /// * [Map<String, String>] language:
-  Future<Response> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, { Map<String, String> language }) async {
+  Future<Response> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, { Map<String, String> language }) async {
     // Verify required params are set.
     if (pipe == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: pipe');
@@ -1194,6 +1196,9 @@ class FakeApi {
     }
     if (context == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: context');
+    }
+    if (allowEmpty == null) {
+     throw ApiException(HttpStatus.badRequest, 'Missing required param: allowEmpty');
     }
 
     final path = r'/fake/test-query-parameters';
@@ -1212,6 +1217,7 @@ class FakeApi {
     if (language != null) {
       queryParams.addAll(_convertParametersForCollectionFormat('', 'language', language));
     }
+      queryParams.addAll(_convertParametersForCollectionFormat('', 'allowEmpty', allowEmpty));
 
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
@@ -1244,9 +1250,11 @@ class FakeApi {
   ///
   /// * [List<String>] context (required):
   ///
+  /// * [String] allowEmpty (required):
+  ///
   /// * [Map<String, String>] language:
-  Future<void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, { Map<String, String> language }) async {
-    final response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context,  language: language );
+  Future<void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, { Map<String, String> language }) async {
+    final response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, allowEmpty,  language: language );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/doc/FakeApi.md
@@ -761,7 +761,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **testQueryParameterCollectionFormat**
-> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language)
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language)
 
 
 
@@ -777,10 +777,11 @@ final ioutil = []; // List<String> |
 final http = []; // List<String> | 
 final url = []; // List<String> | 
 final context = []; // List<String> | 
+final allowEmpty = allowEmpty_example; // String | 
 final language = ; // Map<String, String> | 
 
 try {
-    api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language);
+    api_instance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language);
 } catch (e) {
     print('Exception when calling FakeApi->testQueryParameterCollectionFormat: $e\n');
 }
@@ -795,6 +796,7 @@ Name | Type | Description  | Notes
  **http** | [**List<String>**](String.md)|  | [default to const []]
  **url** | [**List<String>**](String.md)|  | [default to const []]
  **context** | [**List<String>**](String.md)|  | [default to const []]
+ **allowEmpty** | **String**|  | 
  **language** | [**Map<String, String>**](String.md)|  | [optional] [default to const {}]
 
 ### Return type

--- a/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_json_serializable_client_lib_fake/lib/api/fake_api.dart
@@ -1184,8 +1184,10 @@ class FakeApi {
   ///
   /// * [List<String>] context (required):
   ///
+  /// * [String] allowEmpty (required):
+  ///
   /// * [Map<String, String>] language:
-  Future<Response> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, { Map<String, String> language }) async {
+  Future<Response> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, { Map<String, String> language }) async {
     // Verify required params are set.
     if (pipe == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: pipe');
@@ -1201,6 +1203,9 @@ class FakeApi {
     }
     if (context == null) {
      throw ApiException(HttpStatus.badRequest, 'Missing required param: context');
+    }
+    if (allowEmpty == null) {
+     throw ApiException(HttpStatus.badRequest, 'Missing required param: allowEmpty');
     }
 
     final path = r'/fake/test-query-parameters';
@@ -1219,6 +1224,7 @@ class FakeApi {
     if (language != null) {
       queryParams.addAll(_convertParametersForCollectionFormat('', 'language', language));
     }
+      queryParams.addAll(_convertParametersForCollectionFormat('', 'allowEmpty', allowEmpty));
 
     final contentTypes = <String>[];
     final nullableContentType = contentTypes.isNotEmpty ? contentTypes[0] : null;
@@ -1251,9 +1257,11 @@ class FakeApi {
   ///
   /// * [List<String>] context (required):
   ///
+  /// * [String] allowEmpty (required):
+  ///
   /// * [Map<String, String>] language:
-  Future<void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, { Map<String, String> language }) async {
-    final response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context,  language: language );
+  Future<void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, { Map<String, String> language }) async {
+    final response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, allowEmpty,  language: language );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/samples/openapi3/client/petstore/python-legacy/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-legacy/docs/FakeApi.md
@@ -1130,7 +1130,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_query_parameter_collection_format**
-> test_query_parameter_collection_format(pipe, ioutil, http, url, context, language=language)
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context, allow_empty, language=language)
 
 
 
@@ -1160,10 +1160,11 @@ ioutil = ['ioutil_example'] # list[str] |
 http = ['http_example'] # list[str] | 
 url = ['url_example'] # list[str] | 
 context = ['context_example'] # list[str] | 
+allow_empty = 'allow_empty_example' # str | 
 language = {'key': 'language_example'} # dict(str, str) |  (optional)
 
     try:
-        api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context, language=language)
+        api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context, allow_empty, language=language)
     except ApiException as e:
         print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
 ```
@@ -1177,6 +1178,7 @@ Name | Type | Description  | Notes
  **http** | [**list[str]**](str.md)|  | 
  **url** | [**list[str]**](str.md)|  | 
  **context** | [**list[str]**](str.md)|  | 
+ **allow_empty** | **str**|  | 
  **language** | [**dict(str, str)**](str.md)|  | [optional] 
 
 ### Return type

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/fake_api.py
@@ -2415,14 +2415,14 @@ class FakeApi(object):
             collection_formats=collection_formats,
             _request_auth=local_var_params.get('_request_auth'))
 
-    def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
+    def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, allow_empty, **kwargs):  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
 
         To test the collection format in query parameters  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_query_parameter_collection_format(pipe, ioutil, http, url, context, async_req=True)
+        >>> thread = api.test_query_parameter_collection_format(pipe, ioutil, http, url, context, allow_empty, async_req=True)
         >>> result = thread.get()
 
         :param pipe: (required)
@@ -2435,6 +2435,8 @@ class FakeApi(object):
         :type url: list[str]
         :param context: (required)
         :type context: list[str]
+        :param allow_empty: (required)
+        :type allow_empty: str
         :param language:
         :type language: dict(str, str)
         :param async_req: Whether to execute the request asynchronously.
@@ -2453,16 +2455,16 @@ class FakeApi(object):
         :rtype: None
         """
         kwargs['_return_http_data_only'] = True
-        return self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, **kwargs)  # noqa: E501
+        return self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, **kwargs)  # noqa: E501
 
-    def test_query_parameter_collection_format_with_http_info(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
+    def test_query_parameter_collection_format_with_http_info(self, pipe, ioutil, http, url, context, allow_empty, **kwargs):  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
 
         To test the collection format in query parameters  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, async_req=True)
+        >>> thread = api.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, async_req=True)
         >>> result = thread.get()
 
         :param pipe: (required)
@@ -2475,6 +2477,8 @@ class FakeApi(object):
         :type url: list[str]
         :param context: (required)
         :type context: list[str]
+        :param allow_empty: (required)
+        :type allow_empty: str
         :param language:
         :type language: dict(str, str)
         :param async_req: Whether to execute the request asynchronously.
@@ -2508,6 +2512,7 @@ class FakeApi(object):
             'http',
             'url',
             'context',
+            'allow_empty',
             'language'
         ]
         all_params.extend(
@@ -2548,6 +2553,10 @@ class FakeApi(object):
         if self.api_client.client_side_validation and ('context' not in local_var_params or  # noqa: E501
                                                         local_var_params['context'] is None):  # noqa: E501
             raise ApiValueError("Missing the required parameter `context` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'allow_empty' is set
+        if self.api_client.client_side_validation and ('allow_empty' not in local_var_params or  # noqa: E501
+                                                        local_var_params['allow_empty'] is None):  # noqa: E501
+            raise ApiValueError("Missing the required parameter `allow_empty` when calling `test_query_parameter_collection_format`")  # noqa: E501
 
         collection_formats = {}
 
@@ -2571,6 +2580,8 @@ class FakeApi(object):
             collection_formats['context'] = 'multi'  # noqa: E501
         if 'language' in local_var_params and local_var_params['language'] is not None:  # noqa: E501
             query_params.append(('language', local_var_params['language']))  # noqa: E501
+        if 'allow_empty' in local_var_params and local_var_params['allow_empty'] is not None:  # noqa: E501
+            query_params.append(('allowEmpty', local_var_params['allow_empty']))  # noqa: E501
 
         header_params = {}
 

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
@@ -275,9 +275,9 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = {
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class)
     })
-    public Response testQueryParameterCollectionFormat(@ApiParam(value = "", required = true) @QueryParam("pipe") @NotNull @Valid  List<String> pipe,@ApiParam(value = "", required = true) @QueryParam("ioutil") @NotNull @Valid  List<String> ioutil,@ApiParam(value = "", required = true) @QueryParam("http") @NotNull @Valid  List<String> http,@ApiParam(value = "", required = true) @QueryParam("url") @NotNull @Valid  List<String> url,@ApiParam(value = "", required = true) @QueryParam("context") @NotNull @Valid  List<String> context,@ApiParam(value = "") @QueryParam("language") @Valid  Map<String, String> language,@Context SecurityContext securityContext)
+    public Response testQueryParameterCollectionFormat(@ApiParam(value = "", required = true) @QueryParam("pipe") @NotNull @Valid  List<String> pipe,@ApiParam(value = "", required = true) @QueryParam("ioutil") @NotNull @Valid  List<String> ioutil,@ApiParam(value = "", required = true) @QueryParam("http") @NotNull @Valid  List<String> http,@ApiParam(value = "", required = true) @QueryParam("url") @NotNull @Valid  List<String> url,@ApiParam(value = "", required = true) @QueryParam("context") @NotNull @Valid  List<String> context,@ApiParam(value = "", required = true) @QueryParam("allowEmpty") @NotNull  String allowEmpty,@ApiParam(value = "") @QueryParam("language") @Valid  Map<String, String> language,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, language, securityContext);
+        return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, allowEmpty, language, securityContext);
     }
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApiService.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApiService.java
@@ -44,6 +44,6 @@ public abstract class FakeApiService {
     public abstract Response testGroupParameters( @NotNull Integer requiredStringGroup, @NotNull Boolean requiredBooleanGroup, @NotNull Long requiredInt64Group,Integer stringGroup,Boolean booleanGroup,Long int64Group,SecurityContext securityContext) throws NotFoundException;
     public abstract Response testInlineAdditionalProperties(Map<String, String> requestBody,SecurityContext securityContext) throws NotFoundException;
     public abstract Response testJsonFormData(String param,String param2,SecurityContext securityContext) throws NotFoundException;
-    public abstract Response testQueryParameterCollectionFormat( @NotNull List<String> pipe, @NotNull List<String> ioutil, @NotNull List<String> http, @NotNull List<String> url, @NotNull List<String> context,Map<String, String> language,SecurityContext securityContext) throws NotFoundException;
+    public abstract Response testQueryParameterCollectionFormat( @NotNull List<String> pipe, @NotNull List<String> ioutil, @NotNull List<String> http, @NotNull List<String> url, @NotNull List<String> context, @NotNull String allowEmpty,Map<String, String> language,SecurityContext securityContext) throws NotFoundException;
     public abstract Response uploadFileWithRequiredFile(Long petId,FormDataBodyPart requiredFileBodypart,String additionalMetadata,SecurityContext securityContext) throws NotFoundException;
 }

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
@@ -109,7 +109,7 @@ public class FakeApiServiceImpl extends FakeApiService {
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }
     @Override
-    public Response testQueryParameterCollectionFormat( @NotNull List<String> pipe,  @NotNull List<String> ioutil,  @NotNull List<String> http,  @NotNull List<String> url,  @NotNull List<String> context, Map<String, String> language, SecurityContext securityContext) throws NotFoundException {
+    public Response testQueryParameterCollectionFormat( @NotNull List<String> pipe,  @NotNull List<String> ioutil,  @NotNull List<String> http,  @NotNull List<String> url,  @NotNull List<String> context,  @NotNull String allowEmpty, Map<String, String> language, SecurityContext securityContext) throws NotFoundException {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }

--- a/samples/server/petstore/php-laravel/lib/app/Http/Controllers/FakeController.php
+++ b/samples/server/petstore/php-laravel/lib/app/Http/Controllers/FakeController.php
@@ -554,6 +554,11 @@ class FakeController extends Controller
         }
         $context = $input['context'];
 
+        if (!isset($input['allowEmpty'])) {
+            throw new \InvalidArgumentException('Missing the required parameter $allowEmpty when calling testQueryParameterCollectionFormat');
+        }
+        $allowEmpty = $input['allowEmpty'];
+
         $language = $input['language'];
 
 

--- a/samples/server/petstore/php-lumen/lib/app/Http/Controllers/FakeApi.php
+++ b/samples/server/petstore/php-lumen/lib/app/Http/Controllers/FakeApi.php
@@ -550,6 +550,11 @@ class FakeApi extends Controller
         }
         $context = $input['context'];
 
+        if (!isset($input['allow_empty'])) {
+            throw new \InvalidArgumentException('Missing the required parameter $allow_empty when calling testQueryParameterCollectionFormat');
+        }
+        $allow_empty = $input['allow_empty'];
+
         $language = $input['language'];
 
 


### PR DESCRIPTION
* add the special case of empty query parameters to the fake API

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
