### PR TITLE
[Typescript] Improve exception for unknown responses

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -200,7 +200,7 @@ export class {{classname}}ResponseProcessor {
             return body;
             {{/is2xx}}
             {{^is2xx}}
-            throw new ApiException<{{{dataType}}}>({{code}}, body);
+            throw new ApiException<{{{dataType}}}>({{code}}, "{{message}}", body);
             {{/is2xx}}
             {{/dataType}}
             {{^dataType}}
@@ -208,7 +208,7 @@ export class {{classname}}ResponseProcessor {
             return;
             {{/is2xx}}
             {{^is2xx}}
-            throw new ApiException<string>(response.httpStatusCode, "{{message}}");
+            throw new ApiException<undefined>(response.httpStatusCode, "{{message}}", undefined);
             {{/is2xx}}
             {{/dataType}}
         }
@@ -233,8 +233,7 @@ export class {{classname}}ResponseProcessor {
             {{/returnType}}
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     {{/operation}}

--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -233,7 +233,7 @@ export class {{classname}}ResponseProcessor {
             {{/returnType}}
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | {{{fileContentDataType}}} | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     {{/operation}}

--- a/modules/openapi-generator/src/main/resources/typescript/api/exception.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/exception.mustache
@@ -8,7 +8,7 @@
  *
  */
 export class ApiException<T> extends Error {
-    public constructor(public code: number, public body: T) {
-        super("HTTP-Code: " + code + "\nMessage: " + JSON.stringify(body))
+    public constructor(public code: number, message: string, public body: T) {
+        super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body))
     }
 }

--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -290,22 +290,18 @@ export class ResponseContext {
 
     /**
      * Use a heuristic to get a body of unknown data structure.
-     * Try JSON with fall back to plain text and binary.
+     * Return as string if possible, otherwise as binary.
      */
-    public async getBodyAsAny(): Promise<any> {
+    public getBodyAsAny(): Promise<string | {{{fileContentDataType}}} | undefined> {
         try {
-            const body = await this.body.text();
-            try {
-                return JSON.parse(body);
-            } catch {}
-            return body;
+            return this.body.text();
         } catch {}
 
         try {
             return this.body.binary();
         } catch {}
 
-        return undefined;
+        return Promise.resolve(undefined);
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -287,6 +287,26 @@ export class ResponseContext {
         {{/node}}
         {{/platforms}}
     }
+
+    /**
+     * Use a heuristic to get a body of unknown data structure.
+     * Try JSON with fall back to plain text and binary.
+     */
+    public async getBodyAsAny(): Promise<any> {
+        try {
+            const body = await this.body.text();
+            try {
+                return JSON.parse(body);
+            } catch {}
+            return body;
+        } catch {}
+
+        try {
+            return this.body.binary();
+        } catch {}
+
+        return undefined;
+    }
 }
 
 export interface HttpLibrary {

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/DefaultApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/DefaultApi.ts
@@ -134,8 +134,7 @@ export class DefaultApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -160,8 +159,7 @@ export class DefaultApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -186,8 +184,7 @@ export class DefaultApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/DefaultApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/DefaultApi.ts
@@ -134,7 +134,7 @@ export class DefaultApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -159,7 +159,7 @@ export class DefaultApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -184,7 +184,7 @@ export class DefaultApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/exception.ts
@@ -8,7 +8,7 @@
  *
  */
 export class ApiException<T> extends Error {
-    public constructor(public code: number, public body: T) {
-        super("HTTP-Code: " + code + "\nMessage: " + JSON.stringify(body))
+    public constructor(public code: number, message: string, public body: T) {
+        super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body))
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
@@ -201,6 +201,26 @@ export class ResponseContext {
             });
         }
     }
+
+    /**
+     * Use a heuristic to get a body of unknown data structure.
+     * Try JSON with fall back to plain text and binary.
+     */
+    public async getBodyAsAny(): Promise<any> {
+        try {
+            const body = await this.body.text();
+            try {
+                return JSON.parse(body);
+            } catch {}
+            return body;
+        } catch {}
+
+        try {
+            return this.body.binary();
+        } catch {}
+
+        return undefined;
+    }
 }
 
 export interface HttpLibrary {

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/http/http.ts
@@ -204,22 +204,18 @@ export class ResponseContext {
 
     /**
      * Use a heuristic to get a body of unknown data structure.
-     * Try JSON with fall back to plain text and binary.
+     * Return as string if possible, otherwise as binary.
      */
-    public async getBodyAsAny(): Promise<any> {
+    public getBodyAsAny(): Promise<string | Blob | undefined> {
         try {
-            const body = await this.body.text();
-            try {
-                return JSON.parse(body);
-            } catch {}
-            return body;
+            return this.body.text();
         } catch {}
 
         try {
             return this.body.binary();
         } catch {}
 
-        return undefined;
+        return Promise.resolve(undefined);
     }
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -414,7 +414,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -435,7 +435,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -467,7 +467,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -499,7 +499,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -534,7 +534,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -572,7 +572,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -593,7 +593,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -622,7 +622,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -402,7 +402,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid input");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -414,8 +414,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -428,7 +427,7 @@ export class PetApiResponseProcessor {
      public async deletePet(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid pet value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -436,8 +435,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -457,7 +455,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid status value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -469,8 +467,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -490,7 +487,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid tag value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -502,8 +499,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -523,10 +519,10 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Pet not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Pet not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -538,8 +534,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -559,13 +554,13 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Pet not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Pet not found", undefined);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Validation exception");
+            throw new ApiException<undefined>(response.httpStatusCode, "Validation exception", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -577,8 +572,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -591,7 +585,7 @@ export class PetApiResponseProcessor {
      public async updatePetWithForm(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid input");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -599,8 +593,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -629,8 +622,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -145,10 +145,10 @@ export class StoreApiResponseProcessor {
      public async deleteOrder(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Order not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Order not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -156,8 +156,7 @@ export class StoreApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -186,8 +185,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -207,10 +205,10 @@ export class StoreApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Order not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Order not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -222,8 +220,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -243,7 +240,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid Order");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -255,8 +252,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -156,7 +156,7 @@ export class StoreApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -185,7 +185,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -220,7 +220,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -252,7 +252,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -341,7 +341,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -362,7 +362,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -383,7 +383,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -407,7 +407,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -442,7 +442,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -474,7 +474,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -495,7 +495,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -519,7 +519,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -333,7 +333,7 @@ export class UserApiResponseProcessor {
      public async createUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -341,8 +341,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -355,7 +354,7 @@ export class UserApiResponseProcessor {
      public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -363,8 +362,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -377,7 +375,7 @@ export class UserApiResponseProcessor {
      public async createUsersWithListInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -385,8 +383,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -399,10 +396,10 @@ export class UserApiResponseProcessor {
      public async deleteUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -410,8 +407,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -431,10 +427,10 @@ export class UserApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -446,8 +442,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -467,7 +462,7 @@ export class UserApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username/password supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -479,8 +474,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -493,7 +487,7 @@ export class UserApiResponseProcessor {
      public async logoutUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -501,8 +495,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -515,10 +508,10 @@ export class UserApiResponseProcessor {
      public async updateUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid user supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -526,8 +519,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/exception.ts
@@ -8,7 +8,7 @@
  *
  */
 export class ApiException<T> extends Error {
-    public constructor(public code: number, public body: T) {
-        super("HTTP-Code: " + code + "\nMessage: " + JSON.stringify(body))
+    public constructor(public code: number, message: string, public body: T) {
+        super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body))
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
@@ -190,22 +190,18 @@ export class ResponseContext {
 
     /**
      * Use a heuristic to get a body of unknown data structure.
-     * Try JSON with fall back to plain text and binary.
+     * Return as string if possible, otherwise as binary.
      */
-    public async getBodyAsAny(): Promise<any> {
+    public getBodyAsAny(): Promise<string | Buffer | undefined> {
         try {
-            const body = await this.body.text();
-            try {
-                return JSON.parse(body);
-            } catch {}
-            return body;
+            return this.body.text();
         } catch {}
 
         try {
             return this.body.binary();
         } catch {}
 
-        return undefined;
+        return Promise.resolve(undefined);
     }
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/http/http.ts
@@ -187,6 +187,26 @@ export class ResponseContext {
         const fileName = this.getParsedHeader("content-disposition")["filename"] || "";
         return { data, name: fileName };
     }
+
+    /**
+     * Use a heuristic to get a body of unknown data structure.
+     * Try JSON with fall back to plain text and binary.
+     */
+    public async getBodyAsAny(): Promise<any> {
+        try {
+            const body = await this.body.text();
+            try {
+                return JSON.parse(body);
+            } catch {}
+            return body;
+        } catch {}
+
+        try {
+            return this.body.binary();
+        } catch {}
+
+        return undefined;
+    }
 }
 
 export interface HttpLibrary {

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
@@ -412,7 +412,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -433,7 +433,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -465,7 +465,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -497,7 +497,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -532,7 +532,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -570,7 +570,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -591,7 +591,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -620,7 +620,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
@@ -400,7 +400,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid input");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -412,8 +412,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -426,7 +425,7 @@ export class PetApiResponseProcessor {
      public async deletePet(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid pet value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -434,8 +433,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -455,7 +453,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid status value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -467,8 +465,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -488,7 +485,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid tag value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -500,8 +497,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -521,10 +517,10 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Pet not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Pet not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -536,8 +532,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -557,13 +552,13 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Pet not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Pet not found", undefined);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Validation exception");
+            throw new ApiException<undefined>(response.httpStatusCode, "Validation exception", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -575,8 +570,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -589,7 +583,7 @@ export class PetApiResponseProcessor {
      public async updatePetWithForm(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid input");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -597,8 +591,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -627,8 +620,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
@@ -154,7 +154,7 @@ export class StoreApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -183,7 +183,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -218,7 +218,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -250,7 +250,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
@@ -143,10 +143,10 @@ export class StoreApiResponseProcessor {
      public async deleteOrder(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Order not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Order not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -154,8 +154,7 @@ export class StoreApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -184,8 +183,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -205,10 +203,10 @@ export class StoreApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Order not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Order not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -220,8 +218,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -241,7 +238,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid Order");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -253,8 +250,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
@@ -331,7 +331,7 @@ export class UserApiResponseProcessor {
      public async createUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -339,8 +339,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -353,7 +352,7 @@ export class UserApiResponseProcessor {
      public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -361,8 +360,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -375,7 +373,7 @@ export class UserApiResponseProcessor {
      public async createUsersWithListInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -383,8 +381,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -397,10 +394,10 @@ export class UserApiResponseProcessor {
      public async deleteUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -408,8 +405,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -429,10 +425,10 @@ export class UserApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -444,8 +440,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -465,7 +460,7 @@ export class UserApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username/password supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -477,8 +472,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -491,7 +485,7 @@ export class UserApiResponseProcessor {
      public async logoutUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -499,8 +493,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -513,10 +506,10 @@ export class UserApiResponseProcessor {
      public async updateUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid user supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -524,8 +517,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
@@ -339,7 +339,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -360,7 +360,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -381,7 +381,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -405,7 +405,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -440,7 +440,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -472,7 +472,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -493,7 +493,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -517,7 +517,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/exception.ts
@@ -8,7 +8,7 @@
  *
  */
 export class ApiException<T> extends Error {
-    public constructor(public code: number, public body: T) {
-        super("HTTP-Code: " + code + "\nMessage: " + JSON.stringify(body))
+    public constructor(public code: number, message: string, public body: T) {
+        super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body))
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
@@ -219,6 +219,26 @@ export class ResponseContext {
             });
         }
     }
+
+    /**
+     * Use a heuristic to get a body of unknown data structure.
+     * Try JSON with fall back to plain text and binary.
+     */
+    public async getBodyAsAny(): Promise<any> {
+        try {
+            const body = await this.body.text();
+            try {
+                return JSON.parse(body);
+            } catch {}
+            return body;
+        } catch {}
+
+        try {
+            return this.body.binary();
+        } catch {}
+
+        return undefined;
+    }
 }
 
 export interface HttpLibrary {

--- a/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/http/http.ts
@@ -222,22 +222,18 @@ export class ResponseContext {
 
     /**
      * Use a heuristic to get a body of unknown data structure.
-     * Try JSON with fall back to plain text and binary.
+     * Return as string if possible, otherwise as binary.
      */
-    public async getBodyAsAny(): Promise<any> {
+    public getBodyAsAny(): Promise<string | Blob | undefined> {
         try {
-            const body = await this.body.text();
-            try {
-                return JSON.parse(body);
-            } catch {}
-            return body;
+            return this.body.text();
         } catch {}
 
         try {
             return this.body.binary();
         } catch {}
 
-        return undefined;
+        return Promise.resolve(undefined);
     }
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
@@ -405,7 +405,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid input");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -417,8 +417,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -431,7 +430,7 @@ export class PetApiResponseProcessor {
      public async deletePet(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid pet value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -439,8 +438,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -460,7 +458,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid status value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -472,8 +470,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -493,7 +490,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid tag value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -505,8 +502,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -526,10 +522,10 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Pet not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Pet not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -541,8 +537,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -562,13 +557,13 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Pet not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Pet not found", undefined);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Validation exception");
+            throw new ApiException<undefined>(response.httpStatusCode, "Validation exception", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -580,8 +575,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -594,7 +588,7 @@ export class PetApiResponseProcessor {
      public async updatePetWithForm(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid input");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -602,8 +596,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -632,8 +625,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
@@ -417,7 +417,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -438,7 +438,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -470,7 +470,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -502,7 +502,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -537,7 +537,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -575,7 +575,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -596,7 +596,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -625,7 +625,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
@@ -159,7 +159,7 @@ export class StoreApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -188,7 +188,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -223,7 +223,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -255,7 +255,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
@@ -148,10 +148,10 @@ export class StoreApiResponseProcessor {
      public async deleteOrder(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Order not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Order not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -159,8 +159,7 @@ export class StoreApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -189,8 +188,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -210,10 +208,10 @@ export class StoreApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Order not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Order not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -225,8 +223,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -246,7 +243,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid Order");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -258,8 +255,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
@@ -336,7 +336,7 @@ export class UserApiResponseProcessor {
      public async createUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -344,8 +344,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -358,7 +357,7 @@ export class UserApiResponseProcessor {
      public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -366,8 +365,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -380,7 +378,7 @@ export class UserApiResponseProcessor {
      public async createUsersWithListInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -388,8 +386,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -402,10 +399,10 @@ export class UserApiResponseProcessor {
      public async deleteUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -413,8 +410,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -434,10 +430,10 @@ export class UserApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -449,8 +445,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -470,7 +465,7 @@ export class UserApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username/password supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -482,8 +477,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -496,7 +490,7 @@ export class UserApiResponseProcessor {
      public async logoutUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -504,8 +498,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -518,10 +511,10 @@ export class UserApiResponseProcessor {
      public async updateUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid user supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -529,8 +522,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
@@ -344,7 +344,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -365,7 +365,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -386,7 +386,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -410,7 +410,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -445,7 +445,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -477,7 +477,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -498,7 +498,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -522,7 +522,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/exception.ts
@@ -8,7 +8,7 @@
  *
  */
 export class ApiException<T> extends Error {
-    public constructor(public code: number, public body: T) {
-        super("HTTP-Code: " + code + "\nMessage: " + JSON.stringify(body))
+    public constructor(public code: number, message: string, public body: T) {
+        super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body))
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
@@ -190,22 +190,18 @@ export class ResponseContext {
 
     /**
      * Use a heuristic to get a body of unknown data structure.
-     * Try JSON with fall back to plain text and binary.
+     * Return as string if possible, otherwise as binary.
      */
-    public async getBodyAsAny(): Promise<any> {
+    public getBodyAsAny(): Promise<string | Buffer | undefined> {
         try {
-            const body = await this.body.text();
-            try {
-                return JSON.parse(body);
-            } catch {}
-            return body;
+            return this.body.text();
         } catch {}
 
         try {
             return this.body.binary();
         } catch {}
 
-        return undefined;
+        return Promise.resolve(undefined);
     }
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/http/http.ts
@@ -187,6 +187,26 @@ export class ResponseContext {
         const fileName = this.getParsedHeader("content-disposition")["filename"] || "";
         return { data, name: fileName };
     }
+
+    /**
+     * Use a heuristic to get a body of unknown data structure.
+     * Try JSON with fall back to plain text and binary.
+     */
+    public async getBodyAsAny(): Promise<any> {
+        try {
+            const body = await this.body.text();
+            try {
+                return JSON.parse(body);
+            } catch {}
+            return body;
+        } catch {}
+
+        try {
+            return this.body.binary();
+        } catch {}
+
+        return undefined;
+    }
 }
 
 export interface HttpLibrary {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -412,7 +412,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -433,7 +433,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -465,7 +465,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -497,7 +497,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -532,7 +532,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -570,7 +570,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -591,7 +591,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -620,7 +620,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -400,7 +400,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid input");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -412,8 +412,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -426,7 +425,7 @@ export class PetApiResponseProcessor {
      public async deletePet(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid pet value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -434,8 +433,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -455,7 +453,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid status value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -467,8 +465,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -488,7 +485,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid tag value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -500,8 +497,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -521,10 +517,10 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Pet not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Pet not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -536,8 +532,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -557,13 +552,13 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Pet not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Pet not found", undefined);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Validation exception");
+            throw new ApiException<undefined>(response.httpStatusCode, "Validation exception", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -575,8 +570,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -589,7 +583,7 @@ export class PetApiResponseProcessor {
      public async updatePetWithForm(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid input");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -597,8 +591,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -627,8 +620,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -154,7 +154,7 @@ export class StoreApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -183,7 +183,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -218,7 +218,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -250,7 +250,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -143,10 +143,10 @@ export class StoreApiResponseProcessor {
      public async deleteOrder(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Order not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Order not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -154,8 +154,7 @@ export class StoreApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -184,8 +183,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -205,10 +203,10 @@ export class StoreApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Order not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Order not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -220,8 +218,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -241,7 +238,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid Order");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -253,8 +250,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -331,7 +331,7 @@ export class UserApiResponseProcessor {
      public async createUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -339,8 +339,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -353,7 +352,7 @@ export class UserApiResponseProcessor {
      public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -361,8 +360,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -375,7 +373,7 @@ export class UserApiResponseProcessor {
      public async createUsersWithListInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -383,8 +381,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -397,10 +394,10 @@ export class UserApiResponseProcessor {
      public async deleteUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -408,8 +405,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -429,10 +425,10 @@ export class UserApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -444,8 +440,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -465,7 +460,7 @@ export class UserApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username/password supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -477,8 +472,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -491,7 +485,7 @@ export class UserApiResponseProcessor {
      public async logoutUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -499,8 +493,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -513,10 +506,10 @@ export class UserApiResponseProcessor {
      public async updateUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid user supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -524,8 +517,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -339,7 +339,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -360,7 +360,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -381,7 +381,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -405,7 +405,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -440,7 +440,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -472,7 +472,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -493,7 +493,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -517,7 +517,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Blob | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/exception.ts
@@ -8,7 +8,7 @@
  *
  */
 export class ApiException<T> extends Error {
-    public constructor(public code: number, public body: T) {
-        super("HTTP-Code: " + code + "\nMessage: " + JSON.stringify(body))
+    public constructor(public code: number, message: string, public body: T) {
+        super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body))
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
@@ -201,6 +201,26 @@ export class ResponseContext {
             });
         }
     }
+
+    /**
+     * Use a heuristic to get a body of unknown data structure.
+     * Try JSON with fall back to plain text and binary.
+     */
+    public async getBodyAsAny(): Promise<any> {
+        try {
+            const body = await this.body.text();
+            try {
+                return JSON.parse(body);
+            } catch {}
+            return body;
+        } catch {}
+
+        try {
+            return this.body.binary();
+        } catch {}
+
+        return undefined;
+    }
 }
 
 export interface HttpLibrary {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/http/http.ts
@@ -204,22 +204,18 @@ export class ResponseContext {
 
     /**
      * Use a heuristic to get a body of unknown data structure.
-     * Try JSON with fall back to plain text and binary.
+     * Return as string if possible, otherwise as binary.
      */
-    public async getBodyAsAny(): Promise<any> {
+    public getBodyAsAny(): Promise<string | Blob | undefined> {
         try {
-            const body = await this.body.text();
-            try {
-                return JSON.parse(body);
-            } catch {}
-            return body;
+            return this.body.text();
         } catch {}
 
         try {
             return this.body.binary();
         } catch {}
 
-        return undefined;
+        return Promise.resolve(undefined);
     }
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
@@ -414,7 +414,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -435,7 +435,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -467,7 +467,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -499,7 +499,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -534,7 +534,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -572,7 +572,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -593,7 +593,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -622,7 +622,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
@@ -402,7 +402,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid input");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -414,8 +414,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -428,7 +427,7 @@ export class PetApiResponseProcessor {
      public async deletePet(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid pet value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid pet value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -436,8 +435,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -457,7 +455,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid status value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid status value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -469,8 +467,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -490,7 +487,7 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid tag value");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid tag value", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -502,8 +499,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -523,10 +519,10 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Pet not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Pet not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -538,8 +534,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -559,13 +554,13 @@ export class PetApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Pet not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Pet not found", undefined);
         }
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Validation exception");
+            throw new ApiException<undefined>(response.httpStatusCode, "Validation exception", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -577,8 +572,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -591,7 +585,7 @@ export class PetApiResponseProcessor {
      public async updatePetWithForm(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("405", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid input");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid input", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -599,8 +593,7 @@ export class PetApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -629,8 +622,7 @@ export class PetApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
@@ -145,10 +145,10 @@ export class StoreApiResponseProcessor {
      public async deleteOrder(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Order not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Order not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -156,8 +156,7 @@ export class StoreApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -186,8 +185,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -207,10 +205,10 @@ export class StoreApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid ID supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid ID supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Order not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "Order not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -222,8 +220,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -243,7 +240,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid Order");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid Order", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -255,8 +252,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
@@ -156,7 +156,7 @@ export class StoreApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -185,7 +185,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -220,7 +220,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -252,7 +252,7 @@ export class StoreApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
@@ -341,7 +341,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -362,7 +362,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -383,7 +383,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -407,7 +407,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -442,7 +442,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -474,7 +474,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -495,7 +495,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -519,7 +519,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
@@ -333,7 +333,7 @@ export class UserApiResponseProcessor {
      public async createUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -341,8 +341,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -355,7 +354,7 @@ export class UserApiResponseProcessor {
      public async createUsersWithArrayInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -363,8 +362,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -377,7 +375,7 @@ export class UserApiResponseProcessor {
      public async createUsersWithListInput(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -385,8 +383,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -399,10 +396,10 @@ export class UserApiResponseProcessor {
      public async deleteUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -410,8 +407,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -431,10 +427,10 @@ export class UserApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -446,8 +442,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -467,7 +462,7 @@ export class UserApiResponseProcessor {
             return body;
         }
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid username/password supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid username/password supplied", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -479,8 +474,7 @@ export class UserApiResponseProcessor {
             return body;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -493,7 +487,7 @@ export class UserApiResponseProcessor {
      public async logoutUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("0", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "successful operation");
+            throw new ApiException<undefined>(response.httpStatusCode, "successful operation", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -501,8 +495,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
     /**
@@ -515,10 +508,10 @@ export class UserApiResponseProcessor {
      public async updateUser(response: ResponseContext): Promise< void> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("400", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "Invalid user supplied");
+            throw new ApiException<undefined>(response.httpStatusCode, "Invalid user supplied", undefined);
         }
         if (isCodeInRange("404", response.httpStatusCode)) {
-            throw new ApiException<string>(response.httpStatusCode, "User not found");
+            throw new ApiException<undefined>(response.httpStatusCode, "User not found", undefined);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
@@ -526,8 +519,7 @@ export class UserApiResponseProcessor {
             return;
         }
 
-        let body = response.body || "";
-        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+        throw new ApiException<any>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny());
     }
 
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/exception.ts
@@ -8,7 +8,7 @@
  *
  */
 export class ApiException<T> extends Error {
-    public constructor(public code: number, public body: T) {
-        super("HTTP-Code: " + code + "\nMessage: " + JSON.stringify(body))
+    public constructor(public code: number, message: string, public body: T) {
+        super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body))
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
@@ -190,22 +190,18 @@ export class ResponseContext {
 
     /**
      * Use a heuristic to get a body of unknown data structure.
-     * Try JSON with fall back to plain text and binary.
+     * Return as string if possible, otherwise as binary.
      */
-    public async getBodyAsAny(): Promise<any> {
+    public getBodyAsAny(): Promise<string | Buffer | undefined> {
         try {
-            const body = await this.body.text();
-            try {
-                return JSON.parse(body);
-            } catch {}
-            return body;
+            return this.body.text();
         } catch {}
 
         try {
             return this.body.binary();
         } catch {}
 
-        return undefined;
+        return Promise.resolve(undefined);
     }
 }
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/http/http.ts
@@ -187,6 +187,26 @@ export class ResponseContext {
         const fileName = this.getParsedHeader("content-disposition")["filename"] || "";
         return { data, name: fileName };
     }
+
+    /**
+     * Use a heuristic to get a body of unknown data structure.
+     * Try JSON with fall back to plain text and binary.
+     */
+    public async getBodyAsAny(): Promise<any> {
+        try {
+            const body = await this.body.text();
+            try {
+                return JSON.parse(body);
+            } catch {}
+            return body;
+        } catch {}
+
+        try {
+            return this.body.binary();
+        } catch {}
+
+        return undefined;
+    }
 }
 
 export interface HttpLibrary {

--- a/samples/openapi3/client/petstore/typescript/tests/default/package-lock.json
+++ b/samples/openapi3/client/petstore/typescript/tests/default/package-lock.json
@@ -1,8 +1,2017 @@
 {
   "name": "typescript-test",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "typescript-test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@types/rewire": "^2.5.28",
+        "form-data": "^2.5.0",
+        "rewire": "^4.0.1",
+        "ts-node": "^3.3.0",
+        "ts-petstore-client": "file:../../builds/default"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.0.1",
+        "@types/isomorphic-fetch": "0.0.34",
+        "@types/mocha": "^2.2.41",
+        "@types/node": "^8.10.38",
+        "chai": "^4.1.0",
+        "mocha": "^5.2.0",
+        "ts-loader": "^2.3.0",
+        "typescript": "^2.4.1"
+      }
+    },
+    "../../builds/default": {
+      "name": "ts-petstore-client",
+      "version": "1.0.0",
+      "license": "Unlicense",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/node-fetch": "^2.5.7",
+        "btoa": "^1.2.1",
+        "es6-promise": "^4.2.4",
+        "form-data": "^2.5.0",
+        "node-fetch": "^2.6.0",
+        "url-parse": "^1.4.3"
+      },
+      "devDependencies": {
+        "typescript": "^3.9.3"
+      }
+    },
+    "../../builds/default/node_modules/@types/node": {
+      "version": "12.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
+      "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
+      "license": "MIT"
+    },
+    "../../builds/default/node_modules/@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "../../builds/default/node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../builds/default/node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "license": "MIT"
+    },
+    "../../builds/default/node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "../../builds/default/node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "../../builds/default/node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "../../builds/default/node_modules/es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+      "license": "MIT"
+    },
+    "../../builds/default/node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "../../builds/default/node_modules/mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../builds/default/node_modules/mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.40.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "../../builds/default/node_modules/node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "../../builds/default/node_modules/querystringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
+      "license": "MIT"
+    },
+    "../../builds/default/node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "license": "MIT"
+    },
+    "../../builds/default/node_modules/typescript": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "../../builds/default/node_modules/url-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.6.tgz",
+      "integrity": "sha512-CBk7KTZt3FhPsEkYioG6kuCIpWISw+YI8o+3op4+NXwTpvAPxE1ES8+PY8zfaK2L98b1z5oq03UHa4VYpeUxnw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/isomorphic-fetch": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.34.tgz",
+      "integrity": "sha1-PDSD5gbAQTeEOOlRRk8A5OYHBtY=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mocha": {
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "8.10.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.38.tgz",
+      "integrity": "sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/rewire": {
+      "version": "2.5.28",
+      "resolved": "https://registry.npmjs.org/@types/rewire/-/rewire-2.5.28.tgz",
+      "integrity": "sha512-uD0j/AQOa5le7afuK+u+woi8jNKF1vf3DN0H7LCJhft/lNNibUr7VcAesdgtWfEKveZol3ZG1CJqwx2Bhrnl8w==",
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^3.0.4"
+      }
+    },
+    "node_modules/acorn-jsx/node_modules/acorn": {
+      "version": "3.3.0",
+      "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "license": "MIT",
+      "dependencies": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^5.0.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "license": "MIT"
+    },
+    "node_modules/babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "license": "MIT"
+    },
+    "node_modules/big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "license": "MIT"
+    },
+    "node_modules/caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "0.2.0",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "license": "MIT"
+    },
+    "node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "license": "ISC"
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.15.1",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "license": "MIT (https://github.com/thlorenz/deep-is/blob/master/LICENSE)"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+      "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "object-assign": "^4.0.1",
+        "tapable": "^0.2.7"
+      },
+      "engines": {
+        "node": ">=4.3.0 <5.0.0 || >=5.10"
+      }
+    },
+    "node_modules/errno": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "4.19.1",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/espree": {
+      "version": "3.5.4",
+      "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "2.2.0",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "license": "MIT"
+    },
+    "node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "license": "MIT",
+      "dependencies": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "license": "ISC"
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "license": "MIT"
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "license": "ISC",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "license": "MIT",
+      "dependencies": {
+        "parse-passwd": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "license": "MIT"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "license": "ISC"
+    },
+    "node_modules/inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "license": "MIT"
+    },
+    "node_modules/is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/loader-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "license": "ISC",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "license": "ISC"
+    },
+    "node_modules/memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.40.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "license": "ISC"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "license": "ISC"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.6",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/require-uncached": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "license": "MIT",
+      "dependencies": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rewire": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-4.0.1.tgz",
+      "integrity": "sha512-+7RQ/BYwTieHVXetpKhT11UbfF6v1kGhKFrtZN7UDL2PybMsSt/rpLWeEUGF5Ndsl1D5BxiCB14VDJyoX+noYw==",
+      "license": "MIT",
+      "dependencies": {
+        "eslint": "^4.19.1"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.0.5"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "license": "MIT",
+      "dependencies": {
+        "is-promise": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+    },
+    "node_modules/rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dependencies": {
+        "rx-lite": "*"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "license": "ISC"
+    },
+    "node_modules/slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "^0.5.6"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+      "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "license": "MIT"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/ts-loader": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-2.3.7.tgz",
+      "integrity": "sha512-8t3bu2FcEkXb+D4L+Cn8qiK2E2C6Ms4/GQChvz6IMbVurcFHLXrhW4EMtfaol1a1ASQACZGDUGit4NHnX9g7hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.0.1",
+        "enhanced-resolve": "^3.0.0",
+        "loader-utils": "^1.0.2",
+        "semver": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=4.3.0 <5.0.0 || >=5.10"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.3.0.tgz",
+      "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
+      "license": "MIT",
+      "dependencies": {
+        "arrify": "^1.0.0",
+        "chalk": "^2.0.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.0",
+        "tsconfig": "^6.0.0",
+        "v8flags": "^3.0.0",
+        "yn": "^2.0.0"
+      },
+      "bin": {
+        "_ts-node": "dist/_bin.js",
+        "ts-node": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-petstore-client": {
+      "resolved": "../../builds/default",
+      "link": true
+    },
+    "node_modules/tsconfig": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
+      "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
+      "license": "MIT",
+      "dependencies": {
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "^2.0.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "license": "MIT"
+    },
+    "node_modules/v8flags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.1.tgz",
+      "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
+      "dependencies": {
+        "homedir-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "license": "ISC"
+    },
+    "node_modules/write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "license": "ISC"
+    },
+    "node_modules/yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  },
   "dependencies": {
     "@types/chai": {
       "version": "4.1.6",
@@ -67,7 +2076,8 @@
     "ajv-keywords": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "3.1.0",
@@ -1104,6 +3114,14 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -1111,14 +3129,6 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -1229,14 +3239,10 @@
         "es6-promise": "^4.2.4",
         "form-data": "^2.5.0",
         "node-fetch": "^2.6.0",
+        "typescript": "^3.9.3",
         "url-parse": "^1.4.3"
       },
       "dependencies": {
-        "@types/isomorphic-fetch": {
-          "version": "0.0.34",
-          "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.34.tgz",
-          "integrity": "sha1-PDSD5gbAQTeEOOlRRk8A5OYHBtY="
-        },
         "@types/node": {
           "version": "12.12.7",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
@@ -1301,14 +3307,6 @@
             "mime-types": "^2.1.12"
           }
         },
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-          "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-          "requires": {
-            "whatwg-fetch": ">=0.10.0"
-          }
-        },
         "mime-db": {
           "version": "1.40.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -1338,9 +3336,9 @@
           "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
         },
         "typescript": {
-          "version": "2.9.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-          "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
+          "version": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+          "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+          "dev": true
         },
         "url-parse": {
           "version": "1.4.3",
@@ -1350,11 +3348,6 @@
             "querystringify": "^2.0.0",
             "requires-port": "^1.0.0"
           }
-        },
-        "whatwg-fetch": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-          "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
         }
       }
     },

--- a/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
@@ -44,7 +44,8 @@ describe("PetApi", () => {
     })
 
     it("deleteNonExistantPet", async () => {
-        const nonExistantId = Math.floor(Math.random() * 100000);
+        // Use an id that is too big for the server to handle.
+        const nonExistantId = 100000000000000000000000000;
         try {
             await petApi.deletePet(nonExistantId)
         } catch (err) {
@@ -54,6 +55,8 @@ describe("PetApi", () => {
             // here.
             expect(err.code).to.equal(404);
             expect(err.message).to.include("Unknown API Status Code");
+            expect(err.body).to.have.property("code").equal(404);
+            expect(err.body).to.have.property("message");
             return;
         }
         throw new Error("Deleted non-existant pet with id " + nonExistantId + "!");

--- a/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
@@ -12,16 +12,6 @@ tag.id = Math.floor(Math.random() * 100000)
 
 let pet: petstore.Pet;
 
-// NOTE: There seem to be two instances of the api server under the same URL.
-// As an ugly workaround we do all modifications multiple times.
-
-const REPETITIONS = 2;
-async function repeat(func: () => any) {
-    for (let idx = 0; idx < REPETITIONS; idx++) {
-        await func();
-    }
-}
-
 describe("PetApi", () => {
     beforeEach(async () => {
         pet = new petstore.Pet()
@@ -32,7 +22,7 @@ describe("PetApi", () => {
         pet.tags = [ tag ]
         pet.category = undefined
 
-        await repeat(() => petApi.addPet(pet));
+        await petApi.addPet(pet);
     });
 
     it("addPet", async () => {
@@ -41,7 +31,7 @@ describe("PetApi", () => {
     })
 
     it("deletePet", async () => {
-        await repeat(() => petApi.deletePet(pet.id))
+        await petApi.deletePet(pet.id);
         let deletedPet;
         try {
             deletedPet = await petApi.getPetById(pet.id)
@@ -86,7 +76,7 @@ describe("PetApi", () => {
 
     it("updatePet", async () => {
         pet.name = "updated name";
-        await repeat(() => petApi.updatePet(pet));
+        await petApi.updatePet(pet);
         await petApi.updatePet(pet);
 
         const returnedPet = await petApi.getPetById(pet.id);
@@ -96,7 +86,7 @@ describe("PetApi", () => {
 
     it("updatePetWithForm", async () => {
         const updatedName = "updated name";
-        await repeat(() => petApi.updatePetWithForm(pet.id, updatedName));
+        await petApi.updatePetWithForm(pet.id, updatedName);
 
         const returnedPet = await petApi.getPetById(pet.id)
         expect(returnedPet.id).to.equal(pet.id)

--- a/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
@@ -12,7 +12,8 @@ tag.id = Math.floor(Math.random() * 100000)
 
 let pet: petstore.Pet;
 
-// TODO: Make tests more relyable
+// NOTE: There seem to be two instances of the api server
+// As an ugly workaround we do all modifications two times
 
 describe("PetApi", () => {
     beforeEach(async () => {
@@ -25,6 +26,7 @@ describe("PetApi", () => {
         pet.category = undefined
 
         await petApi.addPet(pet);
+        await petApi.addPet(pet);
     });
 
     it("addPet", async () => {
@@ -33,6 +35,7 @@ describe("PetApi", () => {
     })
 
     it("deletePet", async () => {
+        await petApi.deletePet(pet.id)
         await petApi.deletePet(pet.id)
         let deletedPet;
         try {
@@ -62,9 +65,8 @@ describe("PetApi", () => {
     it("updatePet", async () => {
         pet.name = "updated name";
         await petApi.updatePet(pet);
+        await petApi.updatePet(pet);
 
-        // Somehow the updated name only appears ofter the second GET
-        await petApi.getPetById(pet.id);
         const returnedPet = await petApi.getPetById(pet.id);
         expect(returnedPet.id).to.equal(pet.id)
         expect(returnedPet.name).to.equal(pet.name);
@@ -73,9 +75,8 @@ describe("PetApi", () => {
     it("updatePetWithForm", async () => {
         const updatedName = "updated name";
         await petApi.updatePetWithForm(pet.id, updatedName);
+        await petApi.updatePetWithForm(pet.id, updatedName);
 
-        // Somehow the updated name only appears ofter the second GET
-        await petApi.getPetById(pet.id);
         const returnedPet = await petApi.getPetById(pet.id)
         expect(returnedPet.id).to.equal(pet.id)
         expect(returnedPet.name).to.equal(updatedName);

--- a/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
@@ -55,8 +55,8 @@ describe("PetApi", () => {
             // here.
             expect(err.code).to.equal(404);
             expect(err.message).to.include("Unknown API Status Code");
-            expect(err.body).to.have.property("code").equal(404);
-            expect(err.body).to.have.property("message");
+            expect(err.body).to.include("404");
+            expect(err.body).to.include("message");
             return;
         }
         throw new Error("Deleted non-existant pet with id " + nonExistantId + "!");

--- a/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
@@ -1,6 +1,6 @@
 import * as petstore from 'ts-petstore-client'
 
-import { expect, assert } from "chai";
+import { expect } from "chai";
 import * as fs from 'fs';
 
 const configuration = petstore.createConfiguration()
@@ -18,7 +18,9 @@ pet.status = 'available'
 pet.tags = [ tag ]
 pet.category = undefined
 
-describe("PetApi", () =>{ 
+// TODO: Make tests more relyable
+
+describe("PetApi", () => {
     it("addPet", (done) => {
         petApi.addPet(pet).then(() => {
             return petApi.getPetById(pet.id)
@@ -38,8 +40,8 @@ describe("PetApi", () =>{
         }).then((pet: petstore.Pet) => {
             done("Pet with id " + pet.id + " was not deleted!");
         }).catch((err: any) => {
-            if (err.code && err.code == 404) {
-                done();                
+            if (err.code === 404) {
+                done();
             } else {
                 done(err)
             }
@@ -57,17 +59,16 @@ describe("PetApi", () =>{
         })
     })
 
-    // bugged on server side! Code 500
-/*    it("findPetsByTag", (done) => {
+    it("findPetsByTag", (done) => {
         petApi.addPet(pet).then(() => {
             return petApi.findPetsByTags([tag.name])
-        }).then((pets: Pet[]) => {
+        }).then((pets: petstore.Pet[]) => {
             expect(pets.length).to.be.at.least(1);
             done();
         }).catch((err: any) => {
             done(err);
         })
-    })*/
+    })
 
     it("getPetById", (done) => {
         petApi.addPet(pet).then(() => {
@@ -92,6 +93,9 @@ describe("PetApi", () =>{
                 throw err;
             });
         }).then(() => {
+            // Somehow the updated name only appears ofter the second GET
+            return petApi.getPetById(pet.id)
+        }).then(() => {
             return petApi.getPetById(pet.id);
         }).then((returnedPet: petstore.Pet) => {
             expect(returnedPet.id).to.equal(pet.id)
@@ -102,21 +106,23 @@ describe("PetApi", () =>{
         })
     })
 
-// not supported by online swagger api?
-/*    it("updatePetWithForm", (done) => {
+    it("updatePetWithForm", (done) => {
         const updatedName = "updated name";
         petApi.addPet(pet).then(() => {
             return petApi.updatePetWithForm(pet.id, updatedName)
         }).then(() => {
+            // Somehow the updated name only appears ofter the second GET
             return petApi.getPetById(pet.id)
-        }).then((returnedPet: Pet) => {
+        }).then(() => {
+            return petApi.getPetById(pet.id)
+        }).then((returnedPet: petstore.Pet) => {
             expect(returnedPet.id).to.equal(pet.id)
             expect(returnedPet.name).to.equal(updatedName);
             done()
         }).catch((err: any) => {
             done(err)
         })
-    })*/
+    })
 
     it("uploadFile", (done) => {
         const image = fs.readFileSync(__dirname + "/pet.png")

--- a/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
@@ -10,25 +10,29 @@ const tag = new petstore.Tag();
 tag.name = "tag1"
 tag.id = Math.floor(Math.random() * 100000)
 
-const pet = new petstore.Pet()
-pet.id = Math.floor(Math.random() * 100000)
-pet.name = "PetName"
-pet.photoUrls = []
-pet.status = 'available'
-pet.tags = [ tag ]
-pet.category = undefined
+let pet: petstore.Pet;
 
 // TODO: Make tests more relyable
 
 describe("PetApi", () => {
-    it("addPet", async () => {
+    beforeEach(async () => {
+        pet = new petstore.Pet()
+        pet.id = Math.floor(Math.random() * 100000)
+        pet.name = "PetName"
+        pet.photoUrls = []
+        pet.status = 'available'
+        pet.tags = [ tag ]
+        pet.category = undefined
+
         await petApi.addPet(pet);
+    });
+
+    it("addPet", async () => {
         const createdPet = await petApi.getPetById(pet.id)
         expect(createdPet).to.deep.equal(pet);
     })
 
     it("deletePet", async () => {
-        await petApi.addPet(pet);
         await petApi.deletePet(pet.id)
         let deletedPet;
         try {
@@ -41,46 +45,33 @@ describe("PetApi", () => {
     })
 
     it("findPetsByStatus", async () => {
-        await petApi.addPet(pet);
         const pets = await petApi.findPetsByStatus(["available"]);
         expect(pets.length).to.be.at.least(1);
     })
 
     it("findPetsByTag", async () => {
-        await petApi.addPet(pet);
         const pets = await petApi.findPetsByTags([tag.name])
         expect(pets.length).to.be.at.least(1);
     })
 
     it("getPetById", async () => {
-        await petApi.addPet(pet);
         const returnedPet = await petApi.getPetById(pet.id);
         expect(returnedPet).to.deep.equal(pet);
     })
 
     it("updatePet", async () => {
-        const oldName = pet.name
-        const updatedName = "updated name";
-        await petApi.addPet(pet);
-
-        pet.name = updatedName;
-        try {
-            await petApi.updatePet(pet);
-        } finally {
-            pet.name = oldName;
-        }
+        pet.name = "updated name";
+        await petApi.updatePet(pet);
 
         // Somehow the updated name only appears ofter the second GET
         await petApi.getPetById(pet.id);
         const returnedPet = await petApi.getPetById(pet.id);
         expect(returnedPet.id).to.equal(pet.id)
-        expect(returnedPet.name).to.equal(updatedName);
+        expect(returnedPet.name).to.equal(pet.name);
     })
 
     it("updatePetWithForm", async () => {
         const updatedName = "updated name";
-        await petApi.addPet(pet);
-
         await petApi.updatePetWithForm(pet.id, updatedName);
 
         // Somehow the updated name only appears ofter the second GET


### PR DESCRIPTION
For http errors that are not explicitly defined in the api specification, currently the consolidated typescript generator does not retain the body. Instead a generic `[object Object]` string is provided for it in the error message. This is probably an oversight.

Instead we now set the message string and response body attributes on the exception object separately.
Additionally I have added a heuristic which tries to parse the response as JSON, falls back first to plain text, then to binary and then to undefined.

I have added a new `deleteNonExistantPet` integration test to the default typescript/node petstore sample.

This is a template-only change.

Steps:
- Clean up tests
- Change tests to async-await
- Use different pets for each test
- Add test for unknown error response code
- Make body of unexpected error responses available
- Regenerate all consolidated typescript samples

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)