### PR TITLE
[elm] fix for invalid code being generated for enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/elm/fieldDecoder.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/fieldDecoder.mustache
@@ -10,6 +10,7 @@
 {{#isFloat}}Json.Decode.float{{/isFloat}}
 {{#isDouble}}Json.Decode.float{{/isDouble}}
 {{#isBoolean}}Json.Decode.bool{{/isBoolean}}
+{{#isEnum}}{{#lambda.camelcase}}{{classname}}{{enumName}}Decoder{{/lambda.camelcase}}{{/isEnum}}
 {{#isUuid}}Uuid.decoder{{/isUuid}}
 {{^isDateTime}}{{^isDate}}{{^isByteArray}}{{^isBinary}}{{^isString}}{{^isNumeric}}{{^isBoolean}}{{^isUuid}}
 {{#is2xx}}Api.Data.{{/is2xx}}{{#is3xx}}Api.Data.{{/is3xx}}{{#lambda.camelcase}}{{#isEnum}}{{classname}}{{enumName}}{{/isEnum}}{{^isEnum}}{{dataType}}{{/isEnum}}{{/lambda.camelcase}}Decoder

--- a/modules/openapi-generator/src/main/resources/elm/fieldEncoder.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/fieldEncoder.mustache
@@ -10,6 +10,7 @@
 {{#isFloat}}Json.Encode.float{{/isFloat}}
 {{#isDouble}}Json.Encode.float{{/isDouble}}
 {{#isBoolean}}Json.Encode.bool{{/isBoolean}}
+{{#isEnum}}{{#lambda.camelcase}}encode{{classname}}{{enumName}}{{/lambda.camelcase}}{{/isEnum}}
 {{#isUuid}}Uuid.encode{{/isUuid}}
 {{^isDateTime}}{{^isDate}}{{^isByteArray}}{{^isBinary}}{{^isString}}{{^isNumeric}}{{^isBoolean}}{{^isUuid}}
 {{#lambda.camelcase}}encode{{#isEnum}}{{classname}}{{enumName}}{{/isEnum}}{{^isEnum}}{{dataType}}{{/isEnum}}{{/lambda.camelcase}}


### PR DESCRIPTION
Elm code generator produces invalid elm code if there are enums in the OpenAPI specification. As described in #8343 the problem is the missing encoder/decoder for the enum field in the encoder/decoder of the structure. With this patch the encoders/decoders are added as required.

@eriktim 

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
