### PR TITLE
[cpp-ue4] [bugfix] for "generated code doesn't properly check for connection failures"

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-ue4/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/api-header.mustache
@@ -32,17 +32,17 @@ public:
 	{{#operations}}{{#operation}}class {{operationIdCamelCase}}Request;
 	class {{operationIdCamelCase}}Response;
 	{{/operation}}{{/operations}}
-    {{#operations}}{{#operation}}DECLARE_DELEGATE_OneParam(F{{operationIdCamelCase}}Delegate, const {{operationIdCamelCase}}Response&);
-    {{/operation}}{{/operations}}
-    {{#operations}}{{#operation}}{{#description}}/* {{{.}}} */
+	{{#operations}}{{#operation}}DECLARE_DELEGATE_FourParams(F{{operationIdCamelCase}}Delegate, const {{operationIdCamelCase}}Response&, FHttpRequestPtr, FHttpResponsePtr, bool bHttpSuccdeded);
+	{{/operation}}{{/operations}}
+	{{#operations}}{{#operation}}{{#description}}/* {{{.}}} */
 	{{/description}}FHttpRequestPtr {{operationIdCamelCase}}(const {{operationIdCamelCase}}Request& Request, const F{{operationIdCamelCase}}Delegate& Delegate = F{{operationIdCamelCase}}Delegate()) const;
-    {{/operation}}{{/operations}}
+	{{/operation}}{{/operations}}
 private:
-    {{#operations}}{{#operation}}void On{{operationIdCamelCase}}Response(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, F{{operationIdCamelCase}}Delegate Delegate) const;
-    {{/operation}}{{/operations}}
+	{{#operations}}{{#operation}}void On{{operationIdCamelCase}}ProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, F{{operationIdCamelCase}}Delegate Delegate) const;
+	{{/operation}}{{/operations}}
 	FHttpRequestRef CreateHttpRequest(const Request& Request) const;
 	bool IsValid() const;
-	void HandleResponse(FHttpResponsePtr HttpResponse, bool bSucceeded, Response& InOutResponse) const;
+	void TryBuildResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bHttpSucceeded, Response& InOutResponse) const;
 
 	FString Url;
 	TMap<FString,FString> AdditionalHeaderParams;

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/api-header.mustache
@@ -32,7 +32,7 @@ public:
 	{{#operations}}{{#operation}}class {{operationIdCamelCase}}Request;
 	class {{operationIdCamelCase}}Response;
 	{{/operation}}{{/operations}}
-	{{#operations}}{{#operation}}DECLARE_DELEGATE_FourParams(F{{operationIdCamelCase}}Delegate, const {{operationIdCamelCase}}Response&, FHttpRequestPtr, FHttpResponsePtr, bool bHttpSuccdeded);
+	{{#operations}}{{#operation}}DECLARE_DELEGATE_OneParam(F{{operationIdCamelCase}}Delegate, const {{operationIdCamelCase}}Response&);
 	{{/operation}}{{/operations}}
 	{{#operations}}{{#operation}}{{#description}}/* {{{.}}} */
 	{{/description}}FHttpRequestPtr {{operationIdCamelCase}}(const {{operationIdCamelCase}}Request& Request, const F{{operationIdCamelCase}}Delegate& Delegate = F{{operationIdCamelCase}}Delegate()) const;

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/api-operations-source.mustache
@@ -294,7 +294,7 @@ void {{classname}}::{{operationIdCamelCase}}Response::SetHttpResponseCode(EHttpR
 	{{#isDefault}}
 	default:
 	{{/isDefault}}
-		SetResponseString(TEXT("{{message}}"));
+		SetRestResponseDescription(TEXT("{{message}}"));
 		break;
 	{{/responses}}
 	}

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/api-source.mustache
@@ -161,7 +161,7 @@ void {{classname}}::On{{operationIdCamelCase}}ProcessRequestComplete(FHttpReques
 {
 	{{operationIdCamelCase}}Response Response;
 	TryBuildResponse(HttpRequest, HttpResponse, bHttpSucceeded, Response);
-	Delegate.ExecuteIfBound(Response, HttpRequest, HttpResponse, bHttpSucceeded);
+	Delegate.ExecuteIfBound(Response);
 }
 
 {{/operation}}

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/api-source.mustache
@@ -47,7 +47,7 @@ bool {{classname}}::IsValid() const
 
 void {{classname}}::SetHttpRetryManager(FHttpRetrySystem::FManager& InRetryManager)
 {
-	if(RetryManager != &GetHttpRetryManager())
+	if(&InRetryManager != RetryManager)
 	{
 		DefaultRetryManager.Reset();
 		RetryManager = &InRetryManager;
@@ -80,48 +80,59 @@ FHttpRequestRef {{classname}}::CreateHttpRequest(const Request& Request) const
 	}
 }
 
-void {{classname}}::HandleResponse(FHttpResponsePtr HttpResponse, bool bSucceeded, Response& InOutResponse) const
+void {{classname}}::TryBuildResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bHttpSucceeded, Response& InOutResponse) const
 {
-	InOutResponse.SetHttpResponse(HttpResponse);
-	InOutResponse.SetSuccessful(bSucceeded);
+	InOutResponse.SetHttpRequest(HttpRequest); //publish the request
+	InOutResponse.SetHttpResponse(HttpResponse); //might be nullptr
+	InOutResponse.SetHttpRequestSuccessful(bHttpSucceeded); //false is going to be client Failed or Failed_ConnectionError
 
-	if (bSucceeded && HttpResponse.IsValid())
-	{
-		InOutResponse.SetHttpResponseCode((EHttpResponseCodes::Type)HttpResponse->GetResponseCode());
-		FString ContentType = HttpResponse->GetContentType();
-		FString Content;
+	//A ConnectionError is a failure where the client knows the server never received the request.  Often safe to retry but only the application knows for sure.
+	InOutResponse.SetHttpClientConnectionError((HttpRequest->GetStatus() == EHttpRequestStatus::Failed_ConnectionError)); //publish knowledge of initial connection error
 
-		if (ContentType.IsEmpty())
-		{
-			return; // Nothing to parse
-		}
-		else if (ContentType.StartsWith(TEXT("application/json")) || ContentType.StartsWith("text/json"))
-		{
-			Content = HttpResponse->GetContentAsString();
-
-			TSharedPtr<FJsonValue> JsonValue;
-			auto Reader = TJsonReaderFactory<>::Create(Content);
-
-			if (FJsonSerializer::Deserialize(Reader, JsonValue) && JsonValue.IsValid())
-			{
-				if (InOutResponse.FromJson(JsonValue))
-					return; // Successfully parsed
-			}
-		}
-		else if(ContentType.StartsWith(TEXT("text/plain")))
-		{
-			Content = HttpResponse->GetContentAsString();
-			InOutResponse.SetResponseString(Content);
-			return; // Successfully parsed
-		}
-
-		// Report the parse error but do not mark the request as unsuccessful. Data could be partial or malformed, but the request succeeded.
-		UE_LOG(Log{{unrealModuleName}}, Error, TEXT("Failed to deserialize Http response content (type:%s):\n%s"), *ContentType , *Content);
-		return;
+	//handle the potentially null response.
+	if (!HttpResponse.IsValid()){
+		return; //nothing else can be gleaned.
 	}
 
-	// By default, assume we failed to establish connection
-	InOutResponse.SetHttpResponseCode(EHttpResponseCodes::RequestTimeout);
+	//the response code and raw content are retrieved.
+	InOutResponse.SetHttpResponseCode((EHttpResponseCodes::Type)HttpResponse->GetResponseCode()); //also sets RestResponseDescription based on Schema
+	FString ContentType = HttpResponse->GetContentType();
+	if (ContentType.IsEmpty())
+	{
+		return; // Nothing to parse.  Nothing else to glean.
+	}
+	FString Content;
+	Content = HttpResponse->GetContentAsString();
+	InOutResponse.SetRestResponseContent(Content);  //publish the raw string content, as we may not successfully parse it
+
+	//Strictly speaking, we should probably only try to parse the expected return based on the response code.
+	//And it should return different types based on the code's definition in the Schema.
+	//However we're doing a simpler thing here.  We try to parse an expected successful content type
+	//regardless of response code and provide it if we can.
+
+	if (ContentType.StartsWith(TEXT("application/json")) || ContentType.StartsWith("text/json"))
+	{
+		TSharedPtr<FJsonValue> JsonValue;
+		auto Reader = TJsonReaderFactory<>::Create(Content);
+
+		if (FJsonSerializer::Deserialize(Reader, JsonValue) && JsonValue.IsValid())
+		{
+			if (InOutResponse.FromJson(JsonValue)) //sets the parsed value as best it can
+			{
+				InOutResponse.SetRestContentFullyParsed(true); //informs if the parse was fully successful
+				return; // nothing more to glean.
+			}
+		}
+		// note: we could try parsing some conventional alternative returns here such as 3.3 in:
+		// https://www.baeldung.com/rest-api-error-handling-best-practices
+	}
+	else if(ContentType.StartsWith(TEXT("text/plain")))
+	{
+		return; // raw text was already published. nothing more to glean.
+	}
+	//note: we could parse other potential return types here.  Such as https://datatracker.ietf.org/doc/html/rfc7807 which
+	//would have content type: application/problem+json
+
 }
 
 {{#operations}}
@@ -141,16 +152,16 @@ FHttpRequestPtr {{classname}}::{{operationIdCamelCase}}(const {{operationIdCamel
 
 	Request.SetupHttpRequest(HttpRequest);
 
-	HttpRequest->OnProcessRequestComplete().BindRaw(this, &{{classname}}::On{{operationIdCamelCase}}Response, Delegate);
+	HttpRequest->OnProcessRequestComplete().BindRaw(this, &{{classname}}::On{{operationIdCamelCase}}ProcessRequestComplete, Delegate);
 	HttpRequest->ProcessRequest();
 	return HttpRequest;
 }
 
-void {{classname}}::On{{operationIdCamelCase}}Response(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, F{{operationIdCamelCase}}Delegate Delegate) const
+void {{classname}}::On{{operationIdCamelCase}}ProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bHttpSucceeded, F{{operationIdCamelCase}}Delegate Delegate) const
 {
 	{{operationIdCamelCase}}Response Response;
-	HandleResponse(HttpResponse, bSucceeded, Response);
-	Delegate.ExecuteIfBound(Response);
+	TryBuildResponse(HttpRequest, HttpResponse, bHttpSucceeded, Response);
+	Delegate.ExecuteIfBound(Response, HttpRequest, HttpResponse, bHttpSucceeded);
 }
 
 {{/operation}}

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/model-base-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/model-base-header.mustache
@@ -83,10 +83,10 @@ public:
 	bool IsRestRequestSuccessful() const { return RestRequestSuccessful; }
 
 	void SetRestResponseContent(const FString& InResponseContent) { RestResponseContent = InResponseContent; }
-	const FString& GetRestResponseContent() const { return RestResponseContent; }
+	const TOptional<FString>& GetRestResponseContent() const { return RestResponseContent; }
 
 	void SetRestResponseDescription(const FString& InResponseDescription) { RestResponseDescription = InResponseDescription; }
-	const FString& GetRestResponseDescription() const { return RestResponseDescription; }
+	const TOptional<FString>& GetRestResponseDescription() const { return RestResponseDescription; }
 
 	void SetHttpResponse(const FHttpResponsePtr& InHttpResponse) { HttpResponse = InHttpResponse; }
 	const FHttpResponsePtr& GetHttpResponse() const { return HttpResponse; }
@@ -104,8 +104,8 @@ private:
 	EHttpResponseCodes::Type HttpResponseCode = EHttpResponseCodes::Unknown;
 	FHttpResponsePtr HttpResponse;
 	bool RestRequestSuccessful = false;
-	FString RestResponseContent;
-	FString RestResponseDescription;
+	TOptional<FString> RestResponseContent;
+	TOptional<FString> RestResponseDescription;
 	bool RestContentFullyParsed = false;
 
 };

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/model-base-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/model-base-header.mustache
@@ -68,24 +68,46 @@ class {{dllapi}} Response
 public:
 	virtual ~Response() {}
 	virtual bool FromJson(const TSharedPtr<FJsonValue>& JsonValue) = 0;
+	bool ErrorFromJson(const TSharedPtr<FJsonValue>& JsonValue);
 
-	void SetSuccessful(bool InSuccessful) { Successful = InSuccessful; }
-	bool IsSuccessful() const { return Successful; }
+	void SetHttpRequestSuccessful(bool InHttpRequestSuccessful) { HttpRequestSuccessful = InHttpRequestSuccessful; }
+	bool IsHttpRequestSuccessful() const { return HttpRequestSuccessful; }
+
+	void SetHttpClientConnectionError(bool InHttpClientConnectionError) { HttpClientConnectionError = InHttpClientConnectionError; }
+	bool IsHttpClientConnectionError() const { return HttpClientConnectionError; }
 
 	virtual void SetHttpResponseCode(EHttpResponseCodes::Type InHttpResponseCode);
-	EHttpResponseCodes::Type GetHttpResponseCode() const { return ResponseCode; }
+	EHttpResponseCodes::Type GetHttpResponseCode() const { return HttpResponseCode; }
 
-	void SetResponseString(const FString& InResponseString) { ResponseString = InResponseString; }
-	const FString& GetResponseString() const { return ResponseString; }
+	void SetRestRequestSuccessful(bool InRestRequestSuccessful) { RestRequestSuccessful = InRestRequestSuccessful; }
+	bool IsRestRequestSuccessful() const { return RestRequestSuccessful; }
+
+	void SetRestResponseContent(const FString& InResponseContent) { RestResponseContent = InResponseContent; }
+	const FString& GetRestResponseContent() const { return RestResponseContent; }
+
+	void SetRestResponseDescription(const FString& InResponseDescription) { RestResponseDescription = InResponseDescription; }
+	const FString& GetRestResponseDescription() const { return RestResponseDescription; }
 
 	void SetHttpResponse(const FHttpResponsePtr& InHttpResponse) { HttpResponse = InHttpResponse; }
 	const FHttpResponsePtr& GetHttpResponse() const { return HttpResponse; }
 
+	void SetHttpRequest(const FHttpRequestPtr& InHttpRequest) { HttpRequest = InHttpRequest; }
+	const FHttpRequestPtr& GetHttpRequest() const { return HttpRequest; }
+
+	void SetRestContentFullyParsed(bool InRestContentFullyParsed) { RestContentFullyParsed = InRestContentFullyParsed; }
+	bool IsRestContentFullyParsed() const { return RestContentFullyParsed; }
+
 private:
-	bool Successful;
-	EHttpResponseCodes::Type ResponseCode;
-	FString ResponseString;
+	FHttpRequestPtr HttpRequest;
+	bool HttpRequestSuccessful = false;
+	bool HttpClientConnectionError = false;
+	EHttpResponseCodes::Type HttpResponseCode = EHttpResponseCodes::Unknown;
 	FHttpResponsePtr HttpResponse;
+	bool RestRequestSuccessful = false;
+	FString RestResponseContent;
+	FString RestResponseDescription;
+	bool RestContentFullyParsed = false;
+
 };
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/model-base-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/model-base-header.mustache
@@ -97,14 +97,43 @@ public:
 	bool IsRestContentFullyParsed() const { return RestContentFullyParsed; }
 
 private:
+    //Unreal's underlying HTTP request.
 	FHttpRequestPtr HttpRequest;
+
+    //Success or failure of HTTP request as reported by Unreal's HTTP layer.  Canceling the request will also
+    //result in failure here.
 	bool HttpRequestSuccessful = false;
+
+    //Derived information as to whether this was a failure to connect entirely, or alternatively if any data was
+    //sent down the line before the connection failed.
+    //Applications take note here:  If data was sent down the line, it may not be safe to resend, depending on what your
+    //request was asking of the application server.  We don't know if the server processed it or not.
 	bool HttpClientConnectionError = false;
+
+    //Unreal's underlying HTTP response. This is a TSharedPtr and can be checked for IsValid()
+    //IsValid() may return false if there was no response.
+    FHttpResponsePtr HttpResponse;
+
+    //The HTTP response from the server, or EHttpResponseCodes::Unknown if there was no HTTP response.
 	EHttpResponseCodes::Type HttpResponseCode = EHttpResponseCodes::Unknown;
-	FHttpResponsePtr HttpResponse;
+
+    //The REST layer's assessment as to the success of the request.  Typically a response in the 2xx range results in true.
 	bool RestRequestSuccessful = false;
+
+    //The raw (string) content of the REST response.  Note this is TOptional.  If IsSet() == false, then there was no content.
+    //In case of a parsing problem or unexpected result, this will still contain whatever the server sent back.
 	TOptional<FString> RestResponseContent;
+
+    //The REST layer's description of the response type that was received from the server.  This descriptive text comes
+    //from the API Schema upon receiving specified HTTP response codes.
+    //Note this is TOptional.  If IsSet() == false, then there likely was no description for the given response code in
+    //the Schema.
 	TOptional<FString> RestResponseDescription;
+
+    //An assessment from the REST layer as to if the content was fully and properly parsed.
+    //Note, this may need to be treated skeptically.  A partially successful parse will still
+    //result in data being populated.  And a failure to 'fully' parse may be a pedantic failure from an overly
+    //strict reading of the Schema, or a malformed Schema that works well enough.
 	bool RestContentFullyParsed = false;
 
 };

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/model-base-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/model-base-header.mustache
@@ -68,7 +68,6 @@ class {{dllapi}} Response
 public:
 	virtual ~Response() {}
 	virtual bool FromJson(const TSharedPtr<FJsonValue>& JsonValue) = 0;
-	bool ErrorFromJson(const TSharedPtr<FJsonValue>& JsonValue);
 
 	void SetHttpRequestSuccessful(bool InHttpRequestSuccessful) { HttpRequestSuccessful = InHttpRequestSuccessful; }
 	bool IsHttpRequestSuccessful() const { return HttpRequestSuccessful; }

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/model-base-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/model-base-source.mustache
@@ -13,26 +13,22 @@ bool HttpRetryManager::Tick(float DeltaTime)
 }
 
 HttpRetryParams::HttpRetryParams(const FRetryLimitCountSetting& InRetryLimitCountOverride /*= FRetryLimitCountSetting()*/,
-    const FRetryTimeoutRelativeSecondsSetting& InRetryTimeoutRelativeSecondsOverride /*= FRetryTimeoutRelativeSecondsSetting()*/,
-    const FRetryResponseCodes& InRetryResponseCodes /*= FRetryResponseCodes()*/,
-    const FRetryVerbs& InRetryVerbs /*= FRetryVerbs()*/,
-    const FRetryDomainsPtr& InRetryDomains /*= FRetryDomainsPtr() */)
-    : RetryLimitCountOverride(InRetryLimitCountOverride)
-    , RetryTimeoutRelativeSecondsOverride(InRetryTimeoutRelativeSecondsOverride)
-    , RetryResponseCodes(InRetryResponseCodes)
-    , RetryVerbs(InRetryVerbs)
-    , RetryDomains(InRetryDomains)
+	const FRetryTimeoutRelativeSecondsSetting& InRetryTimeoutRelativeSecondsOverride /*= FRetryTimeoutRelativeSecondsSetting()*/,
+	const FRetryResponseCodes& InRetryResponseCodes /*= FRetryResponseCodes()*/,
+	const FRetryVerbs& InRetryVerbs /*= FRetryVerbs()*/,
+	const FRetryDomainsPtr& InRetryDomains /*= FRetryDomainsPtr() */)
+	: RetryLimitCountOverride(InRetryLimitCountOverride)
+	, RetryTimeoutRelativeSecondsOverride(InRetryTimeoutRelativeSecondsOverride)
+	, RetryResponseCodes(InRetryResponseCodes)
+	, RetryVerbs(InRetryVerbs)
+	, RetryDomains(InRetryDomains)
 {
 }
 
 void Response::SetHttpResponseCode(EHttpResponseCodes::Type InHttpResponseCode)
 {
-    ResponseCode = InHttpResponseCode;
-    SetSuccessful(EHttpResponseCodes::IsOk(InHttpResponseCode));
-    if(InHttpResponseCode == EHttpResponseCodes::RequestTimeout)
-    {
-        SetResponseString(TEXT("Request Timeout"));
-    }
+	HttpResponseCode = InHttpResponseCode;
+	SetRestRequestSuccessful(EHttpResponseCodes::IsOk(InHttpResponseCode));
 }
 
 {{#cppNamespaceDeclarations}}

--- a/samples/client/petstore/cpp-ue4/Private/OpenAPIBaseModel.cpp
+++ b/samples/client/petstore/cpp-ue4/Private/OpenAPIBaseModel.cpp
@@ -22,26 +22,22 @@ bool HttpRetryManager::Tick(float DeltaTime)
 }
 
 HttpRetryParams::HttpRetryParams(const FRetryLimitCountSetting& InRetryLimitCountOverride /*= FRetryLimitCountSetting()*/,
-    const FRetryTimeoutRelativeSecondsSetting& InRetryTimeoutRelativeSecondsOverride /*= FRetryTimeoutRelativeSecondsSetting()*/,
-    const FRetryResponseCodes& InRetryResponseCodes /*= FRetryResponseCodes()*/,
-    const FRetryVerbs& InRetryVerbs /*= FRetryVerbs()*/,
-    const FRetryDomainsPtr& InRetryDomains /*= FRetryDomainsPtr() */)
-    : RetryLimitCountOverride(InRetryLimitCountOverride)
-    , RetryTimeoutRelativeSecondsOverride(InRetryTimeoutRelativeSecondsOverride)
-    , RetryResponseCodes(InRetryResponseCodes)
-    , RetryVerbs(InRetryVerbs)
-    , RetryDomains(InRetryDomains)
+	const FRetryTimeoutRelativeSecondsSetting& InRetryTimeoutRelativeSecondsOverride /*= FRetryTimeoutRelativeSecondsSetting()*/,
+	const FRetryResponseCodes& InRetryResponseCodes /*= FRetryResponseCodes()*/,
+	const FRetryVerbs& InRetryVerbs /*= FRetryVerbs()*/,
+	const FRetryDomainsPtr& InRetryDomains /*= FRetryDomainsPtr() */)
+	: RetryLimitCountOverride(InRetryLimitCountOverride)
+	, RetryTimeoutRelativeSecondsOverride(InRetryTimeoutRelativeSecondsOverride)
+	, RetryResponseCodes(InRetryResponseCodes)
+	, RetryVerbs(InRetryVerbs)
+	, RetryDomains(InRetryDomains)
 {
 }
 
 void Response::SetHttpResponseCode(EHttpResponseCodes::Type InHttpResponseCode)
 {
-    ResponseCode = InHttpResponseCode;
-    SetSuccessful(EHttpResponseCodes::IsOk(InHttpResponseCode));
-    if(InHttpResponseCode == EHttpResponseCodes::RequestTimeout)
-    {
-        SetResponseString(TEXT("Request Timeout"));
-    }
+	HttpResponseCode = InHttpResponseCode;
+	SetRestRequestSuccessful(EHttpResponseCodes::IsOk(InHttpResponseCode));
 }
 
 }

--- a/samples/client/petstore/cpp-ue4/Private/OpenAPIPetApiOperations.cpp
+++ b/samples/client/petstore/cpp-ue4/Private/OpenAPIPetApiOperations.cpp
@@ -69,7 +69,7 @@ void OpenAPIPetApi::AddPetResponse::SetHttpResponseCode(EHttpResponseCodes::Type
 	switch ((int)InHttpResponseCode)
 	{
 	case 405:
-		SetResponseString(TEXT("Invalid input"));
+		SetRestResponseDescription(TEXT("Invalid input"));
 		break;
 	}
 }
@@ -132,7 +132,7 @@ void OpenAPIPetApi::DeletePetResponse::SetHttpResponseCode(EHttpResponseCodes::T
 	switch ((int)InHttpResponseCode)
 	{
 	case 400:
-		SetResponseString(TEXT("Invalid pet value"));
+		SetRestResponseDescription(TEXT("Invalid pet value"));
 		break;
 	}
 }
@@ -251,10 +251,10 @@ void OpenAPIPetApi::FindPetsByStatusResponse::SetHttpResponseCode(EHttpResponseC
 	switch ((int)InHttpResponseCode)
 	{
 	case 200:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	case 400:
-		SetResponseString(TEXT("Invalid status value"));
+		SetRestResponseDescription(TEXT("Invalid status value"));
 		break;
 	}
 }
@@ -312,10 +312,10 @@ void OpenAPIPetApi::FindPetsByTagsResponse::SetHttpResponseCode(EHttpResponseCod
 	switch ((int)InHttpResponseCode)
 	{
 	case 200:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	case 400:
-		SetResponseString(TEXT("Invalid tag value"));
+		SetRestResponseDescription(TEXT("Invalid tag value"));
 		break;
 	}
 }
@@ -372,13 +372,13 @@ void OpenAPIPetApi::GetPetByIdResponse::SetHttpResponseCode(EHttpResponseCodes::
 	switch ((int)InHttpResponseCode)
 	{
 	case 200:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	case 400:
-		SetResponseString(TEXT("Invalid ID supplied"));
+		SetRestResponseDescription(TEXT("Invalid ID supplied"));
 		break;
 	case 404:
-		SetResponseString(TEXT("Pet not found"));
+		SetRestResponseDescription(TEXT("Pet not found"));
 		break;
 	}
 }
@@ -434,13 +434,13 @@ void OpenAPIPetApi::UpdatePetResponse::SetHttpResponseCode(EHttpResponseCodes::T
 	switch ((int)InHttpResponseCode)
 	{
 	case 400:
-		SetResponseString(TEXT("Invalid ID supplied"));
+		SetRestResponseDescription(TEXT("Invalid ID supplied"));
 		break;
 	case 404:
-		SetResponseString(TEXT("Pet not found"));
+		SetRestResponseDescription(TEXT("Pet not found"));
 		break;
 	case 405:
-		SetResponseString(TEXT("Validation exception"));
+		SetRestResponseDescription(TEXT("Validation exception"));
 		break;
 	}
 }
@@ -528,7 +528,7 @@ void OpenAPIPetApi::UpdatePetWithFormResponse::SetHttpResponseCode(EHttpResponse
 	switch ((int)InHttpResponseCode)
 	{
 	case 405:
-		SetResponseString(TEXT("Invalid input"));
+		SetRestResponseDescription(TEXT("Invalid input"));
 		break;
 	}
 }
@@ -613,7 +613,7 @@ void OpenAPIPetApi::UploadFileResponse::SetHttpResponseCode(EHttpResponseCodes::
 	switch ((int)InHttpResponseCode)
 	{
 	case 200:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	}
 }

--- a/samples/client/petstore/cpp-ue4/Private/OpenAPIStoreApiOperations.cpp
+++ b/samples/client/petstore/cpp-ue4/Private/OpenAPIStoreApiOperations.cpp
@@ -70,10 +70,10 @@ void OpenAPIStoreApi::DeleteOrderResponse::SetHttpResponseCode(EHttpResponseCode
 	switch ((int)InHttpResponseCode)
 	{
 	case 400:
-		SetResponseString(TEXT("Invalid ID supplied"));
+		SetRestResponseDescription(TEXT("Invalid ID supplied"));
 		break;
 	case 404:
-		SetResponseString(TEXT("Order not found"));
+		SetRestResponseDescription(TEXT("Order not found"));
 		break;
 	}
 }
@@ -126,7 +126,7 @@ void OpenAPIStoreApi::GetInventoryResponse::SetHttpResponseCode(EHttpResponseCod
 	switch ((int)InHttpResponseCode)
 	{
 	case 200:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	}
 }
@@ -183,13 +183,13 @@ void OpenAPIStoreApi::GetOrderByIdResponse::SetHttpResponseCode(EHttpResponseCod
 	switch ((int)InHttpResponseCode)
 	{
 	case 200:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	case 400:
-		SetResponseString(TEXT("Invalid ID supplied"));
+		SetRestResponseDescription(TEXT("Invalid ID supplied"));
 		break;
 	case 404:
-		SetResponseString(TEXT("Order not found"));
+		SetRestResponseDescription(TEXT("Order not found"));
 		break;
 	}
 }
@@ -245,10 +245,10 @@ void OpenAPIStoreApi::PlaceOrderResponse::SetHttpResponseCode(EHttpResponseCodes
 	switch ((int)InHttpResponseCode)
 	{
 	case 200:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	case 400:
-		SetResponseString(TEXT("Invalid Order"));
+		SetRestResponseDescription(TEXT("Invalid Order"));
 		break;
 	}
 }

--- a/samples/client/petstore/cpp-ue4/Private/OpenAPIUserApiOperations.cpp
+++ b/samples/client/petstore/cpp-ue4/Private/OpenAPIUserApiOperations.cpp
@@ -70,7 +70,7 @@ void OpenAPIUserApi::CreateUserResponse::SetHttpResponseCode(EHttpResponseCodes:
 	{
 	case 0:
 	default:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	}
 }
@@ -127,7 +127,7 @@ void OpenAPIUserApi::CreateUsersWithArrayInputResponse::SetHttpResponseCode(EHtt
 	{
 	case 0:
 	default:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	}
 }
@@ -184,7 +184,7 @@ void OpenAPIUserApi::CreateUsersWithListInputResponse::SetHttpResponseCode(EHttp
 	{
 	case 0:
 	default:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	}
 }
@@ -241,10 +241,10 @@ void OpenAPIUserApi::DeleteUserResponse::SetHttpResponseCode(EHttpResponseCodes:
 	switch ((int)InHttpResponseCode)
 	{
 	case 400:
-		SetResponseString(TEXT("Invalid username supplied"));
+		SetRestResponseDescription(TEXT("Invalid username supplied"));
 		break;
 	case 404:
-		SetResponseString(TEXT("User not found"));
+		SetRestResponseDescription(TEXT("User not found"));
 		break;
 	}
 }
@@ -301,13 +301,13 @@ void OpenAPIUserApi::GetUserByNameResponse::SetHttpResponseCode(EHttpResponseCod
 	switch ((int)InHttpResponseCode)
 	{
 	case 200:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	case 400:
-		SetResponseString(TEXT("Invalid username supplied"));
+		SetRestResponseDescription(TEXT("Invalid username supplied"));
 		break;
 	case 404:
-		SetResponseString(TEXT("User not found"));
+		SetRestResponseDescription(TEXT("User not found"));
 		break;
 	}
 }
@@ -366,10 +366,10 @@ void OpenAPIUserApi::LoginUserResponse::SetHttpResponseCode(EHttpResponseCodes::
 	switch ((int)InHttpResponseCode)
 	{
 	case 200:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	case 400:
-		SetResponseString(TEXT("Invalid username/password supplied"));
+		SetRestResponseDescription(TEXT("Invalid username/password supplied"));
 		break;
 	}
 }
@@ -423,7 +423,7 @@ void OpenAPIUserApi::LogoutUserResponse::SetHttpResponseCode(EHttpResponseCodes:
 	{
 	case 0:
 	default:
-		SetResponseString(TEXT("successful operation"));
+		SetRestResponseDescription(TEXT("successful operation"));
 		break;
 	}
 }
@@ -483,10 +483,10 @@ void OpenAPIUserApi::UpdateUserResponse::SetHttpResponseCode(EHttpResponseCodes:
 	switch ((int)InHttpResponseCode)
 	{
 	case 400:
-		SetResponseString(TEXT("Invalid user supplied"));
+		SetRestResponseDescription(TEXT("Invalid user supplied"));
 		break;
 	case 404:
-		SetResponseString(TEXT("User not found"));
+		SetRestResponseDescription(TEXT("User not found"));
 		break;
 	}
 }

--- a/samples/client/petstore/cpp-ue4/Public/OpenAPIBaseModel.h
+++ b/samples/client/petstore/cpp-ue4/Public/OpenAPIBaseModel.h
@@ -78,23 +78,73 @@ public:
 	virtual ~Response() {}
 	virtual bool FromJson(const TSharedPtr<FJsonValue>& JsonValue) = 0;
 
-	void SetSuccessful(bool InSuccessful) { Successful = InSuccessful; }
-	bool IsSuccessful() const { return Successful; }
+	void SetHttpRequestSuccessful(bool InHttpRequestSuccessful) { HttpRequestSuccessful = InHttpRequestSuccessful; }
+	bool IsHttpRequestSuccessful() const { return HttpRequestSuccessful; }
+
+	void SetHttpClientConnectionError(bool InHttpClientConnectionError) { HttpClientConnectionError = InHttpClientConnectionError; }
+	bool IsHttpClientConnectionError() const { return HttpClientConnectionError; }
 
 	virtual void SetHttpResponseCode(EHttpResponseCodes::Type InHttpResponseCode);
-	EHttpResponseCodes::Type GetHttpResponseCode() const { return ResponseCode; }
+	EHttpResponseCodes::Type GetHttpResponseCode() const { return HttpResponseCode; }
 
-	void SetResponseString(const FString& InResponseString) { ResponseString = InResponseString; }
-	const FString& GetResponseString() const { return ResponseString; }
+	void SetRestRequestSuccessful(bool InRestRequestSuccessful) { RestRequestSuccessful = InRestRequestSuccessful; }
+	bool IsRestRequestSuccessful() const { return RestRequestSuccessful; }
+
+	void SetRestResponseContent(const FString& InResponseContent) { RestResponseContent = InResponseContent; }
+	const TOptional<FString>& GetRestResponseContent() const { return RestResponseContent; }
+
+	void SetRestResponseDescription(const FString& InResponseDescription) { RestResponseDescription = InResponseDescription; }
+	const TOptional<FString>& GetRestResponseDescription() const { return RestResponseDescription; }
 
 	void SetHttpResponse(const FHttpResponsePtr& InHttpResponse) { HttpResponse = InHttpResponse; }
 	const FHttpResponsePtr& GetHttpResponse() const { return HttpResponse; }
 
+	void SetHttpRequest(const FHttpRequestPtr& InHttpRequest) { HttpRequest = InHttpRequest; }
+	const FHttpRequestPtr& GetHttpRequest() const { return HttpRequest; }
+
+	void SetRestContentFullyParsed(bool InRestContentFullyParsed) { RestContentFullyParsed = InRestContentFullyParsed; }
+	bool IsRestContentFullyParsed() const { return RestContentFullyParsed; }
+
 private:
-	bool Successful;
-	EHttpResponseCodes::Type ResponseCode;
-	FString ResponseString;
-	FHttpResponsePtr HttpResponse;
+    //Unreal's underlying HTTP request.
+	FHttpRequestPtr HttpRequest;
+
+    //Success or failure of HTTP request as reported by Unreal's HTTP layer.  Canceling the request will also
+    //result in failure here.
+	bool HttpRequestSuccessful = false;
+
+    //Derived information as to whether this was a failure to connect entirely, or alternatively if any data was
+    //sent down the line before the connection failed.
+    //Applications take note here:  If data was sent down the line, it may not be safe to resend, depending on what your
+    //request was asking of the application server.  We don't know if the server processed it or not.
+	bool HttpClientConnectionError = false;
+
+    //Unreal's underlying HTTP response. This is a TSharedPtr and can be checked for IsValid()
+    //IsValid() may return false if there was no response.
+    FHttpResponsePtr HttpResponse;
+
+    //The HTTP response from the server, or EHttpResponseCodes::Unknown if there was no HTTP response.
+	EHttpResponseCodes::Type HttpResponseCode = EHttpResponseCodes::Unknown;
+
+    //The REST layer's assessment as to the success of the request.  Typically a response in the 2xx range results in true.
+	bool RestRequestSuccessful = false;
+
+    //The raw (string) content of the REST response.  Note this is TOptional.  If IsSet() == false, then there was no content.
+    //In case of a parsing problem or unexpected result, this will still contain whatever the server sent back.
+	TOptional<FString> RestResponseContent;
+
+    //The REST layer's description of the response type that was received from the server.  This descriptive text comes
+    //from the API Schema upon receiving specified HTTP response codes.
+    //Note this is TOptional.  If IsSet() == false, then there likely was no description for the given response code in
+    //the Schema.
+	TOptional<FString> RestResponseDescription;
+
+    //An assessment from the REST layer as to if the content was fully and properly parsed.
+    //Note, this may need to be treated skeptically.  A partially successful parse will still
+    //result in data being populated.  And a failure to 'fully' parse may be a pedantic failure from an overly
+    //strict reading of the Schema, or a malformed Schema that works well enough.
+	bool RestContentFullyParsed = false;
+
 };
 
 }

--- a/samples/client/petstore/cpp-ue4/Public/OpenAPIPetApi.h
+++ b/samples/client/petstore/cpp-ue4/Public/OpenAPIPetApi.h
@@ -55,37 +55,37 @@ public:
 	class UploadFileRequest;
 	class UploadFileResponse;
 	
-    DECLARE_DELEGATE_OneParam(FAddPetDelegate, const AddPetResponse&);
-    DECLARE_DELEGATE_OneParam(FDeletePetDelegate, const DeletePetResponse&);
-    DECLARE_DELEGATE_OneParam(FFindPetsByStatusDelegate, const FindPetsByStatusResponse&);
-    DECLARE_DELEGATE_OneParam(FFindPetsByTagsDelegate, const FindPetsByTagsResponse&);
-    DECLARE_DELEGATE_OneParam(FGetPetByIdDelegate, const GetPetByIdResponse&);
-    DECLARE_DELEGATE_OneParam(FUpdatePetDelegate, const UpdatePetResponse&);
-    DECLARE_DELEGATE_OneParam(FUpdatePetWithFormDelegate, const UpdatePetWithFormResponse&);
-    DECLARE_DELEGATE_OneParam(FUploadFileDelegate, const UploadFileResponse&);
-    
-    FHttpRequestPtr AddPet(const AddPetRequest& Request, const FAddPetDelegate& Delegate = FAddPetDelegate()) const;
-    FHttpRequestPtr DeletePet(const DeletePetRequest& Request, const FDeletePetDelegate& Delegate = FDeletePetDelegate()) const;
-    FHttpRequestPtr FindPetsByStatus(const FindPetsByStatusRequest& Request, const FFindPetsByStatusDelegate& Delegate = FFindPetsByStatusDelegate()) const;
-    FHttpRequestPtr FindPetsByTags(const FindPetsByTagsRequest& Request, const FFindPetsByTagsDelegate& Delegate = FFindPetsByTagsDelegate()) const;
-    FHttpRequestPtr GetPetById(const GetPetByIdRequest& Request, const FGetPetByIdDelegate& Delegate = FGetPetByIdDelegate()) const;
-    FHttpRequestPtr UpdatePet(const UpdatePetRequest& Request, const FUpdatePetDelegate& Delegate = FUpdatePetDelegate()) const;
-    FHttpRequestPtr UpdatePetWithForm(const UpdatePetWithFormRequest& Request, const FUpdatePetWithFormDelegate& Delegate = FUpdatePetWithFormDelegate()) const;
-    FHttpRequestPtr UploadFile(const UploadFileRequest& Request, const FUploadFileDelegate& Delegate = FUploadFileDelegate()) const;
-    
+	DECLARE_DELEGATE_OneParam(FAddPetDelegate, const AddPetResponse&);
+	DECLARE_DELEGATE_OneParam(FDeletePetDelegate, const DeletePetResponse&);
+	DECLARE_DELEGATE_OneParam(FFindPetsByStatusDelegate, const FindPetsByStatusResponse&);
+	DECLARE_DELEGATE_OneParam(FFindPetsByTagsDelegate, const FindPetsByTagsResponse&);
+	DECLARE_DELEGATE_OneParam(FGetPetByIdDelegate, const GetPetByIdResponse&);
+	DECLARE_DELEGATE_OneParam(FUpdatePetDelegate, const UpdatePetResponse&);
+	DECLARE_DELEGATE_OneParam(FUpdatePetWithFormDelegate, const UpdatePetWithFormResponse&);
+	DECLARE_DELEGATE_OneParam(FUploadFileDelegate, const UploadFileResponse&);
+	
+	FHttpRequestPtr AddPet(const AddPetRequest& Request, const FAddPetDelegate& Delegate = FAddPetDelegate()) const;
+	FHttpRequestPtr DeletePet(const DeletePetRequest& Request, const FDeletePetDelegate& Delegate = FDeletePetDelegate()) const;
+	FHttpRequestPtr FindPetsByStatus(const FindPetsByStatusRequest& Request, const FFindPetsByStatusDelegate& Delegate = FFindPetsByStatusDelegate()) const;
+	FHttpRequestPtr FindPetsByTags(const FindPetsByTagsRequest& Request, const FFindPetsByTagsDelegate& Delegate = FFindPetsByTagsDelegate()) const;
+	FHttpRequestPtr GetPetById(const GetPetByIdRequest& Request, const FGetPetByIdDelegate& Delegate = FGetPetByIdDelegate()) const;
+	FHttpRequestPtr UpdatePet(const UpdatePetRequest& Request, const FUpdatePetDelegate& Delegate = FUpdatePetDelegate()) const;
+	FHttpRequestPtr UpdatePetWithForm(const UpdatePetWithFormRequest& Request, const FUpdatePetWithFormDelegate& Delegate = FUpdatePetWithFormDelegate()) const;
+	FHttpRequestPtr UploadFile(const UploadFileRequest& Request, const FUploadFileDelegate& Delegate = FUploadFileDelegate()) const;
+	
 private:
-    void OnAddPetResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FAddPetDelegate Delegate) const;
-    void OnDeletePetResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDeletePetDelegate Delegate) const;
-    void OnFindPetsByStatusResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FFindPetsByStatusDelegate Delegate) const;
-    void OnFindPetsByTagsResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FFindPetsByTagsDelegate Delegate) const;
-    void OnGetPetByIdResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FGetPetByIdDelegate Delegate) const;
-    void OnUpdatePetResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FUpdatePetDelegate Delegate) const;
-    void OnUpdatePetWithFormResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FUpdatePetWithFormDelegate Delegate) const;
-    void OnUploadFileResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FUploadFileDelegate Delegate) const;
-    
+	void OnAddPetProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FAddPetDelegate Delegate) const;
+	void OnDeletePetProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDeletePetDelegate Delegate) const;
+	void OnFindPetsByStatusProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FFindPetsByStatusDelegate Delegate) const;
+	void OnFindPetsByTagsProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FFindPetsByTagsDelegate Delegate) const;
+	void OnGetPetByIdProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FGetPetByIdDelegate Delegate) const;
+	void OnUpdatePetProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FUpdatePetDelegate Delegate) const;
+	void OnUpdatePetWithFormProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FUpdatePetWithFormDelegate Delegate) const;
+	void OnUploadFileProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FUploadFileDelegate Delegate) const;
+	
 	FHttpRequestRef CreateHttpRequest(const Request& Request) const;
 	bool IsValid() const;
-	void HandleResponse(FHttpResponsePtr HttpResponse, bool bSucceeded, Response& InOutResponse) const;
+	void TryBuildResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bHttpSucceeded, Response& InOutResponse) const;
 
 	FString Url;
 	TMap<FString,FString> AdditionalHeaderParams;

--- a/samples/client/petstore/cpp-ue4/Public/OpenAPIStoreApi.h
+++ b/samples/client/petstore/cpp-ue4/Public/OpenAPIStoreApi.h
@@ -47,25 +47,25 @@ public:
 	class PlaceOrderRequest;
 	class PlaceOrderResponse;
 	
-    DECLARE_DELEGATE_OneParam(FDeleteOrderDelegate, const DeleteOrderResponse&);
-    DECLARE_DELEGATE_OneParam(FGetInventoryDelegate, const GetInventoryResponse&);
-    DECLARE_DELEGATE_OneParam(FGetOrderByIdDelegate, const GetOrderByIdResponse&);
-    DECLARE_DELEGATE_OneParam(FPlaceOrderDelegate, const PlaceOrderResponse&);
-    
-    FHttpRequestPtr DeleteOrder(const DeleteOrderRequest& Request, const FDeleteOrderDelegate& Delegate = FDeleteOrderDelegate()) const;
-    FHttpRequestPtr GetInventory(const GetInventoryRequest& Request, const FGetInventoryDelegate& Delegate = FGetInventoryDelegate()) const;
-    FHttpRequestPtr GetOrderById(const GetOrderByIdRequest& Request, const FGetOrderByIdDelegate& Delegate = FGetOrderByIdDelegate()) const;
-    FHttpRequestPtr PlaceOrder(const PlaceOrderRequest& Request, const FPlaceOrderDelegate& Delegate = FPlaceOrderDelegate()) const;
-    
+	DECLARE_DELEGATE_OneParam(FDeleteOrderDelegate, const DeleteOrderResponse&);
+	DECLARE_DELEGATE_OneParam(FGetInventoryDelegate, const GetInventoryResponse&);
+	DECLARE_DELEGATE_OneParam(FGetOrderByIdDelegate, const GetOrderByIdResponse&);
+	DECLARE_DELEGATE_OneParam(FPlaceOrderDelegate, const PlaceOrderResponse&);
+	
+	FHttpRequestPtr DeleteOrder(const DeleteOrderRequest& Request, const FDeleteOrderDelegate& Delegate = FDeleteOrderDelegate()) const;
+	FHttpRequestPtr GetInventory(const GetInventoryRequest& Request, const FGetInventoryDelegate& Delegate = FGetInventoryDelegate()) const;
+	FHttpRequestPtr GetOrderById(const GetOrderByIdRequest& Request, const FGetOrderByIdDelegate& Delegate = FGetOrderByIdDelegate()) const;
+	FHttpRequestPtr PlaceOrder(const PlaceOrderRequest& Request, const FPlaceOrderDelegate& Delegate = FPlaceOrderDelegate()) const;
+	
 private:
-    void OnDeleteOrderResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDeleteOrderDelegate Delegate) const;
-    void OnGetInventoryResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FGetInventoryDelegate Delegate) const;
-    void OnGetOrderByIdResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FGetOrderByIdDelegate Delegate) const;
-    void OnPlaceOrderResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FPlaceOrderDelegate Delegate) const;
-    
+	void OnDeleteOrderProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDeleteOrderDelegate Delegate) const;
+	void OnGetInventoryProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FGetInventoryDelegate Delegate) const;
+	void OnGetOrderByIdProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FGetOrderByIdDelegate Delegate) const;
+	void OnPlaceOrderProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FPlaceOrderDelegate Delegate) const;
+	
 	FHttpRequestRef CreateHttpRequest(const Request& Request) const;
 	bool IsValid() const;
