### PR TITLE
[typescript-fetch]: use ReponseError instead of throwing a response (#10477)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -39,7 +39,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw response;
+        throw new ResponseError(response, 'Response returned an error code');
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -100,6 +100,13 @@ export class BaseAPI {
         return next;
     }
 };
+
+export class ResponseError extends Error {
+    name: "ResponseError" = "ResponseError";
+    constructor(public response: Response, msg?: string) {
+        super(msg);
+    }
+}
 
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -50,7 +50,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw response;
+        throw new ResponseError(response, 'Response returned an error code');
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -111,6 +111,13 @@ export class BaseAPI {
         return next;
     }
 };
+
+export class ResponseError extends Error {
+    name: "ResponseError" = "ResponseError";
+    constructor(public response: Response, msg?: string) {
+        super(msg);
+    }
+}
 
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -50,7 +50,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw response;
+        throw new ResponseError(response, 'Response returned an error code');
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -111,6 +111,13 @@ export class BaseAPI {
         return next;
     }
 };
+
+export class ResponseError extends Error {
+    name: "ResponseError" = "ResponseError";
+    constructor(public response: Response, msg?: string) {
+        super(msg);
+    }
+}
 
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -50,7 +50,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw response;
+        throw new ResponseError(response, 'Response returned an error code');
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -111,6 +111,13 @@ export class BaseAPI {
         return next;
     }
 };
+
+export class ResponseError extends Error {
+    name: "ResponseError" = "ResponseError";
+    constructor(public response: Response, msg?: string) {
+        super(msg);
+    }
+}
 
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -50,7 +50,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw response;
+        throw new ResponseError(response, 'Response returned an error code');
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -111,6 +111,13 @@ export class BaseAPI {
         return next;
     }
 };
+
+export class ResponseError extends Error {
+    name: "ResponseError" = "ResponseError";
+    constructor(public response: Response, msg?: string) {
+        super(msg);
+    }
+}
 
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -50,7 +50,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw response;
+        throw new ResponseError(response, 'Response returned an error code');
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -111,6 +111,13 @@ export class BaseAPI {
         return next;
     }
 };
+
+export class ResponseError extends Error {
+    name: "ResponseError" = "ResponseError";
+    constructor(public response: Response, msg?: string) {
+        super(msg);
+    }
+}
 
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -50,7 +50,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw response;
+        throw new ResponseError(response, 'Response returned an error code');
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -111,6 +111,13 @@ export class BaseAPI {
         return next;
     }
 };
+
+export class ResponseError extends Error {
+    name: "ResponseError" = "ResponseError";
+    constructor(public response: Response, msg?: string) {
+        super(msg);
+    }
+}
 
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -50,7 +50,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw response;
+        throw new ResponseError(response, 'Response returned an error code');
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -111,6 +111,13 @@ export class BaseAPI {
         return next;
     }
 };
+
+export class ResponseError extends Error {
+    name: "ResponseError" = "ResponseError";
+    constructor(public response: Response, msg?: string) {
+        super(msg);
+    }
+}
 
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
@@ -50,7 +50,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw response;
+        throw new ResponseError(response, 'Response returned an error code');
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -111,6 +111,13 @@ export class BaseAPI {
         return next;
     }
 };
+
+export class ResponseError extends Error {
+    name: "ResponseError" = "ResponseError";
+    constructor(public response: Response, msg?: string) {
+        super(msg);
+    }
+}
 
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -50,7 +50,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw response;
+        throw new ResponseError(response, 'Response returned an error code');
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -111,6 +111,13 @@ export class BaseAPI {
         return next;
     }
 };
+
+export class ResponseError extends Error {
+    name: "ResponseError" = "ResponseError";
+    constructor(public response: Response, msg?: string) {
+        super(msg);
+    }
+}
 
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -50,7 +50,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw response;
+        throw new ResponseError(response, 'Response returned an error code');
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -111,6 +111,13 @@ export class BaseAPI {
         return next;
     }
 };
+
+export class ResponseError extends Error {
+    name: "ResponseError" = "ResponseError";
+    constructor(public response: Response, msg?: string) {
+        super(msg);
+    }
+}
 
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -50,7 +50,7 @@ export class BaseAPI {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-        throw response;
+        throw new ResponseError(response, 'Response returned an error code');
     }
 
     private createFetchParams(context: RequestOpts, initOverrides?: RequestInit) {
@@ -111,6 +111,13 @@ export class BaseAPI {
         return next;
     }
 };
+
+export class ResponseError extends Error {
+    name: "ResponseError" = "ResponseError";
+    constructor(public response: Response, msg?: string) {
+        super(msg);
+    }
+}
 
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu @taxpon @sebastianhaas  @kenisteward  @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov