### PR TITLE
Add decimal support to ruby generators

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
@@ -78,6 +78,7 @@ abstract public class AbstractRubyCodegen extends DefaultCodegen implements Code
         typeMapping.put("float", "Float");
         typeMapping.put("double", "Float");
         typeMapping.put("number", "Float");
+        typeMapping.put("decimal", "Float");
         typeMapping.put("date", "Date");
         typeMapping.put("DateTime", "Time");
         typeMapping.put("array", "Array");

--- a/samples/client/petstore/ruby-faraday/docs/FormatTest.md
+++ b/samples/client/petstore/ruby-faraday/docs/FormatTest.md
@@ -10,7 +10,7 @@
 | **number** | **Float** |  |  |
 | **float** | **Float** |  | [optional] |
 | **double** | **Float** |  | [optional] |
-| **decimal** | [**Decimal**](Decimal.md) |  | [optional] |
+| **decimal** | **Float** |  | [optional] |
 | **string** | **String** |  | [optional] |
 | **byte** | **String** |  |  |
 | **binary** | **File** |  | [optional] |

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/format_test.rb
@@ -85,7 +85,7 @@ module Petstore
         :'number' => :'Float',
         :'float' => :'Float',
         :'double' => :'Float',
-        :'decimal' => :'Decimal',
+        :'decimal' => :'Float',
         :'string' => :'String',
         :'byte' => :'String',
         :'binary' => :'File',

--- a/samples/client/petstore/ruby/docs/FormatTest.md
+++ b/samples/client/petstore/ruby/docs/FormatTest.md
@@ -10,7 +10,7 @@
 | **number** | **Float** |  |  |
 | **float** | **Float** |  | [optional] |
 | **double** | **Float** |  | [optional] |
-| **decimal** | [**Decimal**](Decimal.md) |  | [optional] |
+| **decimal** | **Float** |  | [optional] |
 | **string** | **String** |  | [optional] |
 | **byte** | **String** |  |  |
 | **binary** | **File** |  | [optional] |

--- a/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -85,7 +85,7 @@ module Petstore
         :'number' => :'Float',
         :'float' => :'Float',
         :'double' => :'Float',
-        :'decimal' => :'Decimal',
+        :'decimal' => :'Float',
         :'string' => :'String',
         :'byte' => :'String',
         :'binary' => :'File',


### PR DESCRIPTION
Add decimal support to ruby generators

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)
