### PR TITLE
fix: :bug: Added ability to override basePath while creating ApiClient instance

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -16,13 +16,18 @@ import querystring from "querystring";
 * @class
 */{{/emitJSDoc}}
 class ApiClient {
-    constructor() {
+    /**
+     * The base URL against which to resolve every API call's (relative) path.
+     * Overrides the default value set in spec file if present
+     * @param {String} basePath
+     */
+    constructor(basePath = '{{{basePath}}}') {
         {{#emitJSDoc}}/**
          * The base URL against which to resolve every API call's (relative) path.
          * @type {String}
          * @default {{{basePath}}}
          */{{/emitJSDoc}}
-        this.basePath = '{{{basePath}}}'.replace(/\/+$/, '');
+        this.basePath = basePath.replace(/\/+$/, '');
 
         {{#emitJSDoc}}/**
          * The authentication methods to be included for all API calls.


### PR DESCRIPTION
Solves #9179
Allows overwriting the basePath, this useful when the base url cannot always be known beforehand.
@CodeNinjai @frol @cliffano This is an update to only the ApiClient constructor

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