-	void HandleResponse(FHttpResponsePtr HttpResponse, bool bSucceeded, Response& InOutResponse) const;
+	void TryBuildResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bHttpSucceeded, Response& InOutResponse) const;
 
 	FString Url;
 	TMap<FString,FString> AdditionalHeaderParams;

--- a/samples/client/petstore/cpp-ue4/Public/OpenAPIUserApi.h
+++ b/samples/client/petstore/cpp-ue4/Public/OpenAPIUserApi.h
@@ -55,37 +55,37 @@ public:
 	class UpdateUserRequest;
 	class UpdateUserResponse;
 	
-    DECLARE_DELEGATE_OneParam(FCreateUserDelegate, const CreateUserResponse&);
-    DECLARE_DELEGATE_OneParam(FCreateUsersWithArrayInputDelegate, const CreateUsersWithArrayInputResponse&);
-    DECLARE_DELEGATE_OneParam(FCreateUsersWithListInputDelegate, const CreateUsersWithListInputResponse&);
-    DECLARE_DELEGATE_OneParam(FDeleteUserDelegate, const DeleteUserResponse&);
-    DECLARE_DELEGATE_OneParam(FGetUserByNameDelegate, const GetUserByNameResponse&);
-    DECLARE_DELEGATE_OneParam(FLoginUserDelegate, const LoginUserResponse&);
-    DECLARE_DELEGATE_OneParam(FLogoutUserDelegate, const LogoutUserResponse&);
-    DECLARE_DELEGATE_OneParam(FUpdateUserDelegate, const UpdateUserResponse&);
-    
-    FHttpRequestPtr CreateUser(const CreateUserRequest& Request, const FCreateUserDelegate& Delegate = FCreateUserDelegate()) const;
-    FHttpRequestPtr CreateUsersWithArrayInput(const CreateUsersWithArrayInputRequest& Request, const FCreateUsersWithArrayInputDelegate& Delegate = FCreateUsersWithArrayInputDelegate()) const;
-    FHttpRequestPtr CreateUsersWithListInput(const CreateUsersWithListInputRequest& Request, const FCreateUsersWithListInputDelegate& Delegate = FCreateUsersWithListInputDelegate()) const;
-    FHttpRequestPtr DeleteUser(const DeleteUserRequest& Request, const FDeleteUserDelegate& Delegate = FDeleteUserDelegate()) const;
-    FHttpRequestPtr GetUserByName(const GetUserByNameRequest& Request, const FGetUserByNameDelegate& Delegate = FGetUserByNameDelegate()) const;
-    FHttpRequestPtr LoginUser(const LoginUserRequest& Request, const FLoginUserDelegate& Delegate = FLoginUserDelegate()) const;
-    FHttpRequestPtr LogoutUser(const LogoutUserRequest& Request, const FLogoutUserDelegate& Delegate = FLogoutUserDelegate()) const;
-    FHttpRequestPtr UpdateUser(const UpdateUserRequest& Request, const FUpdateUserDelegate& Delegate = FUpdateUserDelegate()) const;
-    
+	DECLARE_DELEGATE_OneParam(FCreateUserDelegate, const CreateUserResponse&);
+	DECLARE_DELEGATE_OneParam(FCreateUsersWithArrayInputDelegate, const CreateUsersWithArrayInputResponse&);
+	DECLARE_DELEGATE_OneParam(FCreateUsersWithListInputDelegate, const CreateUsersWithListInputResponse&);
+	DECLARE_DELEGATE_OneParam(FDeleteUserDelegate, const DeleteUserResponse&);
+	DECLARE_DELEGATE_OneParam(FGetUserByNameDelegate, const GetUserByNameResponse&);
+	DECLARE_DELEGATE_OneParam(FLoginUserDelegate, const LoginUserResponse&);
+	DECLARE_DELEGATE_OneParam(FLogoutUserDelegate, const LogoutUserResponse&);
+	DECLARE_DELEGATE_OneParam(FUpdateUserDelegate, const UpdateUserResponse&);
+	
+	FHttpRequestPtr CreateUser(const CreateUserRequest& Request, const FCreateUserDelegate& Delegate = FCreateUserDelegate()) const;
+	FHttpRequestPtr CreateUsersWithArrayInput(const CreateUsersWithArrayInputRequest& Request, const FCreateUsersWithArrayInputDelegate& Delegate = FCreateUsersWithArrayInputDelegate()) const;
+	FHttpRequestPtr CreateUsersWithListInput(const CreateUsersWithListInputRequest& Request, const FCreateUsersWithListInputDelegate& Delegate = FCreateUsersWithListInputDelegate()) const;
+	FHttpRequestPtr DeleteUser(const DeleteUserRequest& Request, const FDeleteUserDelegate& Delegate = FDeleteUserDelegate()) const;
+	FHttpRequestPtr GetUserByName(const GetUserByNameRequest& Request, const FGetUserByNameDelegate& Delegate = FGetUserByNameDelegate()) const;
+	FHttpRequestPtr LoginUser(const LoginUserRequest& Request, const FLoginUserDelegate& Delegate = FLoginUserDelegate()) const;
+	FHttpRequestPtr LogoutUser(const LogoutUserRequest& Request, const FLogoutUserDelegate& Delegate = FLogoutUserDelegate()) const;
+	FHttpRequestPtr UpdateUser(const UpdateUserRequest& Request, const FUpdateUserDelegate& Delegate = FUpdateUserDelegate()) const;
+	
 private:
