### PR TITLE
[php] fix 'mixed' invalid for settype()

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -296,6 +296,9 @@ class ObjectSerializer
         if ($class === 'object') {
             settype($data, 'array');
             return $data;
+        } else if ($class === 'mixed') {
+            settype($data, gettype($data));
+            return $data;
         }
 
         if ($class === '\DateTime') {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -305,6 +305,9 @@ class ObjectSerializer
         if ($class === 'object') {
             settype($data, 'array');
             return $data;
+        } else if ($class === 'mixed') {
+            settype($data, gettype($data));
+            return $data;
         }
 
         if ($class === '\DateTime') {


### PR DESCRIPTION
Fixes: #10575 

Adds an if statement in `ObjectSerializer#deserialize` for the `mixed` openapi type which resolves the correct `class` for the supplied `data`.

@jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko @renepardon

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
