### PR TITLE
[csharp-netcore] verbose null checking

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/modelGeneric.mustache
@@ -132,7 +132,10 @@
             {{^conditionalSerialization}}
             {{^vendorExtensions.x-csharp-value-type}}
             // to ensure "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" is required (not null)
-            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} ?? throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
+            if ({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} == null) {
+                throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
+            }
+            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
             {{/vendorExtensions.x-csharp-value-type}}
             {{#vendorExtensions.x-csharp-value-type}}
             this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
@@ -141,7 +144,10 @@
             {{#conditionalSerialization}}
             {{^vendorExtensions.x-csharp-value-type}}
             // to ensure "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" is required (not null)
-            this._{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} ?? throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
+            if ({{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} == null) {
+                throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
+            }
+            this._{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
             {{/vendorExtensions.x-csharp-value-type}}
             {{#vendorExtensions.x-csharp-value-type}}
             this._{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Animal.cs
@@ -52,7 +52,10 @@ namespace Org.OpenAPITools.Model
         public Animal(string className = default(string), string color = "red")
         {
             // to ensure "className" is required (not null)
-            this._ClassName = className ?? throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            }
+            this._ClassName = className;
             // use default value if no "color" provided
             this.Color = color ?? "red";
             this.AdditionalProperties = new Dictionary<string, object>();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -45,7 +45,10 @@ namespace Org.OpenAPITools.Model
         public AppleReq(string cultivar = default(string), bool mealy = default(bool))
         {
             // to ensure "cultivar" is required (not null)
-            this._Cultivar = cultivar ?? throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+            if (cultivar == null) {
+                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+            }
+            this._Cultivar = cultivar;
             this._Mealy = mealy;
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public BasquePig(string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this._ClassName = className ?? throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+            }
+            this._ClassName = className;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Category.cs
@@ -48,7 +48,10 @@ namespace Org.OpenAPITools.Model
         public Category(long id = default(long), string name = "default-name")
         {
             // to ensure "name" is required (not null)
-            this._Name = name ?? throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            }
+            this._Name = name;
             this._Id = id;
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this._ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+            }
+            this._ShapeType = shapeType;
             // to ensure "quadrilateralType" is required (not null)
-            this._QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+            }
+            this._QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public DanishPig(string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this._ClassName = className ?? throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+            }
+            this._ClassName = className;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this._ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+            }
+            this._ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this._TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+            }
+            this._TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -63,10 +63,16 @@ namespace Org.OpenAPITools.Model
         {
             this._Number = number;
             // to ensure "_byte" is required (not null)
-            this._Byte = _byte ?? throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            if (_byte == null) {
+                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            }
+            this._Byte = _byte;
             this._Date = date;
             // to ensure "password" is required (not null)
-            this._Password = password ?? throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            if (password == null) {
+                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            }
+            this._Password = password;
             this._Integer = integer;
             this._Int32 = int32;
             this._Int64 = int64;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -51,7 +51,10 @@ namespace Org.OpenAPITools.Model
         public GrandparentAnimal(string petType = default(string))
         {
             // to ensure "petType" is required (not null)
-            this._PetType = petType ?? throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+            if (petType == null) {
+                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+            }
+            this._PetType = petType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -45,9 +45,15 @@ namespace Org.OpenAPITools.Model
         public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this._ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+            }
+            this._ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this._TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+            }
+            this._TriangleType = triangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Pet.cs
@@ -106,9 +106,15 @@ namespace Org.OpenAPITools.Model
         public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
-            this._Name = name ?? throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            }
+            this._Name = name;
             // to ensure "photoUrls" is required (not null)
-            this._PhotoUrls = photoUrls ?? throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            if (photoUrls == null) {
+                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            }
+            this._PhotoUrls = photoUrls;
             this._Id = id;
             this._Category = category;
             this._Tags = tags;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public QuadrilateralInterface(string quadrilateralType = default(string))
         {
             // to ensure "quadrilateralType" is required (not null)
-            this._QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+            }
+            this._QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this._ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+            }
+            this._ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this._TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+            }
+            this._TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public ShapeInterface(string shapeType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this._ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+            }
+            this._ShapeType = shapeType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this._ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+            }
+            this._ShapeType = shapeType;
             // to ensure "quadrilateralType" is required (not null)
-            this._QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+            }
+            this._QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public TriangleInterface(string triangleType = default(string))
         {
             // to ensure "triangleType" is required (not null)
-            this._TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+            }
+            this._TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Whale.cs
@@ -49,7 +49,10 @@ namespace Org.OpenAPITools.Model
         public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this._ClassName = className ?? throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+            }
+            this._ClassName = className;
             this._HasBaleen = hasBaleen;
             this._HasTeeth = hasTeeth;
             this.AdditionalProperties = new Dictionary<string, object>();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Zebra.cs
@@ -100,7 +100,10 @@ namespace Org.OpenAPITools.Model
         public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
         {
             // to ensure "className" is required (not null)
-            this._ClassName = className ?? throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+            }
+            this._ClassName = className;
             this._Type = type;
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Animal.cs
@@ -53,7 +53,10 @@ namespace Org.OpenAPITools.Model
         public Animal(string className = default(string), string color = "red")
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            }
+            this.ClassName = className;
             // use default value if no "color" provided
             this.Color = color ?? "red";
             this.AdditionalProperties = new Dictionary<string, object>();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -46,7 +46,10 @@ namespace Org.OpenAPITools.Model
         public AppleReq(string cultivar = default(string), bool mealy = default(bool))
         {
             // to ensure "cultivar" is required (not null)
-            this.Cultivar = cultivar ?? throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+            if (cultivar == null) {
+                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+            }
+            this.Cultivar = cultivar;
             this.Mealy = mealy;
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -48,7 +48,10 @@ namespace Org.OpenAPITools.Model
         public BasquePig(string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+            }
+            this.ClassName = className;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Category.cs
@@ -49,7 +49,10 @@ namespace Org.OpenAPITools.Model
         public Category(long id = default(long), string name = "default-name")
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            }
+            this.Name = name;
             this.Id = id;
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -49,9 +49,15 @@ namespace Org.OpenAPITools.Model
         public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -48,7 +48,10 @@ namespace Org.OpenAPITools.Model
         public DanishPig(string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+            }
+            this.ClassName = className;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -49,9 +49,15 @@ namespace Org.OpenAPITools.Model
         public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -64,10 +64,16 @@ namespace Org.OpenAPITools.Model
         {
             this.Number = number;
             // to ensure "_byte" is required (not null)
-            this.Byte = _byte ?? throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            if (_byte == null) {
+                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            }
+            this.Byte = _byte;
             this.Date = date;
             // to ensure "password" is required (not null)
-            this.Password = password ?? throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            if (password == null) {
+                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            }
+            this.Password = password;
             this.Integer = integer;
             this.Int32 = int32;
             this.Int64 = int64;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -52,7 +52,10 @@ namespace Org.OpenAPITools.Model
         public GrandparentAnimal(string petType = default(string))
         {
             // to ensure "petType" is required (not null)
-            this.PetType = petType ?? throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+            if (petType == null) {
+                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+            }
+            this.PetType = petType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -46,9 +46,15 @@ namespace Org.OpenAPITools.Model
         public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Pet.cs
@@ -87,9 +87,15 @@ namespace Org.OpenAPITools.Model
         public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            }
+            this.Name = name;
             // to ensure "photoUrls" is required (not null)
-            this.PhotoUrls = photoUrls ?? throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            if (photoUrls == null) {
+                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            }
+            this.PhotoUrls = photoUrls;
             this.Id = id;
             this.Category = category;
             this.Tags = tags;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -48,7 +48,10 @@ namespace Org.OpenAPITools.Model
         public QuadrilateralInterface(string quadrilateralType = default(string))
         {
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -49,9 +49,15 @@ namespace Org.OpenAPITools.Model
         public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -48,7 +48,10 @@ namespace Org.OpenAPITools.Model
         public ShapeInterface(string shapeType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+            }
+            this.ShapeType = shapeType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -49,9 +49,15 @@ namespace Org.OpenAPITools.Model
         public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -48,7 +48,10 @@ namespace Org.OpenAPITools.Model
         public TriangleInterface(string triangleType = default(string))
         {
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+            }
+            this.TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Whale.cs
@@ -50,7 +50,10 @@ namespace Org.OpenAPITools.Model
         public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+            }
+            this.ClassName = className;
             this.HasBaleen = hasBaleen;
             this.HasTeeth = hasTeeth;
             this.AdditionalProperties = new Dictionary<string, object>();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Zebra.cs
@@ -81,7 +81,10 @@ namespace Org.OpenAPITools.Model
         public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+            }
+            this.ClassName = className;
             this.Type = type;
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Animal.cs
@@ -52,7 +52,10 @@ namespace Org.OpenAPITools.Model
         public Animal(string className = default(string), string color = "red")
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            }
+            this.ClassName = className;
             // use default value if no "color" provided
             this.Color = color ?? "red";
             this.AdditionalProperties = new Dictionary<string, object>();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -45,7 +45,10 @@ namespace Org.OpenAPITools.Model
         public AppleReq(string cultivar = default(string), bool mealy = default(bool))
         {
             // to ensure "cultivar" is required (not null)
-            this.Cultivar = cultivar ?? throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+            if (cultivar == null) {
+                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+            }
+            this.Cultivar = cultivar;
             this.Mealy = mealy;
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public BasquePig(string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+            }
+            this.ClassName = className;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Category.cs
@@ -48,7 +48,10 @@ namespace Org.OpenAPITools.Model
         public Category(long id = default(long), string name = "default-name")
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            }
+            this.Name = name;
             this.Id = id;
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public DanishPig(string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+            }
+            this.ClassName = className;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -63,10 +63,16 @@ namespace Org.OpenAPITools.Model
         {
             this.Number = number;
             // to ensure "_byte" is required (not null)
-            this.Byte = _byte ?? throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            if (_byte == null) {
+                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            }
+            this.Byte = _byte;
             this.Date = date;
             // to ensure "password" is required (not null)
-            this.Password = password ?? throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            if (password == null) {
+                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            }
+            this.Password = password;
             this.Integer = integer;
             this.Int32 = int32;
             this.Int64 = int64;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -51,7 +51,10 @@ namespace Org.OpenAPITools.Model
         public GrandparentAnimal(string petType = default(string))
         {
             // to ensure "petType" is required (not null)
-            this.PetType = petType ?? throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+            if (petType == null) {
+                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+            }
+            this.PetType = petType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -45,9 +45,15 @@ namespace Org.OpenAPITools.Model
         public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Pet.cs
@@ -86,9 +86,15 @@ namespace Org.OpenAPITools.Model
         public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            }
+            this.Name = name;
             // to ensure "photoUrls" is required (not null)
-            this.PhotoUrls = photoUrls ?? throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            if (photoUrls == null) {
+                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            }
+            this.PhotoUrls = photoUrls;
             this.Id = id;
             this.Category = category;
             this.Tags = tags;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public QuadrilateralInterface(string quadrilateralType = default(string))
         {
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public ShapeInterface(string shapeType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+            }
+            this.ShapeType = shapeType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public TriangleInterface(string triangleType = default(string))
         {
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+            }
+            this.TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Whale.cs
@@ -49,7 +49,10 @@ namespace Org.OpenAPITools.Model
         public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+            }
+            this.ClassName = className;
             this.HasBaleen = hasBaleen;
             this.HasTeeth = hasTeeth;
             this.AdditionalProperties = new Dictionary<string, object>();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Zebra.cs
@@ -80,7 +80,10 @@ namespace Org.OpenAPITools.Model
         public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+            }
