### PR TITLE
[Java] Fix Potential Flaky Tests

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -32,7 +32,10 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Collections;
 
 public class AbstractJavaCodegenTest {
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -210,13 +210,16 @@ public class AbstractJavaCodegenTest {
         codegen.processOpts();
         codegen.preprocessOpenAPI(openAPI);
 
+        final List<String> additionalModelTypeAnnotations = new ArrayList<String>();
+        additionalModelTypeAnnotations.add("@Foo");
+        additionalModelTypeAnnotations.add("@Bar");
+
         final List<String> sortedCodegenAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
         final List<String> sortedAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+
         Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
         Collections.sort(sortedAdditionalModelTypeAnnotations);
-
-        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
-    }
+        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);    }
     
     @Test
     public void testAdditionalModelTypeAnnotationsNewLineLinux() throws Exception {
@@ -228,13 +231,16 @@ public class AbstractJavaCodegenTest {
         codegen.processOpts();
         codegen.preprocessOpenAPI(openAPI);
 
+        final List<String> additionalModelTypeAnnotations = new ArrayList<String>();
+        additionalModelTypeAnnotations.add("@Foo");
+        additionalModelTypeAnnotations.add("@Bar");
+
         final List<String> sortedCodegenAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
         final List<String> sortedAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+
         Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
         Collections.sort(sortedAdditionalModelTypeAnnotations);
-
-        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
-    }
+        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);    }
     
     @Test
     public void testAdditionalModelTypeAnnotationsNewLineWindows() throws Exception {
@@ -252,10 +258,11 @@ public class AbstractJavaCodegenTest {
 
         final List<String> sortedCodegenAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
         final List<String> sortedAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+
         Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
         Collections.sort(sortedAdditionalModelTypeAnnotations);
-
-        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);    }
+        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
+    }
     
     @Test
     public void testAdditionalModelTypeAnnotationsMixed() throws Exception {
@@ -274,10 +281,10 @@ public class AbstractJavaCodegenTest {
 
         final List<String> sortedCodegenAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
         final List<String> sortedAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+
         Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
         Collections.sort(sortedAdditionalModelTypeAnnotations);
-
-        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
+        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
     }
     
     @Test
@@ -294,12 +301,7 @@ public class AbstractJavaCodegenTest {
         additionalModelTypeAnnotations.add("@Foo");
         additionalModelTypeAnnotations.add("@Bar");
 
-        final List<String> sortedCodegenAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
-        final List<String> sortedAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
-        Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
-        Collections.sort(sortedAdditionalModelTypeAnnotations);
-
-        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
+        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
     }
     
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -254,7 +254,7 @@ public class AbstractJavaCodegenTest {
         
         codegen.processOpts();
         codegen.preprocessOpenAPI(openAPI);
-        
+
         final List<String> additionalModelTypeAnnotations = new ArrayList<String>();
         additionalModelTypeAnnotations.add("@Foo");
         additionalModelTypeAnnotations.add("@Bar");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -222,7 +222,8 @@ public class AbstractJavaCodegenTest {
 
         Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
         Collections.sort(sortedAdditionalModelTypeAnnotations);
-        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);    }
+        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
+    }
     
     @Test
     public void testAdditionalModelTypeAnnotationsNewLineLinux() throws Exception {
@@ -243,7 +244,8 @@ public class AbstractJavaCodegenTest {
 
         Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
         Collections.sort(sortedAdditionalModelTypeAnnotations);
-        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);    }
+        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
+    }
     
     @Test
     public void testAdditionalModelTypeAnnotationsNewLineWindows() throws Exception {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -32,9 +32,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 public class AbstractJavaCodegenTest {
 
@@ -211,12 +209,13 @@ public class AbstractJavaCodegenTest {
         
         codegen.processOpts();
         codegen.preprocessOpenAPI(openAPI);
-        
-        final List<String> additionalModelTypeAnnotations = new ArrayList<String>();
-        additionalModelTypeAnnotations.add("@Foo");
-        additionalModelTypeAnnotations.add("@Bar");
 
-        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
+        final List<String> sortedCodegenAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+        final List<String> sortedAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+        Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
+        Collections.sort(sortedAdditionalModelTypeAnnotations);
+
+        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
     }
     
     @Test
@@ -228,12 +227,13 @@ public class AbstractJavaCodegenTest {
         
         codegen.processOpts();
         codegen.preprocessOpenAPI(openAPI);
-        
-        final List<String> additionalModelTypeAnnotations = new ArrayList<String>();
-        additionalModelTypeAnnotations.add("@Foo");
-        additionalModelTypeAnnotations.add("@Bar");
 
-        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
+        final List<String> sortedCodegenAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+        final List<String> sortedAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+        Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
+        Collections.sort(sortedAdditionalModelTypeAnnotations);
+
+        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
     }
     
     @Test
@@ -250,8 +250,12 @@ public class AbstractJavaCodegenTest {
         additionalModelTypeAnnotations.add("@Foo");
         additionalModelTypeAnnotations.add("@Bar");
 
-        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
-    }
+        final List<String> sortedCodegenAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+        final List<String> sortedAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+        Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
+        Collections.sort(sortedAdditionalModelTypeAnnotations);
+
+        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);    }
     
     @Test
     public void testAdditionalModelTypeAnnotationsMixed() throws Exception {
@@ -268,7 +272,12 @@ public class AbstractJavaCodegenTest {
         additionalModelTypeAnnotations.add("@Bar");
         additionalModelTypeAnnotations.add("@Foobar");
 
-        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
+        final List<String> sortedCodegenAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+        final List<String> sortedAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+        Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
+        Collections.sort(sortedAdditionalModelTypeAnnotations);
+
+        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
     }
     
     @Test
@@ -285,7 +294,12 @@ public class AbstractJavaCodegenTest {
         additionalModelTypeAnnotations.add("@Foo");
         additionalModelTypeAnnotations.add("@Bar");
 
-        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
+        final List<String> sortedCodegenAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+        final List<String> sortedAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+        Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
+        Collections.sort(sortedAdditionalModelTypeAnnotations);
+
+        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
     }
     
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -222,7 +222,7 @@ public class AbstractJavaCodegenTest {
 
         Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
         Collections.sort(sortedAdditionalModelTypeAnnotations);
-        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
+        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
     }
     
     @Test
@@ -244,7 +244,7 @@ public class AbstractJavaCodegenTest {
 
         Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
         Collections.sort(sortedAdditionalModelTypeAnnotations);
-        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
+        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
     }
     
     @Test
@@ -266,7 +266,7 @@ public class AbstractJavaCodegenTest {
 
         Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
         Collections.sort(sortedAdditionalModelTypeAnnotations);
-        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
+        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
     }
     
     @Test
@@ -289,7 +289,7 @@ public class AbstractJavaCodegenTest {
 
         Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
         Collections.sort(sortedAdditionalModelTypeAnnotations);
-        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
+        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
     }
     
     @Test
@@ -306,7 +306,12 @@ public class AbstractJavaCodegenTest {
         additionalModelTypeAnnotations.add("@Foo");
         additionalModelTypeAnnotations.add("@Bar");
 
-        Assert.assertEquals(codegen.getAdditionalModelTypeAnnotations(), additionalModelTypeAnnotations);
+        final List<String> sortedCodegenAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+        final List<String> sortedAdditionalModelTypeAnnotations = new ArrayList<>(codegen.getAdditionalModelTypeAnnotations());
+
+        Collections.sort(sortedCodegenAdditionalModelTypeAnnotations);
+        Collections.sort(sortedAdditionalModelTypeAnnotations);
+        Assert.assertEquals(sortedCodegenAdditionalModelTypeAnnotations, sortedAdditionalModelTypeAnnotations);
     }
     
     @Test


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR fixes some potential flaky tests in `org.openapitools.codegen.java.AbstractJavaCodegenTest` file. 

In these tests, we assigned some hardcoded elements into the `codegen`'s `AdditionalModelTypeAnnotations`. 

However, according to the code where we set this value, we split the input string by a regex, convert it to a `HashSet`, and store in an `ArrayList`:

```java
// org/openapitools/codegen/languages/AbstractJavaCodegen.java:347
if (additionalProperties.containsKey(ADDITIONAL_MODEL_TYPE_ANNOTATIONS)) {
    String additionalAnnotationsList = additionalProperties.get(ADDITIONAL_MODEL_TYPE_ANNOTATIONS).toString();
    this.setAdditionalModelTypeAnnotations(new ArrayList<>(Sets.newHashSet(additionalAnnotationsList.trim().split("\\s*(;|\\r?\\n)\\s*"))));
}
```

The problem is that HashSet is not guarantee that the order will remain constant over time according to the [Java documentation](https://docs.oracle.com/javase/7/docs/api/java/util/HashSet.html). Thus, these assertions will fail in some platforms or specific machines that adopt a different iteration order.

To fix it, I sort the both `additionalModelTypeAnnotations` and `codegen.getAdditionalModelTypeAnnotations()` to make sure that their order is deterministic. 


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
