### PR TITLE
[kotlin-spring] kotlin-builder support

### DIFF
--- a/docs/generators/kotlin-spring.md
+++ b/docs/generators/kotlin-spring.md
@@ -18,6 +18,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |gradleBuildFile|generate a gradle build file using the Kotlin DSL| |true|
 |groupId|Generated artifact package's organization (i.e. maven groupId).| |org.openapitools|
 |interfaceOnly|Whether to generate only API interface stubs without the server files.| |false|
+|kotlinBuilder|use kotlin builder| |false|
 |library|library template (sub-template)|<dl><dt>**spring-boot**</dt><dd>Spring-boot Server application.</dd></dl>|spring-boot|
 |modelMutable|Create mutable models| |false|
 |modelPackage|model package for generated code| |org.openapitools.model|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -53,6 +53,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
                     "ApiResponse"
             ));
 
+    public static final String KOTLIN_BUILDER = "kotlinBuilder";
     public static final String TITLE = "title";
     public static final String SERVER_PORT = "serverPort";
     public static final String BASE_PACKAGE = "basePackage";
@@ -72,6 +73,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
     private String serverPort = "8080";
     private String title = "OpenAPI Kotlin Spring";
     private String resourceFolder = "src/main/resources";
+    private boolean kotlinBuilder = false;
     private boolean useBeanValidation = true;
     private boolean exceptionHandler = true;
     private boolean gradleBuildFile = true;
@@ -135,6 +137,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         addOption(CodegenConstants.API_PACKAGE, "api package for generated code", apiPackage);
         addSwitch(EXCEPTION_HANDLER, "generate default global exception handlers (not compatible with reactive. enabling reactive will disable exceptionHandler )", exceptionHandler);
         addSwitch(GRADLE_BUILD_FILE, "generate a gradle build file using the Kotlin DSL", gradleBuildFile);
+        addSwitch(KOTLIN_BUILDER, "use kotlin builder", kotlinBuilder);
         addSwitch(SWAGGER_ANNOTATIONS, "generate swagger annotations to go alongside controllers and models", swaggerAnnotations);
         addSwitch(SERVICE_INTERFACE, "generate service interfaces to go alongside controllers. In most " +
                 "cases this option would be used to update an existing project, so not to override implementations. " +
@@ -243,6 +246,14 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         this.useTags = useTags;
     }
 
+    public boolean getKotlinBuilder() {
+        return kotlinBuilder;
+    }
+
+    public void setKotlinBuilder(final boolean kotlinBuilder) {
+        this.kotlinBuilder = kotlinBuilder;
+    }
+
     @Override
     public void setUseBeanValidation(boolean useBeanValidation) {
         this.useBeanValidation = useBeanValidation;
@@ -342,6 +353,11 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
             this.setServiceImplementation(Boolean.parseBoolean(additionalProperties.get(SERVICE_IMPLEMENTATION).toString()));
         }
         writePropertyBack(SERVICE_IMPLEMENTATION, serviceImplementation);
