### PR TITLE
Fix serialization of inline arrays of free-form objects [python]

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_utils.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_utils.mustache
@@ -1365,7 +1365,7 @@ def model_to_dict(model_instance, serialize=True):
                else:
                    res = []
                    for v in value:
-                       if isinstance(v, PRIMITIVE_TYPES) or v is None:
+                       if isinstance(v, (dict,) + PRIMITIVE_TYPES) or v is None:
                            res.append(v)
                        elif isinstance(v, ModelSimple):
                            res.append(v.value)

--- a/modules/openapi-generator/src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
@@ -1944,6 +1944,11 @@ components:
             items:
               type: integer
               format: int64
+        array_of_free_form_object:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
         array_array_of_model:
           type: array
           items:

--- a/samples/client/petstore/python/petstore_api/model_utils.py
+++ b/samples/client/petstore/python/petstore_api/model_utils.py
@@ -1682,7 +1682,7 @@ def model_to_dict(model_instance, serialize=True):
                else:
                    res = []
                    for v in value:
-                       if isinstance(v, PRIMITIVE_TYPES) or v is None:
+                       if isinstance(v, (dict,) + PRIMITIVE_TYPES) or v is None:
                            res.append(v)
                        elif isinstance(v, ModelSimple):
                            res.append(v.value)

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model_utils.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model_utils.py
@@ -1682,7 +1682,7 @@ def model_to_dict(model_instance, serialize=True):
                else:
                    res = []
                    for v in value:
-                       if isinstance(v, PRIMITIVE_TYPES) or v is None:
+                       if isinstance(v, (dict,) + PRIMITIVE_TYPES) or v is None:
                            res.append(v)
                        elif isinstance(v, ModelSimple):
                            res.append(v.value)

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/model_utils.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/model_utils.py
@@ -1682,7 +1682,7 @@ def model_to_dict(model_instance, serialize=True):
                else:
                    res = []
                    for v in value:
-                       if isinstance(v, PRIMITIVE_TYPES) or v is None:
+                       if isinstance(v, (dict,) + PRIMITIVE_TYPES) or v is None:
                            res.append(v)
                        elif isinstance(v, ModelSimple):
                            res.append(v.value)

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/model_utils.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/model_utils.py
@@ -1682,7 +1682,7 @@ def model_to_dict(model_instance, serialize=True):
                else:
                    res = []
                    for v in value:
-                       if isinstance(v, PRIMITIVE_TYPES) or v is None:
+                       if isinstance(v, (dict,) + PRIMITIVE_TYPES) or v is None:
                            res.append(v)
                        elif isinstance(v, ModelSimple):
                            res.append(v.value)

--- a/samples/openapi3/client/petstore/python/docs/ArrayTest.md
+++ b/samples/openapi3/client/petstore/python/docs/ArrayTest.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **array_of_string** | **[str]** |  | [optional] 
 **array_array_of_integer** | **[[int]]** |  | [optional] 
+**array_of_free_form_object** | **[{str: (bool, date, datetime, dict, float, int, list, str, none_type)}]** |  | [optional] 
 **array_array_of_model** | [**[[ReadOnlyFirst]]**](ReadOnlyFirst.md) |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/array_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/array_test.py
@@ -89,6 +89,7 @@ class ArrayTest(ModelNormal):
         return {
             'array_of_string': ([str],),  # noqa: E501
             'array_array_of_integer': ([[int]],),  # noqa: E501
+            'array_of_free_form_object': ([{str: (bool, date, datetime, dict, float, int, list, str, none_type)}],),  # noqa: E501
             'array_array_of_model': ([[ReadOnlyFirst]],),  # noqa: E501
         }
 
@@ -100,6 +101,7 @@ class ArrayTest(ModelNormal):
     attribute_map = {
         'array_of_string': 'array_of_string',  # noqa: E501
         'array_array_of_integer': 'array_array_of_integer',  # noqa: E501
+        'array_of_free_form_object': 'array_of_free_form_object',  # noqa: E501
         'array_array_of_model': 'array_array_of_model',  # noqa: E501
     }
 
