### PR TITLE
fix: #9976 do not escape already escaped string in examples

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -24,6 +24,7 @@ import com.samskivert.mustache.Template;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.meta.features.*;
+import org.openapitools.codegen.templating.mustache.EscapeDoubleQuoteLambda;
 import org.openapitools.codegen.utils.URLPathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -430,8 +431,7 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         additionalProperties.put("jackson", "true");
 
         // add lambda for mustache templates
-        additionalProperties.put("lambdaEscapeDoubleQuote",
-                (Mustache.Lambda) (fragment, writer) -> writer.write(fragment.execute().replaceAll("\"", Matcher.quoteReplacement("\\\""))));
+        additionalProperties.put("lambdaEscapeDoubleQuote", new EscapeDoubleQuoteLambda());
         additionalProperties.put("lambdaRemoveLineBreak",
                 (Mustache.Lambda) (fragment, writer) -> writer.write(fragment.execute().replaceAll("\\r|\\n", "")));
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -52,6 +52,7 @@ import org.openapitools.codegen.meta.features.ParameterFeature;
 import org.openapitools.codegen.meta.features.SchemaSupportFeature;
 import org.openapitools.codegen.meta.features.SecurityFeature;
 import org.openapitools.codegen.meta.features.WireFormatFeature;
+import org.openapitools.codegen.templating.mustache.EscapeDoubleQuoteLambda;
 import org.openapitools.codegen.templating.mustache.SplitStringLambda;
 import org.openapitools.codegen.templating.mustache.TrimWhitespaceLambda;
 import org.openapitools.codegen.utils.URLPathUtils;
@@ -552,8 +553,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         // add lambda for mustache templates
         additionalProperties.put("lambdaRemoveDoubleQuote", (Mustache.Lambda) (fragment, writer) -> writer
                 .write(fragment.execute().replaceAll("\"", Matcher.quoteReplacement(""))));
-        additionalProperties.put("lambdaEscapeDoubleQuote", (Mustache.Lambda) (fragment, writer) -> writer
-                .write(fragment.execute().replaceAll("\"", Matcher.quoteReplacement("\\\""))));
+        additionalProperties.put("lambdaEscapeDoubleQuote", new EscapeDoubleQuoteLambda());
         additionalProperties.put("lambdaRemoveLineBreak",
                 (Mustache.Lambda) (fragment, writer) -> writer.write(fragment.execute().replaceAll("\\r|\\n", "")));
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/EscapeDoubleQuoteLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/EscapeDoubleQuoteLambda.java
@@ -1,0 +1,31 @@
+package org.openapitools.codegen.templating.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.regex.Matcher;
+
+/**
+ * replace double quotes by escaped double quotes
+ *
+ * Register:
+ * <pre>
+ * additionalProperties.put("escapeDoubleQuote", new EscapeDoubleQuoteLambda());
+ * </pre>
+ *
+ * Use:
+ * <pre>
+ * {{#escapeDoubleQuote}}{{name}}{{/escapeDoubleQuote}}
+ * </pre>
+ */
+public class EscapeDoubleQuoteLambda implements Mustache.Lambda{
+    private static final String REGEX_DOUBLE_QUOTES_NOT_ALREADY_ESCAPED = "(?<!\\\\)\"";
+
+    @Override
+    public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+        writer.write(fragment.execute()
+                .replaceAll(REGEX_DOUBLE_QUOTES_NOT_ALREADY_ESCAPED, Matcher.quoteReplacement("\\\"")));
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/EscapeDoubleQuoteLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/EscapeDoubleQuoteLambdaTest.java
@@ -1,0 +1,38 @@
+package org.openapitools.codegen.templating.mustache;
+
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class EscapeDoubleQuoteLambdaTest extends LambdaTest {
+
+    private Map<String, Object> ctx = context("escapeDoubleQuote", new EscapeDoubleQuoteLambda());
+
+    @Test
+    public void testNoChanges() {
+        test(
+                "no changes",
+                "{{#escapeDoubleQuote}}no changes{{/escapeDoubleQuote}}",
+                ctx
+        );
+    }
+
+    @Test
+    public void testDoubleQuotes() {
+        test(
+                "{\\\"key\\\": \\\"value\\\"}",
+                "{{#escapeDoubleQuote}}{\"key\": \"value\"}{{/escapeDoubleQuote}}",
+                ctx
+        );
+    }
+
+    @Test
+    public void testAlreadyEscapedDoubleQuotes() {
+
+        test(
+                "{\\\"key\\\": \\\"value\\\"}",
+                "{{#escapeDoubleQuote}}{\\\"key\\\": \\\"value\\\"}{{/escapeDoubleQuote}}",
+                ctx
+        );
+    }
+}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
replaced the escapeDoubleQuote lambda so that already escaped double quotes in examples are not escaped again.

cc @nmuesch
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