+            this.ClassName = className;
             this.Type = type;
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Animal.cs
@@ -52,7 +52,10 @@ namespace Org.OpenAPITools.Model
         public Animal(string className = default(string), string color = "red")
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            }
+            this.ClassName = className;
             // use default value if no "color" provided
             this.Color = color ?? "red";
             this.AdditionalProperties = new Dictionary<string, object>();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -45,7 +45,10 @@ namespace Org.OpenAPITools.Model
         public AppleReq(string cultivar = default(string), bool mealy = default(bool))
         {
             // to ensure "cultivar" is required (not null)
-            this.Cultivar = cultivar ?? throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+            if (cultivar == null) {
+                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+            }
+            this.Cultivar = cultivar;
             this.Mealy = mealy;
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public BasquePig(string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+            }
+            this.ClassName = className;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Category.cs
@@ -48,7 +48,10 @@ namespace Org.OpenAPITools.Model
         public Category(long id = default(long), string name = "default-name")
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            }
+            this.Name = name;
             this.Id = id;
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public DanishPig(string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+            }
+            this.ClassName = className;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -63,10 +63,16 @@ namespace Org.OpenAPITools.Model
         {
             this.Number = number;
             // to ensure "_byte" is required (not null)
-            this.Byte = _byte ?? throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            if (_byte == null) {
+                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            }
+            this.Byte = _byte;
             this.Date = date;
             // to ensure "password" is required (not null)
-            this.Password = password ?? throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            if (password == null) {
+                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            }
+            this.Password = password;
             this.Integer = integer;
             this.Int32 = int32;
             this.Int64 = int64;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -51,7 +51,10 @@ namespace Org.OpenAPITools.Model
         public GrandparentAnimal(string petType = default(string))
         {
             // to ensure "petType" is required (not null)
-            this.PetType = petType ?? throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+            if (petType == null) {
+                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+            }
+            this.PetType = petType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -45,9 +45,15 @@ namespace Org.OpenAPITools.Model
         public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -86,9 +86,15 @@ namespace Org.OpenAPITools.Model
         public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            }
+            this.Name = name;
             // to ensure "photoUrls" is required (not null)
-            this.PhotoUrls = photoUrls ?? throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            if (photoUrls == null) {
+                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            }
+            this.PhotoUrls = photoUrls;
             this.Id = id;
             this.Category = category;
             this.Tags = tags;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public QuadrilateralInterface(string quadrilateralType = default(string))
         {
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public ShapeInterface(string shapeType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+            }
+            this.ShapeType = shapeType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public TriangleInterface(string triangleType = default(string))
         {
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+            }
+            this.TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Whale.cs
@@ -49,7 +49,10 @@ namespace Org.OpenAPITools.Model
         public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+            }
+            this.ClassName = className;
             this.HasBaleen = hasBaleen;
             this.HasTeeth = hasTeeth;
             this.AdditionalProperties = new Dictionary<string, object>();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Zebra.cs
@@ -80,7 +80,10 @@ namespace Org.OpenAPITools.Model
         public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+            }
+            this.ClassName = className;
             this.Type = type;
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
@@ -52,7 +52,10 @@ namespace Org.OpenAPITools.Model
         public Animal(string className = default(string), string color = "red")
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            }
+            this.ClassName = className;
             // use default value if no "color" provided
             this.Color = color ?? "red";
             this.AdditionalProperties = new Dictionary<string, object>();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -45,7 +45,10 @@ namespace Org.OpenAPITools.Model
         public AppleReq(string cultivar = default(string), bool mealy = default(bool))
         {
             // to ensure "cultivar" is required (not null)
-            this.Cultivar = cultivar ?? throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+            if (cultivar == null) {
+                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+            }
+            this.Cultivar = cultivar;
             this.Mealy = mealy;
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public BasquePig(string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+            }
+            this.ClassName = className;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
@@ -48,7 +48,10 @@ namespace Org.OpenAPITools.Model
         public Category(long id = default(long), string name = "default-name")
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            }
+            this.Name = name;
             this.Id = id;
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public DanishPig(string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+            }
+            this.ClassName = className;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -63,10 +63,16 @@ namespace Org.OpenAPITools.Model
         {
             this.Number = number;
             // to ensure "_byte" is required (not null)
-            this.Byte = _byte ?? throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            if (_byte == null) {
+                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            }
+            this.Byte = _byte;
             this.Date = date;
             // to ensure "password" is required (not null)
-            this.Password = password ?? throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            if (password == null) {
+                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            }
+            this.Password = password;
             this.Integer = integer;
             this.Int32 = int32;
             this.Int64 = int64;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -51,7 +51,10 @@ namespace Org.OpenAPITools.Model
         public GrandparentAnimal(string petType = default(string))
         {
             // to ensure "petType" is required (not null)
-            this.PetType = petType ?? throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+            if (petType == null) {
+                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+            }
+            this.PetType = petType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -45,9 +45,15 @@ namespace Org.OpenAPITools.Model
         public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
@@ -86,9 +86,15 @@ namespace Org.OpenAPITools.Model
         public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            }
+            this.Name = name;
             // to ensure "photoUrls" is required (not null)
-            this.PhotoUrls = photoUrls ?? throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            if (photoUrls == null) {
+                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            }
+            this.PhotoUrls = photoUrls;
             this.Id = id;
             this.Category = category;
             this.Tags = tags;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public QuadrilateralInterface(string quadrilateralType = default(string))
         {
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public ShapeInterface(string shapeType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+            }
+            this.ShapeType = shapeType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -48,9 +48,15 @@ namespace Org.OpenAPITools.Model
         public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -47,7 +47,10 @@ namespace Org.OpenAPITools.Model
         public TriangleInterface(string triangleType = default(string))
         {
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+            }
+            this.TriangleType = triangleType;
             this.AdditionalProperties = new Dictionary<string, object>();
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Whale.cs
@@ -49,7 +49,10 @@ namespace Org.OpenAPITools.Model
         public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+            }
+            this.ClassName = className;
             this.HasBaleen = hasBaleen;
             this.HasTeeth = hasTeeth;
             this.AdditionalProperties = new Dictionary<string, object>();

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/Zebra.cs
@@ -80,7 +80,10 @@ namespace Org.OpenAPITools.Model
         public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+            }