@@ -146,6 +148,7 @@ class ArrayTest(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             array_of_string ([str]): [optional]  # noqa: E501
             array_array_of_integer ([[int]]): [optional]  # noqa: E501
+            array_of_free_form_object ([{str: (bool, date, datetime, dict, float, int, list, str, none_type)}]): [optional]  # noqa: E501
             array_array_of_model ([[ReadOnlyFirst]]): [optional]  # noqa: E501
         """
 
@@ -230,6 +233,7 @@ class ArrayTest(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             array_of_string ([str]): [optional]  # noqa: E501
             array_array_of_integer ([[int]]): [optional]  # noqa: E501
+            array_of_free_form_object ([{str: (bool, date, datetime, dict, float, int, list, str, none_type)}]): [optional]  # noqa: E501
             array_array_of_model ([[ReadOnlyFirst]]): [optional]  # noqa: E501
         """
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model_utils.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model_utils.py
@@ -1682,7 +1682,7 @@ def model_to_dict(model_instance, serialize=True):
                else:
                    res = []
                    for v in value:
-                       if isinstance(v, PRIMITIVE_TYPES) or v is None:
+                       if isinstance(v, (dict,) + PRIMITIVE_TYPES) or v is None:
                            res.append(v)
                        elif isinstance(v, ModelSimple):
                            res.append(v.value)

--- a/samples/openapi3/client/petstore/python/tests_manual/test_model_utils.py
+++ b/samples/openapi3/client/petstore/python/tests_manual/test_model_utils.py
@@ -1,0 +1,32 @@
+# coding: utf-8
+
+# flake8: noqa
+
+"""
+Run the tests.
+$ pip install nose (optional)
+$ cd OpenAPIPetstore-python
+$ nosetests -v
+"""
+
+import unittest
+
+import petstore_api
+from petstore_api.model.array_test import ArrayTest
+from petstore_api.model.read_only_first import ReadOnlyFirst
+from petstore_api.model_utils import model_to_dict
+
+class ModelUtilsTests(unittest.TestCase):
+
+    def test_model_to_dict(self):
+        model = ArrayTest(
+            array_of_string=["foo", "bar", "baz"],
+            array_array_of_integer=[[1], [2], [3]],
+            array_of_free_form_object=[
+                {"foo": "bar", "baz": 42},
+                {"qux": "quux", "quuz": 42.0}
+            ],
+            array_array_of_model=[[ReadOnlyFirst()]]
+        )
+
+        model_to_dict(model)


### PR DESCRIPTION
Given a spec like:

```
        "type": "array",
        "items": {
          "type": "object",
          "additionalProperties": true
        }
```

the generated code is unable to serialize it (reproduction in commit 834b4e3):

```
test_model_to_dict (tests_manual.test_model_utils.ModelUtilsTests) ... ERROR

======================================================================
ERROR: test_model_to_dict (tests_manual.test_model_utils.ModelUtilsTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jsok/dev/github.com/OpenAPITools/openapi-generator/samples/openapi3/client/petstore/python/tests_manual/test_model_utils.py", line 32, in test_model_to_dict
    model_to_dict(model)
  File "/Users/jsok/dev/github.com/OpenAPITools/openapi-generator/samples/openapi3/client/petstore/python/petstore_api/model_utils.py", line 1690, in model_to_dict
    res.append(model_to_dict(v, serialize=serialize))
  File "/Users/jsok/dev/github.com/OpenAPITools/openapi-generator/samples/openapi3/client/petstore/python/petstore_api/model_utils.py", line 1662, in model_to_dict
    if model_instance._composed_schemas:
AttributeError: 'dict' object has no attribute '_composed_schemas'

----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (errors=1)
```

Subsequent commit 8332732 contains the fix in `model_to_dict`.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@spacether related to our earlier discussion: https://github.com/OpenAPITools/openapi-generator/pull/9153/files#r712601002
@arun-nalla @Jyhess @tomplus