+
+        if (additionalProperties.containsKey(KOTLIN_BUILDER)) {
+            this.setKotlinBuilder(Boolean.parseBoolean(additionalProperties.get(KOTLIN_BUILDER).toString()));
+        }
+        writePropertyBack(KOTLIN_BUILDER, kotlinBuilder);
 
         if (additionalProperties.containsKey(USE_BEANVALIDATION)) {
             this.setUseBeanValidation(convertPropertyToBoolean(USE_BEANVALIDATION));

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/dataClass.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/dataClass.mustache
@@ -1,3 +1,5 @@
+{{#kotlinBuilder}}import com.github.pozo.KotlinBuilder{{/kotlinBuilder}}
+
 /**
  * {{{description}}}
 {{#vars}}
@@ -5,7 +7,7 @@
 {{/vars}}
  */{{#discriminator}}
 {{>typeInfoAnnotation}}{{/discriminator}}
-{{#discriminator}}interface {{classname}}{{/discriminator}}{{^discriminator}}{{#hasVars}}data {{/hasVars}}class {{classname}}(
+{{#discriminator}}interface {{classname}}{{/discriminator}}{{^discriminator}}{{#hasVars}}{{#kotlinBuilder}}@KotlinBuilder{{/kotlinBuilder}} data {{/hasVars}}class {{classname}}(
 {{#requiredVars}}
 {{>dataClassReqVar}}{{^-last}},
 {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}},

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -108,6 +108,8 @@ public class KotlinSpringServerCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(KotlinSpringServerCodegen.SERVICE_INTERFACE), true);
         Assert.assertTrue(codegen.getServiceImplementation());
         Assert.assertEquals(codegen.additionalProperties().get(KotlinSpringServerCodegen.SERVICE_IMPLEMENTATION), true);
+        Assert.assertFalse(codegen.getKotlinBuilder());
+        Assert.assertEquals(codegen.additionalProperties().get(KotlinSpringServerCodegen.KOTLIN_BUILDER), false);
         Assert.assertFalse(codegen.getUseBeanValidation());
         Assert.assertEquals(codegen.additionalProperties().get(KotlinSpringServerCodegen.USE_BEANVALIDATION), false);
         Assert.assertFalse(codegen.isReactive());
@@ -154,6 +156,8 @@ public class KotlinSpringServerCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(KotlinSpringServerCodegen.SERVICE_INTERFACE), true);
         Assert.assertTrue(codegen.getServiceImplementation());
         Assert.assertEquals(codegen.additionalProperties().get(KotlinSpringServerCodegen.SERVICE_IMPLEMENTATION), true);
+        Assert.assertFalse(codegen.getKotlinBuilder());
+        Assert.assertEquals(codegen.additionalProperties().get(KotlinSpringServerCodegen.KOTLIN_BUILDER), false);
         Assert.assertFalse(codegen.getUseBeanValidation());
         Assert.assertEquals(codegen.additionalProperties().get(KotlinSpringServerCodegen.USE_BEANVALIDATION), false);
         Assert.assertFalse(codegen.isReactive());

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Category.kt
@@ -12,12 +12,14 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * A category for a pet
  * @param id 
  * @param name 
  */
-data class Category(
+ data class Category(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("id") val id: kotlin.Long? = null,

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -12,13 +12,15 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * Describes the result of uploading an image resource
  * @param code 
  * @param type 
  * @param message 
  */
-data class ModelApiResponse(
+ data class ModelApiResponse(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("code") val code: kotlin.Int? = null,

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Order.kt
@@ -13,6 +13,8 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * An order for a pets from the pet store
  * @param id 
@@ -22,7 +24,7 @@ import io.swagger.annotations.ApiModelProperty
  * @param status Order Status
  * @param complete 
  */
-data class Order(
+ data class Order(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("id") val id: kotlin.Long? = null,

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -15,6 +15,8 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * A pet for sale in the pet store
  * @param name 
@@ -24,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty
  * @param tags 
  * @param status pet status in the store
  */
-data class Pet(
+ data class Pet(
 
     @ApiModelProperty(example = "doggie", required = true, value = "")
     @field:JsonProperty("name", required = true) val name: kotlin.String,

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -12,12 +12,14 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * A tag for a pet
  * @param id 
  * @param name 
  */
-data class Tag(
+ data class Tag(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("id") val id: kotlin.Long? = null,

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/model/User.kt
@@ -12,6 +12,8 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * A User who is purchasing from the pet store
  * @param id 
@@ -23,7 +25,7 @@ import io.swagger.annotations.ApiModelProperty
  * @param phone 
  * @param userStatus User Status
  */
-data class User(
+ data class User(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("id") val id: kotlin.Long? = null,

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Category.kt
@@ -12,12 +12,14 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * A category for a pet
  * @param id 
  * @param name 
  */
-data class Category(
+ data class Category(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("id") val id: kotlin.Long? = null,

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -12,13 +12,15 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * Describes the result of uploading an image resource
  * @param code 
  * @param type 
  * @param message 
  */
-data class ModelApiResponse(
+ data class ModelApiResponse(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("code") val code: kotlin.Int? = null,

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Order.kt
@@ -13,6 +13,8 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * An order for a pets from the pet store
  * @param id 
@@ -22,7 +24,7 @@ import io.swagger.annotations.ApiModelProperty
  * @param status Order Status
  * @param complete 
  */
-data class Order(
+ data class Order(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("id") val id: kotlin.Long? = null,

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -15,6 +15,8 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * A pet for sale in the pet store
  * @param name 
@@ -24,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty
  * @param tags 
  * @param status pet status in the store
  */
-data class Pet(
+ data class Pet(
 
     @ApiModelProperty(example = "doggie", required = true, value = "")
     @field:JsonProperty("name", required = true) val name: kotlin.String,

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -12,12 +12,14 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * A tag for a pet
  * @param id 
  * @param name 
  */
-data class Tag(
+ data class Tag(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("id") val id: kotlin.Long? = null,

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/model/User.kt
@@ -12,6 +12,8 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * A User who is purchasing from the pet store
  * @param id 
@@ -23,7 +25,7 @@ import io.swagger.annotations.ApiModelProperty
  * @param phone 
  * @param userStatus User Status
  */
-data class User(
+ data class User(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("id") val id: kotlin.Long? = null,

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
@@ -12,12 +12,14 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * A category for a pet
  * @param id 
  * @param name 
  */
-data class Category(
+ data class Category(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("id") val id: kotlin.Long? = null,

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -12,13 +12,15 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * Describes the result of uploading an image resource
  * @param code 
  * @param type 
  * @param message 
  */
-data class ModelApiResponse(
+ data class ModelApiResponse(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("code") val code: kotlin.Int? = null,

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
@@ -13,6 +13,8 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * An order for a pets from the pet store
  * @param id 
@@ -22,7 +24,7 @@ import io.swagger.annotations.ApiModelProperty
  * @param status Order Status
  * @param complete 
  */
-data class Order(
+ data class Order(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("id") val id: kotlin.Long? = null,

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -15,6 +15,8 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * A pet for sale in the pet store
  * @param name 
@@ -24,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty
  * @param tags 
  * @param status pet status in the store
  */
-data class Pet(
+ data class Pet(
 
     @ApiModelProperty(example = "doggie", required = true, value = "")
     @field:JsonProperty("name", required = true) val name: kotlin.String,

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -12,12 +12,14 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * A tag for a pet
  * @param id 
  * @param name 
  */
-data class Tag(
+ data class Tag(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("id") val id: kotlin.Long? = null,

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/User.kt
@@ -12,6 +12,8 @@ import javax.validation.constraints.Size
 import javax.validation.Valid
 import io.swagger.annotations.ApiModelProperty
 
+
+
 /**
  * A User who is purchasing from the pet store
  * @param id 
@@ -23,7 +25,7 @@ import io.swagger.annotations.ApiModelProperty
  * @param phone 
  * @param userStatus User Status
  */
-data class User(
+ data class User(
 
     @ApiModelProperty(example = "null", value = "")
     @field:JsonProperty("id") val id: kotlin.Long? = null,


### PR DESCRIPTION
This PR adds the support of KotlinBuilder
(See https://github.com/Pozo/mapstruct-kotlin).
@KotlinBuilder is interesting when we share models with java projects, because each annotated class will have a corresponding Builder class.

With this PR, each generated model will be annotated with `@KotlinBuilder`.

Given the schema
```
openapi: "3.0.1"
info:
  version: 1.0.0
  title: Users

paths:
  /users:
    get:
      responses:
        200:
          description: users
          content:
            application/json:
              schema:
                type: array
                items:
                  $ref: '#/components/schemas/User'

components:
  schemas:
    User:
      type: object
      required:
        - name
      properties:
        name:
          type: string

```

When we compile with the option `kotlinBuilder=true` it generates
```
@KotlinBuilder data class User(
    @ApiModelProperty(example = "null", required = true, value = "")
    @field:JsonProperty("name", required = true) val name: kotlin.String
)
```


Note :  for the moment the [Lombok compiler plugin](https://kotlinlang.org/docs/lombok.html) doesn't support @Builder, so this library is useful