-    void OnCreateUserResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FCreateUserDelegate Delegate) const;
-    void OnCreateUsersWithArrayInputResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FCreateUsersWithArrayInputDelegate Delegate) const;
-    void OnCreateUsersWithListInputResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FCreateUsersWithListInputDelegate Delegate) const;
-    void OnDeleteUserResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDeleteUserDelegate Delegate) const;
-    void OnGetUserByNameResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FGetUserByNameDelegate Delegate) const;
-    void OnLoginUserResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FLoginUserDelegate Delegate) const;
-    void OnLogoutUserResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FLogoutUserDelegate Delegate) const;
-    void OnUpdateUserResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FUpdateUserDelegate Delegate) const;
-    
+	void OnCreateUserProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FCreateUserDelegate Delegate) const;
+	void OnCreateUsersWithArrayInputProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FCreateUsersWithArrayInputDelegate Delegate) const;
+	void OnCreateUsersWithListInputProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FCreateUsersWithListInputDelegate Delegate) const;
+	void OnDeleteUserProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FDeleteUserDelegate Delegate) const;
+	void OnGetUserByNameProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FGetUserByNameDelegate Delegate) const;
+	void OnLoginUserProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FLoginUserDelegate Delegate) const;
+	void OnLogoutUserProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FLogoutUserDelegate Delegate) const;
+	void OnUpdateUserProcessRequestComplete(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FUpdateUserDelegate Delegate) const;
+	
 	FHttpRequestRef CreateHttpRequest(const Request& Request) const;
 	bool IsValid() const;
