### PR TITLE
[Java] Make it possible to disable generation of swagger annotations

### DIFF
--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -59,6 +59,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src/main/java|
+|swaggerAnnotations|Whether to generate Swagger annotations| |true|
 |useAbstractionForFiles|Use alternative types instead of java.io.File to allow passing bytes without a file on disk. Available on resttemplate library| |false|
 |useBeanValidation|Use BeanValidation API annotations| |false|
 |useGzipFeature|Send gzip-encoded requests| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -159,7 +159,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(USE_ABSTRACTION_FOR_FILES, "Use alternative types instead of java.io.File to allow passing bytes without a file on disk. Available on " + RESTTEMPLATE + " library"));
         cliOptions.add(CliOption.newBoolean(DYNAMIC_OPERATIONS, "Generate operations dynamically at runtime from an OAS", this.dynamicOperations));
         cliOptions.add(CliOption.newString(GRADLE_PROPERTIES, "Append additional Gradle proeprties to the gradle.properties file"));
-        cliOptions.add(CliOption.newBoolean(SWAGGER_ANNOTATIONS, "Whether to generate Swagger annotations"));
+        cliOptions.add(CliOption.newBoolean(SWAGGER_ANNOTATIONS, "Whether to generate Swagger annotations", swaggerAnnotations));
 
         supportedLibraries.put(JERSEY1, "HTTP client: Jersey client 1.19.x. JSON processing: Jackson 2.9.x. Enable gzip request encoding using '-DuseGzipFeature=true'. IMPORTANT NOTE: jersey 1.x is no longer actively maintained so please upgrade to 'jersey2' or other HTTP libraries instead.");
         supportedLibraries.put(JERSEY2, "HTTP client: Jersey client 2.25.1. JSON processing: Jackson 2.9.x");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -64,6 +64,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     public static final String USE_ABSTRACTION_FOR_FILES = "useAbstractionForFiles";
     public static final String DYNAMIC_OPERATIONS = "dynamicOperations";
     public static final String GRADLE_PROPERTIES= "gradleProperties";
+    public static final String SWAGGER_ANNOTATIONS = "swaggerAnnotations";
 
     public static final String PLAY_24 = "play24";
     public static final String PLAY_25 = "play25";
@@ -112,6 +113,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     protected boolean caseInsensitiveResponseHeaders = false;
     protected boolean useAbstractionForFiles = false;
     protected boolean dynamicOperations = false;
+    protected boolean swaggerAnnotations = true;
     protected String gradleProperties;
     protected String authFolder;
     protected String serializationLibrary = null;
@@ -157,6 +159,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(USE_ABSTRACTION_FOR_FILES, "Use alternative types instead of java.io.File to allow passing bytes without a file on disk. Available on " + RESTTEMPLATE + " library"));
         cliOptions.add(CliOption.newBoolean(DYNAMIC_OPERATIONS, "Generate operations dynamically at runtime from an OAS", this.dynamicOperations));
         cliOptions.add(CliOption.newString(GRADLE_PROPERTIES, "Append additional Gradle proeprties to the gradle.properties file"));
+        cliOptions.add(CliOption.newBoolean(SWAGGER_ANNOTATIONS, "Whether to generate Swagger annotations"));
 
         supportedLibraries.put(JERSEY1, "HTTP client: Jersey client 1.19.x. JSON processing: Jackson 2.9.x. Enable gzip request encoding using '-DuseGzipFeature=true'. IMPORTANT NOTE: jersey 1.x is no longer actively maintained so please upgrade to 'jersey2' or other HTTP libraries instead.");
         supportedLibraries.put(JERSEY2, "HTTP client: Jersey client 2.25.1. JSON processing: Jackson 2.9.x");
@@ -325,6 +328,10 @@ public class JavaClientCodegen extends AbstractJavaCodegen
             this.setGradleProperties(additionalProperties.get(GRADLE_PROPERTIES).toString());
         }
         additionalProperties.put(GRADLE_PROPERTIES, gradleProperties);
+
+        if (additionalProperties.containsKey(SWAGGER_ANNOTATIONS)) {
+            this.setSwaggerAnnotations(convertPropertyToBooleanAndWriteBack(SWAGGER_ANNOTATIONS));
+        }
 
         final String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");
         final String apiFolder = (sourceFolder + '/' + apiPackage).replace(".", "/");
@@ -802,6 +809,10 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                 codegenModel.imports.remove("ApiModel");
             }
         }
