### PR TITLE
Updated model generation, addProps handling moved into type object and anyType handling

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2381,7 +2381,7 @@ public class DefaultCodegen implements CodegenConfig {
 
     Map<NamedSchema, CodegenProperty> schemaCodegenPropertyCache = new HashMap<NamedSchema, CodegenProperty>();
 
-    private void updateModelForComposedSchema(CodegenModel m, Schema schema, Map<String, Schema> allDefinitions) {
+    protected void updateModelForComposedSchema(CodegenModel m, Schema schema, Map<String, Schema> allDefinitions) {
         final ComposedSchema composed = (ComposedSchema) schema;
         Map<String, Schema> properties = new LinkedHashMap<String, Schema>();
         List<String> required = new ArrayList<String>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2596,6 +2596,8 @@ public class DefaultCodegen implements CodegenConfig {
             // additionalProperties must be null, ObjectSchema, or empty Schema
             addAdditionPropertiesToCodeGenModel(m, schema);
         }
+        // process 'additionalProperties'
+        setAddProps(schema, m);
     }
 
     protected void updateModelForAnyType(CodegenModel m, Schema schema) {
@@ -2614,6 +2616,8 @@ public class DefaultCodegen implements CodegenConfig {
             // passing null to allProperties and allRequired as there's no parent
             addVars(m, unaliasPropertySchema(schema.getProperties()), schema.getRequired(), null, null);
         }
+        // process 'additionalProperties'
+        setAddProps(schema, m);
     }
 
 
@@ -2776,9 +2780,6 @@ public class DefaultCodegen implements CodegenConfig {
             Collections.sort(m.allVars, comparator);
         }
 
-        // process 'additionalProperties'
-        setAddProps(schema, m);
-
         // post process model properties
         if (m.vars != null) {
             for (CodegenProperty prop : m.vars) {
@@ -2794,7 +2795,7 @@ public class DefaultCodegen implements CodegenConfig {
         return m;
     }
 
-    private void setAddProps(Schema schema, IJsonSchemaValidationProperties property){
+    protected void setAddProps(Schema schema, IJsonSchemaValidationProperties property){
         if (schema.equals(new Schema())) {
             // if we are trying to set additionalProperties on an empty schema stop recursing
             return;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
@@ -1152,5 +1152,7 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
                 addAdditionPropertiesToCodeGenModel(m, schema);
             }
         }
+        // process 'additionalProperties'
+        setAddProps(schema, m);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
@@ -385,5 +385,7 @@ public class GoServerCodegen extends AbstractGoCodegen {
                 addAdditionPropertiesToCodeGenModel(m, schema);
             }
         }
+        // process 'additionalProperties'
+        setAddProps(schema, m);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFServerCodegen.java
@@ -354,5 +354,7 @@ public class JavaCXFServerCodegen extends AbstractJavaJAXRSServerCodegen
                 addAdditionPropertiesToCodeGenModel(m, schema);
             }
         }
+        // process 'additionalProperties'
+        setAddProps(schema, m);
     }
 }

