### PR TITLE
[typescript-axios] Use CommonJS when using ES5 as target as per Typescript docs

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/tsconfig.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/tsconfig.mustache
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "{{#supportsES6}}ES6{{/supportsES6}}{{^supportsES6}}ES5{{/supportsES6}}",
-    "module": "{{#supportsES6}}ES6{{/supportsES6}}{{^supportsES6}}ES5{{/supportsES6}}",
+    "module": "{{#supportsES6}}ES6{{/supportsES6}}{{^supportsES6}}CommonJS{{/supportsES6}}",
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDir": ".",

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/tsconfig.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "ES5",
-    "module": "ES5",
+    "module": "CommonJS",
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDir": ".",

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/tsconfig.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "target": "ES5",
-    "module": "ES5",
+    "module": "CommonJS",
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDir": ".",

--- a/samples/client/petstore/typescript-axios/tests/default/tsconfig.json
+++ b/samples/client/petstore/typescript-axios/tests/default/tsconfig.json
@@ -1,20 +1,13 @@
 {
-    "compilerOptions": {
-        "moduleResolution": "node",
-        "module": "ES5",
-        "target": "ES5",
-        "noImplicitAny": true,
-        "sourceMap": false,
-        "outDir": "dist",
-        "types": [
-            "mocha"
-        ],
-        "lib": [
-            "es6",
-            "dom"
-        ]
-    },
-    "exclude": [
-        "node_modules"
-    ]
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "CommonJS",
+    "target": "ES5",
+    "noImplicitAny": true,
+    "sourceMap": false,
+    "outDir": "dist",
+    "types": ["mocha"],
+    "lib": ["es6", "dom"]
+  },
+  "exclude": ["node_modules"]
 }

--- a/samples/client/petstore/typescript-axios/tests/default/tsconfig.json
+++ b/samples/client/petstore/typescript-axios/tests/default/tsconfig.json
@@ -1,13 +1,20 @@
 {
-  "compilerOptions": {
-    "moduleResolution": "node",
-    "module": "CommonJS",
-    "target": "ES5",
-    "noImplicitAny": true,
-    "sourceMap": false,
-    "outDir": "dist",
-    "types": ["mocha"],
-    "lib": ["es6", "dom"]
-  },
-  "exclude": ["node_modules"]
+    "compilerOptions": {
+        "moduleResolution": "node",
+        "module": "CommonJS",
+        "target": "ES5",
+        "noImplicitAny": true,
+        "sourceMap": false,
+        "outDir": "dist",
+        "types": [
+            "mocha"
+        ],
+        "lib": [
+            "es6",
+            "dom"
+        ]
+    },
+    "exclude": [
+        "node_modules"
+    ]
 }


### PR DESCRIPTION
Fixes failing tests in #10308 by fixing a mistake from myself according to [TypeScript docs](https://www.typescriptlang.org/tsconfig#module)

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
