### PR TITLE
Fixes serialization of array items with lists or dicts inside in model_to_dict [python]

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_utils.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_utils.mustache
@@ -1328,6 +1328,45 @@ def validate_and_convert_types(input_value, required_types_mixed, path_to_item,
     return input_value
 
 
+def _model_to_dict_core(value, serialize):
+    """Core aux function for returning the model properties as a dict
+    Args:
+        value : _data_store of the model instance that
+            will be converted to a dict.
+
+    Keyword Args:
+        serialize (bool): if True, the keys in the dict will be values from
+            attribute_map
+    """
+    if hasattr(value, '_data_store'):
+        return model_to_dict(value, serialize=serialize)
+    elif isinstance(value, list):
+        if not value:
+            # empty list or None
+            return value
+        else:
+            res = []
+            for v in value:
+                if isinstance(v, PRIMITIVE_TYPES) or v is None:
+                    res.append(v)
+                elif isinstance(v, ModelSimple):
+                    res.append(v.value)
+                else:
+                    res.append(_model_to_dict_core(v, serialize=serialize))
+            return res
+    elif isinstance(value, dict):
+        return dict(map(
+            lambda item: (item[0],
+                          _model_to_dict_core(item[1], serialize=serialize))
+            if hasattr(item[1], '_data_store') else item,
+            value.items()
+        ))
+    elif isinstance(value, ModelSimple):
+        return value.value
+    else:
+        return value
+
+
 def model_to_dict(model_instance, serialize=True):
     """Returns the model properties as a dict
 
@@ -1358,33 +1397,7 @@ def model_to_dict(model_instance, serialize=True):
                     seen_json_attribute_names.add(attr)
                 except KeyError:
                     used_fallback_python_attribute_names.add(attr)
-            if isinstance(value, list):
-               if not value:
-                   # empty list or None
-                   result[attr] = value
-               else:
-                   res = []
-                   for v in value:
-                       if isinstance(v, PRIMITIVE_TYPES) or v is None:
-                           res.append(v)
-                       elif isinstance(v, ModelSimple):
-                           res.append(v.value)
-                       else:
-                           res.append(model_to_dict(v, serialize=serialize))
-                   result[attr] = res
-            elif isinstance(value, dict):
-                result[attr] = dict(map(
-                    lambda item: (item[0],
-                                  model_to_dict(item[1], serialize=serialize))
-                    if hasattr(item[1], '_data_store') else item,
-                    value.items()
-                ))
-            elif isinstance(value, ModelSimple):
-                result[attr] = value.value
-            elif hasattr(value, '_data_store'):
-                result[attr] = model_to_dict(value, serialize=serialize)
-            else:
-                result[attr] = value
+            result[attr] = _model_to_dict_core(value, serialize)
     if serialize:
         for python_key in used_fallback_python_attribute_names:
             json_key = py_to_json_map.get(python_key)


### PR DESCRIPTION
Fixes serialization of array items with lists or dicts inside in model_to_dict [python]

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
For python model_utils.py , fix for serialization when it is a list of lists or dicts as it is failing due to a bad recursive function. 

For more details on the issue, please visit https://github.com/OpenAPITools/openapi-generator/pull/9153#discussion_r712619047 posted by @jsok.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