-	void HandleResponse(FHttpResponsePtr HttpResponse, bool bSucceeded, Response& InOutResponse) const;
+	void TryBuildResponse(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bHttpSucceeded, Response& InOutResponse) const;
 
 	FString Url;
 	TMap<FString,FString> AdditionalHeaderParams;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

fixes #10315 

As described in the original bug report, there were issues with response handling.  Specifically surrounding connection failures and what was eventually termed an "opinionated part of the handling."

This pull request restructures the building of the response and disambiguates parts of it.  It also documents heavily the purpose of the published and processed items in the response.  From the commits themselves:

- fixed likely mistake in assigning RetryManager field.
- reworked response handling to better incorporate client connection errors and more granular information.
- differentiated various strings and returns in the response between http and rest.  e.g. RestRequestSuccesful and HttpRequestSuccesful are two different things.
- removed an instance of the client setting an arbitrary server response.
- renamed HandleRespons to TryBuildResponse.  The response may not have actually happened.
- Added HttpRequest to the Response.
- Renamed internal operationResponse to operationProcessRequestComplete.  Mirror's Unreal's naming for what it's handling.
- converted some white-space spaces to tabs.
- changed rest response content and description to TOptional.
- reordering and documenting Response data.

This is a breaking changeset for downstream developers.  The disambiguation of parts of the response will very likely break application code that uses it.  And unfortunately, I suspect that's necessary.

