### PR TITLE
[Ruby][Faraday][#10137] Fix config request options and timeout

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -73,9 +73,6 @@
       update_params_for_auth! header_params, query_params, opts[:auth_names]
 
       req_opts = {
-        :method => http_method,
-        :headers => header_params,
-        :params => query_params,
         :params_encoding => @config.params_encoding,
         :timeout => @config.timeout,
         :verbose => @config.debugging
@@ -83,13 +80,13 @@
 
       if [:post, :patch, :put, :delete].include?(http_method)
         req_body = build_request_body(header_params, form_params, opts[:body])
-        req_opts.update :body => req_body
         if @config.debugging
           @config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
         end
       end
       request.headers = header_params
       request.body = req_body
+      request.options = OpenStruct.new(req_opts)
       request.url url
       request.params = query_params
       download_file(request) if opts[:return_type] == 'File'

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -110,7 +110,6 @@ module {{moduleName}}
       @server_operation_variables = {}
       @api_key = {}
       @api_key_prefix = {}
-      @timeout = 0
       @client_side_validation = true
       {{#isFaraday}}
       @ssl_verify = true
@@ -118,6 +117,7 @@ module {{moduleName}}
       @ssl_ca_file = nil
       @ssl_client_cert = nil
       @ssl_client_key = nil
+      @timeout = 60
       {{/isFaraday}}
       {{^isFaraday}}
       @verify_ssl = true
@@ -125,6 +125,7 @@ module {{moduleName}}
       @params_encoding = nil
       @cert_file = nil
       @key_file = nil
+      @timeout = 0
       {{/isFaraday}}
       @debugging = false
       @inject_format = false

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -117,9 +117,6 @@ module Petstore
       update_params_for_auth! header_params, query_params, opts[:auth_names]
 
       req_opts = {
-        :method => http_method,
-        :headers => header_params,
-        :params => query_params,
         :params_encoding => @config.params_encoding,
         :timeout => @config.timeout,
         :verbose => @config.debugging
@@ -127,13 +124,13 @@ module Petstore
 
       if [:post, :patch, :put, :delete].include?(http_method)
         req_body = build_request_body(header_params, form_params, opts[:body])
-        req_opts.update :body => req_body
         if @config.debugging
           @config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
         end
       end
       request.headers = header_params
       request.body = req_body
+      request.options = OpenStruct.new(req_opts)
       request.url url
       request.params = query_params
       download_file(request) if opts[:return_type] == 'File'

--- a/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -142,13 +142,13 @@ module Petstore
       @server_operation_variables = {}
       @api_key = {}
       @api_key_prefix = {}
-      @timeout = 0
       @client_side_validation = true
       @ssl_verify = true
       @ssl_verify_mode = nil
       @ssl_ca_file = nil
       @ssl_client_cert = nil
       @ssl_client_key = nil
+      @timeout = 60
       @debugging = false
       @inject_format = false
       @force_ending_format = false


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
