### PR TITLE
Accept header forces application/json type even if server 

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -101,10 +101,6 @@ func selectHeaderAccept(accepts []string) string {
 		return ""
 	}
 
-	if contains(accepts, "application/json") {
-		return "application/json"
-	}
-
 	return strings.Join(accepts, ",")
 }
 

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -109,10 +109,6 @@ func selectHeaderAccept(accepts []string) string {
 		return ""
 	}
 
-	if contains(accepts, "application/json") {
-		return "application/json"
-	}
-
 	return strings.Join(accepts, ",")
 }
 

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
@@ -94,10 +94,6 @@ func selectHeaderAccept(accepts []string) string {
 		return ""
 	}
 
-	if contains(accepts, "application/json") {
-		return "application/json"
-	}
-
 	return strings.Join(accepts, ",")
 }
 

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -112,10 +112,6 @@ func selectHeaderAccept(accepts []string) string {
 		return ""
 	}
 
-	if contains(accepts, "application/json") {
-		return "application/json"
-	}
-
 	return strings.Join(accepts, ",")
 }
 


### PR DESCRIPTION
https://github.com/OpenAPITools/openapi-generator/issues/10340


When API returns mixed content - 200 returns File/Binary and 500 returns JSON which is typical for error handling.
Generated code will include two accept headers. Problem is that selectHeaderAccept function that builds headers always forces accept headers to be JSON. This will crash as the server only knows how to return zip content type.

Example:
https://github.com/redhat-developer/app-services-sdk-go/blob/main/registryinstance/apiv1internal/client/api_admin.go#L1004-L1007

Request is mixed with zip and json on 500:
```
 ],
        "responses": {
          "200": {
            "content": {
              "application/zip": {
                "schema": {
                  "$ref": "#/components/schemas/FileContent"
                }
              }
            },
            "description": "Response when the export is successful."
          },
          "500": {
            "$ref": "#/components/responses/ServerError"
          }
        },
```      

Headers are generated properly but request is later made with "application/json"
```
HTTPHeaderAccepts := []string{"application/zip", "application/json"}

```