Also, I do not have the resources to test it extensively.  I have tested it on my local code-base with plenty of artificially induced client and server failure situations, to check robustness.  But I don't have a breadth of APIs and servers to test against.  I think a change as extensive as this, requires more eyes and testing than I can provide.

Looking at the diff for TryBuildResponse is probably not as useful as looking at the full version of it. The changes are substantial.  Similarly I'd suggest looking at the whole response object with the comments in place.

The overall approach to the TryBuildResponse method is now one of publishing and processing, in a less than "opinionated" manner.  In hopes that it publishes and processes everything that one would need, without requiring diving deeper into the Unreal HTTP layer.  But ultimately it provides the access to that layer if needed.

For reference, I'm providing some example code here of how I use this data in my own project.

First, a template method for general REST request and response handling structure (using my BP wrapper classes, but close enough to the underlying objects to be understood):
```c++
	template<typename U, typename V, typename  W>
	UFUNCTION(BlueprintCallable, Category = "URESTView")
	void DoHandleRESTRequest(U * request, W * api, TFunction<void (V*)> on_success, TFunction<void(V*)> on_connection_fail, TFunction<void(V*)> on_unknown_fail )
	{
		request->OnResponseEvent.AddLambda([this,on_success, on_connection_fail, on_unknown_fail](U * request, V * response)
		{
			if (!response->IsHttpRequestSuccessful())
			{
				if (response->IsHttpClientConnectionError())
				{
					this->LogError("The client couldn't connect.");
					on_connection_fail(response);
				} else
				{
					this->LogError("HTTP request failed.");
					on_unknown_fail(response);
				}
				return;
			}
			if (!response->IsRestRequestSuccessful())
			{
				this->LogError("The REST request failed.  HTTP Response Code: " + FString::FromInt(response->GetHttpResponseCode()) );
				if (response->RestResponseDescriptionIsSet())
				{
					this->LogInformation("REST Response Description: " + response->GetRestResponseDescription());
				}
				if (response->RestResponseContentIsSet())
				{
					this->LogInformation("REST Response Content: " + response->GetRestResponseContent());
				}
				on_unknown_fail(response);
				return;
			}
			if (!response->IsRestContentFullyParsed())
			{
				this->LogWarning("The REST response didn't parse fully as per the Schema.");
			}
			on_success(response);
			return;
		});
		request->ExecuteRequest(api);
	}
```

