### PR TITLE
[gradle]: allow setting custom engines other than handlebars

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -644,6 +644,8 @@ open class GenerateTask : DefaultTask() {
             engine.ifNotEmpty { value ->
                 if ("handlebars".equals(value, ignoreCase = true)) {
                     configurator.setTemplatingEngineName("handlebars")
+                } else {
+                    configurator.setTemplatingEngineName(value)
                 }
             }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The openapi-gradle generator plugin has a strict check on the `engine` param to only set the parameter if `handlebars` is set as value. Otherwise the parameter is ignored. This is currently blocking anyone from specifiying custom template engines (https://openapi-generator.tech/docs/templating/#custom-engines) when using the official gradle plugin.

This change will set the `engine` param to the user-provided value, even if it's not `handlebars`.

The engine param was initially added in: https://github.com/OpenAPITools/openapi-generator/pull/5686

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
