### PR TITLE
Dart: mark jaguar for deprecation

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -24,7 +24,7 @@ The following generators are available:
 * [dart](generators/dart.md)  
 * [dart-dio](generators/dart-dio.md)  
 * [dart-dio-next (experimental)](generators/dart-dio-next.md)  
-* [dart-jaguar](generators/dart-jaguar.md)  
+* [dart-jaguar (deprecated)](generators/dart-jaguar.md)  
 * [eiffel](generators/eiffel.md)  
 * [elixir](generators/elixir.md)  
 * [elm](generators/elm.md)  

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartJaguarClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartJaguarClientCodegen.java
@@ -17,6 +17,8 @@
 package org.openapitools.codegen.languages;
 
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.meta.GeneratorMetadata;
+import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.*;
 import org.openapitools.codegen.utils.ModelUtils;
 
@@ -87,6 +89,10 @@ public class DartJaguarClientCodegen extends AbstractDartCodegen {
                         ClientModificationFeature.BasePath
                 )
         );
+
+        generatorMetadata = GeneratorMetadata.newBuilder(generatorMetadata)
+                .stability(Stability.DEPRECATED)
+                .build();
 
         outputFolder = "generated-code/dart-jaguar";
         embeddedTemplateDir = templateDir = "dart-jaguar";


### PR DESCRIPTION
Dart jaguar doesn't work with newer versions of Dart, there are no contributors to this generator, and it doesn't even generate correct code #5583.

I suggest marking it as deprecated and removing in the future, only changes in last 12 months were forced maintenance changes to keep it in sync with other Dart generators.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
