### PR TITLE
[java][jersey2] use implementation, add min version of maven, gradle in the README

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/README.mustache
@@ -21,7 +21,12 @@
 Building the API client library requires:
 
 1. Java {{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}+
+{{#jersey2}}
+2. Maven (3.8.3+)/Gradle (7.2+)
+{{/jersey2}}
+{{^jersey2}}
 2. Maven/Gradle
+{{/jersey2}}
 
 ## Installation
 
@@ -57,7 +62,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "{{{groupId}}}:{{{artifactId}}}:{{{artifactVersion}}}"
+  repositories {
+    mavenCentral()     // Needed if the '{{{artifactId}}}' jar has been published to maven central.
+    mavenLocal()       // Needed if the '{{{artifactId}}}' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "{{{groupId}}}:{{{artifactId}}}:{{{artifactVersion}}}"
+  }
 ```
 
 ### Others

--- a/samples/client/petstore/java/apache-httpclient/README.md
+++ b/samples/client/petstore/java/apache-httpclient/README.md
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-apache-httpclient:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-apache-httpclient' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-apache-httpclient' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-apache-httpclient:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/client/petstore/java/google-api-client/README.md
+++ b/samples/client/petstore/java/google-api-client/README.md
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-google-api-client:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-google-api-client' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-google-api-client' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-google-api-client:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/client/petstore/java/jersey1/README.md
+++ b/samples/client/petstore/java/jersey1/README.md
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-java-client-jersey1:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-java-client-jersey1' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-java-client-jersey1' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-java-client-jersey1:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/README.md
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/README.md
@@ -14,7 +14,7 @@ This spec is mainly for testing Petstore server and contains fake endpoints, mod
 Building the API client library requires:
 
 1. Java 1.8+
-2. Maven/Gradle
+2. Maven (3.8.3+)/Gradle (7.2+)
 
 ## Installation
 
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-jersey2-java8-localdatetime:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-jersey2-java8-localdatetime' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-jersey2-java8-localdatetime' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-jersey2-java8-localdatetime:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/client/petstore/java/jersey2-java8/README.md
+++ b/samples/client/petstore/java/jersey2-java8/README.md
@@ -14,7 +14,7 @@ This spec is mainly for testing Petstore server and contains fake endpoints, mod
 Building the API client library requires:
 
 1. Java 1.8+
-2. Maven/Gradle
+2. Maven (3.8.3+)/Gradle (7.2+)
 
 ## Installation
 
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-jersey2-java8:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-jersey2-java8' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-jersey2-java8' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-jersey2-java8:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/client/petstore/java/resteasy/README.md
+++ b/samples/client/petstore/java/resteasy/README.md
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-resteasy:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-resteasy' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-resteasy' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-resteasy:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/client/petstore/java/resttemplate-withXml/README.md
+++ b/samples/client/petstore/java/resttemplate-withXml/README.md
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-resttemplate-withxml:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-resttemplate-withxml' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-resttemplate-withxml' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-resttemplate-withxml:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/client/petstore/java/resttemplate/README.md
+++ b/samples/client/petstore/java/resttemplate/README.md
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-resttemplate:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-resttemplate' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-resttemplate' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-resttemplate:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/client/petstore/java/vertx-no-nullable/README.md
+++ b/samples/client/petstore/java/vertx-no-nullable/README.md
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-vertx-no-nullable:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-vertx-no-nullable' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-vertx-no-nullable' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-vertx-no-nullable:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/client/petstore/java/vertx/README.md
+++ b/samples/client/petstore/java/vertx/README.md
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-vertx:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-vertx' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-vertx' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-vertx:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/client/petstore/java/webclient-nulable-arrays/README.md
+++ b/samples/client/petstore/java/webclient-nulable-arrays/README.md
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-webclient-nullable-arrays:v1"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-webclient-nullable-arrays' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-webclient-nullable-arrays' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-webclient-nullable-arrays:v1"
+  }
 ```
 
 ### Others

--- a/samples/client/petstore/java/webclient/README.md
+++ b/samples/client/petstore/java/webclient/README.md
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-webclient:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-webclient' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-webclient' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-webclient:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/README.md
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/README.md
@@ -14,7 +14,7 @@ This specification shows how to use x-auth-id-alias extension for API keys.
 Building the API client library requires:
 
 1. Java 1.7+
-2. Maven/Gradle
+2. Maven (3.8.3+)/Gradle (7.2+)
 
 ## Installation
 
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:openapi3-extensions-x-auth-id-alias-jersey2-java8:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'openapi3-extensions-x-auth-id-alias-jersey2-java8' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'openapi3-extensions-x-auth-id-alias-jersey2-java8' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:openapi3-extensions-x-auth-id-alias-jersey2-java8:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/README.md
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/README.md
@@ -14,7 +14,7 @@ test
 Building the API client library requires:
 
 1. Java 1.8+
-2. Maven/Gradle
+2. Maven (3.8.3+)/Gradle (7.2+)
 
 ## Installation
 
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-openapi3-jersey2-java8-special-characters:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-openapi3-jersey2-java8-special-characters' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-openapi3-jersey2-java8-special-characters' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-openapi3-jersey2-java8-special-characters:1.0.0"
+  }
 ```
 
 ### Others

--- a/samples/openapi3/client/petstore/java/jersey2-java8/README.md
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/README.md
@@ -14,7 +14,7 @@ This spec is mainly for testing Petstore server and contains fake endpoints, mod
 Building the API client library requires:
 
 1. Java 1.8+
-2. Maven/Gradle
+2. Maven (3.8.3+)/Gradle (7.2+)
 
 ## Installation
 
@@ -50,7 +50,14 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "org.openapitools:petstore-openapi3-jersey2-java8:1.0.0"
+  repositories {
+    mavenCentral()     // Needed if the 'petstore-openapi3-jersey2-java8' jar has been published to maven central.
+    mavenLocal()       // Needed if the 'petstore-openapi3-jersey2-java8' jar has been published to the local maven repo.
+  }
+
+  dependencies {
+     implementation "org.openapitools:petstore-openapi3-jersey2-java8:1.0.0"
+  }
 ```
 
 ### Others


### PR DESCRIPTION
- use implementation instead of compile
- add min version of maven, gradle in the README

To close https://github.com/OpenAPITools/openapi-generator/issues/10524
To close https://github.com/OpenAPITools/openapi-generator/issues/10526

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5x.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @nmuesch (2021/01)