and further, a use of this templated method in a ClientView object, from my codebase:
```c++
void ULegalEntitiesManagerView::RequestUpdateLegalEntity(UFPLLegalEntity* entry)
{
	auto request = NewObject<UFPLOrgbuilderApiUpdateLegalEntityRequest>();
	request->SetId(entry->GetId().ToString());
	request->SetLegalEntity(entry);
	this->LogInformation("Requesting commit of LegalEntity: " + entry->GetId().ToString());
	DoHandleRESTRequest<UFPLOrgbuilderApiUpdateLegalEntityRequest,UFPLOrgbuilderApiUpdateLegalEntityResponse,UFPLOrgbuilderApi>(request,this->api,
		[this](auto response)
		{
			this->LogInformation("Successful commit of LegalEntity.");
			auto returned = response->GetContent();
			this->OnReplaceLegalEntity.Broadcast(returned);
			this->OnShowManager.Broadcast();
		},
		[this](auto response)
		{
			this->LogInformation("The server never received the commit. It's safe to retry.");
			this->OnShowManager.Broadcast();
		},
		[this](auto response)
		{
			this->LogInformation("The server may have received and processed the update.  But it's safe to retry the commit.");
			this->OnShowManager.Broadcast();
		}
	);
	this->DoCancelableRequest("Updating LegalEntitity: " + entry->GetId().ToString(),[request](){request->CancelRequest();});
	
}
```

