### PR TITLE
Changing from scriptName to x-codegen-script-name to fix dockerfile

### DIFF
--- a/modules/openapi-generator/src/main/resources/bash/Dockerfile.mustache
+++ b/modules/openapi-generator/src/main/resources/bash/Dockerfile.mustache
@@ -2,10 +2,10 @@ FROM alpine:3.12.0
 
 RUN apk add --update --no-cache curl ca-certificates bash bash-completion zsh curl git vim ncurses util-linux
 
-ADD {{scriptName}} /usr/bin/{{scriptName}}
-ADD _{{scriptName}} /usr/local/share/zsh/site-functions/_{{scriptName}}
-ADD {{scriptName}}.bash-completion /etc/bash-completion.d/{{scriptName}}
-RUN chmod 755 /usr/bin/{{scriptName}}
+ADD {{x-codegen-script-name}} /usr/bin/{{x-codegen-script-name}}
+ADD _{{x-codegen-script-name}} /usr/local/share/zsh/site-functions/_{{x-codegen-script-name}}
+ADD {{x-codegen-script-name}}.bash-completion /etc/bash-completion.d/{{x-codegen-script-name}}
+RUN chmod 755 /usr/bin/{{x-codegen-script-name}}
 
 #
 # Install oh-my-zsh
@@ -17,7 +17,7 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh
 #
 RUN echo '\n\
 . /etc/bash_completion\n\
-source /etc/bash-completion.d/{{scriptName}}\n\
+source /etc/bash-completion.d/{{x-codegen-script-name}}\n\
 ' >> ~/.bashrc
 
 #
@@ -51,13 +51,13 @@ For convenience, you can export the following environment variables:\n\
 $(tput setaf 7)Basic usage:$(tput sgr0)\n\
 \n\
 $(tput setaf 3)Print the list of operations available on the service$(tput sgr0)\n\
-$ {{scriptName}} -h\n\
+$ {{x-codegen-script-name}} -h\n\
 \n\
 $(tput setaf 3)Print the service description$(tput sgr0)\n\
-$ {{scriptName}} --about\n\
+$ {{x-codegen-script-name}} --about\n\
 \n\
 $(tput setaf 3)Print detailed information about specific operation$(tput sgr0)\n\
-$ {{scriptName}} <operationId> -h\n\
+$ {{x-codegen-script-name}} <operationId> -h\n\
 \n\
 By default you are logged into Zsh with full autocompletion for your REST API,\n\
 but you can switch to Bash, where basic autocompletion is also supported.\n\


### PR DESCRIPTION
This is a PR to fix the issue with the Bash Code generator not making valid docker files - see issue: https://github.com/OpenAPITools/openapi-generator/issues/10589

The mustache template is looking for `scriptName` which is not set - however `x-codegen-script-name` is set so I've modified the template to use the set variable


<!-- Please check the completed items below -->
### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

This targets Bash
@frol (2017/07) @bkryza (2017/08) @kenjones-cisco (2017/09)