### PR TITLE
[Kotlin-spring] fix default value for @ApiParam

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -268,7 +268,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
     @Override
     public String escapeQuotationMark(String input) {
         // remove " to avoid code injection
-        return input.replace("\"", "");
+        return input.replaceAll("\"", "");
     }
 
     @Override
@@ -999,7 +999,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
             if (p.getDefault() != null) {
                 String _default = (String) p.getDefault();
                 if (p.getEnum() == null) {
-                    return "\"" + escapeText(_default) + "\"";
+                    return escapeText(_default);
                 } else {
                     // convert to enum var name later in postProcessModels
                     return _default;


### PR DESCRIPTION
This PR fixes default value for String into @ApiParam.

For example given this schema :
```yaml
openapi: "3.0.1"
info:
  version: 1.0.0
  title: Users

paths:
  /users/search:
    post:
      parameters:
        - name: name
          in: header
          description: The name of the user
          schema:
            type: string
            default: "bond"
      responses:
        default:
          description: ""
```

The generator without the fix produces this code which doesn't compile because of invalid `defaultValue` attribute
```
    fun usersSearchPost(@ApiParam(value = "The name of the user" , defaultValue=""bond"") @RequestHeader(value="name", required=false) name: kotlin.String
): ResponseEntity<Unit>
```

with the fix it compiles correctly
```
fun usersSearchPost(@ApiParam(value = "The name of the user" , defaultValue="bond") @RequestHeader(value="name", required=false) name: kotlin.String
): ResponseEntity<Unit>
```