Of note in these client usage examples is that most information is being published back to the user.  But a client application layer could also make use the same information to execute more complex behavior.

One thing this adjustment has made fairly clear is that this part of the generated code will likely required substantial rework at a later time.

A schema can define different "content" or return types for an endpoint depending on the server response code.  And as it sits, this (and the prior) implementation will make the mistake of trying to parse the first specified response in the schema, every time, no matter the response code.  Which works well enough to get things working for simple Schemas.

Further, it also won't handle common rest styled errors either.  There are two points in the comments were I've noted that we could expand to check for and parse some well known error types.  But those kinds of expansion are beyond the scope of this fix.

It's debatable as to if the TryBuildResponse method should try to parse Content from a server response that doesn't match the response code in the schema.  I have left the behavior in place where it'll try anyway and gracefully fail to do so.  Which doesn't match a pedantic reading of the Schema, but is instead very lenient towards the server and Schema.

Finally, I apologize for some ugliness to the diff.  The codebase is clearly a tab indented set, and I took the opportunity to include some fixes where some lines in the files I was working in were erroneously space intended.  So, if you can't figure out why some lines seem to be changing as they don't relate to the changes above and don't seem substantive, consider that it may be a whitespace fix.  If this is a serious issue, I can go back and squash out those fixes.

For now, this is a draft pull request.  Largely because I think it needs more testing before it could be merged.  Also, because I have not addressed the issue of how to (or if to) signal these kinds of breaking changes.

tagging @Kahncode 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
