### PR TITLE
Show an error instead of NPE when schema is not defined

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3031,7 +3031,7 @@ public class DefaultCodegen implements CodegenConfig {
                 descendentSchemas.add(mm);
                 Schema cs = ModelUtils.getSchema(openAPI, modelName);
                 if (cs == null) { // cannot lookup the model based on the name
-                    LOGGER.warn("Skipped the schema '{}' as it doesn't seem to be defined.", modelName);
+                    LOGGER.error("Failed to lookup the schema '{}' when processing oneOf/anyOf. Please check to ensure it's defined properly.", modelName);
                 } else {
                     Map<String, Object> vendorExtensions = cs.getExtensions();
                     if (vendorExtensions != null && !vendorExtensions.isEmpty() && vendorExtensions.containsKey("x-discriminator-value")) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3030,13 +3030,16 @@ public class DefaultCodegen implements CodegenConfig {
                 MappedModel mm = new MappedModel(modelName, toModelName(modelName));
                 descendentSchemas.add(mm);
                 Schema cs = ModelUtils.getSchema(openAPI, modelName);
-                Map<String, Object> vendorExtensions = cs.getExtensions();
-                if (vendorExtensions != null && !vendorExtensions.isEmpty() && vendorExtensions.containsKey("x-discriminator-value")) {
-                    String xDiscriminatorValue = (String) vendorExtensions.get("x-discriminator-value");
-                    mm = new MappedModel(xDiscriminatorValue, toModelName(modelName));
-                    descendentSchemas.add(mm);
+                if (cs == null) { // cannot lookup the model based on the name
+                    LOGGER.warn("Skipped the schema '{}' as it doesn't seem to be defined.", modelName);
+                } else {
+                    Map<String, Object> vendorExtensions = cs.getExtensions();
+                    if (vendorExtensions != null && !vendorExtensions.isEmpty() && vendorExtensions.containsKey("x-discriminator-value")) {
+                        String xDiscriminatorValue = (String) vendorExtensions.get("x-discriminator-value");
+                        mm = new MappedModel(xDiscriminatorValue, toModelName(modelName));
+                        descendentSchemas.add(mm);
+                    }
                 }
-
             }
         }
         return descendentSchemas;


### PR DESCRIPTION
Show an error instead of NPE when schema is not defined in oneOf/anyOf
```
Exception in thread "main" java.lang.RuntimeException: Could not process model 'Problem'.Please make sure that your schema is correct!
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:499)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:899)
	at org.openapitools.codegen.cmd.Generate.execute(Generate.java:441)
	at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
Caused by: java.lang.NullPointerException
	at org.openapitools.codegen.DefaultCodegen.getOneOfAnyOfDescendants(DefaultCodegen.java:3019)
	at org.openapitools.codegen.DefaultCodegen.createDiscriminator(DefaultCodegen.java:3131)
	at org.openapitools.codegen.DefaultCodegen.fromModel(DefaultCodegen.java:2405)
	at org.openapitools.codegen.languages.AbstractJavaCodegen.fromModel(AbstractJavaCodegen.java:1175)
	at org.openapitools.codegen.languages.JavaClientCodegen.fromModel(JavaClientCodegen.java:781)
	at org.openapitools.codegen.DefaultGenerator.processModels(DefaultGenerator.java:1274)
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:494)
	... 4 more

```

cc @OpenAPITools/generator-core-team 


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
