### PR TITLE
Add message and more context to RequiredError

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -48,7 +48,7 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
         {{#required}}
         // verify required parameter '{{paramName}}' is not null or undefined
         if ({{paramName}} === null || {{paramName}} === undefined) {
-            throw new RequiredError('Required parameter {{paramName}} was null or undefined when calling {{nickname}}.');
+            throw new RequiredError("{{classname}}", "{{nickname}}", "{{paramName}}");
         }
 
         {{/required}}

--- a/modules/openapi-generator/src/main/resources/typescript/api/baseapi.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/baseapi.mustache
@@ -38,7 +38,7 @@ export class BaseAPIRequestFactory {
  */
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
+    constructor(public api: string, public method: string, public field: string) {
+        super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/baseapi.ts
@@ -31,7 +31,7 @@ export class BaseAPIRequestFactory {
  */
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
+    constructor(public api: string, public method: string, public field: string) {
+        super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -26,7 +26,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
-            throw new RequiredError('Required parameter pet was null or undefined when calling addPet.');
+            throw new RequiredError("PetApi", "addPet", "pet");
         }
 
 
@@ -71,7 +71,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling deletePet.');
+            throw new RequiredError("PetApi", "deletePet", "petId");
         }
 
 
@@ -108,7 +108,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'status' is not null or undefined
         if (status === null || status === undefined) {
-            throw new RequiredError('Required parameter status was null or undefined when calling findPetsByStatus.');
+            throw new RequiredError("PetApi", "findPetsByStatus", "status");
         }
 
 
@@ -145,7 +145,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'tags' is not null or undefined
         if (tags === null || tags === undefined) {
-            throw new RequiredError('Required parameter tags was null or undefined when calling findPetsByTags.');
+            throw new RequiredError("PetApi", "findPetsByTags", "tags");
         }
 
 
@@ -182,7 +182,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling getPetById.');
+            throw new RequiredError("PetApi", "getPetById", "petId");
         }
 
 
@@ -214,7 +214,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
-            throw new RequiredError('Required parameter pet was null or undefined when calling updatePet.');
+            throw new RequiredError("PetApi", "updatePet", "pet");
         }
 
 
@@ -260,7 +260,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling updatePetWithForm.');
+            throw new RequiredError("PetApi", "updatePetWithForm", "petId");
         }
 
 
@@ -325,7 +325,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling uploadFile.');
+            throw new RequiredError("PetApi", "uploadFile", "petId");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/StoreApi.ts
@@ -26,7 +26,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
-            throw new RequiredError('Required parameter orderId was null or undefined when calling deleteOrder.');
+            throw new RequiredError("StoreApi", "deleteOrder", "orderId");
         }
 
 
@@ -78,7 +78,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
-            throw new RequiredError('Required parameter orderId was null or undefined when calling getOrderById.');
+            throw new RequiredError("StoreApi", "getOrderById", "orderId");
         }
 
 
@@ -104,7 +104,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'order' is not null or undefined
         if (order === null || order === undefined) {
-            throw new RequiredError('Required parameter order was null or undefined when calling placeOrder.');
+            throw new RequiredError("StoreApi", "placeOrder", "order");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/UserApi.ts
@@ -26,7 +26,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUser.');
+            throw new RequiredError("UserApi", "createUser", "user");
         }
 
 
@@ -68,7 +68,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUsersWithArrayInput.');
+            throw new RequiredError("UserApi", "createUsersWithArrayInput", "user");
         }
 
 
@@ -110,7 +110,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUsersWithListInput.');
+            throw new RequiredError("UserApi", "createUsersWithListInput", "user");
         }
 
 
@@ -153,7 +153,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling deleteUser.');
+            throw new RequiredError("UserApi", "deleteUser", "username");
         }
 
 
@@ -185,7 +185,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling getUserByName.');
+            throw new RequiredError("UserApi", "getUserByName", "username");
         }
 
 
@@ -212,13 +212,13 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling loginUser.');
+            throw new RequiredError("UserApi", "loginUser", "username");
         }
 
 
         // verify required parameter 'password' is not null or undefined
         if (password === null || password === undefined) {
-            throw new RequiredError('Required parameter password was null or undefined when calling loginUser.');
+            throw new RequiredError("UserApi", "loginUser", "password");
         }
 
 
