### PR TITLE
Updated the HTML2 Doc Curl Examples to provide sample Request Body & Query Param examples.

### DIFF
--- a/modules/openapi-generator/src/main/resources/htmlDocs2/index.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/index.mustache
@@ -248,11 +248,7 @@
 
                         <div class="tab-content">
                           <div class="tab-pane active" id="examples-{{baseName}}-{{nickname}}-0-curl">
-                            <pre class="prettyprint"><code class="language-bsh">curl -X {{vendorExtensions.x-codegen-http-method-upper-case}}{{#authMethods}}\
-{{#isApiKey}}{{#isKeyInHeader}}-H "{{keyParamName}}: [[apiKey]]"{{/isKeyInHeader}}{{/isApiKey}}{{^isBasicBearer}}{{#isBasic}} -H "Authorization: Basic [[basicHash]]"{{/isBasic}}{{/isBasicBearer}}{{#isBasicBearer}} -H "Authorization: Bearer [[accessToken]]"{{/isBasicBearer}}{{/authMethods}}{{#hasProduces}}\
- -H "Accept: {{#produces}}{{{mediaType}}}{{^-last}},{{/-last}}{{/produces}}"{{/hasProduces}}{{#hasConsumes}}\
- -H "Content-Type: {{#consumes}}{{{mediaType}}}{{^-last}},{{/-last}}{{/consumes}}"{{/hasConsumes}}\
- "{{basePath}}{{path}}{{#hasQueryParams}}?{{#queryParams}}{{^-first}}&{{/-first}}{{baseName}}={{vendorExtensions.x-eg}}{{/queryParams}}{{/hasQueryParams}}"</code></pre>
+                            <pre class="prettyprint"><code class="language-bsh">{{>sample_curl}}</code></pre>
                           </div>
                           <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-0-java">
                             <pre class="prettyprint"><code class="language-java">{{>sample_java}}</code></pre>

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/sample_curl.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/sample_curl.mustache
@@ -1,0 +1,6 @@
+curl -X {{vendorExtensions.x-codegen-http-method-upper-case}}{{#authMethods}} \
+{{#isApiKey}}{{#isKeyInHeader}}-H "{{keyParamName}}: [[apiKey]]"{{/isKeyInHeader}}{{/isApiKey}}{{^isBasicBearer}}{{#isBasic}} -H "Authorization: Basic [[basicHash]]"{{/isBasic}}{{/isBasicBearer}}{{#isBasicBearer}} -H "Authorization: Bearer [[accessToken]]"{{/isBasicBearer}}{{/authMethods}}{{#hasProduces}} \
+ -H "Accept: {{#produces}}{{{mediaType}}}{{^-last}},{{/-last}}{{/produces}}"{{/hasProduces}}{{#hasConsumes}} \
+ -H "Content-Type: {{#consumes}}{{{mediaType}}}{{^-last}},{{/-last}}{{/consumes}}"{{/hasConsumes}} \
+ "{{basePath}}{{path}}{{#hasQueryParams}}?{{#queryParams}}{{^-first}}&{{/-first}}{{baseName}}={{{example}}}{{/queryParams}}{{/hasQueryParams}}"{{#requestBodyExamples}} \
+ -d '{{example}}'{{/requestBodyExamples}}


### PR DESCRIPTION
Addressed the issue in #9384 where query strings in curl examples were not displaying their example values.
I also refactored the code out so that the curl example into its own mustache file, and provided the request body examples as well.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
