### PR TITLE
refactor: equals avoids null

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/AuthorTemplate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/AuthorTemplate.java
@@ -56,7 +56,7 @@ public class AuthorTemplate extends OpenApiGeneratorCommand {
             if ("jar".equals(uri.getScheme())) {
                 Optional<FileSystemProvider> provider = FileSystemProvider.installedProviders()
                         .stream()
-                        .filter(p -> p.getScheme().equalsIgnoreCase("jar"))
+                        .filter(p -> "jar".equalsIgnoreCase(p.getScheme()))
                         .findFirst();
 
                 if (!provider.isPresent()) {

--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/OpenAPI2SpringBoot.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/OpenAPI2SpringBoot.java
@@ -33,7 +33,7 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
 
     @Override
     public void run(String... arg0) {
-        if (arg0.length > 0 && arg0[0].equals("exitcode")) {
+        if (arg0.length > 0 && "exitcode".equals(arg0[0])) {
             throw new ExitException();
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3767,7 +3767,7 @@ public class DefaultCodegen implements CodegenConfig {
     protected ApiResponse findMethodResponse(ApiResponses responses) {
         String code = null;
         for (String responseCode : responses.keySet()) {
-            if (responseCode.startsWith("2") || responseCode.equals("default")) {
+            if (responseCode.startsWith("2") || "default".equals(responseCode)) {
                 if (code == null || code.compareTo(responseCode) > 0) {
                     code = responseCode;
                 }
@@ -3833,7 +3833,7 @@ public class DefaultCodegen implements CodegenConfig {
                 // generate examples
                 String exampleStatusCode = "200";
                 for (String key : operation.getResponses().keySet()) {
-                    if (operation.getResponses().get(key) == methodResponse && !key.equals("default")) {
+                    if (operation.getResponses().get(key) == methodResponse && !"default".equals(key)) {
                         exampleStatusCode = key;
                     }
                 }
@@ -4741,7 +4741,7 @@ public class DefaultCodegen implements CodegenConfig {
     // TODO revise below as it should be replaced by ModelUtils.isFileSchema(parameterSchema)
     public boolean isDataTypeFile(String dataType) {
         if (dataType != null) {
-            return dataType.toLowerCase(Locale.ROOT).equals("file");
+            return "file".equals(dataType.toLowerCase(Locale.ROOT));
         } else {
             return false;
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -1489,7 +1489,7 @@ public class DefaultGenerator implements Generator {
                     // as documented for symlinks. So we need to trim any / or ./ from the start,
                     // as nobody should be generating into system root and our expectation is no ./
                     String relativePath = removeStart(removeStart(f.toString(), "." + File.separator), File.separator);
-                    if (File.separator.equals("\\")) {
+                    if ("\\".equals(File.separator)) {
                         // ensure that windows outputs same FILES format
                         relativePath = relativePath.replace(File.separator, "/");
                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/ignore/rules/Rule.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/ignore/rules/Rule.java
@@ -92,9 +92,9 @@ public abstract class Rule {
         // NOTE: Comments that start with a : (e.g. //:) are pulled from git documentation for .gitignore
         // see: https://github.com/git/git/blob/90f7b16b3adc78d4bbabbd426fb69aa78c714f71/Documentation/gitignore.txt
         Rule rule = null;
-        if (definition.equals(".")) {
+        if (".".equals(definition)) {
             return new InvalidRule(null, definition, "Pattern '.' is invalid.");
-        } else if (definition.equals("!.")) {
+        } else if ("!.".equals(definition)) {
             return new InvalidRule(null, definition, "Pattern '!.' is invalid.");
         } else if (definition.startsWith("..")) {
             return new InvalidRule(null, definition, "Pattern '..' is invalid.");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -280,7 +280,7 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
     @Override
     protected boolean needToImport(String type) {
         // Import everything, unless it is from dart:core.
-        return StringUtils.isNotBlank(type) && (!imports.containsKey(type) || !imports.get(type).equals("dart:core"));
+        return StringUtils.isNotBlank(type) && (!imports.containsKey(type) || !"dart:core".equals(imports.get(type)));
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -575,7 +575,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 typeMapping.put("DateTime", "OffsetDateTime");
                 importMapping.put("OffsetDateTime", "java.time.OffsetDateTime");
             }
-        } else if (dateLibrary.equals("legacy")) {
+        } else if ("legacy".equals(dateLibrary)) {
             additionalProperties.put("legacyDates", "true");
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -749,7 +749,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         String specialChar = specialCharacters.getKey();
         String replacementChar = specialCharacters.getValue();
         // Underscore is the only special character we'll allow
-        if (!specialChar.equals("_") && word.contains(specialChar)) {
+        if (!"_".equals(specialChar) && word.contains(specialChar)) {
             return replaceCharacters(word, specialChar, replacementChar);
         }
         return word;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonConnexionServerCodegen.java
@@ -645,8 +645,8 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
             if (operation.consumes != null) {
                 if (operation.consumes.size() == 1) {
                     Map<String, String> consume = operation.consumes.get(0);
-                    if (!("application/json".equals(consume.get(MEDIA_TYPE))
-                            || consume.get(MEDIA_TYPE).endsWith("+json"))) {
+                    if (!"application/json".equals(consume.get(MEDIA_TYPE))
+                            || consume.get(MEDIA_TYPE).endsWith("+json")) {
                         skipTests.put("reason", consume.get(MEDIA_TYPE) + " not supported by Connexion");
                         if ("multipart/form-data".equals(consume.get(MEDIA_TYPE))) {
                             operation.isMultipart = Boolean.TRUE;
@@ -674,7 +674,7 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
             if (operation.produces != null) {
                 for (Map<String, String> produce : operation.produces) {
                     operation.vendorExtensions.put("x-prefered-produce", produce);
-                    if (produce.get(MEDIA_TYPE).equals("application/json")) {
+                    if ("application/json".equals(produce.get(MEDIA_TYPE))) {
                         break;
                     }
                 }
@@ -684,7 +684,7 @@ public abstract class AbstractPythonConnexionServerCodegen extends AbstractPytho
             }
             if (operation.requestBodyExamples != null) {
                 for (Map<String, String> example : operation.requestBodyExamples) {
-                    if (example.get("contentType") != null && example.get("contentType").equals("application/json")) {
+                    if ("application/json".equals(example.get("contentType"))) {
                         operation.bodyParam.example = example.get("example");
                     }
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AndroidClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AndroidClientCodegen.java
@@ -242,8 +242,8 @@ public class AndroidClientCodegen extends DefaultCodegen implements CodegenConfi
         if (typeMapping.containsKey(openAPIType)) {
             type = typeMapping.get(openAPIType);
             if (languageSpecificPrimitives.contains(type) || type.indexOf(".") >= 0 ||
-                    type.equals("Map") || type.equals("List") ||
-                    type.equals("File") || type.equals("Date")) {
+                    "Map".equals(type) || "List".equals(type) ||
+                    "File".equals(type) || "Date".equals(type)) {
                 return type;
             }
         } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ApexClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ApexClientCodegen.java
@@ -254,7 +254,7 @@ public class ApexClientCodegen extends AbstractApexCodegen {
     }
 
     public void setBuildMethod(String buildMethod) {
-        if (buildMethod.equals("ant")) {
+        if ("ant".equals(buildMethod)) {
             this.srcPath = "deploy/";
         }
         this.buildMethod = buildMethod;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -472,7 +472,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                             continue;
                         }
 
-                        if(consumesString.toString().equals("")) {
+                        if("".equals(consumesString.toString())) {
                             consumesString = new StringBuilder("\"" + consume.get("mediaType") + "\"");
                         }
                         else {
@@ -480,7 +480,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                         }
 
                         // In a multipart/form-data consuming context binary data is best handled by an IFormFile
-                        if (!consume.get("mediaType").equals("multipart/form-data")) {
+                        if (!"multipart/form-data".equals(consume.get("mediaType"))) {
                             continue;
                         }
 
@@ -500,7 +500,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                         }
                     }
 
-                    if(!consumesString.toString().equals("")) {
+                    if(!"".equals(consumesString.toString())) {
                         operation.vendorExtensions.put("x-aspnetcore-consumes", consumesString.toString());
                     }
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/BashClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/BashClientCodegen.java
@@ -652,7 +652,7 @@ public class BashClientCodegen extends DefaultCodegen implements CodegenConfig {
                 if (codesample instanceof ObjectNode) {
                     ObjectNode codesample_object = (ObjectNode) codesample;
 
-                    if ((codesample_object.get("lang").asText()).equals("Shell")) {
+                    if ("Shell".equals((codesample_object.get("lang").asText()))) {
 
                         op.vendorExtensions.put("x-bash-codegen-sample",
                                 escapeUnsafeCharacters(

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -275,7 +275,7 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
             }
             if (op.consumes != null) {
                 for (Map<String, String> consume : op.consumes) {
-                    if (consume.get("mediaType") != null && consume.get("mediaType").equals("application/json")) {
+                    if ("application/json".equals(consume.get("mediaType"))) {
                         consumeJson = true;
                     }
                 }
@@ -462,7 +462,7 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
      */
     @Override
     public String modelFileFolder() {
-        return (outputFolder + "/model").replace("/", File.separator);
+        return outputFolder + "/model".replace("/", File.separator);
     }
 
     /**
@@ -471,11 +471,11 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
      */
     @Override
     public String apiFileFolder() {
-        return (outputFolder + "/api").replace("/", File.separator);
+        return outputFolder + "/api".replace("/", File.separator);
     }
 
     private String implFileFolder() {
-        return (outputFolder + "/" + implFolder).replace("/", File.separator);
+        return outputFolder + "/" + implFolder.replace("/", File.separator);
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
@@ -322,7 +322,7 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
     }
 
     protected boolean isFileSchema(CodegenProperty property) {
-        return property.baseType.equals("HttpContent");
+        return "HttpContent".equals(property.baseType);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTinyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTinyClientCodegen.java
@@ -292,11 +292,11 @@ public class CppTinyClientCodegen extends AbstractCppCodegen implements CodegenC
 
     @Override
     public String toModelImport(String name) {
-        if (name.equals("std::string")) {
+        if ("std::string".equals(name)) {
             return "#include <string>";
-        } else if (name.equals("std::list")) {
+        } else if ("std::list".equals(name)) {
             return "#include <list>";
-        } else if (name.equals("Map")) {
+        } else if ("Map".equals(name)) {
             return "#include <map>";
         }
         return "#include \"" + name + ".h\"";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTizenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTizenClientCodegen.java
@@ -219,11 +219,11 @@ public class CppTizenClientCodegen extends AbstractCppCodegen implements Codegen
 
     @Override
     public String toModelImport(String name) {
-        if (name.equals("std::string")) {
+        if ("std::string".equals(name)) {
             return "#include <string>";
-        } else if (name.equals("std::map")) {
+        } else if ("std::map".equals(name)) {
             return "#include <map>";
-        } else if (name.equals("std::list")) {
+        } else if ("std::list".equals(name)) {
             return "#include <list>";
         }
         return "#include \"" + name + ".h\"";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -273,7 +273,7 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
 
         for (CodegenOperation op : operationList) {
             for (CodegenParameter param : op.bodyParams) {
-                if (param.baseType != null && param.baseType.equalsIgnoreCase("Uint8List") && op.isMultipart) {
+                if ("Uint8List".equalsIgnoreCase(param.baseType) && op.isMultipart) {
                     param.baseType = "MultipartFile";
                     param.dataType = "MultipartFile";
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioNextClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioNextClientCodegen.java
@@ -359,9 +359,9 @@ public class DartDioNextClientCodegen extends AbstractDartCodegen {
             //
             // The following block removes the required import for Uint8List if it is no
             // longer in use.
-            if (op.allParams.stream().noneMatch(param -> param.dataType.equals("Uint8List"))
+            if (op.allParams.stream().noneMatch(param -> "Uint8List".equals(param.dataType))
                     && op.responses.stream().filter(response -> response.dataType != null)
-                            .noneMatch(response -> response.dataType.equals("Uint8List"))) {
+                            .noneMatch(response -> "Uint8List".equals(response.dataType))) {
                 // Remove unused imports after processing
                 op.imports.remove("Uint8List");
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartJaguarClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartJaguarClientCodegen.java
@@ -262,29 +262,29 @@ public class DartJaguarClientCodegen extends AbstractDartCodegen {
                 for (Map<String, String> consume : op.consumes) {
                     if (consume.containsKey("mediaType")) {
                         String type = consume.get("mediaType");
-                        isJson = type.equalsIgnoreCase("application/json");
-                        isProto = type.equalsIgnoreCase("application/octet-stream");
-                        isForm = type.equalsIgnoreCase("application/x-www-form-urlencoded");
-                        isMultipart = type.equalsIgnoreCase("multipart/form-data");
+                        isJson = "application/json".equalsIgnoreCase(type);
+                        isProto = "application/octet-stream".equalsIgnoreCase(type);
+                        isForm = "application/x-www-form-urlencoded".equalsIgnoreCase(type);
+                        isMultipart = "multipart/form-data".equalsIgnoreCase(type);
                         break;
                     }
                 }
             }
 
             for (CodegenParameter param : op.allParams) {
-                if (param.baseType != null && param.baseType.equalsIgnoreCase("List<int>") && isMultipart) {
+                if ("List<int>".equalsIgnoreCase(param.baseType) && isMultipart) {
                     param.baseType = "MultipartFile";
                     param.dataType = "MultipartFile";
                 }
             }
             for (CodegenParameter param : op.formParams) {
-                if (param.baseType != null && param.baseType.equalsIgnoreCase("List<int>") && isMultipart) {
+                if ("List<int>".equalsIgnoreCase(param.baseType) && isMultipart) {
                     param.baseType = "MultipartFile";
                     param.dataType = "MultipartFile";
                 }
             }
             for (CodegenParameter param : op.bodyParams) {
-                if (param.baseType != null && param.baseType.equalsIgnoreCase("List<int>") && isMultipart) {
+                if ("List<int>".equalsIgnoreCase(param.baseType) && isMultipart) {
                     param.baseType = "MultipartFile";
                     param.dataType = "MultipartFile";
                 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -591,7 +591,7 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
             this.jsonSchema = o.jsonSchema;
             this.vendorExtensions = o.vendorExtensions;
 
-            this.isDefinedDefault = (this.code.equals("0") || this.code.equals("default"));
+            this.isDefinedDefault = ("0".equals(this.code) || "default".equals(this.code));
         }
 
         public String codeMappingKey() {
@@ -744,8 +744,8 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
                     returnEntry.append(returnBaseType);
                     returnEntry.append(".t");
                 } else {
-                    if (exResponse.containerType.equals("array") ||
-                            exResponse.containerType.equals("set")) {
+                    if ("array".equals(exResponse.containerType) ||
+                            "set".equals(exResponse.containerType)) {
                         returnEntry.append("list(");
                         if (!exResponse.primitiveType) {
                             returnEntry.append(moduleName);
@@ -753,7 +753,7 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
                         }
                         returnEntry.append(exResponse.baseType);
                         returnEntry.append(".t)");
-                    } else if (exResponse.containerType.equals("map")) {
+                    } else if ("map".equals(exResponse.containerType)) {
                         returnEntry.append("map()");
                     }
                 }
@@ -822,7 +822,7 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
 
         private boolean getRequiresHttpcWorkaround() {
             // Only POST/PATCH/PUT are affected from the httpc bug
-            if (!(this.httpMethod.equals("POST") || this.httpMethod.equals("PATCH") || this.httpMethod.equals("PUT"))) {
+            if (!("POST".equals(this.httpMethod) || "PATCH".equals(this.httpMethod) || "PUT".equals(this.httpMethod))) {
                 return false;
             }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
@@ -563,7 +563,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
 
         // Add the HTTP method and return type
         String returnType = op.returnType;
-        if (returnType == null || returnType.equals("null")) {
+        if (returnType == null || "null".equals(returnType)) {
             returnType = "NoContent";
         }
         if (returnType.indexOf(" ") >= 0) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellYesodServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellYesodServerCodegen.java
@@ -447,7 +447,7 @@ public class HaskellYesodServerCodegen extends DefaultCodegen implements Codegen
         op.vendorExtensions.put("x-handler", handler);
         op.vendorExtensions.put("x-param-indent", paramIndent);
         op.vendorExtensions.put("x-resource", resource);
-        op.vendorExtensions.put("x-is-get-or-post", op.httpMethod.equals("GET") || op.httpMethod.equals("POST"));
+        op.vendorExtensions.put("x-is-get-or-post", "GET".equals(op.httpMethod) || "POST".equals(op.httpMethod));
         for (CodegenParameter param : op.pathParams) {
             param.vendorExtensions.put("x-handler", handler);
             param.vendorExtensions.put("x-param-indent", paramIndent);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFExtServerCodegen.java
@@ -234,7 +234,7 @@ public class JavaCXFExtServerCodegen extends JavaCXFServerCodegen implements CXF
         }
 
         private boolean isIndexed() {
-            return isListContainer || isArray && !dataType.equals("byte[]");
+            return isListContainer || isArray && !"byte[]".equals(dataType);
         }
 
         private boolean isListItem() {
@@ -337,7 +337,7 @@ public class JavaCXFExtServerCodegen extends JavaCXFServerCodegen implements CXF
     private void appendArrayValue(StringBuilder buffer, String indent, CodegenOperation op, CodegenVariable var,
                                   String localVar, Collection<String> localVars, Map<String, CodegenModel> models) {
 
-        if (var.dataType.equals("byte[]")) {
+        if ("byte[]".equals(var.dataType)) {
             // Byte arrays are represented as Base64-encoded strings.
             appendByteArrayValue(buffer, indent, op, var, localVar, localVars, models);
         } else {
@@ -586,8 +586,8 @@ public class JavaCXFExtServerCodegen extends JavaCXFServerCodegen implements CXF
             long minDate = MIN_DATE;
             long maxDate = MAX_DATE;
             if (var != null) {
-                DateFormat df = var.dataFormat.equals("date-time") ? ISO8601_DATETIME_FORMAT.get() : ISO8601_DATE_FORMAT.get();
-                String isoFormat = var.dataFormat.equals("date-time") ? "date-time" : "full-date";
+                DateFormat df = "date-time".equals(var.dataFormat) ? ISO8601_DATETIME_FORMAT.get() : ISO8601_DATE_FORMAT.get();
+                String isoFormat = "date-time".equals(var.dataFormat) ? "date-time" : "full-date";
                 if (var.minimum != null) {
                     try {
                         minDate = df.parse(var.minimum).getTime();
@@ -812,7 +812,7 @@ public class JavaCXFExtServerCodegen extends JavaCXFServerCodegen implements CXF
     private void appendScalarValue(StringBuilder buffer, String indent, CodegenOperation op, CodegenVariable var,
                                    String localVar, Collection<String> localVars, Map<String, CodegenModel> models) {
 
-        if (!var.isPrimitiveType && !DATE_TYPES.contains(var.dataType) || var.dataType.equals("Object")) {
+        if (!var.isPrimitiveType && !DATE_TYPES.contains(var.dataType) || "Object".equals(var.dataType)) {
             // All other non-container types: allocate a new object on the heap.
             appendObjectValue(buffer, indent, op, var, localVar, localVars, models);
         } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMicronautClientCodegen.java
@@ -112,7 +112,7 @@ public class JavaMicronautClientCodegen extends AbstractJavaCodegen implements B
         cliOptions.add(testToolOption);
 
         // Remove the date library option
-        cliOptions.stream().filter(o -> o.getOpt().equals("dateLibrary")).findFirst()
+        cliOptions.stream().filter(o -> "dateLibrary".equals(o.getOpt())).findFirst()
                 .ifPresent(v -> cliOptions.remove(v));
 
         // Add reserved words

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaPKMSTServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaPKMSTServerCodegen.java
@@ -471,7 +471,7 @@ public class JavaPKMSTServerCodegen extends AbstractJavaCodegen {
         // get vendor extensions
 
         Map<String, Object> vendorExt = openAPI.getInfo().getExtensions();
-        if (vendorExt != null && !vendorExt.toString().equals("")) {
+        if (vendorExt != null && !"".equals(vendorExt.toString())) {
             if (vendorExt.containsKey("x-codegen")) {
 
                 Map<String, String> uris = (Map<String, String>) vendorExt.get("x-codegen");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaPlayFrameworkCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaPlayFrameworkCodegen.java
@@ -327,10 +327,10 @@ public class JavaPlayFrameworkCodegen extends AbstractJavaCodegen implements Bea
                 }
 
                 if (operation.returnType != null) {
-                    if (operation.returnType.equals("Boolean")) {
+                    if ("Boolean".equals(operation.returnType)) {
                         operation.vendorExtensions.put("x-missing-return-info-if-needed", "true");
                     }
-                    if (operation.returnType.equals("BigDecimal")) {
+                    if ("BigDecimal".equals(operation.returnType)) {
                         operation.vendorExtensions.put("x-missing-return-info-if-needed", "1.0");
                     }
                     if (operation.returnType.startsWith("List")) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptApolloClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptApolloClientCodegen.java
@@ -347,7 +347,7 @@ public class JavascriptApolloClientCodegen extends DefaultCodegen implements Cod
     private String createPath(String... segments) {
         StringBuilder buf = new StringBuilder();
         for (String segment : segments) {
-            if (!StringUtils.isEmpty(segment) && !segment.equals(".")) {
+            if (!StringUtils.isEmpty(segment) && !".".equals(segment)) {
                 if (buf.length() != 0)
                     buf.append(File.separatorChar);
                 buf.append(segment);
@@ -865,9 +865,9 @@ public class JavascriptApolloClientCodegen extends DefaultCodegen implements Cod
 
     private String getJSDocType(CodegenModel cm, CodegenProperty cp) {
         if (Boolean.TRUE.equals(cp.isContainer)) {
-            if (cp.containerType.equals("array"))
+            if ("array".equals(cp.containerType))
                 return "Array.<" + cp.items + ">";
-            else if (cp.containerType.equals("map"))
+            else if ("map".equals(cp.containerType))
                 return "Object.<String, " + cp.items + ">";
         }
         String dataType = trimBrackets(cp.datatypeWithEnum);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
@@ -379,7 +379,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
     private String createPath(String... segments) {
         StringBuilder buf = new StringBuilder();
         for (String segment : segments) {
-            if (!StringUtils.isEmpty(segment) && !segment.equals(".")) {
+            if (!StringUtils.isEmpty(segment) && !".".equals(segment)) {
                 if (buf.length() != 0)
                     buf.append(File.separatorChar);
                 buf.append(segment);
@@ -926,9 +926,9 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
 
     private String getJSDocType(CodegenModel cm, CodegenProperty cp) {
         if (Boolean.TRUE.equals(cp.isContainer)) {
-            if (cp.containerType.equals("array") || cp.containerType.equals("set"))
+            if ("array".equals(cp.containerType) || "set".equals(cp.containerType))
                 return "Array.<" + getJSDocType(cm, cp.items) + ">";
-            else if (cp.containerType.equals("map"))
+            else if ("map".equals(cp.containerType))
                 return "Object.<String, " + getJSDocType(cm, cp.items) + ">";
         }
         String dataType = trimBrackets(cp.datatypeWithEnum);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClosureAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClosureAngularClientCodegen.java
@@ -231,10 +231,10 @@ public class JavascriptClosureAngularClientCodegen extends DefaultCodegen implem
             return "Object";
         }
         String type = super.getTypeDeclaration(p);
-        if (type.equals("boolean") ||
-                type.equals("Date") ||
-                type.equals("number") ||
-                type.equals("string")) {
+        if ("boolean".equals(type) ||
+                "Date".equals(type) ||
+                "number".equals(type) ||
+                "string".equals(type)) {
             return type;
                 }
         return apiPackage + "." + type;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
@@ -244,7 +244,7 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
         public HTTPRequest(String method, String path, @Nullable List<Parameter> query, @Nullable HTTPBody body,
                            @Nullable HTTPParameters params, @Nullable List<k6Check> k6Checks) {
             // NOTE: https://k6.io/docs/javascript-api/k6-http/del-url-body-params
-            this.method = method.equals("delete") ? "del" : method;
+            this.method = "delete".equals(method) ? "del" : method;
             this.path = path;
             this.query = query;
             this.body = body;
@@ -418,7 +418,7 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
                 final PathItem.HttpMethod method = methodOperation.getKey();
 
                 for (Map.Entry<String, ApiResponse> resp : operation.getResponses().entrySet()) {
-                    String statusData = resp.getKey().equals("default") ? "200" : resp.getKey();
+                    String statusData = "default".equals(resp.getKey()) ? "200" : resp.getKey();
                     int status = Integer.parseInt(statusData);
                     if (status >= 200 && status < 300) {
                         k6Checks.add(new k6Check(status, resp.getValue().getDescription()));
@@ -429,7 +429,7 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
                     String defaultContentType = hasFormParameter(openAPI, operation) ? "application/x-www-form-urlencoded" : "application/json";
                     List<String> consumes = new ArrayList<>(getConsumesInfo(openAPI, operation));
                     String contentTypeValue = consumes == null || consumes.isEmpty() ? defaultContentType : consumes.get(0);
-                    if (contentTypeValue.equals("*/*"))
+                    if ("*/*".equals(contentTypeValue))
                         contentTypeValue = "application/json";
                     Parameter contentType = new Parameter("Content-Type", getDoubleQuotedString(contentTypeValue));
                     httpParams.add(contentType);
@@ -452,13 +452,13 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
                             Schema nestedSchema = ModelUtils.getSchema(openAPI, parameter.baseType);
                             CodegenModel model = fromModel(parameter.paramName, nestedSchema);
                             reference = generateNestedModelTemplate(model);
-                            if (parameter.dataType.equals("List")) {
+                            if ("List".equals(parameter.dataType)) {
                                 reference = "[" + reference + "]";
                             }
                         }
 
                         Parameter k6Parameter;
-                        if (parameter.dataType.equals("File")) {
+                        if ("File".equals(parameter.dataType)) {
                             k6Parameter = new Parameter(parameter.paramName,
                                     "http.file(open(\"/path/to/file.bin\", \"b\"), \"test.bin\")");
                         } else {
@@ -482,7 +482,7 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
                                 break;
                             case "path":
                             case "query":
-                                if (parameter.getIn().equals("query"))
+                                if ("query".equals(parameter.getIn()))
                                     queryParams.add(new Parameter(parameter.getName(), getTemplateVariable(parameter.getName())));
                                 if (!pathVariables.containsKey(path)) {
                                     // use 'example' field defined at the parameter level of OpenAPI spec
@@ -641,7 +641,7 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
     private String createPath(String... segments) {
         StringBuilder buf = new StringBuilder();
         for (String segment : segments) {
-            if (!StringUtils.isEmpty(segment) && !segment.equals(".")) {
+            if (!StringUtils.isEmpty(segment) && !".".equals(segment)) {
                 if (buf.length() != 0)
                     buf.append(File.separatorChar);
                 buf.append(segment);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -329,8 +329,8 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
         }
 
         // infrastructure destination folder
-        final String infrastructureFolder = (sourceFolder + File.separator + packageName + File.separator + "infrastructure").replace(".", "/");
-        authFolder = (sourceFolder + File.separator + packageName + File.separator + "auth").replace(".", "/");
+        final String infrastructureFolder = sourceFolder + File.separator + packageName + File.separator + "infrastructure".replace(".", "/");
+        authFolder = sourceFolder + File.separator + packageName + File.separator + "auth".replace(".", "/");
 
         // additional properties
         if (additionalProperties.containsKey(DATE_LIBRARY)) {
@@ -681,7 +681,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
                 // modify the data type of binary form parameters to a more friendly type for multiplatform builds
                 if (MULTIPLATFORM.equals(getLibrary()) && operation.allParams != null) {
                     for (CodegenParameter param : operation.allParams) {
-                        if (param.dataFormat != null && param.dataFormat.equals("binary")) {
+                        if ("binary".equals(param.dataFormat)) {
                             param.baseType = param.dataType = "io.ktor.client.request.forms.InputProvider";
                         }
                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -454,7 +454,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
                 basePath = basePath.substring(0, pos);
             }
 
-            if (basePath.equals("")) {
+            if ("".equals(basePath)) {
                 basePath = "default";
             } else {
                 co.subresourceOperation = !co.path.isEmpty();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KtormSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KtormSchemaCodegen.java
@@ -293,7 +293,7 @@ public class KtormSchemaCodegen extends AbstractKotlinCodegen {
             Map<String, Object> ktormSchema = new HashMap<String, Object>();
             Map<String, Object> tableDefinition = new HashMap<String, Object>();
 
-            if (getIdentifierNamingConvention().equals("snake_case") && !modelName.equals(tableName)) {
+            if ("snake_case".equals(getIdentifierNamingConvention()) && !modelName.equals(tableName)) {
                 // add original name in table comment
                 String commentExtra = "Original model name - " + modelName + ".";
                 modelDescription = (modelDescription == null || modelDescription.isEmpty()) ? commentExtra : modelDescription + ". " + commentExtra;
@@ -365,7 +365,7 @@ public class KtormSchemaCodegen extends AbstractKotlinCodegen {
 
         vendorExtensions.put(VENDOR_EXTENSION_SCHEMA, ktormSchema);
 
-        if (getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+        if ("snake_case".equals(getIdentifierNamingConvention()) && !baseName.equals(colName)) {
             // add original name in column comment
             String commentExtra = "Original param name - " + baseName + ".";
             description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
@@ -948,7 +948,7 @@ public class KtormSchemaCodegen extends AbstractKotlinCodegen {
     private Map<String, Object> toColumnTypeDefault(String defaultValue, String dataType, String dataFormat) {
         String sqlType = toColumnType(dataType, dataFormat);
         String sqlDefault = "";
-        if (defaultValue == null || defaultValue.toUpperCase(Locale.ROOT).equals("NULL")) {
+        if (defaultValue == null || "NULL".equals(defaultValue.toUpperCase(Locale.ROOT))) {
             sqlType = "null";
         }
         //special case for keywords if needed
@@ -1001,7 +1001,7 @@ public class KtormSchemaCodegen extends AbstractKotlinCodegen {
      */
     public String toTableName(String name) {
         String identifier = toIdentifier(name, tableNamePrefix, tableNameSuffix);
-        if (identifierNamingConvention.equals("snake_case")) {
+        if ("snake_case".equals(identifierNamingConvention)) {
             identifier = underscore(identifier);
         }
         if (identifier.length() > IDENTIFIER_MAX_LENGTH) {
@@ -1020,7 +1020,7 @@ public class KtormSchemaCodegen extends AbstractKotlinCodegen {
      */
     public String toColumnName(String name) {
         String identifier = toIdentifier(name, columnNamePrefix, columnNameSuffix);
-        if (identifierNamingConvention.equals("snake_case")) {
+        if ("snake_case".equals(identifierNamingConvention)) {
             identifier = underscore(identifier);
         }
         if (identifier.length() > IDENTIFIER_MAX_LENGTH) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MysqlSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MysqlSchemaCodegen.java
@@ -266,7 +266,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             Map<String, Object> mysqlSchema = new HashMap<String, Object>();
             Map<String, Object> tableDefinition = new HashMap<String, Object>();
 
-            if (this.getIdentifierNamingConvention().equals("snake_case") && !modelName.equals(tableName)) {
+            if ("snake_case".equals(this.getIdentifierNamingConvention()) && !modelName.equals(tableName)) {
                 // add original name in table comment
                 String commentExtra = "Original model name - " + modelName + ".";
                 modelDescription = (modelDescription == null || modelDescription.isEmpty()) ? commentExtra : modelDescription + ". " + commentExtra;
@@ -349,7 +349,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
-        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+        if ("snake_case".equals(this.getIdentifierNamingConvention()) && !baseName.equals(colName)) {
             // add original name in column comment
             String commentExtra = "Original param name - " + baseName + ".";
             description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
@@ -440,7 +440,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
-        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+        if ("snake_case".equals(this.getIdentifierNamingConvention()) && !baseName.equals(colName)) {
             // add original name in column comment
             String commentExtra = "Original param name - " + baseName + ".";
             description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
@@ -522,7 +522,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
-        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+        if ("snake_case".equals(this.getIdentifierNamingConvention()) && !baseName.equals(colName)) {
             // add original name in column comment
             String commentExtra = "Original param name - " + baseName + ".";
             description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
@@ -582,7 +582,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
-        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+        if ("snake_case".equals(this.getIdentifierNamingConvention()) && !baseName.equals(colName)) {
             // add original name in column comment
             String commentExtra = "Original param name - " + baseName + ".";
             description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
@@ -607,12 +607,12 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
                 String value = String.valueOf(enumValues.get(i));
                 columnDataTypeArguments.add(toCodegenMysqlDataTypeArgument(value));
             }
-        } else if (dataType.equals("MEDIUMBLOB")) {
+        } else if ("MEDIUMBLOB".equals(dataType)) {
             columnDefinition.put("colDataType", "MEDIUMBLOB");
         } else {
             String matchedStringType = getMysqlMatchedStringDataType(minLength, maxLength);
             columnDefinition.put("colDataType", matchedStringType);
-            if (matchedStringType.equals("CHAR") || matchedStringType.equals("VARCHAR")) {
+            if ("CHAR".equals(matchedStringType) || "VARCHAR".equals(matchedStringType)) {
                 columnDefinition.put("colDataTypeArguments", columnDataTypeArguments);
                 columnDataTypeArguments.add(toCodegenMysqlDataTypeArgument((maxLength != null) ? maxLength : 255));
             }
@@ -660,7 +660,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
-        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+        if ("snake_case".equals(this.getIdentifierNamingConvention()) && !baseName.equals(colName)) {
             // add original name in column comment
             String commentExtra = "Original param name - " + baseName + ".";
             description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
@@ -713,7 +713,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
-        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+        if ("snake_case".equals(this.getIdentifierNamingConvention()) && !baseName.equals(colName)) {
             // add original name in column comment
             String commentExtra = "Original param name - " + baseName + ".";
             description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
@@ -769,7 +769,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
-        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+        if ("snake_case".equals(this.getIdentifierNamingConvention()) && !baseName.equals(colName)) {
             // add original name in column comment
             String commentExtra = "Original param name - " + baseName + ".";
             description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
@@ -839,7 +839,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
      */
     public HashMap<String, Object> toCodegenMysqlDataTypeDefault(String defaultValue, String mysqlDataType) {
         HashMap<String, Object> defaultMap = new HashMap<String, Object>();
-        if (defaultValue == null || defaultValue.toUpperCase(Locale.ROOT).equals("NULL")) {
+        if (defaultValue == null || "NULL".equals(defaultValue.toUpperCase(Locale.ROOT))) {
             defaultMap.put("defaultValue", "NULL");
             defaultMap.put("isString", false);
             defaultMap.put("isNumeric", false);
@@ -854,7 +854,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             case "INT":
             case "BIGINT":
                 // SERIAL DEFAULT VALUE is a special case. In the definition of an integer column, it is an alias for NOT NULL AUTO_INCREMENT UNIQUE
-                if (defaultValue.equals("SERIAL DEFAULT VALUE")) {
+                if ("SERIAL DEFAULT VALUE".equals(defaultValue)) {
                     defaultMap.put("defaultValue", defaultValue);
                     defaultMap.put("isString", false);
                     defaultMap.put("isNumeric", false);
@@ -869,7 +869,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             case "TIMESTAMP":
             case "DATETIME":
                 // The exception is that, for TIMESTAMP and DATETIME columns, you can specify CURRENT_TIMESTAMP as the default
-                if (defaultValue.equals("CURRENT_TIMESTAMP")) {
+                if ("CURRENT_TIMESTAMP".equals(defaultValue)) {
                     defaultMap.put("defaultValue", defaultValue);
                     defaultMap.put("isString", false);
                     defaultMap.put("isNumeric", false);
@@ -993,7 +993,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
                         mysqlDateAndTimeTypes.contains(dataType.toUpperCase(Locale.ROOT)) ||
                         mysqlStringTypes.contains(dataType.toUpperCase(Locale.ROOT)) ||
                         mysqlSpatialTypes.contains(dataType.toUpperCase(Locale.ROOT)) ||
-                        dataType.toUpperCase(Locale.ROOT).equals("JSON")
+                        "JSON".equals(dataType.toUpperCase(Locale.ROOT))
         );
     }
 
@@ -1022,7 +1022,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
      */
     public String toTableName(String name) {
         String identifier = toMysqlIdentifier(name, tableNamePrefix, tableNameSuffix);
-        if (identifierNamingConvention.equals("snake_case")) {
+        if ("snake_case".equals(identifierNamingConvention)) {
             identifier = underscore(identifier);
         }
         if (identifier.length() > IDENTIFIER_MAX_LENGTH) {
@@ -1041,7 +1041,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
      */
     public String toColumnName(String name) {
         String identifier = toMysqlIdentifier(name, columnNamePrefix, columnNameSuffix);
-        if (identifierNamingConvention.equals("snake_case")) {
+        if ("snake_case".equals(identifierNamingConvention)) {
             identifier = underscore(identifier);
         }
         if (identifier.length() > IDENTIFIER_MAX_LENGTH) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NodeJSExpressServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NodeJSExpressServerCodegen.java
@@ -186,7 +186,7 @@ public class NodeJSExpressServerCodegen extends DefaultCodegen implements Codege
     public String apiFilename(String templateName, String tag) {
         String result = super.apiFilename(templateName, tag);
 
-        if (templateName.equals("service.mustache")) {
+        if ("service.mustache".equals(templateName)) {
             String stringToMatch = File.separator + "controllers" + File.separator;
             String replacement = File.separator + implFolder + File.separator;
             result = result.replace(stringToMatch, replacement);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ObjcClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ObjcClientCodegen.java
@@ -246,7 +246,7 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
 
         if (additionalProperties.containsKey(CORE_DATA)) {
             Object coreData = additionalProperties.get(CORE_DATA);
-            if (((String) coreData).equalsIgnoreCase("true")) {
+            if ("true".equalsIgnoreCase(((String) coreData))) {
                 generateCoreData = true;
             }
         }
@@ -697,7 +697,7 @@ public class ObjcClientCodegen extends DefaultCodegen implements CodegenConfig {
             }
         } else if (ModelUtils.isBooleanSchema(p)) {
             if (p.getDefault() != null) {
-                if (p.getDefault().toString().equalsIgnoreCase("false"))
+                if ("false".equalsIgnoreCase(p.getDefault().toString()))
                     return "@(NO)";
                 else
                     return "@(YES)";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLaravelServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLaravelServerCodegen.java
@@ -286,7 +286,7 @@ public class PhpLaravelServerCodegen extends AbstractPhpCodegen {
     @Override
     public String apiFilename(String templateName, String tag) {
         String suffix = apiTemplateFiles().get(templateName);
-        if (templateName.equals("api.mustache")) {
+        if ("api.mustache".equals(templateName)) {
             return controllerFileFolder() + '/' + toControllerName(tag) + suffix;
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PowerShellClientCodegen.java
@@ -1350,7 +1350,7 @@ public class PowerShellClientCodegen extends DefaultCodegen implements CodegenCo
 
         if (
             StringUtils.isEmpty(codegenExample) ||
-            codegenExample.equals("null") ||
+            "null".equals(codegenExample) ||
             codegenExample.equals(genericStringExample)
         ) {
             example.append("My" + codegenName);
@@ -1379,7 +1379,7 @@ public class PowerShellClientCodegen extends DefaultCodegen implements CodegenCo
     private String constructNumericExample(String codegenExample) {
         StringBuilder example = new StringBuilder();
 
-        if (StringUtils.isEmpty(codegenExample) || codegenExample.equals("null")) {
+        if (StringUtils.isEmpty(codegenExample) || "null".equals(codegenExample)) {
             example.append("0");
         } else {
             example.append(codegenExample);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -140,7 +140,7 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
         // add the models and apis folders
         supportingFiles.add(new SupportingFile("__init__models.mustache", packagePath() + File.separatorChar + "models", "__init__.py"));
         SupportingFile originalInitModel = supportingFiles.stream()
-                .filter(sf -> sf.getTemplateFile().equals("__init__model.mustache"))
+                .filter(sf -> "__init__model.mustache".equals(sf.getTemplateFile()))
                 .reduce((a, b) -> {
                     throw new IllegalStateException("Multiple elements: " + a + ", " + b);
                 })
@@ -861,9 +861,9 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
             originalSpecVersion = originalSpecVersion.substring(0, 1);
 
         }
-        Boolean v2DisallowAdditionalPropertiesIfNotPresentAddPropsNullCase = (getAdditionalProperties(p) == null && this.getDisallowAdditionalPropertiesIfNotPresent() && originalSpecVersion.equals("2"));
+        Boolean v2DisallowAdditionalPropertiesIfNotPresentAddPropsNullCase = (getAdditionalProperties(p) == null && this.getDisallowAdditionalPropertiesIfNotPresent() && "2".equals(originalSpecVersion));
         Schema emptySchema = new Schema();
-        Boolean v2WithCompositionAddPropsAnyTypeSchemaCase = (getAdditionalProperties(p) != null && emptySchema.equals(getAdditionalProperties(p)) && originalSpecVersion.equals("2"));
+        Boolean v2WithCompositionAddPropsAnyTypeSchemaCase = (getAdditionalProperties(p) != null && emptySchema.equals(getAdditionalProperties(p)) && "2".equals(originalSpecVersion));
         if (isFreeFormObject(p) && (v2DisallowAdditionalPropertiesIfNotPresentAddPropsNullCase || v2WithCompositionAddPropsAnyTypeSchemaCase)) {
             // for v2 specs only, input AnyType schemas (type unset) or schema {} results in FreeFromObject schemas
             // per https://github.com/swagger-api/swagger-parser/issues/1378
@@ -878,7 +878,7 @@ public class PythonClientCodegen extends PythonLegacyClientCodegen {
         if (ModelUtils.isNullable(ModelUtils.getReferencedSchema(this.openAPI, p))) {
             fullSuffix = ", none_type" + suffix;
         }
-        Boolean v3WithCompositionAddPropsAnyTypeSchemaCase = (getAdditionalProperties(p) != null && emptySchema.equals(getAdditionalProperties(p)) && originalSpecVersion.equals("3"));
+        Boolean v3WithCompositionAddPropsAnyTypeSchemaCase = (getAdditionalProperties(p) != null && emptySchema.equals(getAdditionalProperties(p)) && "3".equals(originalSpecVersion));
         if (isFreeFormObject(p) && v3WithCompositionAddPropsAnyTypeSchemaCase) {
             // v3 code path, use case: type object schema with no other schema info
             return prefix + "{str: (bool, date, datetime, dict, float, int, list, str, none_type)}" + fullSuffix;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
@@ -212,7 +212,7 @@ public class PythonFastAPIServerCodegen extends AbstractPythonCodegen {
 
                 if (operation.requestBodyExamples != null) {
                     for (Map<String, String> example : operation.requestBodyExamples) {
-                        if (example.get("contentType") != null && example.get("contentType").equals("application/json")) {
+                        if ("application/json".equals(example.get("contentType"))) {
                             // Make an example dictionary more python-like (snake-case, etc.).
                             // If fails, use the original string.
                             try {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -186,8 +186,8 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         }
         return "id".equals(name) ||
                 "ids".equals(name) ||
-                (name.length() >= 3 && name.substring(name.length() - 2).equals("Id")) ||
-                (name.length() >= 4 && name.substring(name.length() - 3).equals("Ids"));
+                (name.length() >= 3 && "Id".equals(name.substring(name.length() - 2))) ||
+                (name.length() >= 4 && "Ids".equals(name.substring(name.length() - 3)));
     }
 
     @Override
@@ -383,11 +383,11 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         } else if (var.isEnum) {
             var.defaultValue = "'" + var._enum.get(0) + "'";
             updateCodegenPropertyEnum(var);
-        } else if (var.dataType.equalsIgnoreCase("string")) {
+        } else if ("string".equalsIgnoreCase(var.dataType)) {
             var.defaultValue = "\"\"";
-        } else if (var.dataType.equalsIgnoreCase("number")) {
+        } else if ("number".equalsIgnoreCase(var.dataType)) {
             var.defaultValue = "0";
-        } else if (var.dataType.equalsIgnoreCase("boolean")) {
+        } else if ("boolean".equalsIgnoreCase(var.dataType)) {
             var.defaultValue = "false";
         } else {
             if (var.allowableValues != null && var.allowableValues.get("enumVars") instanceof ArrayList && ((ArrayList) var.allowableValues.get("enumVars")).get(0) instanceof HashMap) {
@@ -687,7 +687,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             var.datatypeWithEnum = var.datatypeWithEnum.replace(var.enumName, parentClassName + var.enumName);
 
             // need to post-process defaultValue, was computed with previous var.datatypeWithEnum
-            if (var.defaultValue != null && !var.defaultValue.equals("undefined")) {
+            if (var.defaultValue != null && !"undefined".equals(var.defaultValue)) {
                 int dotPos = var.defaultValue.indexOf(".");
                 if (dotPos != -1) {
                     var.defaultValue = var.datatypeWithEnum + var.defaultValue.substring(dotPos);
@@ -725,7 +725,7 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             } else if (var.isUniqueId) {
                 var.dataTypeAlternate = "string";
             }
-            if (var.defaultValue == null || var.defaultValue.equals("undefined")) {
+            if (var.defaultValue == null || "undefined".equals(var.defaultValue)) {
                 this.autoSetDefaultValueForProperty(var);
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/WsdlSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/WsdlSchemaCodegen.java
@@ -164,13 +164,13 @@ public class WsdlSchemaCodegen extends DefaultCodegen implements CodegenConfig {
         if (param.isPrimitiveType) {
             param.dataType = param.dataType.toLowerCase(Locale.getDefault());
         }
-        if (param.dataFormat != null && param.dataFormat.equalsIgnoreCase("date")) {
+        if ("date".equalsIgnoreCase(param.dataFormat)) {
             param.dataType = "date";
         }
-        if (param.dataFormat != null && param.dataFormat.equalsIgnoreCase("date-time")) {
+        if ("date-time".equalsIgnoreCase(param.dataFormat)) {
             param.dataType = "dateTime";
         }
-        if (param.dataFormat != null && param.dataFormat.equalsIgnoreCase("uuid")) {
+        if ("uuid".equalsIgnoreCase(param.dataFormat)) {
             param.dataType = "string";
         }
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocGeneratorTest.java
@@ -68,7 +68,7 @@ public class AsciidocGeneratorTest {
         List<File> files = generator.opts(clientOptInput).generate();
         boolean markupFileGenerated = false;
         for (File file : files) {
-            if (file.getName().equals("index.adoc")) {
+            if ("index.adoc".equals(file.getName())) {
                 markupFileGenerated = true;
                 String markupContent = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
                 // check on some basic asciidoc markup content
@@ -99,7 +99,7 @@ public class AsciidocGeneratorTest {
         List<File> files = generator.opts(configurator.toClientOptInput()).generate();
         boolean markupFileGenerated = false;
         for (File file : files) {
-            if (file.getName().equals("index.adoc")) {
+            if ("index.adoc".equals(file.getName())) {
                 markupFileGenerated = true;
                 String markupContent = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
                 Assert.assertTrue(markupContent.contains(":specDir: SPEC-DIR"),
@@ -134,7 +134,7 @@ public class AsciidocGeneratorTest {
         boolean markupFileGenerated = false;
         List<File> files = generator.opts(configurator.toClientOptInput()).generate();
         for (File file : files) {
-            if (file.getName().equals("index.adoc")) {
+            if ("index.adoc".equals(file.getName())) {
                 markupFileGenerated = true;
                 String markupContent = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
                 Assert.assertFalse(markupContent.contains(":specDir: SPEC-DIR"),

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocSampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocSampleGeneratorTest.java
@@ -43,7 +43,7 @@ public class AsciidocSampleGeneratorTest {
         List<File> files = generator.opts(configurator.toClientOptInput()).generate();
 
         for (File file : files) {
-            if (file.getName().equals("index.adoc")) {
+            if ("index.adoc".equals(file.getName())) {
                 this.markupFileName = file.getAbsoluteFile().toString();
                 this.markupContent = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
             }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -546,14 +546,14 @@ public class JavaClientCodegenTest {
         final List<CodegenOperation> codegenOperations = defaultGenerator.processPaths(openAPI.getPaths()).get("Pet");
 
         // Verify GET only has 'read' scope
-        final CodegenOperation getCodegenOperation = codegenOperations.stream().filter(it -> it.httpMethod.equals("GET")).collect(Collectors.toList()).get(0);
+        final CodegenOperation getCodegenOperation = codegenOperations.stream().filter(it -> "GET".equals(it.httpMethod)).collect(Collectors.toList()).get(0);
         assertTrue(getCodegenOperation.hasAuthMethods);
         assertEquals(getCodegenOperation.authMethods.size(), 1);
         final List<Map<String, Object>> getScopes = getCodegenOperation.authMethods.get(0).scopes;
         assertEquals(getScopes.size(), 1, "GET scopes don't match. actual::" + getScopes);
 
         // POST operation should have both 'read' and 'write' scope on it
-        final CodegenOperation postCodegenOperation = codegenOperations.stream().filter(it -> it.httpMethod.equals("POST")).collect(Collectors.toList()).get(0);
+        final CodegenOperation postCodegenOperation = codegenOperations.stream().filter(it -> "POST".equals(it.httpMethod)).collect(Collectors.toList()).get(0);
         assertTrue(postCodegenOperation.hasAuthMethods);
         assertEquals(postCodegenOperation.authMethods.size(), 1);
         final List<Map<String, Object>> postScopes = postCodegenOperation.authMethods.get(0).scopes;
@@ -601,7 +601,7 @@ public class JavaClientCodegenTest {
         defaultGenerator.opts(clientOptInput);
         final List<CodegenOperation> codegenOperations = defaultGenerator.processPaths(openAPI.getPaths()).get("Pet");
 
-        final CodegenOperation getCodegenOperation = codegenOperations.stream().filter(it -> it.httpMethod.equals("GET")).collect(Collectors.toList()).get(0);
+        final CodegenOperation getCodegenOperation = codegenOperations.stream().filter(it -> "GET".equals(it.httpMethod)).collect(Collectors.toList()).get(0);
         assertTrue(getCodegenOperation.hasAuthMethods);
         assertEquals(getCodegenOperation.authMethods.size(), 2);
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -186,7 +186,7 @@ public class KotlinSpringServerCodegenTest {
         Assert.assertEquals(codegen.apiTemplateFiles().get("apiInterface.mustache"), ".kt");
         Assert.assertEquals(codegen.apiTemplateFiles().get("apiInterface.mustache"), ".kt");
 
-        Assert.assertTrue(codegen.supportingFiles().stream().anyMatch(supportingFile -> supportingFile.getTemplateFile().equals("apiUtil.mustache")));
+        Assert.assertTrue(codegen.supportingFiles().stream().anyMatch(supportingFile -> "apiUtil.mustache".equals(supportingFile.getTemplateFile())));
     }
 
     @Test(description = "test delegate with tags")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -58,7 +58,7 @@ public class RubyClientCodegenTest {
         List<File> files = generator.opts(clientOptInput).generate();
         boolean apiFileGenerated = false;
         for (File file : files) {
-            if (file.getName().equals("default_api.rb")) {
+            if ("default_api.rb".equals(file.getName())) {
                 apiFileGenerated = true;
                 // Ruby client should set the path unescaped in the api file
                 assertTrue(FileUtils.readFileToString(file, StandardCharsets.UTF_8).contains("local_var_path = '/foo=bar'"));
@@ -122,7 +122,7 @@ public class RubyClientCodegenTest {
         List<File> files = generator.opts(clientOptInput).generate();
         boolean apiFileGenerated = false;
         for (File file : files) {
-            if (file.getName().equals("default_api.rb")) {
+            if ("default_api.rb".equals(file.getName())) {
                 apiFileGenerated = true;
                 // Ruby client should set the path unescaped in the api file
                 assertTrue(FileUtils.readFileToString(file, StandardCharsets.UTF_8).contains("local_var_path = '/default/Resources/{id}'"));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
@@ -368,7 +368,7 @@ public class ScalaAkkaClientCodegenTest {
 
         TestUtils.ensureContainsFile(files, output, "src/main/scala/hello/world/model/SomeObj.scala");
 
-        File someObj = files.stream().filter(f -> f.getName().equals("SomeObj.scala"))
+        File someObj = files.stream().filter(f -> "SomeObj.scala".equals(f.getName()))
                 .findFirst().get();
 
         byte[] fileContents = Files.readAllBytes(someObj.toPath());
@@ -411,7 +411,7 @@ public class ScalaAkkaClientCodegenTest {
 
         TestUtils.ensureContainsFile(files, output, "src/main/scala/hello/world/model/SomeObj.scala");
 
-        File someObj = files.stream().filter(f -> f.getName().equals("SomeObj.scala"))
+        File someObj = files.stream().filter(f -> "SomeObj.scala".equals(f.getName()))
                 .findFirst().get();
 
         byte[] fileContents = Files.readAllBytes(someObj.toPath());

--- a/samples/client/petstore/android/volley/src/main/java/org/openapitools/client/ApiInvoker.java
+++ b/samples/client/petstore/android/volley/src/main/java/org/openapitools/client/ApiInvoker.java
@@ -158,7 +158,7 @@ public class ApiInvoker {
     collectionFormat = (collectionFormat == null || collectionFormat.isEmpty() ? "csv" : collectionFormat); // default: csv
 
     // create the params based on the collection format
-    if (collectionFormat.equals("multi")) {
+    if ("multi".equals(collectionFormat)) {
       for (Object item : valueCollection) {
         params.add(new Pair(name, parameterToString(item)));
       }
@@ -168,13 +168,13 @@ public class ApiInvoker {
 
     String delimiter = ",";
 
-    if (collectionFormat.equals("csv")) {
+    if ("csv".equals(collectionFormat)) {
       delimiter = ",";
-    } else if (collectionFormat.equals("ssv")) {
+    } else if ("ssv".equals(collectionFormat)) {
       delimiter = " ";
-    } else if (collectionFormat.equals("tsv")) {
+    } else if ("tsv".equals(collectionFormat)) {
       delimiter = "\t";
-    } else if (collectionFormat.equals("pipes")) {
+    } else if ("pipes".equals(collectionFormat)) {
       delimiter = "|";
     }
 

--- a/samples/server/petstore/java-pkmst/src/main/java/com/prokarma/pkmst/logging/HttpLoggingFilter.java
+++ b/samples/server/petstore/java-pkmst/src/main/java/com/prokarma/pkmst/logging/HttpLoggingFilter.java
@@ -97,7 +97,7 @@ public class HttpLoggingFilter implements Filter {
     while (requestParamNames.hasMoreElements()) {
       String requestParamName = (String) requestParamNames.nextElement();
       String requestParamValue;
-      if (requestParamName.equalsIgnoreCase("password")) {
+      if ("password".equalsIgnoreCase(requestParamName)) {
         requestParamValue = "********";
       } else {
         requestParamValue = request.getParameter(requestParamName);


### PR DESCRIPTION
@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @nmuesch

It is preferable to place string literals on the left-hand side of an `equals()` or `equalsIgnoreCase()` method call.
This prevents null pointer exceptions from being raised, as a string literal can never be null by definition.

Happy Hacktoberfest!


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


Co-authored-by: Moderne <team@moderne.io>