--- a/samples/client/petstore/python/docs/AnimalFarm.md
+++ b/samples/client/petstore/python/docs/AnimalFarm.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | [**[Animal]**](Animal.md) |  | 
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python/docs/EnumClass.md
+++ b/samples/client/petstore/python/docs/EnumClass.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | **str** |  | defaults to "-efg",  must be one of ["_abc", "-efg", "(xyz)", ]
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python/docs/NumberWithValidations.md
+++ b/samples/client/petstore/python/docs/NumberWithValidations.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | **float** |  | 
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python/docs/StringEnum.md
+++ b/samples/client/petstore/python/docs/StringEnum.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | **str** |  |  must be one of ["placed", "approved", "delivered", ]
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python/petstore_api/model/animal_farm.py
+++ b/samples/client/petstore/python/petstore_api/model/animal_farm.py
@@ -60,14 +60,7 @@ class AnimalFarm(ModelSimple):
     validations = {
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        lazy_import()
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 

--- a/samples/client/petstore/python/petstore_api/model/enum_class.py
+++ b/samples/client/petstore/python/petstore_api/model/enum_class.py
@@ -61,13 +61,7 @@ class EnumClass(ModelSimple):
     validations = {
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 

--- a/samples/client/petstore/python/petstore_api/model/number_with_validations.py
+++ b/samples/client/petstore/python/petstore_api/model/number_with_validations.py
@@ -60,13 +60,7 @@ class NumberWithValidations(ModelSimple):
         },
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 

--- a/samples/client/petstore/python/petstore_api/model/string_enum.py
+++ b/samples/client/petstore/python/petstore_api/model/string_enum.py
@@ -61,13 +61,7 @@ class StringEnum(ModelSimple):
     validations = {
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 

--- a/samples/openapi3/client/petstore/python/docs/AnimalFarm.md
+++ b/samples/openapi3/client/petstore/python/docs/AnimalFarm.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | [**[Animal]**](Animal.md) |  | 
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/ArrayOfEnums.md
+++ b/samples/openapi3/client/petstore/python/docs/ArrayOfEnums.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | [**[StringEnum]**](StringEnum.md) |  | 
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/BooleanEnum.md
+++ b/samples/openapi3/client/petstore/python/docs/BooleanEnum.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | **bool** |  | defaults to True,  must be one of [True, ]
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/EnumClass.md
+++ b/samples/openapi3/client/petstore/python/docs/EnumClass.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | **str** |  | defaults to "-efg",  must be one of ["_abc", "-efg", "(xyz)", ]
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/IntegerEnum.md
+++ b/samples/openapi3/client/petstore/python/docs/IntegerEnum.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | **int** |  |  must be one of [0, 1, 2, ]
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/IntegerEnumOneValue.md
+++ b/samples/openapi3/client/petstore/python/docs/IntegerEnumOneValue.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | **int** |  | defaults to 0,  must be one of [0, ]
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/IntegerEnumWithDefaultValue.md
+++ b/samples/openapi3/client/petstore/python/docs/IntegerEnumWithDefaultValue.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | **int** |  | defaults to 0,  must be one of [0, 1, 2, ]
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/NumberWithValidations.md
+++ b/samples/openapi3/client/petstore/python/docs/NumberWithValidations.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | **float** |  | 
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/StringEnum.md
+++ b/samples/openapi3/client/petstore/python/docs/StringEnum.md
@@ -7,7 +7,6 @@ Name | Type | Description | Notes
 **value** | **str** |  |  must be one of ["placed", "approved", "delivered", "single quoted", '''multiple
 lines''', '''double quote 
  with newline''', ]
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/StringEnumWithDefaultValue.md
+++ b/samples/openapi3/client/petstore/python/docs/StringEnumWithDefaultValue.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | **str** |  | defaults to "placed",  must be one of ["placed", "approved", "delivered", ]
-**any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/animal_farm.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/animal_farm.py
@@ -60,14 +60,7 @@ class AnimalFarm(ModelSimple):
     validations = {
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        lazy_import()
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/array_of_enums.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/array_of_enums.py
@@ -60,14 +60,7 @@ class ArrayOfEnums(ModelSimple):
     validations = {
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        lazy_import()
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/boolean_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/boolean_enum.py
@@ -59,13 +59,7 @@ class BooleanEnum(ModelSimple):
     validations = {
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/enum_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/enum_class.py
@@ -61,13 +61,7 @@ class EnumClass(ModelSimple):
     validations = {
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum.py
@@ -61,13 +61,7 @@ class IntegerEnum(ModelSimple):
     validations = {
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum_one_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum_one_value.py
@@ -59,13 +59,7 @@ class IntegerEnumOneValue(ModelSimple):
     validations = {
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum_with_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum_with_default_value.py
@@ -61,13 +61,7 @@ class IntegerEnumWithDefaultValue(ModelSimple):
     validations = {
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/number_with_validations.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/number_with_validations.py
@@ -60,13 +60,7 @@ class NumberWithValidations(ModelSimple):
         },
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/string_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/string_enum.py
@@ -67,13 +67,7 @@ lines''',
     validations = {
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = True
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/string_enum_with_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/string_enum_with_default_value.py
@@ -61,13 +61,7 @@ class StringEnumWithDefaultValue(ModelSimple):
     validations = {
     }
 
-    @cached_property
-    def additional_properties_type():
-        """
-        This must be a method because a model may have properties that are
-        of type self, this must run after the class is loaded
-        """
-        return (bool, date, datetime, dict, float, int, list, str, none_type,)  # noqa: E501
+    additional_properties_type = None
 
     _nullable = False
 


### PR DESCRIPTION
Updated model generation, addProps handling moved into type object and anyType handling
additionalProperties are only meaningful when schema type is anyType or object
so process them in only in those use cases.
- updateModelForComposedSchema made protected so generators can override it if they choose

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
