### PR TITLE
cpp-qt-client: Fix cppcheck warnings

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
@@ -25,7 +25,7 @@ void {{classname}}::initializeServerConfigs() {
     //varying endpoint server
     {{#servers}}
     QList<{{prefix}}ServerConfiguration> serverConf = QList<{{prefix}}ServerConfiguration>();
-{{/servers}}
+    {{/servers}}
 {{#vendorExtensions.x-cpp-global-server-list}}
     defaultConf.append({{prefix}}ServerConfiguration(
     QUrl("{{{url}}}"),

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
@@ -23,7 +23,9 @@ void {{classname}}::initializeServerConfigs(){
     //Default server
     QList<{{prefix}}ServerConfiguration> defaultConf = QList<{{prefix}}ServerConfiguration>();
     //varying endpoint server
+    {{#servers}}
     QList<{{prefix}}ServerConfiguration> serverConf = QList<{{prefix}}ServerConfiguration>();
+{{/servers}}
 {{#vendorExtensions.x-cpp-global-server-list}}
     defaultConf.append({{prefix}}ServerConfiguration(
     QUrl("{{{url}}}"),
@@ -125,9 +127,9 @@ int {{classname}}::addServerConfiguration(const QString &operation, const QUrl &
     * @param description A String that describes the server
     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
     */
-void {{classname}}::setNewServerForAllOperations(const QUrl &url, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables){
-    for(auto e : _serverIndices.keys()){
-        setServerIndex(e, addServerConfiguration(e, url, description, variables));
+void {{classname}}::setNewServerForAllOperations(const QUrl &url, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables) {
+    for (auto keyIt = _serverIndices.keyBegin(); keyIt != _serverIndices.keyEnd(); keyIt++) {
+        setServerIndex(*keyIt, addServerConfiguration(*keyIt, url, description, variables));
     }
 }
 
@@ -157,7 +159,7 @@ void {{classname}}::abortRequests(){
     emit abortRequestsSignal();
 }
 
-QString {{classname}}::getParamStylePrefix(QString style){
+QString {{classname}}::getParamStylePrefix(const QString &style){
     if(style == "matrix"){
         return ";";
     }else if(style == "label"){
@@ -175,7 +177,7 @@ QString {{classname}}::getParamStylePrefix(QString style){
     }
 }
 
-QString {{classname}}::getParamStyleSuffix(QString style){
+QString {{classname}}::getParamStyleSuffix(const QString &style){
     if(style == "matrix"){
         return "=";
     }else if(style == "label"){
@@ -193,7 +195,7 @@ QString {{classname}}::getParamStyleSuffix(QString style){
     }
 }
 
-QString {{classname}}::getParamStyleDelimiter(QString style, QString name, bool isExplode){
+QString {{classname}}::getParamStyleDelimiter(const QString &style, const QString &name, bool isExplode) {
 
     if(style == "matrix"){
         return (isExplode) ? ";" + name + "=" : ",";
@@ -653,12 +655,14 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         }
     }
 {{/cookieParams}}
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &{{prefix}}HttpRequestWorker::on_execution_finished, this, &{{classname}}::{{nickname}}Callback);
     connect(this, &{{classname}}::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<{{prefix}}HttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<{{prefix}}HttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -667,15 +671,11 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
 }
 
 void {{classname}}::{{nickname}}Callback({{prefix}}HttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     {{#returnType}}
     {{#isArray}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
@@ -11,15 +11,15 @@ namespace {{this}} {
 {{classname}}::{{classname}}(const int timeOut)
     : _timeOut(timeOut),
       _manager(nullptr),
-      isResponseCompressionEnabled(false),
-      isRequestCompressionEnabled(false) {
+      _isResponseCompressionEnabled(false),
+      _isRequestCompressionEnabled(false) {
     initializeServerConfigs();
 }
 
 {{classname}}::~{{classname}}() {
 }
 
-void {{classname}}::initializeServerConfigs(){
+void {{classname}}::initializeServerConfigs() {
     //Default server
     QList<{{prefix}}ServerConfiguration> defaultConf = QList<{{prefix}}ServerConfiguration>();
     //varying endpoint server
@@ -60,23 +60,24 @@ void {{classname}}::initializeServerConfigs(){
 * returns 0 on success and -1, -2 or -3 on failure.
 * -1 when the variable does not exist and -2 if the value is not defined in the enum and -3 if the operation or server index is not found
 */
-int {{classname}}::setDefaultServerValue(int serverIndex, const QString &operation, const QString &variable, const QString &value){
+int {{classname}}::setDefaultServerValue(int serverIndex, const QString &operation, const QString &variable, const QString &value) {
     auto it = _serverConfigs.find(operation);
-    if(it != _serverConfigs.end() && serverIndex < it.value().size() ){
+    if (it != _serverConfigs.end() && serverIndex < it.value().size()) {
       return _serverConfigs[operation][serverIndex].setDefaultValue(variable,value);
     }
     return -3;
 }
-void {{classname}}::setServerIndex(const QString &operation, int serverIndex){
-    if(_serverIndices.contains(operation) && serverIndex < _serverConfigs.find(operation).value().size() )
+void {{classname}}::setServerIndex(const QString &operation, int serverIndex) {
+    if (_serverIndices.contains(operation) && serverIndex < _serverConfigs.find(operation).value().size()) {
         _serverIndices[operation] = serverIndex;
+    }
 }
 
-void {{classname}}::setApiKey(const QString &apiKeyName, const QString &apiKey){
+void {{classname}}::setApiKey(const QString &apiKeyName, const QString &apiKey) {
     _apiKeys.insert(apiKeyName,apiKey);
 }
 
-void {{classname}}::setBearerToken(const QString &token){
+void {{classname}}::setBearerToken(const QString &token) {
     _bearerToken = token;
 }
 
@@ -109,14 +110,14 @@ void {{classname}}::setNetworkAccessManager(QNetworkAccessManager* manager) {
     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
     * returns the index of the new server config on success and -1 if the operation is not found
     */
-int {{classname}}::addServerConfiguration(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables){
-    if(_serverConfigs.contains(operation)){
+int {{classname}}::addServerConfiguration(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables) {
+    if (_serverConfigs.contains(operation)) {
         _serverConfigs[operation].append({{prefix}}ServerConfiguration(
                     url,
                     description,
                     variables));
         return _serverConfigs[operation].size()-1;
-    }else{
+    } else {
         return -1;
     }
 }
@@ -139,85 +140,85 @@ void {{classname}}::setNewServerForAllOperations(const QUrl &url, const QString 
     * @param description A String that describes the server
     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
     */
-void {{classname}}::setNewServer(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables){
+void {{classname}}::setNewServer(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, {{prefix}}ServerVariable> &variables) {
     setServerIndex(operation, addServerConfiguration(operation, url, description, variables));
 }
 
 void {{classname}}::addHeaders(const QString &key, const QString &value) {
-    defaultHeaders.insert(key, value);
+    _defaultHeaders.insert(key, value);
 }
 
 void {{classname}}::enableRequestCompression() {
-    isRequestCompressionEnabled = true;
+    _isRequestCompressionEnabled = true;
 }
 
 void {{classname}}::enableResponseCompression() {
-    isResponseCompressionEnabled = true;
+    _isResponseCompressionEnabled = true;
 }
 
-void {{classname}}::abortRequests(){
+void {{classname}}::abortRequests() {
     emit abortRequestsSignal();
 }
 
-QString {{classname}}::getParamStylePrefix(const QString &style){
-    if(style == "matrix"){
+QString {{classname}}::getParamStylePrefix(const QString &style) {
+    if (style == "matrix") {
         return ";";
-    }else if(style == "label"){
+    } else if (style == "label") {
         return ".";
-    }else if(style == "form"){
+    } else if (style == "form") {
         return "&";
-    }else if(style == "simple"){
+    } else if (style == "simple") {
         return "";
-    }else if(style == "spaceDelimited"){
+    } else if (style == "spaceDelimited") {
         return "&";
-    }else if(style == "pipeDelimited"){
+    } else if (style == "pipeDelimited") {
         return "&";
-    }else{
+    } else {
         return "none";
     }
 }
 
-QString {{classname}}::getParamStyleSuffix(const QString &style){
-    if(style == "matrix"){
+QString {{classname}}::getParamStyleSuffix(const QString &style) {
+    if (style == "matrix") {
         return "=";
-    }else if(style == "label"){
+    } else if (style == "label") {
         return "";
-    }else if(style == "form"){
+    } else if (style == "form") {
         return "=";
-    }else if(style == "simple"){
+    } else if (style == "simple") {
         return "";
-    }else if(style == "spaceDelimited"){
+    } else if (style == "spaceDelimited") {
         return "=";
-    }else if(style == "pipeDelimited"){
+    } else if (style == "pipeDelimited") {
         return "=";
-    }else{
+    } else {
         return "none";
     }
 }
 
 QString {{classname}}::getParamStyleDelimiter(const QString &style, const QString &name, bool isExplode) {
 
-    if(style == "matrix"){
+    if (style == "matrix") {
         return (isExplode) ? ";" + name + "=" : ",";
 
-    }else if(style == "label"){
+    } else if (style == "label") {
         return (isExplode) ? "." : ",";
 
-    }else if(style == "form"){
+    } else if (style == "form") {
         return (isExplode) ? "&" + name + "=" : ",";
 
-    }else if(style == "simple"){
+    } else if (style == "simple") {
         return ",";
-    }else if(style == "spaceDelimited"){
+    } else if (style == "spaceDelimited") {
         return (isExplode) ? "&" + name + "=" : " ";
 
-    }else if(style == "pipeDelimited"){
+    } else if (style == "pipeDelimited") {
         return (isExplode) ? "&" + name + "=" : "|";
 
-    }else if(style == "deepObject"){
+    } else if (style == "deepObject") {
         return (isExplode) ? "&" : "none";
 
-    }else {
+    } else {
         return "none";
     }
 }
@@ -227,11 +228,11 @@ QString {{classname}}::getParamStyleDelimiter(const QString &style, const QStrin
 void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}} &{{/required}}{{^required}}const ::{{cppNamespace}}::OptionalParam<{{{dataType}}}> &{{/required}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) {
     QString fullPath = QString(_serverConfigs["{{nickname}}"][_serverIndices.value("{{nickname}}")].URL()+"{{{path}}}");
     {{#authMethods}}{{#isApiKey}}{{#isKeyInHeader}}
-    if(_apiKeys.contains("{{name}}")){
+    if (_apiKeys.contains("{{name}}")) {
         addHeaders("{{name}}",_apiKeys.find("{{name}}").value());
     }
     {{/isKeyInHeader}}{{#isKeyInQuery}}
-    if(_apiKeys.contains("{{name}}")){
+    if (_apiKeys.contains("{{name}}")) {
         if (fullPath.indexOf("?") > 0)
             fullPath.append("&");
         else
@@ -239,22 +240,22 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         fullPath.append("{{{name}}}=").append(_apiKeys.find("{{name}}").value());
     }
     {{/isKeyInQuery}}{{/isApiKey}}{{#isBasicBearer}}
-    if(!_bearerToken.isEmpty())
+    if (!_bearerToken.isEmpty())
         addHeaders("Authorization", "Bearer " + _bearerToken);
     {{/isBasicBearer}}{{#isBasicBasic}}
-    if(!_username.isEmpty() && !_password.isEmpty()){
+    if (!_username.isEmpty() && !_password.isEmpty()) {
         QByteArray b64;
         b64.append(_username.toUtf8() + ":" + _password.toUtf8());
         addHeaders("Authorization","Basic " + b64.toBase64());
     }{{/isBasicBasic}}{{/authMethods}}
     {{#pathParams}}
-    {{^required}}if({{paramName}}.hasValue()){{/required}}
+    {{^required}}if ({{paramName}}.hasValue()) {{/required}}
     {
         QString {{paramName}}PathParam("{");
         {{paramName}}PathParam.append("{{baseName}}").append("}");
         QString pathPrefix, pathSuffix, pathDelimiter;
         QString pathStyle = "{{style}}";
-        if(pathStyle == "")
+        if (pathStyle == "")
             pathStyle = "simple";
         pathPrefix = getParamStylePrefix(pathStyle);
         pathSuffix = getParamStyleSuffix(pathStyle);
@@ -310,7 +311,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         {{/isPrimitiveType}}
 {{/collectionFormat}}
 {{#collectionFormat}}
-        if({{{paramName}}}{{^required}}.value(){{/required}}.size() > 0) {
+        if ({{{paramName}}}{{^required}}.value(){{/required}}.size() > 0) {
             QString paramString = (pathStyle == "matrix") ? pathPrefix+"{{baseName}}"+pathSuffix : pathPrefix;
             qint32 count = 0;
             foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
@@ -329,10 +330,10 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     QString queryPrefix, querySuffix, queryDelimiter, queryStyle;
     {{/hasQueryParams}}
     {{#queryParams}}
-    {{^required}}if({{paramName}}.hasValue()){{/required}}
+    {{^required}}if ({{paramName}}.hasValue()){{/required}}
     {
         queryStyle = "{{style}}";
-        if(queryStyle == "")
+        if (queryStyle == "")
             queryStyle = "form";
         queryPrefix = getParamStylePrefix(queryStyle);
         querySuffix = getParamStyleSuffix(queryStyle);
@@ -394,7 +395,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
 {{/isPrimitiveType}}
 {{/collectionFormat}}
 {{#collectionFormat}}
-        if({{{paramName}}}{{^required}}.value(){{/required}}.size() > 0) {
+        if ({{{paramName}}}{{^required}}.value(){{/required}}.size() > 0) {
             if (QString("{{collectionFormat}}").indexOf("multi") == 0) {
                 foreach ({{{baseType}}} t, {{paramName}}{{^required}}.value(){{/required}}) {
                     if (fullPath.indexOf("?") > 0)
@@ -476,21 +477,21 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     {{prefix}}HttpRequestWorker *worker = new {{prefix}}HttpRequestWorker(this, _manager);
     worker->setTimeOut(_timeOut);
     worker->setWorkingDirectory(_workingDirectory);{{#contentCompression}}
-    worker->setResponseCompressionEnabled(isResponseCompressionEnabled);
-    worker->setRequestCompressionEnabled(isRequestCompressionEnabled);{{/contentCompression}}
+    worker->setResponseCompressionEnabled(_isResponseCompressionEnabled);
+    worker->setRequestCompressionEnabled(_isRequestCompressionEnabled);{{/contentCompression}}
     {{prefix}}HttpRequestInput input(fullPath, "{{httpMethod}}");
 
 {{#formParams}}
     {{#first}}
     QString formPrefix,formSuffix, formDelimiter;
     QString formStyle = "{{style}}";
-    if(formStyle == "")
+    if (formStyle == "")
         formStyle = "form";
     formPrefix = getParamStylePrefix(formStyle);
     formSuffix = getParamStyleSuffix(formStyle);
     formDelimiter = getParamStyleDelimiter(formStyle, "{{baseName}}", {{isExplode}});
     {{/first}}
-    {{^required}}if({{paramName}}.hasValue()){{/required}}
+    {{^required}}if ({{paramName}}.hasValue()){{/required}}
     {
 {{^isFile}}
         input.add_var("{{baseName}}", ::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value(){{/required}}));
@@ -501,7 +502,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     }
 {{/formParams}}
 {{#bodyParams}}
-    {{^required}}if({{paramName}}.hasValue()){{/required}}{
+    {{^required}}if ({{paramName}}.hasValue()){{/required}}{
 {{#isContainer}}
 {{#isArray}}
         QJsonDocument doc(::{{cppNamespace}}::toJsonValue({{paramName}}{{^required}}.value(){{/required}}).toArray());{{/isArray}}{{#isMap}}
@@ -516,7 +517,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
 {{/isContainer}}
     }{{/bodyParams}}
 {{#headerParams}}
-    {{^required}}if({{paramName}}.hasValue()){{/required}}
+    {{^required}}if ({{paramName}}.hasValue()){{/required}}
     {
     {{^collectionFormat}}
     {{^isPrimitiveType}}
@@ -583,9 +584,9 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     }
 {{/headerParams}}
 {{#cookieParams}}
-    {{^required}}if({{paramName}}.hasValue()){{/required}}
+    {{^required}}if ({{paramName}}.hasValue()){{/required}}
     {
-        if(QString("{{style}}").indexOf("form") == 0){
+        if (QString("{{style}}").indexOf("form") == 0) {
         {{^collectionFormat}}
         {{^isPrimitiveType}}
         {{^isExplode}}
@@ -632,7 +633,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         {{/isExplode}}
         {{/isPrimitiveType}}
         {{#isPrimitiveType}}
-            if(!::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value(){{/required}}).isEmpty()) {
+            if (!::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value(){{/required}}).isEmpty()) {
                 input.headers.insert("Cookie", "{{baseName}}="+::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value(){{/required}}));
             }
         {{/isPrimitiveType}}
@@ -655,7 +656,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         }
     }
 {{/cookieParams}}
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/api-header.mustache
@@ -43,9 +43,9 @@ public:
     void enableRequestCompression();
     void enableResponseCompression();
     void abortRequests();
-    QString getParamStylePrefix(QString style);
-    QString getParamStyleSuffix(QString style);
-    QString getParamStyleDelimiter(QString style, QString name, bool isExplode);
+    QString getParamStylePrefix(const QString &style);
+    QString getParamStyleSuffix(const QString &style);
+    QString getParamStyleDelimiter(const QString &style, const QString &name, bool isExplode);
 {{#operations}}{{#operation}}
 {{#hasParams}}    /**
     {{#allParams}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/api-header.mustache
@@ -70,9 +70,9 @@ private:
     int _timeOut;
     QString _workingDirectory;
     QNetworkAccessManager* _manager;
-    QMap<QString, QString> defaultHeaders;
-    bool isResponseCompressionEnabled;
-    bool isRequestCompressionEnabled;
+    QMap<QString, QString> _defaultHeaders;
+    bool _isResponseCompressionEnabled;
+    bool _isRequestCompressionEnabled;
 {{#operations}}{{#operation}}
     void {{nickname}}Callback({{prefix}}HttpRequestWorker *worker);{{/operation}}{{/operations}}
 

--- a/samples/client/petstore/cpp-qt/client/PFXPetApi.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXPetApi.cpp
@@ -19,15 +19,15 @@ namespace test_namespace {
 PFXPetApi::PFXPetApi(const int timeOut)
     : _timeOut(timeOut),
       _manager(nullptr),
-      isResponseCompressionEnabled(false),
-      isRequestCompressionEnabled(false) {
+      _isResponseCompressionEnabled(false),
+      _isRequestCompressionEnabled(false) {
     initializeServerConfigs();
 }
 
 PFXPetApi::~PFXPetApi() {
 }
 
-void PFXPetApi::initializeServerConfigs(){
+void PFXPetApi::initializeServerConfigs() {
     //Default server
     QList<PFXServerConfiguration> defaultConf = QList<PFXServerConfiguration>();
     //varying endpoint server
@@ -57,23 +57,24 @@ void PFXPetApi::initializeServerConfigs(){
 * returns 0 on success and -1, -2 or -3 on failure.
 * -1 when the variable does not exist and -2 if the value is not defined in the enum and -3 if the operation or server index is not found
 */
-int PFXPetApi::setDefaultServerValue(int serverIndex, const QString &operation, const QString &variable, const QString &value){
+int PFXPetApi::setDefaultServerValue(int serverIndex, const QString &operation, const QString &variable, const QString &value) {
     auto it = _serverConfigs.find(operation);
-    if(it != _serverConfigs.end() && serverIndex < it.value().size() ){
+    if (it != _serverConfigs.end() && serverIndex < it.value().size()) {
       return _serverConfigs[operation][serverIndex].setDefaultValue(variable,value);
     }
     return -3;
 }
-void PFXPetApi::setServerIndex(const QString &operation, int serverIndex){
-    if(_serverIndices.contains(operation) && serverIndex < _serverConfigs.find(operation).value().size() )
+void PFXPetApi::setServerIndex(const QString &operation, int serverIndex) {
+    if (_serverIndices.contains(operation) && serverIndex < _serverConfigs.find(operation).value().size()) {
         _serverIndices[operation] = serverIndex;
+    }
 }
 
-void PFXPetApi::setApiKey(const QString &apiKeyName, const QString &apiKey){
+void PFXPetApi::setApiKey(const QString &apiKeyName, const QString &apiKey) {
     _apiKeys.insert(apiKeyName,apiKey);
 }
 
-void PFXPetApi::setBearerToken(const QString &token){
+void PFXPetApi::setBearerToken(const QString &token) {
     _bearerToken = token;
 }
 
@@ -106,14 +107,14 @@ void PFXPetApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
     * returns the index of the new server config on success and -1 if the operation is not found
     */
-int PFXPetApi::addServerConfiguration(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
-    if(_serverConfigs.contains(operation)){
+int PFXPetApi::addServerConfiguration(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables) {
+    if (_serverConfigs.contains(operation)) {
         _serverConfigs[operation].append(PFXServerConfiguration(
                     url,
                     description,
                     variables));
         return _serverConfigs[operation].size()-1;
-    }else{
+    } else {
         return -1;
     }
 }
@@ -136,85 +137,85 @@ void PFXPetApi::setNewServerForAllOperations(const QUrl &url, const QString &des
     * @param description A String that describes the server
     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
     */
-void PFXPetApi::setNewServer(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+void PFXPetApi::setNewServer(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables) {
     setServerIndex(operation, addServerConfiguration(operation, url, description, variables));
 }
 
 void PFXPetApi::addHeaders(const QString &key, const QString &value) {
-    defaultHeaders.insert(key, value);
+    _defaultHeaders.insert(key, value);
 }
 
 void PFXPetApi::enableRequestCompression() {
-    isRequestCompressionEnabled = true;
+    _isRequestCompressionEnabled = true;
 }
 
 void PFXPetApi::enableResponseCompression() {
-    isResponseCompressionEnabled = true;
+    _isResponseCompressionEnabled = true;
 }
 
-void PFXPetApi::abortRequests(){
+void PFXPetApi::abortRequests() {
     emit abortRequestsSignal();
 }
 
-QString PFXPetApi::getParamStylePrefix(const QString &style){
-    if(style == "matrix"){
+QString PFXPetApi::getParamStylePrefix(const QString &style) {
+    if (style == "matrix") {
         return ";";
-    }else if(style == "label"){
+    } else if (style == "label") {
         return ".";
-    }else if(style == "form"){
+    } else if (style == "form") {
         return "&";
-    }else if(style == "simple"){
+    } else if (style == "simple") {
         return "";
-    }else if(style == "spaceDelimited"){
+    } else if (style == "spaceDelimited") {
         return "&";
-    }else if(style == "pipeDelimited"){
+    } else if (style == "pipeDelimited") {
         return "&";
-    }else{
+    } else {
         return "none";
     }
 }
 
-QString PFXPetApi::getParamStyleSuffix(const QString &style){
-    if(style == "matrix"){
+QString PFXPetApi::getParamStyleSuffix(const QString &style) {
+    if (style == "matrix") {
         return "=";
-    }else if(style == "label"){
+    } else if (style == "label") {
         return "";
-    }else if(style == "form"){
+    } else if (style == "form") {
         return "=";
-    }else if(style == "simple"){
+    } else if (style == "simple") {
         return "";
-    }else if(style == "spaceDelimited"){
+    } else if (style == "spaceDelimited") {
         return "=";
-    }else if(style == "pipeDelimited"){
+    } else if (style == "pipeDelimited") {
         return "=";
-    }else{
+    } else {
         return "none";
     }
 }
 
 QString PFXPetApi::getParamStyleDelimiter(const QString &style, const QString &name, bool isExplode) {
 
-    if(style == "matrix"){
+    if (style == "matrix") {
         return (isExplode) ? ";" + name + "=" : ",";
 
-    }else if(style == "label"){
+    } else if (style == "label") {
         return (isExplode) ? "." : ",";
 
-    }else if(style == "form"){
+    } else if (style == "form") {
         return (isExplode) ? "&" + name + "=" : ",";
 
-    }else if(style == "simple"){
+    } else if (style == "simple") {
         return ",";
-    }else if(style == "spaceDelimited"){
+    } else if (style == "spaceDelimited") {
         return (isExplode) ? "&" + name + "=" : " ";
 
-    }else if(style == "pipeDelimited"){
+    } else if (style == "pipeDelimited") {
         return (isExplode) ? "&" + name + "=" : "|";
 
-    }else if(style == "deepObject"){
+    } else if (style == "deepObject") {
         return (isExplode) ? "&" : "none";
 
-    }else {
+    } else {
         return "none";
     }
 }
@@ -232,7 +233,7 @@ void PFXPetApi::addPet(const PFXPet &body) {
         QByteArray output = body.asJson().toUtf8();
         input.request_body.append(output);
     }
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -274,7 +275,7 @@ void PFXPetApi::deletePet(const qint64 &pet_id, const ::test_namespace::Optional
         pet_idPathParam.append("petId").append("}");
         QString pathPrefix, pathSuffix, pathDelimiter;
         QString pathStyle = "";
-        if(pathStyle == "")
+        if (pathStyle == "")
             pathStyle = "simple";
         pathPrefix = getParamStylePrefix(pathStyle);
         pathSuffix = getParamStyleSuffix(pathStyle);
@@ -288,13 +289,13 @@ void PFXPetApi::deletePet(const qint64 &pet_id, const ::test_namespace::Optional
     PFXHttpRequestInput input(fullPath, "DELETE");
 
 
-    if(api_key.hasValue())
+    if (api_key.hasValue())
     {
         if (!::test_namespace::toStringValue(api_key.value()).isEmpty()) {
             input.headers.insert("api_key", ::test_namespace::toStringValue(api_key.value()));
         }
         }
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -334,12 +335,12 @@ void PFXPetApi::findPetsByStatus(const QList<QString> &status) {
     
     {
         queryStyle = "form";
-        if(queryStyle == "")
+        if (queryStyle == "")
             queryStyle = "form";
         queryPrefix = getParamStylePrefix(queryStyle);
         querySuffix = getParamStyleSuffix(queryStyle);
         queryDelimiter = getParamStyleDelimiter(queryStyle, "status", false);
-        if(status.size() > 0) {
+        if (status.size() > 0) {
             if (QString("csv").indexOf("multi") == 0) {
                 foreach (QString t, status) {
                     if (fullPath.indexOf("?") > 0)
@@ -422,7 +423,7 @@ void PFXPetApi::findPetsByStatus(const QList<QString> &status) {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -472,12 +473,12 @@ void PFXPetApi::findPetsByTags(const QList<QString> &tags) {
     
     {
         queryStyle = "form";
-        if(queryStyle == "")
+        if (queryStyle == "")
             queryStyle = "form";
         queryPrefix = getParamStylePrefix(queryStyle);
         querySuffix = getParamStyleSuffix(queryStyle);
         queryDelimiter = getParamStyleDelimiter(queryStyle, "tags", false);
-        if(tags.size() > 0) {
+        if (tags.size() > 0) {
             if (QString("csv").indexOf("multi") == 0) {
                 foreach (QString t, tags) {
                     if (fullPath.indexOf("?") > 0)
@@ -560,7 +561,7 @@ void PFXPetApi::findPetsByTags(const QList<QString> &tags) {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -606,7 +607,7 @@ void PFXPetApi::findPetsByTagsCallback(PFXHttpRequestWorker *worker) {
 void PFXPetApi::getPetById(const qint64 &pet_id) {
     QString fullPath = QString(_serverConfigs["getPetById"][_serverIndices.value("getPetById")].URL()+"/pet/{petId}");
     
-    if(_apiKeys.contains("api_key")){
+    if (_apiKeys.contains("api_key")) {
         addHeaders("api_key",_apiKeys.find("api_key").value());
     }
     
@@ -616,7 +617,7 @@ void PFXPetApi::getPetById(const qint64 &pet_id) {
         pet_idPathParam.append("petId").append("}");
         QString pathPrefix, pathSuffix, pathDelimiter;
         QString pathStyle = "";
-        if(pathStyle == "")
+        if (pathStyle == "")
             pathStyle = "simple";
         pathPrefix = getParamStylePrefix(pathStyle);
         pathSuffix = getParamStyleSuffix(pathStyle);
@@ -630,7 +631,7 @@ void PFXPetApi::getPetById(const qint64 &pet_id) {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -677,7 +678,7 @@ void PFXPetApi::updatePet(const PFXPet &body) {
         QByteArray output = body.asJson().toUtf8();
         input.request_body.append(output);
     }
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -719,7 +720,7 @@ void PFXPetApi::updatePetWithForm(const qint64 &pet_id, const ::test_namespace::
         pet_idPathParam.append("petId").append("}");
         QString pathPrefix, pathSuffix, pathDelimiter;
         QString pathStyle = "";
-        if(pathStyle == "")
+        if (pathStyle == "")
             pathStyle = "simple";
         pathPrefix = getParamStylePrefix(pathStyle);
         pathSuffix = getParamStyleSuffix(pathStyle);
@@ -732,16 +733,16 @@ void PFXPetApi::updatePetWithForm(const qint64 &pet_id, const ::test_namespace::
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
-    if(name.hasValue())
+    if (name.hasValue())
     {
         input.add_var("name", ::test_namespace::toStringValue(name.value()));
     }
-    if(status.hasValue())
+    if (status.hasValue())
     {
         input.add_var("status", ::test_namespace::toStringValue(status.value()));
     }
 
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -783,7 +784,7 @@ void PFXPetApi::uploadFile(const qint64 &pet_id, const ::test_namespace::Optiona
         pet_idPathParam.append("petId").append("}");
         QString pathPrefix, pathSuffix, pathDelimiter;
         QString pathStyle = "";
-        if(pathStyle == "")
+        if (pathStyle == "")
             pathStyle = "simple";
         pathPrefix = getParamStylePrefix(pathStyle);
         pathSuffix = getParamStyleSuffix(pathStyle);
@@ -796,16 +797,16 @@ void PFXPetApi::uploadFile(const qint64 &pet_id, const ::test_namespace::Optiona
     worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
 
-    if(additional_metadata.hasValue())
+    if (additional_metadata.hasValue())
     {
         input.add_var("additionalMetadata", ::test_namespace::toStringValue(additional_metadata.value()));
     }
-    if(file.hasValue())
+    if (file.hasValue())
     {
         input.add_file("file", file.value().local_filename, file.value().request_filename, file.value().mime_type);
     }
 
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 

--- a/samples/client/petstore/cpp-qt/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt/client/PFXPetApi.h
@@ -113,9 +113,9 @@ private:
     int _timeOut;
     QString _workingDirectory;
     QNetworkAccessManager* _manager;
-    QMap<QString, QString> defaultHeaders;
-    bool isResponseCompressionEnabled;
-    bool isRequestCompressionEnabled;
+    QMap<QString, QString> _defaultHeaders;
+    bool _isResponseCompressionEnabled;
+    bool _isRequestCompressionEnabled;
 
     void addPetCallback(PFXHttpRequestWorker *worker);
     void deletePetCallback(PFXHttpRequestWorker *worker);

--- a/samples/client/petstore/cpp-qt/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt/client/PFXPetApi.h
@@ -53,9 +53,9 @@ public:
     void enableRequestCompression();
     void enableResponseCompression();
     void abortRequests();
-    QString getParamStylePrefix(QString style);
-    QString getParamStyleSuffix(QString style);
-    QString getParamStyleDelimiter(QString style, QString name, bool isExplode);
+    QString getParamStylePrefix(const QString &style);
+    QString getParamStyleSuffix(const QString &style);
+    QString getParamStyleDelimiter(const QString &style, const QString &name, bool isExplode);
 
     /**
     * @param[in]  body PFXPet [required]

--- a/samples/client/petstore/cpp-qt/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXStoreApi.cpp
@@ -19,15 +19,15 @@ namespace test_namespace {
 PFXStoreApi::PFXStoreApi(const int timeOut)
     : _timeOut(timeOut),
       _manager(nullptr),
-      isResponseCompressionEnabled(false),
-      isRequestCompressionEnabled(false) {
+      _isResponseCompressionEnabled(false),
+      _isRequestCompressionEnabled(false) {
     initializeServerConfigs();
 }
 
 PFXStoreApi::~PFXStoreApi() {
 }
 
-void PFXStoreApi::initializeServerConfigs(){
+void PFXStoreApi::initializeServerConfigs() {
     //Default server
     QList<PFXServerConfiguration> defaultConf = QList<PFXServerConfiguration>();
     //varying endpoint server
@@ -49,23 +49,24 @@ void PFXStoreApi::initializeServerConfigs(){
 * returns 0 on success and -1, -2 or -3 on failure.
 * -1 when the variable does not exist and -2 if the value is not defined in the enum and -3 if the operation or server index is not found
 */
-int PFXStoreApi::setDefaultServerValue(int serverIndex, const QString &operation, const QString &variable, const QString &value){
+int PFXStoreApi::setDefaultServerValue(int serverIndex, const QString &operation, const QString &variable, const QString &value) {
     auto it = _serverConfigs.find(operation);
-    if(it != _serverConfigs.end() && serverIndex < it.value().size() ){
+    if (it != _serverConfigs.end() && serverIndex < it.value().size()) {
       return _serverConfigs[operation][serverIndex].setDefaultValue(variable,value);
     }
     return -3;
 }
-void PFXStoreApi::setServerIndex(const QString &operation, int serverIndex){
-    if(_serverIndices.contains(operation) && serverIndex < _serverConfigs.find(operation).value().size() )
+void PFXStoreApi::setServerIndex(const QString &operation, int serverIndex) {
+    if (_serverIndices.contains(operation) && serverIndex < _serverConfigs.find(operation).value().size()) {
         _serverIndices[operation] = serverIndex;
+    }
 }
 
-void PFXStoreApi::setApiKey(const QString &apiKeyName, const QString &apiKey){
+void PFXStoreApi::setApiKey(const QString &apiKeyName, const QString &apiKey) {
     _apiKeys.insert(apiKeyName,apiKey);
 }
 
-void PFXStoreApi::setBearerToken(const QString &token){
+void PFXStoreApi::setBearerToken(const QString &token) {
     _bearerToken = token;
 }
 
@@ -98,14 +99,14 @@ void PFXStoreApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
     * returns the index of the new server config on success and -1 if the operation is not found
     */
-int PFXStoreApi::addServerConfiguration(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
-    if(_serverConfigs.contains(operation)){
+int PFXStoreApi::addServerConfiguration(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables) {
+    if (_serverConfigs.contains(operation)) {
         _serverConfigs[operation].append(PFXServerConfiguration(
                     url,
                     description,
                     variables));
         return _serverConfigs[operation].size()-1;
-    }else{
+    } else {
         return -1;
     }
 }
@@ -128,85 +129,85 @@ void PFXStoreApi::setNewServerForAllOperations(const QUrl &url, const QString &d
     * @param description A String that describes the server
     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
     */
-void PFXStoreApi::setNewServer(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+void PFXStoreApi::setNewServer(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables) {
     setServerIndex(operation, addServerConfiguration(operation, url, description, variables));
 }
 
 void PFXStoreApi::addHeaders(const QString &key, const QString &value) {
-    defaultHeaders.insert(key, value);
+    _defaultHeaders.insert(key, value);
 }
 
 void PFXStoreApi::enableRequestCompression() {
-    isRequestCompressionEnabled = true;
+    _isRequestCompressionEnabled = true;
 }
 
 void PFXStoreApi::enableResponseCompression() {
-    isResponseCompressionEnabled = true;
+    _isResponseCompressionEnabled = true;
 }
 
-void PFXStoreApi::abortRequests(){
+void PFXStoreApi::abortRequests() {
     emit abortRequestsSignal();
 }
 
-QString PFXStoreApi::getParamStylePrefix(const QString &style){
-    if(style == "matrix"){
+QString PFXStoreApi::getParamStylePrefix(const QString &style) {
+    if (style == "matrix") {
         return ";";
-    }else if(style == "label"){
+    } else if (style == "label") {
         return ".";
-    }else if(style == "form"){
+    } else if (style == "form") {
         return "&";
-    }else if(style == "simple"){
+    } else if (style == "simple") {
         return "";
-    }else if(style == "spaceDelimited"){
+    } else if (style == "spaceDelimited") {
         return "&";
-    }else if(style == "pipeDelimited"){
+    } else if (style == "pipeDelimited") {
         return "&";
-    }else{
+    } else {
         return "none";
     }
 }
 
-QString PFXStoreApi::getParamStyleSuffix(const QString &style){
-    if(style == "matrix"){
+QString PFXStoreApi::getParamStyleSuffix(const QString &style) {
+    if (style == "matrix") {
         return "=";
-    }else if(style == "label"){
+    } else if (style == "label") {
         return "";
-    }else if(style == "form"){
+    } else if (style == "form") {
         return "=";
-    }else if(style == "simple"){
+    } else if (style == "simple") {
         return "";
-    }else if(style == "spaceDelimited"){
+    } else if (style == "spaceDelimited") {
         return "=";
-    }else if(style == "pipeDelimited"){
+    } else if (style == "pipeDelimited") {
         return "=";
-    }else{
+    } else {
         return "none";
     }
 }
 
 QString PFXStoreApi::getParamStyleDelimiter(const QString &style, const QString &name, bool isExplode) {
 
-    if(style == "matrix"){
+    if (style == "matrix") {
         return (isExplode) ? ";" + name + "=" : ",";
 
-    }else if(style == "label"){
+    } else if (style == "label") {
         return (isExplode) ? "." : ",";
 
-    }else if(style == "form"){
+    } else if (style == "form") {
         return (isExplode) ? "&" + name + "=" : ",";
 
-    }else if(style == "simple"){
+    } else if (style == "simple") {
         return ",";
-    }else if(style == "spaceDelimited"){
+    } else if (style == "spaceDelimited") {
         return (isExplode) ? "&" + name + "=" : " ";
 
-    }else if(style == "pipeDelimited"){
+    } else if (style == "pipeDelimited") {
         return (isExplode) ? "&" + name + "=" : "|";
 
-    }else if(style == "deepObject"){
+    } else if (style == "deepObject") {
         return (isExplode) ? "&" : "none";
 
-    }else {
+    } else {
         return "none";
     }
 }
@@ -220,7 +221,7 @@ void PFXStoreApi::deleteOrder(const QString &order_id) {
         order_idPathParam.append("orderId").append("}");
         QString pathPrefix, pathSuffix, pathDelimiter;
         QString pathStyle = "";
-        if(pathStyle == "")
+        if (pathStyle == "")
             pathStyle = "simple";
         pathPrefix = getParamStylePrefix(pathStyle);
         pathSuffix = getParamStyleSuffix(pathStyle);
@@ -234,7 +235,7 @@ void PFXStoreApi::deleteOrder(const QString &order_id) {
     PFXHttpRequestInput input(fullPath, "DELETE");
 
 
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -270,7 +271,7 @@ void PFXStoreApi::deleteOrderCallback(PFXHttpRequestWorker *worker) {
 void PFXStoreApi::getInventory() {
     QString fullPath = QString(_serverConfigs["getInventory"][_serverIndices.value("getInventory")].URL()+"/store/inventory");
     
-    if(_apiKeys.contains("api_key")){
+    if (_apiKeys.contains("api_key")) {
         addHeaders("api_key",_apiKeys.find("api_key").value());
     }
     
@@ -280,7 +281,7 @@ void PFXStoreApi::getInventory() {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -332,7 +333,7 @@ void PFXStoreApi::getOrderById(const qint64 &order_id) {
         order_idPathParam.append("orderId").append("}");
         QString pathPrefix, pathSuffix, pathDelimiter;
         QString pathStyle = "";
-        if(pathStyle == "")
+        if (pathStyle == "")
             pathStyle = "simple";
         pathPrefix = getParamStylePrefix(pathStyle);
         pathSuffix = getParamStyleSuffix(pathStyle);
@@ -346,7 +347,7 @@ void PFXStoreApi::getOrderById(const qint64 &order_id) {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -393,7 +394,7 @@ void PFXStoreApi::placeOrder(const PFXOrder &body) {
         QByteArray output = body.asJson().toUtf8();
         input.request_body.append(output);
     }
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 

--- a/samples/client/petstore/cpp-qt/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXStoreApi.cpp
@@ -31,7 +31,6 @@ void PFXStoreApi::initializeServerConfigs(){
     //Default server
     QList<PFXServerConfiguration> defaultConf = QList<PFXServerConfiguration>();
     //varying endpoint server
-    QList<PFXServerConfiguration> serverConf = QList<PFXServerConfiguration>();
     defaultConf.append(PFXServerConfiguration(
     QUrl("http://petstore.swagger.io/v2"),
     "No description provided",
@@ -117,9 +116,9 @@ int PFXStoreApi::addServerConfiguration(const QString &operation, const QUrl &ur
     * @param description A String that describes the server
     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
     */
-void PFXStoreApi::setNewServerForAllOperations(const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
-    for(auto e : _serverIndices.keys()){
-        setServerIndex(e, addServerConfiguration(e, url, description, variables));
+void PFXStoreApi::setNewServerForAllOperations(const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables) {
+    for (auto keyIt = _serverIndices.keyBegin(); keyIt != _serverIndices.keyEnd(); keyIt++) {
+        setServerIndex(*keyIt, addServerConfiguration(*keyIt, url, description, variables));
     }
 }
 
@@ -149,7 +148,7 @@ void PFXStoreApi::abortRequests(){
     emit abortRequestsSignal();
 }
 
-QString PFXStoreApi::getParamStylePrefix(QString style){
+QString PFXStoreApi::getParamStylePrefix(const QString &style){
     if(style == "matrix"){
         return ";";
     }else if(style == "label"){
@@ -167,7 +166,7 @@ QString PFXStoreApi::getParamStylePrefix(QString style){
     }
 }
 
-QString PFXStoreApi::getParamStyleSuffix(QString style){
+QString PFXStoreApi::getParamStyleSuffix(const QString &style){
     if(style == "matrix"){
         return "=";
     }else if(style == "label"){
@@ -185,7 +184,7 @@ QString PFXStoreApi::getParamStyleSuffix(QString style){
     }
 }
 
-QString PFXStoreApi::getParamStyleDelimiter(QString style, QString name, bool isExplode){
+QString PFXStoreApi::getParamStyleDelimiter(const QString &style, const QString &name, bool isExplode) {
 
     if(style == "matrix"){
         return (isExplode) ? ";" + name + "=" : ",";
@@ -235,12 +234,14 @@ void PFXStoreApi::deleteOrder(const QString &order_id) {
     PFXHttpRequestInput input(fullPath, "DELETE");
 
 
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXStoreApi::deleteOrderCallback);
     connect(this, &PFXStoreApi::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -249,15 +250,11 @@ void PFXStoreApi::deleteOrder(const QString &order_id) {
 }
 
 void PFXStoreApi::deleteOrderCallback(PFXHttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     worker->deleteLater();
 
@@ -283,12 +280,14 @@ void PFXStoreApi::getInventory() {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXStoreApi::getInventoryCallback);
     connect(this, &PFXStoreApi::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -297,15 +296,11 @@ void PFXStoreApi::getInventory() {
 }
 
 void PFXStoreApi::getInventoryCallback(PFXHttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     QMap<QString, qint32> output;
     QString json(worker->response);
@@ -351,12 +346,14 @@ void PFXStoreApi::getOrderById(const qint64 &order_id) {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXStoreApi::getOrderByIdCallback);
     connect(this, &PFXStoreApi::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -365,15 +362,11 @@ void PFXStoreApi::getOrderById(const qint64 &order_id) {
 }
 
 void PFXStoreApi::getOrderByIdCallback(PFXHttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     PFXOrder output(QString(worker->response));
     worker->deleteLater();
@@ -400,12 +393,14 @@ void PFXStoreApi::placeOrder(const PFXOrder &body) {
         QByteArray output = body.asJson().toUtf8();
         input.request_body.append(output);
     }
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXStoreApi::placeOrderCallback);
     connect(this, &PFXStoreApi::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -414,15 +409,11 @@ void PFXStoreApi::placeOrder(const PFXOrder &body) {
 }
 
 void PFXStoreApi::placeOrderCallback(PFXHttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     PFXOrder output(QString(worker->response));
     worker->deleteLater();

--- a/samples/client/petstore/cpp-qt/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt/client/PFXStoreApi.h
@@ -52,9 +52,9 @@ public:
     void enableRequestCompression();
     void enableResponseCompression();
     void abortRequests();
-    QString getParamStylePrefix(QString style);
-    QString getParamStyleSuffix(QString style);
-    QString getParamStyleDelimiter(QString style, QString name, bool isExplode);
+    QString getParamStylePrefix(const QString &style);
+    QString getParamStyleSuffix(const QString &style);
+    QString getParamStyleDelimiter(const QString &style, const QString &name, bool isExplode);
 
     /**
     * @param[in]  order_id QString [required]

--- a/samples/client/petstore/cpp-qt/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt/client/PFXStoreApi.h
@@ -85,9 +85,9 @@ private:
     int _timeOut;
     QString _workingDirectory;
     QNetworkAccessManager* _manager;
-    QMap<QString, QString> defaultHeaders;
-    bool isResponseCompressionEnabled;
-    bool isRequestCompressionEnabled;
+    QMap<QString, QString> _defaultHeaders;
+    bool _isResponseCompressionEnabled;
+    bool _isRequestCompressionEnabled;
 
     void deleteOrderCallback(PFXHttpRequestWorker *worker);
     void getInventoryCallback(PFXHttpRequestWorker *worker);

--- a/samples/client/petstore/cpp-qt/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXUserApi.cpp
@@ -31,7 +31,6 @@ void PFXUserApi::initializeServerConfigs(){
     //Default server
     QList<PFXServerConfiguration> defaultConf = QList<PFXServerConfiguration>();
     //varying endpoint server
-    QList<PFXServerConfiguration> serverConf = QList<PFXServerConfiguration>();
     defaultConf.append(PFXServerConfiguration(
     QUrl("http://petstore.swagger.io/v2"),
     "No description provided",
@@ -125,9 +124,9 @@ int PFXUserApi::addServerConfiguration(const QString &operation, const QUrl &url
     * @param description A String that describes the server
     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
     */
-void PFXUserApi::setNewServerForAllOperations(const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
-    for(auto e : _serverIndices.keys()){
-        setServerIndex(e, addServerConfiguration(e, url, description, variables));
+void PFXUserApi::setNewServerForAllOperations(const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables) {
+    for (auto keyIt = _serverIndices.keyBegin(); keyIt != _serverIndices.keyEnd(); keyIt++) {
+        setServerIndex(*keyIt, addServerConfiguration(*keyIt, url, description, variables));
     }
 }
 
@@ -157,7 +156,7 @@ void PFXUserApi::abortRequests(){
     emit abortRequestsSignal();
 }
 
-QString PFXUserApi::getParamStylePrefix(QString style){
+QString PFXUserApi::getParamStylePrefix(const QString &style){
     if(style == "matrix"){
         return ";";
     }else if(style == "label"){
@@ -175,7 +174,7 @@ QString PFXUserApi::getParamStylePrefix(QString style){
     }
 }
 
-QString PFXUserApi::getParamStyleSuffix(QString style){
+QString PFXUserApi::getParamStyleSuffix(const QString &style){
     if(style == "matrix"){
         return "=";
     }else if(style == "label"){
@@ -193,7 +192,7 @@ QString PFXUserApi::getParamStyleSuffix(QString style){
     }
 }
 
-QString PFXUserApi::getParamStyleDelimiter(QString style, QString name, bool isExplode){
+QString PFXUserApi::getParamStyleDelimiter(const QString &style, const QString &name, bool isExplode) {
 
     if(style == "matrix"){
         return (isExplode) ? ";" + name + "=" : ",";
@@ -233,12 +232,14 @@ void PFXUserApi::createUser(const PFXUser &body) {
         QByteArray output = body.asJson().toUtf8();
         input.request_body.append(output);
     }
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::createUserCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -247,15 +248,11 @@ void PFXUserApi::createUser(const PFXUser &body) {
 }
 
 void PFXUserApi::createUserCallback(PFXHttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     worker->deleteLater();
 
@@ -281,12 +278,14 @@ void PFXUserApi::createUsersWithArrayInput(const QList<PFXUser> &body) {
         QByteArray bytes = doc.toJson();
         input.request_body.append(bytes);
     }
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::createUsersWithArrayInputCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -295,15 +294,11 @@ void PFXUserApi::createUsersWithArrayInput(const QList<PFXUser> &body) {
 }
 
 void PFXUserApi::createUsersWithArrayInputCallback(PFXHttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     worker->deleteLater();
 
@@ -329,12 +324,14 @@ void PFXUserApi::createUsersWithListInput(const QList<PFXUser> &body) {
         QByteArray bytes = doc.toJson();
         input.request_body.append(bytes);
     }
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::createUsersWithListInputCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -343,15 +340,11 @@ void PFXUserApi::createUsersWithListInput(const QList<PFXUser> &body) {
 }
 
 void PFXUserApi::createUsersWithListInputCallback(PFXHttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     worker->deleteLater();
 
@@ -387,12 +380,14 @@ void PFXUserApi::deleteUser(const QString &username) {
     PFXHttpRequestInput input(fullPath, "DELETE");
 
 
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::deleteUserCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -401,15 +396,11 @@ void PFXUserApi::deleteUser(const QString &username) {
 }
 
 void PFXUserApi::deleteUserCallback(PFXHttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     worker->deleteLater();
 
@@ -445,12 +436,14 @@ void PFXUserApi::getUserByName(const QString &username) {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::getUserByNameCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -459,15 +452,11 @@ void PFXUserApi::getUserByName(const QString &username) {
 }
 
 void PFXUserApi::getUserByNameCallback(PFXHttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     PFXUser output(QString(worker->response));
     worker->deleteLater();
@@ -521,12 +510,14 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::loginUserCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -535,15 +526,11 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
 }
 
 void PFXUserApi::loginUserCallback(PFXHttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     QString output;
     ::test_namespace::fromStringValue(QString(worker->response), output);
@@ -567,12 +554,14 @@ void PFXUserApi::logoutUser() {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::logoutUserCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -581,15 +570,11 @@ void PFXUserApi::logoutUser() {
 }
 
 void PFXUserApi::logoutUserCallback(PFXHttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     worker->deleteLater();
 
@@ -629,12 +614,14 @@ void PFXUserApi::updateUser(const QString &username, const PFXUser &body) {
         QByteArray output = body.asJson().toUtf8();
         input.request_body.append(output);
     }
-    foreach (QString key, this->defaultHeaders.keys()) { input.headers.insert(key, this->defaultHeaders.value(key)); }
+    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+        input.headers.insert(keyValueIt->first, keyValueIt->second);
+    }
 
     connect(worker, &PFXHttpRequestWorker::on_execution_finished, this, &PFXUserApi::updateUserCallback);
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
-    connect(worker, &QObject::destroyed, [this](){
-        if(findChildren<PFXHttpRequestWorker*>().count() == 0){
+    connect(worker, &QObject::destroyed, this, [this]() {
+        if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
             emit allPendingRequestsCompleted();
         }
     });
@@ -643,15 +630,11 @@ void PFXUserApi::updateUser(const QString &username, const PFXUser &body) {
 }
 
 void PFXUserApi::updateUserCallback(PFXHttpRequestWorker *worker) {
-    QString msg;
     QString error_str = worker->error_str;
     QNetworkReply::NetworkError error_type = worker->error_type;
 
-    if (worker->error_type == QNetworkReply::NoError) {
-        msg = QString("Success! %1 bytes").arg(worker->response.length());
-    } else {
-        msg = "Error: " + worker->error_str;
-        error_str = QString("%1, %2").arg(worker->error_str).arg(QString(worker->response));
+    if (worker->error_type != QNetworkReply::NoError) {
+        error_str = QString("%1, %2").arg(worker->error_str, QString(worker->response));
     }
     worker->deleteLater();
 

--- a/samples/client/petstore/cpp-qt/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXUserApi.cpp
@@ -19,15 +19,15 @@ namespace test_namespace {
 PFXUserApi::PFXUserApi(const int timeOut)
     : _timeOut(timeOut),
       _manager(nullptr),
-      isResponseCompressionEnabled(false),
-      isRequestCompressionEnabled(false) {
+      _isResponseCompressionEnabled(false),
+      _isRequestCompressionEnabled(false) {
     initializeServerConfigs();
 }
 
 PFXUserApi::~PFXUserApi() {
 }
 
-void PFXUserApi::initializeServerConfigs(){
+void PFXUserApi::initializeServerConfigs() {
     //Default server
     QList<PFXServerConfiguration> defaultConf = QList<PFXServerConfiguration>();
     //varying endpoint server
@@ -57,23 +57,24 @@ void PFXUserApi::initializeServerConfigs(){
 * returns 0 on success and -1, -2 or -3 on failure.
 * -1 when the variable does not exist and -2 if the value is not defined in the enum and -3 if the operation or server index is not found
 */
-int PFXUserApi::setDefaultServerValue(int serverIndex, const QString &operation, const QString &variable, const QString &value){
+int PFXUserApi::setDefaultServerValue(int serverIndex, const QString &operation, const QString &variable, const QString &value) {
     auto it = _serverConfigs.find(operation);
-    if(it != _serverConfigs.end() && serverIndex < it.value().size() ){
+    if (it != _serverConfigs.end() && serverIndex < it.value().size()) {
       return _serverConfigs[operation][serverIndex].setDefaultValue(variable,value);
     }
     return -3;
 }
-void PFXUserApi::setServerIndex(const QString &operation, int serverIndex){
-    if(_serverIndices.contains(operation) && serverIndex < _serverConfigs.find(operation).value().size() )
+void PFXUserApi::setServerIndex(const QString &operation, int serverIndex) {
+    if (_serverIndices.contains(operation) && serverIndex < _serverConfigs.find(operation).value().size()) {
         _serverIndices[operation] = serverIndex;
+    }
 }
 
-void PFXUserApi::setApiKey(const QString &apiKeyName, const QString &apiKey){
+void PFXUserApi::setApiKey(const QString &apiKeyName, const QString &apiKey) {
     _apiKeys.insert(apiKeyName,apiKey);
 }
 
-void PFXUserApi::setBearerToken(const QString &token){
+void PFXUserApi::setBearerToken(const QString &token) {
     _bearerToken = token;
 }
 
@@ -106,14 +107,14 @@ void PFXUserApi::setNetworkAccessManager(QNetworkAccessManager* manager) {
     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
     * returns the index of the new server config on success and -1 if the operation is not found
     */
-int PFXUserApi::addServerConfiguration(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
-    if(_serverConfigs.contains(operation)){
+int PFXUserApi::addServerConfiguration(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables) {
+    if (_serverConfigs.contains(operation)) {
         _serverConfigs[operation].append(PFXServerConfiguration(
                     url,
                     description,
                     variables));
         return _serverConfigs[operation].size()-1;
-    }else{
+    } else {
         return -1;
     }
 }
@@ -136,85 +137,85 @@ void PFXUserApi::setNewServerForAllOperations(const QUrl &url, const QString &de
     * @param description A String that describes the server
     * @param variables A map between a variable name and its value. The value is used for substitution in the server's URL template.
     */
-void PFXUserApi::setNewServer(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables){
+void PFXUserApi::setNewServer(const QString &operation, const QUrl &url, const QString &description, const QMap<QString, PFXServerVariable> &variables) {
     setServerIndex(operation, addServerConfiguration(operation, url, description, variables));
 }
 
 void PFXUserApi::addHeaders(const QString &key, const QString &value) {
-    defaultHeaders.insert(key, value);
+    _defaultHeaders.insert(key, value);
 }
 
 void PFXUserApi::enableRequestCompression() {
-    isRequestCompressionEnabled = true;
+    _isRequestCompressionEnabled = true;
 }
 
 void PFXUserApi::enableResponseCompression() {
-    isResponseCompressionEnabled = true;
+    _isResponseCompressionEnabled = true;
 }
 
-void PFXUserApi::abortRequests(){
+void PFXUserApi::abortRequests() {
     emit abortRequestsSignal();
 }
 
-QString PFXUserApi::getParamStylePrefix(const QString &style){
-    if(style == "matrix"){
+QString PFXUserApi::getParamStylePrefix(const QString &style) {
+    if (style == "matrix") {
         return ";";
-    }else if(style == "label"){
+    } else if (style == "label") {
         return ".";
-    }else if(style == "form"){
+    } else if (style == "form") {
         return "&";
-    }else if(style == "simple"){
+    } else if (style == "simple") {
         return "";
-    }else if(style == "spaceDelimited"){
+    } else if (style == "spaceDelimited") {
         return "&";
-    }else if(style == "pipeDelimited"){
+    } else if (style == "pipeDelimited") {
         return "&";
-    }else{
+    } else {
         return "none";
     }
 }
 
-QString PFXUserApi::getParamStyleSuffix(const QString &style){
-    if(style == "matrix"){
+QString PFXUserApi::getParamStyleSuffix(const QString &style) {
+    if (style == "matrix") {
         return "=";
-    }else if(style == "label"){
+    } else if (style == "label") {
         return "";
-    }else if(style == "form"){
+    } else if (style == "form") {
         return "=";
-    }else if(style == "simple"){
+    } else if (style == "simple") {
         return "";
-    }else if(style == "spaceDelimited"){
+    } else if (style == "spaceDelimited") {
         return "=";
-    }else if(style == "pipeDelimited"){
+    } else if (style == "pipeDelimited") {
         return "=";
-    }else{
+    } else {
         return "none";
     }
 }
 
 QString PFXUserApi::getParamStyleDelimiter(const QString &style, const QString &name, bool isExplode) {
 
-    if(style == "matrix"){
+    if (style == "matrix") {
         return (isExplode) ? ";" + name + "=" : ",";
 
-    }else if(style == "label"){
+    } else if (style == "label") {
         return (isExplode) ? "." : ",";
 
-    }else if(style == "form"){
+    } else if (style == "form") {
         return (isExplode) ? "&" + name + "=" : ",";
 
-    }else if(style == "simple"){
+    } else if (style == "simple") {
         return ",";
-    }else if(style == "spaceDelimited"){
+    } else if (style == "spaceDelimited") {
         return (isExplode) ? "&" + name + "=" : " ";
 
-    }else if(style == "pipeDelimited"){
+    } else if (style == "pipeDelimited") {
         return (isExplode) ? "&" + name + "=" : "|";
 
-    }else if(style == "deepObject"){
+    } else if (style == "deepObject") {
         return (isExplode) ? "&" : "none";
 
-    }else {
+    } else {
         return "none";
     }
 }
@@ -232,7 +233,7 @@ void PFXUserApi::createUser(const PFXUser &body) {
         QByteArray output = body.asJson().toUtf8();
         input.request_body.append(output);
     }
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -278,7 +279,7 @@ void PFXUserApi::createUsersWithArrayInput(const QList<PFXUser> &body) {
         QByteArray bytes = doc.toJson();
         input.request_body.append(bytes);
     }
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -324,7 +325,7 @@ void PFXUserApi::createUsersWithListInput(const QList<PFXUser> &body) {
         QByteArray bytes = doc.toJson();
         input.request_body.append(bytes);
     }
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -366,7 +367,7 @@ void PFXUserApi::deleteUser(const QString &username) {
         usernamePathParam.append("username").append("}");
         QString pathPrefix, pathSuffix, pathDelimiter;
         QString pathStyle = "";
-        if(pathStyle == "")
+        if (pathStyle == "")
             pathStyle = "simple";
         pathPrefix = getParamStylePrefix(pathStyle);
         pathSuffix = getParamStyleSuffix(pathStyle);
@@ -380,7 +381,7 @@ void PFXUserApi::deleteUser(const QString &username) {
     PFXHttpRequestInput input(fullPath, "DELETE");
 
 
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -422,7 +423,7 @@ void PFXUserApi::getUserByName(const QString &username) {
         usernamePathParam.append("username").append("}");
         QString pathPrefix, pathSuffix, pathDelimiter;
         QString pathStyle = "";
-        if(pathStyle == "")
+        if (pathStyle == "")
             pathStyle = "simple";
         pathPrefix = getParamStylePrefix(pathStyle);
         pathSuffix = getParamStyleSuffix(pathStyle);
@@ -436,7 +437,7 @@ void PFXUserApi::getUserByName(const QString &username) {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -477,7 +478,7 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
     
     {
         queryStyle = "";
-        if(queryStyle == "")
+        if (queryStyle == "")
             queryStyle = "form";
         queryPrefix = getParamStylePrefix(queryStyle);
         querySuffix = getParamStyleSuffix(queryStyle);
@@ -492,7 +493,7 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
     
     {
         queryStyle = "";
-        if(queryStyle == "")
+        if (queryStyle == "")
             queryStyle = "form";
         queryPrefix = getParamStylePrefix(queryStyle);
         querySuffix = getParamStyleSuffix(queryStyle);
@@ -510,7 +511,7 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -554,7 +555,7 @@ void PFXUserApi::logoutUser() {
     PFXHttpRequestInput input(fullPath, "GET");
 
 
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 
@@ -596,7 +597,7 @@ void PFXUserApi::updateUser(const QString &username, const PFXUser &body) {
         usernamePathParam.append("username").append("}");
         QString pathPrefix, pathSuffix, pathDelimiter;
         QString pathStyle = "";
-        if(pathStyle == "")
+        if (pathStyle == "")
             pathStyle = "simple";
         pathPrefix = getParamStylePrefix(pathStyle);
         pathSuffix = getParamStyleSuffix(pathStyle);
@@ -614,7 +615,7 @@ void PFXUserApi::updateUser(const QString &username, const PFXUser &body) {
         QByteArray output = body.asJson().toUtf8();
         input.request_body.append(output);
     }
-    for (auto keyValueIt = defaultHeaders.keyValueBegin(); keyValueIt != defaultHeaders.keyValueEnd(); keyValueIt++) {
+    for (auto keyValueIt = _defaultHeaders.keyValueBegin(); keyValueIt != _defaultHeaders.keyValueEnd(); keyValueIt++) {
         input.headers.insert(keyValueIt->first, keyValueIt->second);
     }
 

--- a/samples/client/petstore/cpp-qt/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt/client/PFXUserApi.h
@@ -107,9 +107,9 @@ private:
     int _timeOut;
     QString _workingDirectory;
     QNetworkAccessManager* _manager;
-    QMap<QString, QString> defaultHeaders;
-    bool isResponseCompressionEnabled;
-    bool isRequestCompressionEnabled;
+    QMap<QString, QString> _defaultHeaders;
+    bool _isResponseCompressionEnabled;
+    bool _isRequestCompressionEnabled;
 
     void createUserCallback(PFXHttpRequestWorker *worker);
     void createUsersWithArrayInputCallback(PFXHttpRequestWorker *worker);

--- a/samples/client/petstore/cpp-qt/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt/client/PFXUserApi.h
@@ -52,9 +52,9 @@ public:
     void enableRequestCompression();
     void enableResponseCompression();
     void abortRequests();
-    QString getParamStylePrefix(QString style);
-    QString getParamStyleSuffix(QString style);
-    QString getParamStyleDelimiter(QString style, QString name, bool isExplode);
+    QString getParamStylePrefix(const QString &style);
+    QString getParamStyleSuffix(const QString &style);
+    QString getParamStyleDelimiter(const QString &style, const QString &name, bool isExplode);
 
     /**
     * @param[in]  body PFXUser [required]


### PR DESCRIPTION
Here is a list of improvement to fix most of the cppcheck and clazy warning by a generated code:
- Remove unsused variable
- Don't create temporary item when iterating
- Pass QString parameter by const reference
- Pass a context object as 3rd connect parameter (https://github.com/KDE/clazy/blob/master/docs/checks/README-connect-3arg-lambda.md)

The second commit improve the coding style.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@ravinikam @stkrwork @etherealjoy @muttleyxd