### PR TITLE
ci(drone): fix duplicate pipeline names

### DIFF
--- a/CI/.drone.yml
+++ b/CI/.drone.yml
@@ -1,6 +1,6 @@
 kind: pipeline
 type: docker
-name: default
+name: java11-test
 steps:
 # test Java 11 HTTP client
 - name: java11-test
@@ -20,7 +20,7 @@ steps:
 ---
 kind: pipeline
 type: docker
-name: default
+name: nim-client-test
 steps:
 # test nim client
 - name: nim-client-test
@@ -31,7 +31,7 @@ steps:
 ---
 kind: pipeline
 type: docker
-name: default
+name: protobuf-schema-test
 steps:
 # test protobuf schema generator
 - name: protobuf-schema-test
@@ -46,7 +46,7 @@ steps:
 ---
 kind: pipeline
 type: docker
-name: default
+name: aspnetcore-test
 steps:
 # test aspnetcore 3.x
 - name: aspnetcore-test
@@ -58,7 +58,7 @@ steps:
 ---
 kind: pipeline
 type: docker
-name: default
+name: ocaml-test
 steps:
 # test ocaml petstore client
 - name: ocaml-test
@@ -75,7 +75,7 @@ steps:
 ---
 kind: pipeline
 type: docker
-name: default
+name: haskell-client-test
 steps:
 # test haskell client
 - name: haskell-client-test
@@ -86,7 +86,7 @@ steps:
 ---
 kind: pipeline
 type: docker
-name: default
+name: erlang
 steps:
 # test erlang client and server
 - name: erlang


### PR DESCRIPTION
Drone requires unique pipeline names, which PR #10423 (5c45465) missed.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
