### PR TITLE
Give enums valid names when specified with x-enum-varnames

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -874,7 +874,7 @@ WeatherType:
     - Rainy
 ```
 
-In the example for the integer value `42`, the description will be `Blue sky` and the name of the enum item will be `Sunny` (some generators changes it to `SUNNY` to respect some coding convention).
+In the example for the integer value `42`, the description will be `Blue sky` and the name of the enum item will be `Sunny`, `SUNNY`, or `sunny` depending on the enum conventions of the target language. The name will be modified to be a valid enum name if necessary, for example spaces might become underscores.
 
 ### ObjC
 #### x-objc-operationId

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -5726,14 +5726,18 @@ public class DefaultCodegen implements CodegenConfig {
 
     protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String dataType) {
         if (vendorExtensions != null) {
-            updateEnumVarsWithExtensions(enumVars, vendorExtensions, "x-enum-varnames", "name");
-            updateEnumVarsWithExtensions(enumVars, vendorExtensions, "x-enum-descriptions", "enumDescription");
+            updateEnumVarsWithExtensions(enumVars, vendorExtensions, "x-enum-varnames", "name", dataType);
+            updateEnumVarsWithExtensions(enumVars, vendorExtensions, "x-enum-descriptions", "enumDescription", dataType);
         }
     }
 
-    private void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String extensionKey, String key) {
+    private void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String extensionKey, String key, String dataType) {
         if (vendorExtensions.containsKey(extensionKey)) {
             List<String> values = (List<String>) vendorExtensions.get(extensionKey);
+            if (extensionKey.equals("x-enum-varnames"))
+            {
+                values = values.stream().map(v -> toEnumVarName(v, dataType)).collect(Collectors.toList());
+            }
             int size = Math.min(enumVars.size(), values.size());
             for (int i = 0; i < size; i++) {
                 enumVars.get(i).put(key, values.get(i));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -796,11 +796,11 @@ public class DefaultCodegenTest {
         List<Map<String, Object>> enumVars = (List<Map<String, Object>>) cm.getAllowableValues().get("enumVars");
         Assert.assertNotNull(enumVars);
         Assert.assertNotNull(enumVars.get(0));
-        Assert.assertEquals(enumVars.get(0).getOrDefault("name", ""), "DOGVAR");
+        Assert.assertEquals(enumVars.get(0).getOrDefault("name", ""), "DOG_VARIABLE");
         Assert.assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"dog\"");
         Assert.assertEquals(enumVars.get(0).getOrDefault("enumDescription", ""), "This is a dog");
         Assert.assertNotNull(enumVars.get(1));
-        Assert.assertEquals(enumVars.get(1).getOrDefault("name", ""), "CATVAR");
+        Assert.assertEquals(enumVars.get(1).getOrDefault("name", ""), "CAT_VARIABLE");
         Assert.assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"cat\"");
         Assert.assertEquals(enumVars.get(1).getOrDefault("enumDescription", ""), "This is a cat");
     }
@@ -2010,7 +2010,7 @@ public class DefaultCodegenTest {
         allowableValues.put("values", Arrays.asList("dog", "cat"));
         cm.setAllowableValues(allowableValues);
         cm.dataType = "String";
-        final List<String> aliases = Arrays.asList("DOGVAR", "CATVAR");
+        final List<String> aliases = Arrays.asList("Dog variable", "Cat variable");
         final List<String> descriptions = Arrays.asList("This is a dog", "This is a cat");
         Map<String, Object> extensions = new HashMap<>();
         extensions.put("x-enum-varnames", aliases);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -267,7 +267,7 @@ public class JavaClientCodegenTest {
         Assert.assertNotNull(enumVars);
         Map<String, String> testedEnumVar = enumVars.get(0);
         Assert.assertNotNull(testedEnumVar);
-        Assert.assertEquals(testedEnumVar.getOrDefault("name", ""), "ONE");
+        Assert.assertEquals(testedEnumVar.getOrDefault("name", ""), "NUMBER_ONE");
         Assert.assertEquals(testedEnumVar.getOrDefault("value", ""), "1");
     }
 


### PR DESCRIPTION
This changes how x-enum-varnames behaves. Issue #3246 already describes the problem quite well, but to summarize, the current codegen just takes the value specified by x-enum-varnames and sets the enum variable name to it. This causes the generation of bad code when the specified name isn't a valid variable name, such as because it contains spaces. Additionally, different languages have different conventions for enum names, so for you may want `Partly cloudy` to generate `PARTLY_CLOUDY` in Java but `PartyCloudy` in TypeScript.

This change now passes the user-specified name to the language-specific `toEnumVarName` function for processing, so that the generated variable name is legal for the target language, and so that it conforms to language conventions or any other generator-specific settings that have been set. This is what issue #3246 refers to as "option 1" for a fix.

If there is any other information I can provide, please let me know 😃

Fix #3246

### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