+        if (!swaggerAnnotations) {
+            codegenModel.imports.remove("ApiModel");
+            codegenModel.imports.remove("ApiModelProperty");
+        }
         return codegenModel;
     }
 
@@ -994,6 +1005,10 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 
     public void setGradleProperties(final String gradleProperties) {
         this.gradleProperties= gradleProperties;
+    }
+
+    public void setSwaggerAnnotations(boolean swaggerAnnotations) {
+        this.swaggerAnnotations = swaggerAnnotations;
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -330,8 +330,9 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         additionalProperties.put(GRADLE_PROPERTIES, gradleProperties);
 
         if (additionalProperties.containsKey(SWAGGER_ANNOTATIONS)) {
-            this.setSwaggerAnnotations(convertPropertyToBooleanAndWriteBack(SWAGGER_ANNOTATIONS));
+            this.setSwaggerAnnotations(convertPropertyToBoolean(SWAGGER_ANNOTATIONS));
         }
+        additionalProperties.put(SWAGGER_ANNOTATIONS, swaggerAnnotations);
 
         final String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");
         final String apiFolder = (sourceFolder + '/' + apiPackage).replace(".", "/");

--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -125,7 +125,9 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
+    {{#swaggerAnnotations}}
     swagger_annotations_version = "1.5.22"
+    {{/swaggerAnnotations}}
     jackson_version = "2.12.1"
     jackson_databind_version = "2.10.5.1"
     {{#openApiNullable}}
@@ -141,7 +143,9 @@ ext {
 }
 
 dependencies {
+    {{#swaggerAnnotations}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swaggerAnnotations}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "com.sun.jersey:jersey-client:$jersey_version"
     implementation "com.sun.jersey.contribs:jersey-multipart:$jersey_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache/pom.mustache
@@ -232,11 +232,13 @@
     </profiles>
 
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
 
         <!-- @Nullable annotation -->
         <dependency>
@@ -360,7 +362,9 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.5.21</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         <httpclient-version>4.5.13</httpclient-version>
         <jackson-version>2.12.1</jackson-version>
         {{#threetenbp}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -99,7 +99,9 @@ test {
 }
 
 ext {
+    {{#swaggerAnnotations}}
     swagger_annotations_version = "1.5.24"
+    {{/swaggerAnnotations}}
     jackson_version = "2.10.3"
     jackson_databind_version = "2.10.3"
     {{#openApiNullable}}
@@ -116,7 +118,9 @@ ext {
 }
 
 dependencies {
+    {{#swaggerAnnotations}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swaggerAnnotations}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.github.openfeign:feign-core:$feign_version"
     implementation "io.github.openfeign:feign-jackson:$feign_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.sbt.mustache
@@ -9,7 +9,9 @@ lazy val root = (project in file(".")).
     publishArtifact in (Compile, packageDoc) := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
+      {{#swaggerAnnotations}}
       "io.swagger" % "swagger-annotations" % "1.5.24" % "compile",
+      {{/swaggerAnnotations}}
       "com.google.code.findbugs" % "jsr305" % "3.0.2" % "compile",
       "io.github.openfeign" % "feign-core" % "10.11" % "compile",
       "io.github.openfeign" % "feign-jackson" % "10.11" % "compile",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
@@ -213,11 +213,13 @@
     </profiles>
 
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
 
         <!-- @Nullable annotation -->
         <dependency>
@@ -360,7 +362,9 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.5.24</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         <feign-version>10.11</feign-version>
         <feign-form-version>3.8.0</feign-form-version>
         <jackson-version>2.10.3</jackson-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
@@ -107,7 +107,9 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
+    {{#swaggerAnnotations}}
     swagger_annotations_version = "1.5.22"
+    {{/swaggerAnnotations}}
     jackson_version = "2.12.1"
     jackson_databind_version = "2.10.5.1"
     {{#openApiNullable}}
@@ -124,7 +126,9 @@ ext {
 }
 
 dependencies {
+    {{#swaggerAnnotations}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swaggerAnnotations}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "com.google.api-client:google-api-client:${google_api_client_version}"
     implementation "org.glassfish.jersey.core:jersey-common:${jersey_common_version}"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.sbt.mustache
@@ -9,7 +9,9 @@ lazy val root = (project in file(".")).
     publishArtifact in (Compile, packageDoc) := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
+      {{#swaggerAnnotations}}
       "io.swagger" % "swagger-annotations" % "1.5.22",
+      {{/swaggerAnnotations}}
       "com.google.api-client" % "google-api-client" % "1.23.0",
       "org.glassfish.jersey.core" % "jersey-common" % "2.25.1",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.12.1" % "compile",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
@@ -217,11 +217,13 @@
     </profiles>
 
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
         <!-- @Nullable annotation -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -314,7 +316,9 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         <google-api-client-version>1.30.2</google-api-client-version>
         <jersey-common-version>2.25.1</jersey-common-version>
         <jackson-version>2.12.1</jackson-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -108,7 +108,9 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
+    {{#swaggerAnnotations}}
     swagger_annotations_version = "1.5.22"
+    {{/swaggerAnnotations}}
     jackson_version = "2.10.5"
     jackson_databind_version = "2.10.5.1"
     {{#openApiNullable}}
@@ -129,7 +131,9 @@ ext {
 }
 
 dependencies {
+    {{#swaggerAnnotations}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swaggerAnnotations}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "org.glassfish.jersey.core:jersey-client:$jersey_version"
     implementation "org.glassfish.jersey.inject:jersey-hk2:$jersey_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.sbt.mustache
@@ -9,7 +9,9 @@ lazy val root = (project in file(".")).
     publishArtifact in (Compile, packageDoc) := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
+      {{#swaggerAnnotations}}
       "io.swagger" % "swagger-annotations" % "1.5.22",
+      {{/swaggerAnnotations}}
       "org.glassfish.jersey.core" % "jersey-client" % "2.27",
       "org.glassfish.jersey.inject" % "jersey-hk2" % "2.27",
       "org.glassfish.jersey.media" % "jersey-media-multipart" % "2.27",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
@@ -2,8 +2,8 @@
  * {{description}}{{^description}}{{classname}}{{/description}}{{#isDeprecated}}
  * @deprecated{{/isDeprecated}}
  */{{#isDeprecated}}
-@Deprecated{{/isDeprecated}}{{#description}}
-@ApiModel(description = "{{{.}}}"){{/description}}
+@Deprecated{{/isDeprecated}}{{#swaggerAnnotations}}{{#description}}
+@ApiModel(description = "{{{.}}}"){{/description}}{{/swaggerAnnotations}}
 {{#jackson}}
 @JsonPropertyOrder({
 {{#vars}}
@@ -207,7 +207,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
 {{^required}}
   @javax.annotation.Nullable
 {{/required}}
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  {{#swaggerAnnotations}}@ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}"){{/swaggerAnnotations}}
 {{#vendorExtensions.x-extra-annotation}}
   {{{vendorExtensions.x-extra-annotation}}}
 {{/vendorExtensions.x-extra-annotation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -232,11 +232,13 @@
     </profiles>
 
     <dependencies>
+       {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
 
         <!-- @Nullable annotation -->
         <dependency>
@@ -371,7 +373,9 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.6.1</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         <jersey-version>2.30.1</jersey-version>
         <jackson-version>2.10.5</jackson-version>
         <jackson-databind-version>2.10.5.1</jackson-databind-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/build.gradle.mustache
@@ -61,7 +61,9 @@ artifacts {
 
 
 ext {
+    {{#swaggerAnnotations}}
     swagger_annotations_version = "1.5.22"
+    {{/swaggerAnnotations}}
     jackson_version = "2.10.4"
     jakarta_annotation_version = "1.3.5"
     junit_version = "4.13.1"
@@ -71,7 +73,9 @@ ext {
 }
 
 dependencies {
+    {{#swaggerAnnotations}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swaggerAnnotations}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
@@ -5,8 +5,8 @@ import {{invokerPackage}}.JSON;
  * {{description}}{{^description}}{{classname}}{{/description}}{{#isDeprecated}}
  * @deprecated{{/isDeprecated}}
  */{{#isDeprecated}}
-@Deprecated{{/isDeprecated}}{{#description}}
-@ApiModel(description = "{{{.}}}"){{/description}}
+@Deprecated{{/isDeprecated}}{{#swaggerAnnotations}}{{#description}}
+@ApiModel(description = "{{{.}}}"){{/description}}{{/swaggerAnnotations}}
 {{#jackson}}
 @JsonPropertyOrder({
 {{#vars}}
@@ -210,7 +210,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
 {{^required}}
   @javax.annotation.Nullable
 {{/required}}
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  {{#swaggerAnnotations}}@ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}"){{/swaggerAnnotations}}
 {{#vendorExtensions.x-extra-annotation}}
   {{{vendorExtensions.x-extra-annotation}}}
 {{/vendorExtensions.x-extra-annotation}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
@@ -161,11 +161,13 @@
     </profiles>
 
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
 
         <!-- JSON processing: jackson -->
         <dependency>
@@ -225,7 +227,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <jackson-version>2.10.4</jackson-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -106,7 +106,9 @@ ext {
 }
 
 dependencies {
+    {{#swaggerAnnotations}}
     implementation 'io.swagger:swagger-annotations:1.5.24'
+    {{/swaggerAnnotations}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'com.squareup.okhttp3:logging-interceptor:4.9.1'

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.sbt.mustache
@@ -9,7 +9,9 @@ lazy val root = (project in file(".")).
     publishArtifact in (Compile, packageDoc) := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
+      {{#swaggerAnnotations}}
       "io.swagger" % "swagger-annotations" % "1.5.24",
+      {{/swaggerAnnotations}}
       "com.squareup.okhttp3" % "okhttp" % "4.9.1",
       "com.squareup.okhttp3" % "logging-interceptor" % "4.9.1",
       "com.google.code.gson" % "gson" % "2.8.6",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -217,11 +217,13 @@
     </profiles>
 
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
         <!-- @Nullable annotation -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
@@ -22,7 +22,9 @@ import io.restassured.common.mapper.TypeRef;
 {{/jackson}}
 import io.restassured.http.Method;
 import io.restassured.response.Response;
+{{#swaggerAnnotations}}
 import io.swagger.annotations.*;
+{{/swaggerAnnotations}}
 
 import java.lang.reflect.Type;
 import java.util.function.Consumer;
@@ -34,7 +36,9 @@ import {{invokerPackage}}.JSON;
 {{/gson}}
 import static io.restassured.http.Method.*;
 
+{{#swaggerAnnotations}}
 @Api(value = "{{{baseName}}}")
+{{/swaggerAnnotations}}
 public class {{classname}} {
 
     private Supplier<RequestSpecBuilder> reqSpecSupplier;
@@ -68,12 +72,14 @@ public class {{classname}} {
 {{#operations}}
 {{#operation}}
 
+    {{#swaggerAnnotations}}
     @ApiOperation(value = "{{{summary}}}",
             notes = "{{{notes}}}",
             nickname = "{{{operationId}}}",
             tags = { {{#tags}}{{#name}}"{{{.}}}"{{/name}}{{^-last}}, {{/-last}}{{/tags}} })
     @ApiResponses(value = { {{#responses}}
             @ApiResponse(code = {{{code}}}, message = "{{{message}}}") {{^-last}},{{/-last}}{{/responses}} })
+    {{/swaggerAnnotations}}
     {{#isDeprecated}}
     @Deprecated
     {{/isDeprecated}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
@@ -95,7 +95,9 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
+    {{#swaggerAnnotations}}
     swagger_annotations_version = "1.5.21"
+    {{/swaggerAnnotations}}
     rest_assured_version = "4.3.0"
     junit_version = "4.13.1"
 {{#jackson}}
@@ -123,7 +125,9 @@ ext {
 }
 
 dependencies {
+    {{#swaggerAnnotations}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swaggerAnnotations}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.rest-assured:rest-assured:$rest_assured_version"
 {{#jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.sbt.mustache
@@ -9,7 +9,9 @@ lazy val root = (project in file(".")).
     publishArtifact in (Compile, packageDoc) := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
+      {{#swaggerAnnotations}}
       "io.swagger" % "swagger-annotations" % "1.5.21",
+      {{/swaggerAnnotations}}
       "io.rest-assured" % "rest-assured" % "4.3.0",
       "io.rest-assured" % "scala-support" % "4.3.0",
       "com.google.code.findbugs" % "jsr305" % "3.0.2",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
@@ -219,11 +219,13 @@
     {{/jackson}}
 
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
         <!-- @Nullable annotation -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -346,7 +348,9 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.5.21</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         <rest-assured.version>4.3.0</rest-assured.version>
         <gson-version>2.8.6</gson-version>
         <gson-fire-version>1.8.4</gson-fire-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
@@ -94,7 +94,9 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
+    {{#swaggerAnnotations}}
     swagger_annotations_version = "1.5.22"
+    {{/swaggerAnnotations}}
     jackson_version = "2.10.5"
     jackson_databind_version = "2.10.5.1"
     {{#openApiNullable}}
@@ -107,7 +109,9 @@ ext {
 }
 
 dependencies {
+    {{#swaggerAnnotations}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swaggerAnnotations}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "org.jboss.resteasy:resteasy-client:$resteasy_version"
     implementation "org.jboss.resteasy:resteasy-multipart-provider:$resteasy_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.sbt.mustache
@@ -9,7 +9,9 @@ lazy val root = (project in file(".")).
     publishArtifact in (Compile, packageDoc) := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
+      {{#swaggerAnnotations}}
       "io.swagger" % "swagger-annotations" % "1.5.22" % "compile",
+      {{/swaggerAnnotations}}
       "org.jboss.resteasy" % "resteasy-client" % "3.1.3.Final" % "compile",
       "org.jboss.resteasy" % "resteasy-multipart-provider" % "4.5.11.Final" % "compile",
       "org.jboss.resteasy" % "resteasy-jackson2-provider" % "4.5.11.Final" % "compile",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -166,11 +166,13 @@
         </plugins>
     </build>
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
         <!-- @Nullable annotation -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -272,7 +274,9 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         <resteasy-version>4.5.11.Final</resteasy-version>
         <jackson-version>2.10.5</jackson-version>
         <jackson-databind-version>2.10.5.1</jackson-databind-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -107,7 +107,9 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
+    {{#swaggerAnnotations}}
     swagger_annotations_version = "1.5.22"
+    {{/swaggerAnnotations}}
     jackson_version = "2.10.5"
     jackson_databind_version = "2.10.5.1"
     {{#openApiNullable}}
@@ -123,7 +125,9 @@ ext {
 }
 
 dependencies {
+    {{#swaggerAnnotations}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swaggerAnnotations}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "org.springframework:spring-web:$spring_web_version"
     implementation "org.springframework:spring-context:$spring_web_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -211,11 +211,13 @@
     </profiles>
 
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
 
         <!-- @Nullable annotation -->
         <dependency>
@@ -315,7 +317,9 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         <spring-web-version>5.2.5.RELEASE</spring-web-version>
         <jackson-version>2.10.5</jackson-version>
         <jackson-databind-version>2.10.5.1</jackson-databind-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
@@ -104,7 +104,9 @@ ext {
     okhttp_version = "2.7.5"
     oltu_version = "1.0.1"
     retrofit_version = "1.9.0"
+    {{#swaggerAnnotations}}
     swagger_annotations_version = "1.5.21"
+    {{/swaggerAnnotations}}
     jakarta_annotation_version = "1.3.5"
     junit_version = "4.13.1"
     jodatime_version = "2.9.3"
@@ -117,7 +119,9 @@ dependencies {
     implementation "com.squareup.okhttp:okhttp:$okhttp_version"
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "com.squareup.retrofit:retrofit:$retrofit_version"
+    {{#swaggerAnnotations}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swaggerAnnotations}}
     implementation "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"
     implementation "joda-time:joda-time:$jodatime_version"
     {{#threetenbp}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.sbt.mustache
@@ -11,7 +11,9 @@ lazy val root = (project in file(".")).
     libraryDependencies ++= Seq(
       "com.squareup.okhttp" % "okhttp" % "2.7.5" % "compile",
       "com.squareup.retrofit" % "retrofit" % "1.9.0" % "compile",
+      {{#swaggerAnnotations}}
       "io.swagger" % "swagger-annotations" % "1.5.21" % "compile",
+      {{/swaggerAnnotations}}
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.1" % "compile",
       "joda-time" % "joda-time" % "2.9.3" % "compile",
       {{#threetenbp}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/pom.mustache
@@ -217,11 +217,13 @@
     </profiles>
 
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
         <!-- @Nullable annotation -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -280,7 +282,9 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.5.21</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         <retrofit-version>1.9.0</retrofit-version>
         <okhttp-version>2.7.5</okhttp-version>
         <jodatime-version>2.9.9</jodatime-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -126,7 +126,9 @@ ext {
     play_version = "2.6.7"
     {{/play26}}
     {{/usePlayWS}}
+    {{#swaggerAnnotations}}
     swagger_annotations_version = "1.5.22"
+    {{/swaggerAnnotations}}
     junit_version = "4.13.1"
     {{#useRxJava}}
     rx_java_version = "1.3.0"
@@ -162,7 +164,9 @@ dependencies {
     implementation 'com.github.akarnokd:rxjava3-retrofit-adapter:3.0.0'
     implementation "io.reactivex.rxjava3:rxjava:$rx_java_version"
     {{/useRxJava3}}
+    {{#swaggerAnnotations}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swaggerAnnotations}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation ("org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"){
         exclude group:'org.apache.oltu.oauth2' , module: 'org.apache.oltu.oauth2.common'

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.sbt.mustache
@@ -42,7 +42,9 @@ lazy val root = (project in file(".")).
       "com.github.akarnokd" % "rxjava3-retrofit-adapter" % "3.0.0" % "compile",
       "io.reactivex.rxjava3" % "rxjava" % "3.0.4" % "compile",
       {{/useRxJava3}}
+      {{#swaggerAnnotations}}
       "io.swagger" % "swagger-annotations" % "1.5.21" % "compile",
+      {{/swaggerAnnotations}}
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.1" % "compile",
       {{#joda}}
       "joda-time" % "joda-time" % "2.9.9" % "compile",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -217,11 +217,13 @@
     </profiles>
 
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
         <!-- @Nullable annotation -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -407,7 +409,9 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.3</gson-fire-version>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         {{#usePlayWS}}
         <jackson-version>2.12.1</jackson-version>
         {{#play24}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
@@ -27,7 +27,9 @@ task execute(type:JavaExec) {
 }
 
 ext {
+    {{#swaggerAnnotations}}
     swagger_annotations_version = "1.5.21"
+    {{/swaggerAnnotations}}
     jackson_version = "2.10.5"
     jackson_databind_version = "2.10.5.1"
     vertx_version = "3.4.2"
@@ -42,7 +44,9 @@ ext {
 }
 
 dependencies {
+    {{#swaggerAnnotations}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swaggerAnnotations}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.vertx:vertx-web-client:$vertx_version"
     implementation "io.vertx:vertx-rx-java:$vertx_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
@@ -211,11 +211,13 @@
     </profiles>
 
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
 
         <!-- @Nullable annotation -->
         <dependency>
@@ -305,7 +307,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <vertx-version>3.4.2</vertx-version>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         <jackson-version>2.10.5</jackson-version>
         <jackson-databind>2.10.5.1</jackson-databind>
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
@@ -123,7 +123,9 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
+    {{#swaggerAnnotations}}
     swagger_annotations_version = "1.6.2"
+    {{/swaggerAnnotations}}
     spring_web_version = "2.4.3"
     jackson_version = "2.11.3"
     jackson_databind_version = "2.11.3"
@@ -138,7 +140,9 @@ ext {
 }
 
 dependencies {
+    {{#swaggerAnnotations}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swaggerAnnotations}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.projectreactor:reactor-core:$reactor_version"
     implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_web_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
@@ -66,11 +66,13 @@
     </build>
 
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
 
         <!-- @Nullable annotation -->
         <dependency>
@@ -148,7 +150,9 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.6.2</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         <spring-web-version>2.4.3</spring-web-version>
         <jackson-version>2.11.3</jackson-version>
         <jackson-databind-version>2.11.3</jackson-databind-version>

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -2,8 +2,8 @@
  * {{description}}{{^description}}{{classname}}{{/description}}{{#isDeprecated}}
  * @deprecated{{/isDeprecated}}
  */{{#isDeprecated}}
-@Deprecated{{/isDeprecated}}{{#description}}
-@ApiModel(description = "{{{.}}}"){{/description}}
+@Deprecated{{/isDeprecated}}{{#swaggerAnnotations}}{{#description}}
+@ApiModel(description = "{{{.}}}"){{/description}}{{/swaggerAnnotations}}
 {{#jackson}}
 @JsonPropertyOrder({
 {{#vars}}
@@ -193,7 +193,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
 {{#jsonb}}
   @JsonbProperty("{{baseName}}")
 {{/jsonb}}
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  {{#swaggerAnnotations}}@ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}"){{/swaggerAnnotations}}
 {{#vendorExtensions.x-extra-annotation}}
   {{{vendorExtensions.x-extra-annotation}}}
 {{/vendorExtensions.x-extra-annotation}}

--- a/modules/openapi-generator/src/main/resources/Java/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pom.mustache
@@ -232,11 +232,13 @@
     </profiles>
 
     <dependencies>
+        {{#swaggerAnnotations}}
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        {{/swaggerAnnotations}}
 
         <!-- @Nullable annotation -->
         <dependency>
@@ -360,7 +362,9 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        {{#swaggerAnnotations}}
         <swagger-annotations-version>1.5.21</swagger-annotations-version>
+        {{/swaggerAnnotations}}
         <jersey-version>1.19.4</jersey-version>
         <jackson-version>2.12.1</jackson-version>
         {{#threetenbp}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Closes #8719 Added 'swaggerAnnotations' option for disabling generation of swagger annotations for 'java' generator
