### PR TITLE
fix(rust,client): re-enable TLS support for reqwest with supportAsync

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
@@ -22,7 +22,6 @@ reqwest = "~0.9"
 {{#supportAsync}}
 [dependencies.reqwest]
 version = "^0.11"
-default-features = false
 features = ["json", "multipart"]
 {{/supportAsync}}
 {{/reqwest}}

--- a/samples/client/petstore/rust/reqwest/petstore-async/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-async/Cargo.toml
@@ -11,7 +11,6 @@ serde_json = "^1.0"
 url = "^2.2"
 [dependencies.reqwest]
 version = "^0.11"
-default-features = false
 features = ["json", "multipart"]
 
 [dev-dependencies]


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The existing reqwest codegen disables the default reqwest crate features when `supportAsync=true`: this inadvertently has the effect of disabling reqwest's TLS support entirely.

This PR keeps the default features, which matches the behaviour of `supportAsync=false`, and keeps the default TLS support enabled.

- Tracking issue: #10421

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05)
