### PR TITLE
Add hasQueryParamsOrAuth to reflect apiKey in query

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -88,6 +88,15 @@ public class CodegenOperation {
     }
 
     /**
+     * Check if there's at least one query parameter or passing API keys in query
+     *
+     * @return true if query parameter exists or passing API keys in query, false otherwise
+     */
+    public boolean getHasQueryParamsOrAuth() {
+        return getHasQueryParams() || (authMethods != null && authMethods.stream().anyMatch(authMethod -> authMethod.isKeyInQuery));
+    }
+
+    /**
      * Check if there's at least one header parameter
      *
      * @return true if header parameter exists, false otherwise

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -178,7 +178,7 @@ export class {{classname}} {
 {{/required}}
 {{/allParams}}
 
-{{#hasQueryParams}}
+{{#hasQueryParamsOrAuth}}
         let localVarQueryParameters = new HttpParams({encoder: this.encoder});
 {{#queryParams}}
         {{#isArray}}
@@ -209,7 +209,7 @@ export class {{classname}} {
         {{/isArray}}
 {{/queryParams}}
 
-{{/hasQueryParams}}
+{{/hasQueryParamsOrAuth}}
         let localVarHeaders = this.defaultHeaders;
 {{#headerParams}}
         {{#isArray}}
@@ -359,9 +359,9 @@ export class {{classname}} {
     {{#httpContextInOptions}}
                 context: localVarHttpContext,
     {{/httpContextInOptions}}
-    {{#hasQueryParams}}
+    {{#hasQueryParamsOrAuth}}
                 params: localVarQueryParameters,
-    {{/hasQueryParams}}
+    {{/hasQueryParamsOrAuth}}
     {{#isResponseFile}}
                 responseType: "blob",
     {{/isResponseFile}}


### PR DESCRIPTION
Compilation fails in generated typescript-angular client when an
`apiKey` is passed in query due to an uninitialised variable.

This change adds `getHasQueryParamsOrAuth()` to reflect if there's at
least one query parameter or passing API keys in query in the
`hasQueryParamsOrAuth` template variable.

To test, generate a typescript-angular client using a security schema like the
following:
```
securitySchemes:
  APIKeyQueryParam:
    type: apiKey
    in: query
    name: api_key
```
and compile it.
fixes #3701 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
