### PR TITLE
[dart-dio-next] Fix oneOf handling in dart

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2078,6 +2078,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (exts != null && exts.containsKey("x-one-of-name")) {
             return (String) exts.get("x-one-of-name");
         }
+        if (names.size() == 1) return names.get(0);
         return "oneOf<" + String.join(",", names) + ">";
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -491,8 +491,13 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
     @Override
     public String getSchemaType(Schema p) {
 		if (p instanceof ComposedSchema) {
-            if (((ComposedSchema) p).getOneOf() != null) {
-                return "dynamic";
+			ComposedSchema cs = (ComposedSchema) p;
+            if (cs.getOneOf() != null) {
+				List<Schema> schemas = ModelUtils.getInterfaces(cs);
+				if(schemas.size() != 1) {
+					return "dynamic";
+				}
+				p = schemas.get(0);
             }
         }
         String openAPIType = super.getSchemaType(p);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.servers.Server;
@@ -489,6 +490,11 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
 
     @Override
     public String getSchemaType(Schema p) {
+		if (p instanceof ComposedSchema) {
+            if (((ComposedSchema) p).getOneOf() != null) {
+                return "dynamic";
+            }
+        }
         String openAPIType = super.getSchemaType(p);
         if (openAPIType == null) {
             LOGGER.error("No Type defined for Schema {}", p);


### PR DESCRIPTION
Currently oneOf is not handled correctly in dart, this PR fixes that. It contains a commit from https://github.com/OpenAPITools/openapi-generator/pull/6914 as well as an extra commit added to handle the single oneOf case as a nullable type.
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jaumard @josh-burton @amondnet @sbu-WBT @kuhnroyal @agilob @ahmednfwela