@@ -279,13 +279,13 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling updateUser.');
+            throw new RequiredError("UserApi", "updateUser", "username");
         }
 
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling updateUser.');
+            throw new RequiredError("UserApi", "updateUser", "user");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/baseapi.ts
@@ -31,7 +31,7 @@ export class BaseAPIRequestFactory {
  */
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
+    constructor(public api: string, public method: string, public field: string) {
+        super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
@@ -24,7 +24,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
-            throw new RequiredError('Required parameter pet was null or undefined when calling addPet.');
+            throw new RequiredError("PetApi", "addPet", "pet");
         }
 
 
@@ -69,7 +69,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling deletePet.');
+            throw new RequiredError("PetApi", "deletePet", "petId");
         }
 
 
@@ -106,7 +106,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'status' is not null or undefined
         if (status === null || status === undefined) {
-            throw new RequiredError('Required parameter status was null or undefined when calling findPetsByStatus.');
+            throw new RequiredError("PetApi", "findPetsByStatus", "status");
         }
 
 
@@ -143,7 +143,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'tags' is not null or undefined
         if (tags === null || tags === undefined) {
-            throw new RequiredError('Required parameter tags was null or undefined when calling findPetsByTags.');
+            throw new RequiredError("PetApi", "findPetsByTags", "tags");
         }
 
 
@@ -180,7 +180,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling getPetById.');
+            throw new RequiredError("PetApi", "getPetById", "petId");
         }
 
 
@@ -212,7 +212,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
-            throw new RequiredError('Required parameter pet was null or undefined when calling updatePet.');
+            throw new RequiredError("PetApi", "updatePet", "pet");
         }
 
 
@@ -258,7 +258,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling updatePetWithForm.');
+            throw new RequiredError("PetApi", "updatePetWithForm", "petId");
         }
 
 
@@ -323,7 +323,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling uploadFile.');
+            throw new RequiredError("PetApi", "uploadFile", "petId");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/StoreApi.ts
@@ -24,7 +24,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
-            throw new RequiredError('Required parameter orderId was null or undefined when calling deleteOrder.');
+            throw new RequiredError("StoreApi", "deleteOrder", "orderId");
         }
 
 
@@ -76,7 +76,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
-            throw new RequiredError('Required parameter orderId was null or undefined when calling getOrderById.');
+            throw new RequiredError("StoreApi", "getOrderById", "orderId");
         }
 
 
@@ -102,7 +102,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'order' is not null or undefined
         if (order === null || order === undefined) {
-            throw new RequiredError('Required parameter order was null or undefined when calling placeOrder.');
+            throw new RequiredError("StoreApi", "placeOrder", "order");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/UserApi.ts
@@ -24,7 +24,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUser.');
+            throw new RequiredError("UserApi", "createUser", "user");
         }
 
 
@@ -66,7 +66,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUsersWithArrayInput.');
+            throw new RequiredError("UserApi", "createUsersWithArrayInput", "user");
         }
 
 
@@ -108,7 +108,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUsersWithListInput.');
+            throw new RequiredError("UserApi", "createUsersWithListInput", "user");
         }
 
 
@@ -151,7 +151,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling deleteUser.');
+            throw new RequiredError("UserApi", "deleteUser", "username");
         }
 
 
@@ -183,7 +183,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling getUserByName.');
+            throw new RequiredError("UserApi", "getUserByName", "username");
         }
 
 
@@ -210,13 +210,13 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling loginUser.');
+            throw new RequiredError("UserApi", "loginUser", "username");
         }
 
 
         // verify required parameter 'password' is not null or undefined
         if (password === null || password === undefined) {
-            throw new RequiredError('Required parameter password was null or undefined when calling loginUser.');
+            throw new RequiredError("UserApi", "loginUser", "password");
         }
 
 
@@ -277,13 +277,13 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling updateUser.');
+            throw new RequiredError("UserApi", "updateUser", "username");
         }
 
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling updateUser.');
+            throw new RequiredError("UserApi", "updateUser", "user");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/baseapi.ts
@@ -31,7 +31,7 @@ export class BaseAPIRequestFactory {
  */
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
+    constructor(public api: string, public method: string, public field: string) {
+        super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
@@ -28,7 +28,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
-            throw new RequiredError('Required parameter pet was null or undefined when calling addPet.');
+            throw new RequiredError("PetApi", "addPet", "pet");
         }
 
 
@@ -73,7 +73,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling deletePet.');
+            throw new RequiredError("PetApi", "deletePet", "petId");
         }
 
 