+            this.ClassName = className;
             this.Type = type;
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Animal.cs
@@ -49,7 +49,10 @@ namespace Org.OpenAPITools.Model
         public Animal(string className = default(string), string color = "red")
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Animal and cannot be null");
+            }
+            this.ClassName = className;
             // use default value if no "color" provided
             this.Color = color ?? "red";
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -45,7 +45,10 @@ namespace Org.OpenAPITools.Model
         public AppleReq(string cultivar = default(string), bool mealy = default(bool))
         {
             // to ensure "cultivar" is required (not null)
-            this.Cultivar = cultivar ?? throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+            if (cultivar == null) {
+                throw new ArgumentNullException("cultivar is a required property for AppleReq and cannot be null");
+            }
+            this.Cultivar = cultivar;
             this.Mealy = mealy;
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -44,7 +44,10 @@ namespace Org.OpenAPITools.Model
         public BasquePig(string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for BasquePig and cannot be null");
+            }
+            this.ClassName = className;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Category.cs
@@ -45,7 +45,10 @@ namespace Org.OpenAPITools.Model
         public Category(long id = default(long), string name = "default-name")
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Category and cannot be null");
+            }
+            this.Name = name;
             this.Id = id;
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -45,9 +45,15 @@ namespace Org.OpenAPITools.Model
         public ComplexQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ComplexQuadrilateral and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for ComplexQuadrilateral and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -44,7 +44,10 @@ namespace Org.OpenAPITools.Model
         public DanishPig(string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for DanishPig and cannot be null");
+            }
+            this.ClassName = className;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -45,9 +45,15 @@ namespace Org.OpenAPITools.Model
         public EquilateralTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for EquilateralTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for EquilateralTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -60,10 +60,16 @@ namespace Org.OpenAPITools.Model
         {
             this.Number = number;
             // to ensure "_byte" is required (not null)
-            this.Byte = _byte ?? throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            if (_byte == null) {
+                throw new ArgumentNullException("_byte is a required property for FormatTest and cannot be null");
+            }
+            this.Byte = _byte;
             this.Date = date;
             // to ensure "password" is required (not null)
-            this.Password = password ?? throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            if (password == null) {
+                throw new ArgumentNullException("password is a required property for FormatTest and cannot be null");
+            }
+            this.Password = password;
             this.Integer = integer;
             this.Int32 = int32;
             this.Int64 = int64;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -48,7 +48,10 @@ namespace Org.OpenAPITools.Model
         public GrandparentAnimal(string petType = default(string))
         {
             // to ensure "petType" is required (not null)
-            this.PetType = petType ?? throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+            if (petType == null) {
+                throw new ArgumentNullException("petType is a required property for GrandparentAnimal and cannot be null");
+            }
+            this.PetType = petType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -45,9 +45,15 @@ namespace Org.OpenAPITools.Model
         public IsoscelesTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for IsoscelesTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for IsoscelesTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pet.cs
@@ -83,9 +83,15 @@ namespace Org.OpenAPITools.Model
         public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            }
+            this.Name = name;
             // to ensure "photoUrls" is required (not null)
-            this.PhotoUrls = photoUrls ?? throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            if (photoUrls == null) {
+                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            }
+            this.PhotoUrls = photoUrls;
             this.Id = id;
             this.Category = category;
             this.Tags = tags;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -44,7 +44,10 @@ namespace Org.OpenAPITools.Model
         public QuadrilateralInterface(string quadrilateralType = default(string))
         {
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for QuadrilateralInterface and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -45,9 +45,15 @@ namespace Org.OpenAPITools.Model
         public ScaleneTriangle(string shapeType = default(string), string triangleType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ScaleneTriangle and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for ScaleneTriangle and cannot be null");
+            }
+            this.TriangleType = triangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -44,7 +44,10 @@ namespace Org.OpenAPITools.Model
         public ShapeInterface(string shapeType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for ShapeInterface and cannot be null");
+            }
+            this.ShapeType = shapeType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -45,9 +45,15 @@ namespace Org.OpenAPITools.Model
         public SimpleQuadrilateral(string shapeType = default(string), string quadrilateralType = default(string))
         {
             // to ensure "shapeType" is required (not null)
-            this.ShapeType = shapeType ?? throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+            if (shapeType == null) {
+                throw new ArgumentNullException("shapeType is a required property for SimpleQuadrilateral and cannot be null");
+            }
+            this.ShapeType = shapeType;
             // to ensure "quadrilateralType" is required (not null)
-            this.QuadrilateralType = quadrilateralType ?? throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+            if (quadrilateralType == null) {
+                throw new ArgumentNullException("quadrilateralType is a required property for SimpleQuadrilateral and cannot be null");
+            }
+            this.QuadrilateralType = quadrilateralType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -44,7 +44,10 @@ namespace Org.OpenAPITools.Model
         public TriangleInterface(string triangleType = default(string))
         {
             // to ensure "triangleType" is required (not null)
-            this.TriangleType = triangleType ?? throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+            if (triangleType == null) {
+                throw new ArgumentNullException("triangleType is a required property for TriangleInterface and cannot be null");
+            }
+            this.TriangleType = triangleType;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Whale.cs
@@ -46,7 +46,10 @@ namespace Org.OpenAPITools.Model
         public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Whale and cannot be null");
+            }
+            this.ClassName = className;
             this.HasBaleen = hasBaleen;
             this.HasTeeth = hasTeeth;
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -80,7 +80,10 @@ namespace Org.OpenAPITools.Model
         public Zebra(TypeEnum? type = default(TypeEnum?), string className = default(string)) : base()
         {
             // to ensure "className" is required (not null)
-            this.ClassName = className ?? throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+            if (className == null) {
+                throw new ArgumentNullException("className is a required property for Zebra and cannot be null");
+            }
+            this.ClassName = className;
             this.Type = type;
             this.AdditionalProperties = new Dictionary<string, object>();
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Pet.cs
@@ -84,9 +84,15 @@ namespace Org.OpenAPITools.Model
         public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
-            this.Name = name ?? throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            if (name == null) {
+                throw new ArgumentNullException("name is a required property for Pet and cannot be null");
+            }
+            this.Name = name;
             // to ensure "photoUrls" is required (not null)
-            this.PhotoUrls = photoUrls ?? throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            if (photoUrls == null) {
+                throw new ArgumentNullException("photoUrls is a required property for Pet and cannot be null");
+            }
+            this.PhotoUrls = photoUrls;
             this.Id = id;
             this.Category = category;
             this.Tags = tags;


### PR DESCRIPTION
This patch addresses an issue where csharp-netcore failed to generate compilable code when required attributes were of complex types.

By using the non-shorthand syntax for checking if the value is set, and throwing an error in that case, the compile issues have been resolved.

Closes #9442
Closes #5442

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
