### PR TITLE
[csharp-netcore] allow to specify content-type for files

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/ApiClient.mustache
@@ -279,7 +279,7 @@ namespace {{packageName}}.Client
                 foreach (var fileParam in options.FileParameters)
                 {
                     var content = new StreamContent(fileParam.Value.Content);
-                    content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                    content.Headers.ContentType = new MediaTypeHeaderValue(fileParam.Value.ContentType);
                     multipartContent.Add(content, fileParam.Key,
                         fileParam.Value.Name);
                 }

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/FileParameter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/libraries/httpclient/FileParameter.mustache
@@ -16,6 +16,11 @@ namespace {{packageName}}.Client
         public string Name { get; set; } = "no_name_provided";
 
         /// <summary>
+        /// The content type of the file
+        /// </summary>
+        public string ContentType { get; set; } = "application/octet-stream";
+
+        /// <summary>
         /// The content of the file
         /// </summary>
         public Stream Content { get; set; }
@@ -41,6 +46,19 @@ namespace {{packageName}}.Client
         public FileParameter(string filename, Stream content)
         {
             Name = filename;
+            Content = content;
+        }
+
+        /// <summary>
+        /// Construct a FileParameter from name and content
+        /// </summary>
+        /// <param name="filename">The filename</param>
+        /// <param name="contentType">The content type of the file</param>
+        /// <param name="content">The file content</param>
+        public FileParameter(string filename, string contentType, Stream content)
+        {
+            Name = filename;
+            ContentType = contentType;
             Content = content;
         }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -278,7 +278,7 @@ namespace Org.OpenAPITools.Client
                 foreach (var fileParam in options.FileParameters)
                 {
                     var content = new StreamContent(fileParam.Value.Content);
-                    content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                    content.Headers.ContentType = new MediaTypeHeaderValue(fileParam.Value.ContentType);
                     multipartContent.Add(content, fileParam.Key,
                         fileParam.Value.Name);
                 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/FileParameter.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/FileParameter.cs
@@ -24,6 +24,11 @@ namespace Org.OpenAPITools.Client
         public string Name { get; set; } = "no_name_provided";
 
         /// <summary>
+        /// The content type of the file
+        /// </summary>
+        public string ContentType { get; set; } = "application/octet-stream";
+
+        /// <summary>
         /// The content of the file
         /// </summary>
         public Stream Content { get; set; }
@@ -49,6 +54,19 @@ namespace Org.OpenAPITools.Client
         public FileParameter(string filename, Stream content)
         {
             Name = filename;
+            Content = content;
+        }
+
+        /// <summary>
+        /// Construct a FileParameter from name and content
+        /// </summary>
+        /// <param name="filename">The filename</param>
+        /// <param name="contentType">The content type of the file</param>
+        /// <param name="content">The file content</param>
+        public FileParameter(string filename, string contentType, Stream content)
+        {
+            Name = filename;
+            ContentType = contentType;
             Content = content;
         }
 


### PR DESCRIPTION
The changes allow to specify content-type for files sent using csharp-netcore client. If content-type is not set explicitly it will be set to `application/octet-stream` as it is currently set fo all files.

To close #10472


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