@@ -110,7 +110,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'status' is not null or undefined
         if (status === null || status === undefined) {
-            throw new RequiredError('Required parameter status was null or undefined when calling findPetsByStatus.');
+            throw new RequiredError("PetApi", "findPetsByStatus", "status");
         }
 
 
@@ -147,7 +147,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'tags' is not null or undefined
         if (tags === null || tags === undefined) {
-            throw new RequiredError('Required parameter tags was null or undefined when calling findPetsByTags.');
+            throw new RequiredError("PetApi", "findPetsByTags", "tags");
         }
 
 
@@ -184,7 +184,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling getPetById.');
+            throw new RequiredError("PetApi", "getPetById", "petId");
         }
 
 
@@ -216,7 +216,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
-            throw new RequiredError('Required parameter pet was null or undefined when calling updatePet.');
+            throw new RequiredError("PetApi", "updatePet", "pet");
         }
 
 
@@ -262,7 +262,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling updatePetWithForm.');
+            throw new RequiredError("PetApi", "updatePetWithForm", "petId");
         }
 
 
@@ -327,7 +327,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling uploadFile.');
+            throw new RequiredError("PetApi", "uploadFile", "petId");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/StoreApi.ts
@@ -28,7 +28,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
-            throw new RequiredError('Required parameter orderId was null or undefined when calling deleteOrder.');
+            throw new RequiredError("StoreApi", "deleteOrder", "orderId");
         }
 
 
@@ -80,7 +80,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
-            throw new RequiredError('Required parameter orderId was null or undefined when calling getOrderById.');
+            throw new RequiredError("StoreApi", "getOrderById", "orderId");
         }
 
 
@@ -106,7 +106,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'order' is not null or undefined
         if (order === null || order === undefined) {
-            throw new RequiredError('Required parameter order was null or undefined when calling placeOrder.');
+            throw new RequiredError("StoreApi", "placeOrder", "order");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/UserApi.ts
@@ -28,7 +28,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUser.');
+            throw new RequiredError("UserApi", "createUser", "user");
         }
 
 
@@ -70,7 +70,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUsersWithArrayInput.');
+            throw new RequiredError("UserApi", "createUsersWithArrayInput", "user");
         }
 
 
@@ -112,7 +112,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUsersWithListInput.');
+            throw new RequiredError("UserApi", "createUsersWithListInput", "user");
         }
 
 
@@ -155,7 +155,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling deleteUser.');
+            throw new RequiredError("UserApi", "deleteUser", "username");
         }
 
 
@@ -187,7 +187,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling getUserByName.');
+            throw new RequiredError("UserApi", "getUserByName", "username");
         }
 
 
@@ -214,13 +214,13 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling loginUser.');
+            throw new RequiredError("UserApi", "loginUser", "username");
         }
 
 
         // verify required parameter 'password' is not null or undefined
         if (password === null || password === undefined) {
-            throw new RequiredError('Required parameter password was null or undefined when calling loginUser.');
+            throw new RequiredError("UserApi", "loginUser", "password");
         }
 
 
@@ -281,13 +281,13 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling updateUser.');
+            throw new RequiredError("UserApi", "updateUser", "username");
         }
 
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling updateUser.');
+            throw new RequiredError("UserApi", "updateUser", "user");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/baseapi.ts
@@ -34,7 +34,7 @@ export class BaseAPIRequestFactory {
  */
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
+    constructor(public api: string, public method: string, public field: string) {
+        super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -24,7 +24,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
-            throw new RequiredError('Required parameter pet was null or undefined when calling addPet.');
+            throw new RequiredError("PetApi", "addPet", "pet");
         }
 
 
@@ -69,7 +69,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling deletePet.');
+            throw new RequiredError("PetApi", "deletePet", "petId");
         }
 
 
@@ -106,7 +106,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'status' is not null or undefined
         if (status === null || status === undefined) {
-            throw new RequiredError('Required parameter status was null or undefined when calling findPetsByStatus.');
+            throw new RequiredError("PetApi", "findPetsByStatus", "status");
         }
 
 
@@ -143,7 +143,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'tags' is not null or undefined
         if (tags === null || tags === undefined) {
-            throw new RequiredError('Required parameter tags was null or undefined when calling findPetsByTags.');
+            throw new RequiredError("PetApi", "findPetsByTags", "tags");
         }
 
 
@@ -180,7 +180,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling getPetById.');
+            throw new RequiredError("PetApi", "getPetById", "petId");
         }
 
 
@@ -212,7 +212,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
-            throw new RequiredError('Required parameter pet was null or undefined when calling updatePet.');
+            throw new RequiredError("PetApi", "updatePet", "pet");
         }
 
 
@@ -258,7 +258,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling updatePetWithForm.');
+            throw new RequiredError("PetApi", "updatePetWithForm", "petId");
         }
 
 
@@ -323,7 +323,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling uploadFile.');
+            throw new RequiredError("PetApi", "uploadFile", "petId");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -24,7 +24,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
-            throw new RequiredError('Required parameter orderId was null or undefined when calling deleteOrder.');
+            throw new RequiredError("StoreApi", "deleteOrder", "orderId");
         }
 
 
@@ -76,7 +76,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
-            throw new RequiredError('Required parameter orderId was null or undefined when calling getOrderById.');
+            throw new RequiredError("StoreApi", "getOrderById", "orderId");
         }
 
 
@@ -102,7 +102,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'order' is not null or undefined
         if (order === null || order === undefined) {
-            throw new RequiredError('Required parameter order was null or undefined when calling placeOrder.');
+            throw new RequiredError("StoreApi", "placeOrder", "order");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -24,7 +24,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUser.');
+            throw new RequiredError("UserApi", "createUser", "user");
         }
 
 
@@ -66,7 +66,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUsersWithArrayInput.');
+            throw new RequiredError("UserApi", "createUsersWithArrayInput", "user");
         }
 
 
@@ -108,7 +108,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUsersWithListInput.');
+            throw new RequiredError("UserApi", "createUsersWithListInput", "user");
         }
 
 
@@ -151,7 +151,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling deleteUser.');
+            throw new RequiredError("UserApi", "deleteUser", "username");
         }
 
 
@@ -183,7 +183,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling getUserByName.');
+            throw new RequiredError("UserApi", "getUserByName", "username");
         }
 
 
@@ -210,13 +210,13 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling loginUser.');
+            throw new RequiredError("UserApi", "loginUser", "username");
         }
 
 
         // verify required parameter 'password' is not null or undefined
         if (password === null || password === undefined) {
-            throw new RequiredError('Required parameter password was null or undefined when calling loginUser.');
+            throw new RequiredError("UserApi", "loginUser", "password");
         }
 
 
@@ -277,13 +277,13 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling updateUser.');
+            throw new RequiredError("UserApi", "updateUser", "username");
         }
 
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling updateUser.');
+            throw new RequiredError("UserApi", "updateUser", "user");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/baseapi.ts
@@ -31,7 +31,7 @@ export class BaseAPIRequestFactory {
  */
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
+    constructor(public api: string, public method: string, public field: string) {
+        super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
@@ -26,7 +26,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
-            throw new RequiredError('Required parameter pet was null or undefined when calling addPet.');
+            throw new RequiredError("PetApi", "addPet", "pet");
         }
 
 
@@ -71,7 +71,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling deletePet.');
+            throw new RequiredError("PetApi", "deletePet", "petId");
         }
 
 
@@ -108,7 +108,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'status' is not null or undefined
         if (status === null || status === undefined) {
-            throw new RequiredError('Required parameter status was null or undefined when calling findPetsByStatus.');
+            throw new RequiredError("PetApi", "findPetsByStatus", "status");
         }
 
 
@@ -145,7 +145,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'tags' is not null or undefined
         if (tags === null || tags === undefined) {
-            throw new RequiredError('Required parameter tags was null or undefined when calling findPetsByTags.');
+            throw new RequiredError("PetApi", "findPetsByTags", "tags");
         }
 
 
@@ -182,7 +182,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling getPetById.');
+            throw new RequiredError("PetApi", "getPetById", "petId");
         }
 
 
@@ -214,7 +214,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'pet' is not null or undefined
         if (pet === null || pet === undefined) {
-            throw new RequiredError('Required parameter pet was null or undefined when calling updatePet.');
+            throw new RequiredError("PetApi", "updatePet", "pet");
         }
 
 
@@ -260,7 +260,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling updatePetWithForm.');
+            throw new RequiredError("PetApi", "updatePetWithForm", "petId");
         }
 
 
@@ -325,7 +325,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'petId' is not null or undefined
         if (petId === null || petId === undefined) {
-            throw new RequiredError('Required parameter petId was null or undefined when calling uploadFile.');
+            throw new RequiredError("PetApi", "uploadFile", "petId");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/StoreApi.ts
@@ -26,7 +26,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
-            throw new RequiredError('Required parameter orderId was null or undefined when calling deleteOrder.');
+            throw new RequiredError("StoreApi", "deleteOrder", "orderId");
         }
 
 
@@ -78,7 +78,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'orderId' is not null or undefined
         if (orderId === null || orderId === undefined) {
-            throw new RequiredError('Required parameter orderId was null or undefined when calling getOrderById.');
+            throw new RequiredError("StoreApi", "getOrderById", "orderId");
         }
 
 
@@ -104,7 +104,7 @@ export class StoreApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'order' is not null or undefined
         if (order === null || order === undefined) {
-            throw new RequiredError('Required parameter order was null or undefined when calling placeOrder.');
+            throw new RequiredError("StoreApi", "placeOrder", "order");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/UserApi.ts
@@ -26,7 +26,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUser.');
+            throw new RequiredError("UserApi", "createUser", "user");
         }
 
 
@@ -68,7 +68,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUsersWithArrayInput.');
+            throw new RequiredError("UserApi", "createUsersWithArrayInput", "user");
         }
 
 
@@ -110,7 +110,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling createUsersWithListInput.');
+            throw new RequiredError("UserApi", "createUsersWithListInput", "user");
         }
 
 
@@ -153,7 +153,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling deleteUser.');
+            throw new RequiredError("UserApi", "deleteUser", "username");
         }
 
 
@@ -185,7 +185,7 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling getUserByName.');
+            throw new RequiredError("UserApi", "getUserByName", "username");
         }
 
 
@@ -212,13 +212,13 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling loginUser.');
+            throw new RequiredError("UserApi", "loginUser", "username");
         }
 
 
         // verify required parameter 'password' is not null or undefined
         if (password === null || password === undefined) {
-            throw new RequiredError('Required parameter password was null or undefined when calling loginUser.');
+            throw new RequiredError("UserApi", "loginUser", "password");
         }
 
 
@@ -279,13 +279,13 @@ export class UserApiRequestFactory extends BaseAPIRequestFactory {
 
         // verify required parameter 'username' is not null or undefined
         if (username === null || username === undefined) {
-            throw new RequiredError('Required parameter username was null or undefined when calling updateUser.');
+            throw new RequiredError("UserApi", "updateUser", "username");
         }
 
 
         // verify required parameter 'user' is not null or undefined
         if (user === null || user === undefined) {
-            throw new RequiredError('Required parameter user was null or undefined when calling updateUser.');
+            throw new RequiredError("UserApi", "updateUser", "user");
         }
 
 

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/baseapi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/baseapi.ts
@@ -31,7 +31,7 @@ export class BaseAPIRequestFactory {
  */
 export class RequiredError extends Error {
     name: "RequiredError" = "RequiredError";
-    constructor(public field: string, msg?: string) {
-        super(msg);
+    constructor(public api: string, public method: string, public field: string) {
+        super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }
 }

--- a/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
@@ -62,6 +62,21 @@ describe("PetApi", () => {
         throw new Error("Deleted non-existant pet with id " + nonExistantId + "!");
     })
 
+    it("failRunTimeRequiredParameterCheck", async () => {
+        try {
+            await petApi.deletePet(null)
+        } catch (err) {
+            expect(err.api).to.equal("PetApi");
+            expect(err.message).to.include("PetApi");
+            expect(err.method).to.equal("deletePet");
+            expect(err.message).to.include("deletePet");
+            expect(err.field).to.equal("petId");
+            expect(err.message).to.include("petId");
+            return;
+        }
+        throw new Error("Accepted missing parameter!");
+    })
+
     it("findPetsByStatus", async () => {
         const pets = await petApi.findPetsByStatus(["available"]);
         expect(pets.length).to.be.at.least(1);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Changes the `RequiredError` exceptions class to retain the api class, method and field names as context.
Most importantly the actual error message is now in the `message` field, where it belongs.
Added an integration test to check it works. Verify with:
```
mvn integration-test -f samples/openapi3/client/petstore/typescript/tests/default/pom.xml
```

Fixes #10459 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvn clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02)
