### PR TITLE
[crystal][client] Add param default values to method definitions and refactor methods to use only keyword args if the method has more than one param

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -24,7 +24,7 @@ import java.util.*;
 
 public class CodegenOperation {
     public final List<CodegenProperty> responseHeaders = new ArrayList<CodegenProperty>();
-    public boolean hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOptionalParams, hasRequiredParams,
+    public boolean hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOnlyOneParam = false, hasOptionalParams, hasRequiredParams,
             returnTypeIsPrimitive, returnSimpleType, subresourceOperation, isMap,
             isArray, isMultipart,
             isResponseBinary = false, isResponseFile = false, hasReference = false,
@@ -277,6 +277,7 @@ public class CodegenOperation {
         sb.append(", hasConsumes=").append(hasConsumes);
         sb.append(", hasProduces=").append(hasProduces);
         sb.append(", hasParams=").append(hasParams);
+        sb.append(", hasOnlyOneParam=").append(hasOnlyOneParam);
         sb.append(", hasOptionalParams=").append(hasOptionalParams);
         sb.append(", hasRequiredParams=").append(hasRequiredParams);
         sb.append(", returnTypeIsPrimitive=").append(returnTypeIsPrimitive);
@@ -351,6 +352,7 @@ public class CodegenOperation {
                 hasConsumes == that.hasConsumes &&
                 hasProduces == that.hasProduces &&
                 hasParams == that.hasParams &&
+                hasOnlyOneParam == that.hasOnlyOneParam &&
                 hasOptionalParams == that.hasOptionalParams &&
                 hasRequiredParams == that.hasRequiredParams &&
                 returnTypeIsPrimitive == that.returnTypeIsPrimitive &&
@@ -418,7 +420,7 @@ public class CodegenOperation {
     @Override
     public int hashCode() {
 
-        return Objects.hash(responseHeaders, hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOptionalParams,
+        return Objects.hash(responseHeaders, hasAuthMethods, hasConsumes, hasProduces, hasParams, hasOnlyOneParam, hasOptionalParams,
                 hasRequiredParams, returnTypeIsPrimitive, returnSimpleType, subresourceOperation, isMap,
                 isArray, isMultipart, isResponseBinary, isResponseFile, hasReference, hasDefaultResponse, isRestfulIndex,
                 isRestfulShow, isRestfulCreate, isRestfulUpdate, isRestfulDestroy, isRestful, isDeprecated,

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4145,6 +4145,9 @@ public class DefaultCodegen implements CodegenConfig {
         if (op.allParams.size() > 0) {
             op.hasParams = true;
         }
+        if (op.allParams.size() == 1) {
+            op.hasOnlyOneParam = true;
+        }
         op.hasRequiredParams = op.requiredParams.size() > 0;
 
         // set Restful Flag

--- a/modules/openapi-generator/src/main/resources/crystal/api.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/api.mustache
@@ -130,7 +130,7 @@ module {{moduleName}}
       # query parameters
       query_params = Hash(String, String).new
       {{#queryParams}}
-      query_params["{{{baseName}}}"] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}) unless {{{paramName}}}.nil? || {{{paramName}}}.empty?{{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{^isString}}.to_s{{/isString}}{{^isRequired}} unless {{{paramName}}}.nil?{{/isRequired}}{{/collectionFormat}}
+      query_params["{{{baseName}}}"] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}.to_s{{/collectionFormat}}{{^isRequired}} unless {{{paramName}}}.nil?{{#collectionFormat}} || {{{paramName}}}.empty?{{/collectionFormat}}{{/isRequired}}
       {{/queryParams}}
 
       # header parameters
@@ -144,13 +144,23 @@ module {{moduleName}}
       header_params["Content-Type"] = @api_client.select_header_content_type([{{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}}])
       {{/hasConsumes}}
       {{#headerParams}}
-      header_params["{{{baseName}}}"] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}) unless {{{paramName}}}.nil? || {{{paramName}}}.empty?{{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{^isString}}.to_s{{/isString}}{{^isRequired}} unless {{{paramName}}}.nil?{{/isRequired}}{{/collectionFormat}}
+      header_params["{{{baseName}}}"] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}.to_s{{/collectionFormat}}{{^isRequired}} unless {{{paramName}}}.nil?{{#collectionFormat}} || {{{paramName}}}.empty?{{/collectionFormat}}{{/isRequired}}
       {{/headerParams}}
 
       # form parameters
       form_params = Hash(Symbol, (String | ::File)).new
       {{#formParams}}
-      form_params[:"{{baseName}}"] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}) unless {{{paramName}}}.nil? || {{{paramName}}}.empty?{{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{^isFile}}{{^isString}}.to_s{{/isString}}{{/isFile}}{{^isRequired}} unless {{{paramName}}}.nil?{{/isRequired}}{{/collectionFormat}}
+      {{#isFile}}
+      {{#isRequired}}
+      form_params[:"{{baseName}}"] = {{paramName}}.nil? ? "" : {{paramName}}
+      {{/isRequired}}
+      {{^isRequired}}
+      form_params[:"{{baseName}}"] = {{paramName}} unless {{paramName}}.nil?
+      {{/isRequired}}
+      {{/isFile}}
+      {{^isFile}}
+      form_params[:"{{baseName}}"] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}.to_s{{/collectionFormat}}{{^isRequired}} unless {{{paramName}}}.nil?{{#collectionFormat}} || {{{paramName}}}.empty?{{/collectionFormat}}{{/isRequired}}
+      {{/isFile}}
       {{/formParams}}
 
       # http body (model)

--- a/modules/openapi-generator/src/main/resources/crystal/api.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/api.mustache
@@ -23,7 +23,7 @@ module {{moduleName}}
     {{/required}}
     {{/allParams}}
     # @return [{{{returnType}}}{{^returnType}}nil{{/returnType}}]
-    def {{operationId}}({{#allParams}}{{paramName}} : {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}})
+    def {{operationId}}({{#requiredParams}}{{paramName}} : {{{dataType}}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#hasRequiredParams}}{{#hasOptionalParams}}, {{/hasOptionalParams}}{{/hasRequiredParams}}{{#optionalParams}}{{paramName}} : {{{dataType}}}?{{^defaultValue}} = nil{{/defaultValue}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/optionalParams}})
       {{#returnType}}data, _status_code, _headers = {{/returnType}}{{operationId}}_with_http_info({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
       {{#returnType}}data{{/returnType}}{{^returnType}}nil{{/returnType}}
     end
@@ -40,7 +40,7 @@ module {{moduleName}}
     {{/required}}
     {{/allParams}}
     # @return [Array<({{{returnType}}}{{^returnType}}nil{{/returnType}}, Integer, Hash)>] {{#returnType}}{{{.}}} data{{/returnType}}{{^returnType}}nil{{/returnType}}, response status code and response headers
-    def {{operationId}}_with_http_info({{#allParams}}{{paramName}} : {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/allParams}})
+    def {{operationId}}_with_http_info({{#requiredParams}}{{paramName}} : {{{dataType}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#hasRequiredParams}}{{#hasOptionalParams}}, {{/hasOptionalParams}}{{/hasRequiredParams}}{{#optionalParams}}{{paramName}} : {{{dataType}}}?{{^-last}}, {{/-last}}{{/optionalParams}})
       if @api_client.config.debugging
         Log.debug {"Calling API: {{classname}}.{{operationId}} ..."}
       end

--- a/modules/openapi-generator/src/main/resources/crystal/api.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/api.mustache
@@ -23,7 +23,7 @@ module {{moduleName}}
     {{/required}}
     {{/allParams}}
     # @return [{{{returnType}}}{{^returnType}}nil{{/returnType}}]
-    def {{operationId}}({{#hasParams}}*, {{/hasParams}}{{#requiredParams}}{{paramName}} : {{{dataType}}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#hasRequiredParams}}{{#hasOptionalParams}}, {{/hasOptionalParams}}{{/hasRequiredParams}}{{#optionalParams}}{{paramName}} : {{{dataType}}}?{{^defaultValue}} = nil{{/defaultValue}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/optionalParams}})
+    def {{operationId}}({{#hasParams}}{{^hasOnlyOneParam}}*, {{/hasOnlyOneParam}}{{/hasParams}}{{#requiredParams}}{{paramName}} : {{{dataType}}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#hasRequiredParams}}{{#hasOptionalParams}}, {{/hasOptionalParams}}{{/hasRequiredParams}}{{#optionalParams}}{{paramName}} : {{{dataType}}}?{{^defaultValue}} = nil{{/defaultValue}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/optionalParams}})
       {{#returnType}}data, _status_code, _headers = {{/returnType}}{{operationId}}_with_http_info({{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
       {{#returnType}}data{{/returnType}}{{^returnType}}nil{{/returnType}}
     end
@@ -40,7 +40,7 @@ module {{moduleName}}
     {{/required}}
     {{/allParams}}
     # @return [Array<({{{returnType}}}{{^returnType}}nil{{/returnType}}, Integer, Hash)>] {{#returnType}}{{{.}}} data{{/returnType}}{{^returnType}}nil{{/returnType}}, response status code and response headers
-    def {{operationId}}_with_http_info({{#hasParams}}*, {{/hasParams}}{{#requiredParams}}{{paramName}} : {{{dataType}}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#hasRequiredParams}}{{#hasOptionalParams}}, {{/hasOptionalParams}}{{/hasRequiredParams}}{{#optionalParams}}{{paramName}} : {{{dataType}}}?{{^defaultValue}} = nil{{/defaultValue}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/optionalParams}})
+    def {{operationId}}_with_http_info({{#hasParams}}{{^hasOnlyOneParam}}*, {{/hasOnlyOneParam}}{{/hasParams}}{{#requiredParams}}{{paramName}} : {{{dataType}}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#hasRequiredParams}}{{#hasOptionalParams}}, {{/hasOptionalParams}}{{/hasRequiredParams}}{{#optionalParams}}{{paramName}} : {{{dataType}}}?{{^defaultValue}} = nil{{/defaultValue}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/optionalParams}})
       if @api_client.config.debugging
         Log.debug {"Calling API: {{classname}}.{{operationId}} ..."}
       end

--- a/modules/openapi-generator/src/main/resources/crystal/api.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/api.mustache
@@ -23,8 +23,8 @@ module {{moduleName}}
     {{/required}}
     {{/allParams}}
     # @return [{{{returnType}}}{{^returnType}}nil{{/returnType}}]
-    def {{operationId}}({{#requiredParams}}{{paramName}} : {{{dataType}}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#hasRequiredParams}}{{#hasOptionalParams}}, {{/hasOptionalParams}}{{/hasRequiredParams}}{{#optionalParams}}{{paramName}} : {{{dataType}}}?{{^defaultValue}} = nil{{/defaultValue}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/optionalParams}})
-      {{#returnType}}data, _status_code, _headers = {{/returnType}}{{operationId}}_with_http_info({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
+    def {{operationId}}({{#hasParams}}*, {{/hasParams}}{{#requiredParams}}{{paramName}} : {{{dataType}}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#hasRequiredParams}}{{#hasOptionalParams}}, {{/hasOptionalParams}}{{/hasRequiredParams}}{{#optionalParams}}{{paramName}} : {{{dataType}}}?{{^defaultValue}} = nil{{/defaultValue}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/optionalParams}})
+      {{#returnType}}data, _status_code, _headers = {{/returnType}}{{operationId}}_with_http_info({{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}})
       {{#returnType}}data{{/returnType}}{{^returnType}}nil{{/returnType}}
     end
 
@@ -40,7 +40,7 @@ module {{moduleName}}
     {{/required}}
     {{/allParams}}
     # @return [Array<({{{returnType}}}{{^returnType}}nil{{/returnType}}, Integer, Hash)>] {{#returnType}}{{{.}}} data{{/returnType}}{{^returnType}}nil{{/returnType}}, response status code and response headers
-    def {{operationId}}_with_http_info({{#requiredParams}}{{paramName}} : {{{dataType}}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#hasRequiredParams}}{{#hasOptionalParams}}, {{/hasOptionalParams}}{{/hasRequiredParams}}{{#optionalParams}}{{paramName}} : {{{dataType}}}?{{^-last}}, {{/-last}}{{/optionalParams}})
+    def {{operationId}}_with_http_info({{#hasParams}}*, {{/hasParams}}{{#requiredParams}}{{paramName}} : {{{dataType}}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/requiredParams}}{{#hasRequiredParams}}{{#hasOptionalParams}}, {{/hasOptionalParams}}{{/hasRequiredParams}}{{#optionalParams}}{{paramName}} : {{{dataType}}}?{{^defaultValue}} = nil{{/defaultValue}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/optionalParams}})
       if @api_client.config.debugging
         Log.debug {"Calling API: {{classname}}.{{operationId}} ..."}
       end
@@ -125,12 +125,12 @@ module {{moduleName}}
       {{/hasValidation}}
       {{/allParams}}
       # resource path
-      local_var_path = "{{{path}}}"{{#pathParams}}.sub("{" + "{{baseName}}" + "}", URI.encode({{paramName}}.to_s){{^strictSpecBehavior}}.gsub("%2F", "/"){{/strictSpecBehavior}}){{/pathParams}}
+      local_var_path = "{{{path}}}"{{#pathParams}}.sub("{" + "{{baseName}}" + "}", URI.encode_path({{paramName}}.to_s){{^strictSpecBehavior}}.gsub("%2F", "/"){{/strictSpecBehavior}}){{/pathParams}}
 
       # query parameters
       query_params = Hash(String, String).new
       {{#queryParams}}
-      query_params["{{{baseName}}}"] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}.to_s unless {{{paramName}}}.nil?{{/collectionFormat}}
+      query_params["{{{baseName}}}"] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}) unless {{{paramName}}}.nil? || {{{paramName}}}.empty?{{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{^isString}}.to_s{{/isString}}{{^isRequired}} unless {{{paramName}}}.nil?{{/isRequired}}{{/collectionFormat}}
       {{/queryParams}}
 
       # header parameters
@@ -144,13 +144,13 @@ module {{moduleName}}
       header_params["Content-Type"] = @api_client.select_header_content_type([{{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}}])
       {{/hasConsumes}}
       {{#headerParams}}
-      header_params["{{{baseName}}}"] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{/collectionFormat}}
+      header_params["{{{baseName}}}"] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}) unless {{{paramName}}}.nil? || {{{paramName}}}.empty?{{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{^isString}}.to_s{{/isString}}{{^isRequired}} unless {{{paramName}}}.nil?{{/isRequired}}{{/collectionFormat}}
       {{/headerParams}}
 
       # form parameters
       form_params = Hash(Symbol, (String | ::File)).new
       {{#formParams}}
-      form_params[:"{{baseName}}"] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}} unless {{{paramName}}}.nil?{{/collectionFormat}}
+      form_params[:"{{baseName}}"] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}) unless {{{paramName}}}.nil? || {{{paramName}}}.empty?{{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{^isFile}}{{^isString}}.to_s{{/isString}}{{/isFile}}{{^isRequired}} unless {{{paramName}}}.nil?{{/isRequired}}{{/collectionFormat}}
       {{/formParams}}
 
       # http body (model)

--- a/modules/openapi-generator/src/main/resources/crystal/partial_model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/partial_model_generic.mustache
@@ -4,14 +4,22 @@
   class {{classname}}{{#parent}} < {{{.}}}{{/parent}}
     include JSON::Serializable
 
-    {{#vars}}
+    {{#requiredVars}}
     {{#description}}
     # {{{.}}}
     {{/description}}
-    @[JSON::Field(key: "{{{baseName}}}", type: {{{dataType}}}{{#defaultValue}}, default: {{{defaultValue}}}{{/defaultValue}}{{#isNullable}}, nillable: true, emit_null: true{{/isNullable}})]
+    @[JSON::Field(key: "{{{baseName}}}", type: {{{dataType}}}{{#defaultValue}}, default: {{{defaultValue}}}{{/defaultValue}})]
     property {{{name}}} : {{{dataType}}}
 
-  {{/vars}}
+    {{/requiredVars}}
+    {{#optionalVars}}
+    {{#description}}
+    # {{{.}}}
+    {{/description}}
+    @[JSON::Field(key: "{{{baseName}}}", type: {{{dataType}}}?{{#defaultValue}}, default: {{{defaultValue}}}{{/defaultValue}}{{#isNullable}}, nilable: true, emit_null: true{{/isNullable}})]
+    property {{{name}}} : {{{dataType}}}?
+
+    {{/optionalVars}}
 {{#hasEnums}}
     class EnumAttributeValidator
       getter datatype : String
@@ -74,7 +82,7 @@
     {{/discriminator}}
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize({{#vars}}@{{{name}}} : {{{dataType}}}{{^required}}?{{/required}}{{^-last}}, {{/-last}}{{/vars}})
+    def initialize({{#requiredVars}}@{{{name}}} : {{{dataType}}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}}, {{/hasOptional}}{{/hasRequired}}{{#optionalVars}}@{{{name}}} : {{{dataType}}}?{{^defaultValue}} = nil{{/defaultValue}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/optionalVars}})
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/modules/openapi-generator/src/main/resources/crystal/partial_model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/partial_model_generic.mustache
@@ -11,7 +11,7 @@
     {{#description}}
     # {{{.}}}
     {{/description}}
-    @[JSON::Field(key: "{{{baseName}}}", type: {{{dataType}}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}}, default: {{{defaultValue}}}{{/defaultValue}}{{#isNullable}}, nilable: true, emit_null: true{{/isNullable}})]
+    @[JSON::Field(key: "{{{baseName}}}", type: {{{dataType}}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}}, default: {{{defaultValue}}}{{/defaultValue}}{{#isNullable}}, nillable: true, emit_null: true{{/isNullable}})]
     property {{{name}}} : {{{dataType}}}{{#isNullable}}?{{/isNullable}}
 
     {{/requiredVars}}
@@ -22,7 +22,7 @@
     {{#description}}
     # {{{.}}}
     {{/description}}
-    @[JSON::Field(key: "{{{baseName}}}", type: {{{dataType}}}?{{#defaultValue}}, default: {{{defaultValue}}}{{/defaultValue}}{{#isNullable}}, nilable: true, emit_null: true{{/isNullable}})]
+    @[JSON::Field(key: "{{{baseName}}}", type: {{{dataType}}}?{{#defaultValue}}, default: {{{defaultValue}}}{{/defaultValue}}, nillable: true{{#isNullable}}, emit_null: true{{/isNullable}})]
     property {{{name}}} : {{{dataType}}}?
 
     {{/optionalVars}}

--- a/modules/openapi-generator/src/main/resources/crystal/partial_model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/partial_model_generic.mustache
@@ -4,14 +4,20 @@
   class {{classname}}{{#parent}} < {{{.}}}{{/parent}}
     include JSON::Serializable
 
+    {{#hasRequired}}
+    # Required properties
+    {{/hasRequired}}
     {{#requiredVars}}
     {{#description}}
     # {{{.}}}
     {{/description}}
-    @[JSON::Field(key: "{{{baseName}}}", type: {{{dataType}}}{{#defaultValue}}, default: {{{defaultValue}}}{{/defaultValue}})]
-    property {{{name}}} : {{{dataType}}}
+    @[JSON::Field(key: "{{{baseName}}}", type: {{{dataType}}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}}, default: {{{defaultValue}}}{{/defaultValue}}{{#isNullable}}, nilable: true, emit_null: true{{/isNullable}})]
+    property {{{name}}} : {{{dataType}}}{{#isNullable}}?{{/isNullable}}
 
     {{/requiredVars}}
+    {{#hasOptional}}
+    # Optional properties
+    {{/hasOptional}}
     {{#optionalVars}}
     {{#description}}
     # {{{.}}}
@@ -82,7 +88,7 @@
     {{/discriminator}}
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize({{#requiredVars}}@{{{name}}} : {{{dataType}}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}}, {{/hasOptional}}{{/hasRequired}}{{#optionalVars}}@{{{name}}} : {{{dataType}}}?{{^defaultValue}} = nil{{/defaultValue}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/optionalVars}})
+    def initialize({{#hasVars}}*, {{/hasVars}}{{#requiredVars}}@{{{name}}} : {{{dataType}}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}}, {{/hasOptional}}{{/hasRequired}}{{#optionalVars}}@{{{name}}} : {{{dataType}}}?{{^defaultValue}} = nil{{/defaultValue}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}}{{^-last}}, {{/-last}}{{/optionalVars}})
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/pom.xml
+++ b/pom.xml
@@ -568,6 +568,18 @@
             </modules>
         </profile>
         <profile>
+            <id>crystal-client</id>
+            <activation>
+                <property>
+                    <name>env</name>
+                    <value>java</value>
+                </property>
+            </activation>
+            <modules>
+                <module>samples/client/petstore/crystal</module>
+            </modules>
+        </profile>
+        <profile>
             <id>haskell-http-client</id>
             <activation>
                 <property>

--- a/samples/client/petstore/crystal/spec/api/pet_api_spec.cr
+++ b/samples/client/petstore/crystal/spec/api/pet_api_spec.cr
@@ -97,12 +97,13 @@ describe "PetApi" do
 
       result = api_instance.get_pet_by_id(pet_id: pet_id)
       result.id.should eq pet_id
-      result.category.id.should eq pet_id + 10
-      result.category.name.should eq "crystal category"
+      category = result.category.not_nil!
+      category.id.should eq pet_id + 10
+      category.name.should eq "crystal category"
       result.name.should eq "crystal"
       result.photo_urls.should eq ["https://crystal-lang.org"]
       result.status.should eq "available" 
-      result.tags[0].id.should eq pet_id + 100
+      result.tags.not_nil![0].id.should eq pet_id + 100
     end
   end
 

--- a/samples/client/petstore/crystal/src/petstore/api/pet_api.cr
+++ b/samples/client/petstore/crystal/src/petstore/api/pet_api.cr
@@ -20,15 +20,15 @@ module Petstore
     # Add a new pet to the store
     # @param pet [Pet] Pet object that needs to be added to the store
     # @return [Pet]
-    def add_pet(pet : Pet)
-      data, _status_code, _headers = add_pet_with_http_info(pet)
+    def add_pet(*, pet : Pet)
+      data, _status_code, _headers = add_pet_with_http_info(pet: pet)
       data
     end
 
     # Add a new pet to the store
     # @param pet [Pet] Pet object that needs to be added to the store
     # @return [Array<(Pet, Integer, Hash)>] Pet data, response status code and response headers
-    def add_pet_with_http_info(pet : Pet)
+    def add_pet_with_http_info(*, pet : Pet)
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.add_pet ..."}
       end
@@ -79,15 +79,15 @@ module Petstore
     # Deletes a pet
     # @param pet_id [Int64] Pet id to delete
     # @return [nil]
-    def delete_pet(pet_id : Int64, api_key : String? = nil)
-      delete_pet_with_http_info(pet_id, api_key)
+    def delete_pet(*, pet_id : Int64, api_key : String? = nil)
+      delete_pet_with_http_info(pet_id: pet_id, api_key: api_key)
       nil
     end
 
     # Deletes a pet
     # @param pet_id [Int64] Pet id to delete
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def delete_pet_with_http_info(pet_id : Int64, api_key : String?)
+    def delete_pet_with_http_info(*, pet_id : Int64, api_key : String? = nil)
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.delete_pet ..."}
       end
@@ -96,14 +96,14 @@ module Petstore
         raise ArgumentError.new("Missing the required parameter 'pet_id' when calling PetApi.delete_pet")
       end
       # resource path
-      local_var_path = "/pet/{petId}".sub("{" + "petId" + "}", URI.encode(pet_id.to_s).gsub("%2F", "/"))
+      local_var_path = "/pet/{petId}".sub("{" + "petId" + "}", URI.encode_path(pet_id.to_s).gsub("%2F", "/"))
 
       # query parameters
       query_params = Hash(String, String).new
 
       # header parameters
       header_params = Hash(String, String).new
-      header_params["api_key"] = api_key
+      header_params["api_key"] = api_key unless api_key.nil?
 
       # form parameters
       form_params = Hash(Symbol, (String | ::File)).new
@@ -136,8 +136,8 @@ module Petstore
     # Multiple status values can be provided with comma separated strings
     # @param status [Array(String)] Status values that need to be considered for filter
     # @return [Array(Pet)]
-    def find_pets_by_status(status : Array(String))
-      data, _status_code, _headers = find_pets_by_status_with_http_info(status)
+    def find_pets_by_status(*, status : Array(String))
+      data, _status_code, _headers = find_pets_by_status_with_http_info(status: status)
       data
     end
 
@@ -145,7 +145,7 @@ module Petstore
     # Multiple status values can be provided with comma separated strings
     # @param status [Array(String)] Status values that need to be considered for filter
     # @return [Array<(Array(Pet), Integer, Hash)>] Array(Pet) data, response status code and response headers
-    def find_pets_by_status_with_http_info(status : Array(String))
+    def find_pets_by_status_with_http_info(*, status : Array(String))
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.find_pets_by_status ..."}
       end
@@ -158,7 +158,7 @@ module Petstore
 
       # query parameters
       query_params = Hash(String, String).new
-      query_params["status"] = @api_client.build_collection_param(status, :csv)
+      query_params["status"] = @api_client.build_collection_param(status, :csv) unless status.nil? || status.empty?
 
       # header parameters
       header_params = Hash(String, String).new
@@ -196,8 +196,8 @@ module Petstore
     # Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
     # @param tags [Array(String)] Tags to filter by
     # @return [Array(Pet)]
-    def find_pets_by_tags(tags : Array(String))
-      data, _status_code, _headers = find_pets_by_tags_with_http_info(tags)
+    def find_pets_by_tags(*, tags : Array(String))
+      data, _status_code, _headers = find_pets_by_tags_with_http_info(tags: tags)
       data
     end
 
@@ -205,7 +205,7 @@ module Petstore
     # Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
     # @param tags [Array(String)] Tags to filter by
     # @return [Array<(Array(Pet), Integer, Hash)>] Array(Pet) data, response status code and response headers
-    def find_pets_by_tags_with_http_info(tags : Array(String))
+    def find_pets_by_tags_with_http_info(*, tags : Array(String))
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.find_pets_by_tags ..."}
       end
@@ -218,7 +218,7 @@ module Petstore
 
       # query parameters
       query_params = Hash(String, String).new
-      query_params["tags"] = @api_client.build_collection_param(tags, :csv)
+      query_params["tags"] = @api_client.build_collection_param(tags, :csv) unless tags.nil? || tags.empty?
 
       # header parameters
       header_params = Hash(String, String).new
@@ -256,8 +256,8 @@ module Petstore
     # Returns a single pet
     # @param pet_id [Int64] ID of pet to return
     # @return [Pet]
-    def get_pet_by_id(pet_id : Int64)
-      data, _status_code, _headers = get_pet_by_id_with_http_info(pet_id)
+    def get_pet_by_id(*, pet_id : Int64)
+      data, _status_code, _headers = get_pet_by_id_with_http_info(pet_id: pet_id)
       data
     end
 
@@ -265,7 +265,7 @@ module Petstore
     # Returns a single pet
     # @param pet_id [Int64] ID of pet to return
     # @return [Array<(Pet, Integer, Hash)>] Pet data, response status code and response headers
-    def get_pet_by_id_with_http_info(pet_id : Int64)
+    def get_pet_by_id_with_http_info(*, pet_id : Int64)
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.get_pet_by_id ..."}
       end
@@ -274,7 +274,7 @@ module Petstore
         raise ArgumentError.new("Missing the required parameter 'pet_id' when calling PetApi.get_pet_by_id")
       end
       # resource path
-      local_var_path = "/pet/{petId}".sub("{" + "petId" + "}", URI.encode(pet_id.to_s).gsub("%2F", "/"))
+      local_var_path = "/pet/{petId}".sub("{" + "petId" + "}", URI.encode_path(pet_id.to_s).gsub("%2F", "/"))
 
       # query parameters
       query_params = Hash(String, String).new
@@ -314,15 +314,15 @@ module Petstore
     # Update an existing pet
     # @param pet [Pet] Pet object that needs to be added to the store
     # @return [Pet]
-    def update_pet(pet : Pet)
-      data, _status_code, _headers = update_pet_with_http_info(pet)
+    def update_pet(*, pet : Pet)
+      data, _status_code, _headers = update_pet_with_http_info(pet: pet)
       data
     end
 
     # Update an existing pet
     # @param pet [Pet] Pet object that needs to be added to the store
     # @return [Array<(Pet, Integer, Hash)>] Pet data, response status code and response headers
-    def update_pet_with_http_info(pet : Pet)
+    def update_pet_with_http_info(*, pet : Pet)
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.update_pet ..."}
       end
@@ -373,15 +373,15 @@ module Petstore
     # Updates a pet in the store with form data
     # @param pet_id [Int64] ID of pet that needs to be updated
     # @return [nil]
-    def update_pet_with_form(pet_id : Int64, name : String? = nil, status : String? = nil)
-      update_pet_with_form_with_http_info(pet_id, name, status)
+    def update_pet_with_form(*, pet_id : Int64, name : String? = nil, status : String? = nil)
+      update_pet_with_form_with_http_info(pet_id: pet_id, name: name, status: status)
       nil
     end
 
     # Updates a pet in the store with form data
     # @param pet_id [Int64] ID of pet that needs to be updated
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def update_pet_with_form_with_http_info(pet_id : Int64, name : String?, status : String?)
+    def update_pet_with_form_with_http_info(*, pet_id : Int64, name : String? = nil, status : String? = nil)
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.update_pet_with_form ..."}
       end
@@ -390,7 +390,7 @@ module Petstore
         raise ArgumentError.new("Missing the required parameter 'pet_id' when calling PetApi.update_pet_with_form")
       end
       # resource path
-      local_var_path = "/pet/{petId}".sub("{" + "petId" + "}", URI.encode(pet_id.to_s).gsub("%2F", "/"))
+      local_var_path = "/pet/{petId}".sub("{" + "petId" + "}", URI.encode_path(pet_id.to_s).gsub("%2F", "/"))
 
       # query parameters
       query_params = Hash(String, String).new
@@ -432,15 +432,15 @@ module Petstore
     # uploads an image
     # @param pet_id [Int64] ID of pet to update
     # @return [ApiResponse]
-    def upload_file(pet_id : Int64, additional_metadata : String? = nil, file : ::File? = nil)
-      data, _status_code, _headers = upload_file_with_http_info(pet_id, additional_metadata, file)
+    def upload_file(*, pet_id : Int64, additional_metadata : String? = nil, file : ::File? = nil)
+      data, _status_code, _headers = upload_file_with_http_info(pet_id: pet_id, additional_metadata: additional_metadata, file: file)
       data
     end
 
     # uploads an image
     # @param pet_id [Int64] ID of pet to update
     # @return [Array<(ApiResponse, Integer, Hash)>] ApiResponse data, response status code and response headers
-    def upload_file_with_http_info(pet_id : Int64, additional_metadata : String?, file : ::File?)
+    def upload_file_with_http_info(*, pet_id : Int64, additional_metadata : String? = nil, file : ::File? = nil)
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.upload_file ..."}
       end
@@ -449,7 +449,7 @@ module Petstore
         raise ArgumentError.new("Missing the required parameter 'pet_id' when calling PetApi.upload_file")
       end
       # resource path
-      local_var_path = "/pet/{petId}/uploadImage".sub("{" + "petId" + "}", URI.encode(pet_id.to_s).gsub("%2F", "/"))
+      local_var_path = "/pet/{petId}/uploadImage".sub("{" + "petId" + "}", URI.encode_path(pet_id.to_s).gsub("%2F", "/"))
 
       # query parameters
       query_params = Hash(String, String).new

--- a/samples/client/petstore/crystal/src/petstore/api/pet_api.cr
+++ b/samples/client/petstore/crystal/src/petstore/api/pet_api.cr
@@ -20,7 +20,7 @@ module Petstore
     # Add a new pet to the store
     # @param pet [Pet] Pet object that needs to be added to the store
     # @return [Pet]
-    def add_pet(*, pet : Pet)
+    def add_pet(pet : Pet)
       data, _status_code, _headers = add_pet_with_http_info(pet: pet)
       data
     end
@@ -28,7 +28,7 @@ module Petstore
     # Add a new pet to the store
     # @param pet [Pet] Pet object that needs to be added to the store
     # @return [Array<(Pet, Integer, Hash)>] Pet data, response status code and response headers
-    def add_pet_with_http_info(*, pet : Pet)
+    def add_pet_with_http_info(pet : Pet)
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.add_pet ..."}
       end
@@ -136,7 +136,7 @@ module Petstore
     # Multiple status values can be provided with comma separated strings
     # @param status [Array(String)] Status values that need to be considered for filter
     # @return [Array(Pet)]
-    def find_pets_by_status(*, status : Array(String))
+    def find_pets_by_status(status : Array(String))
       data, _status_code, _headers = find_pets_by_status_with_http_info(status: status)
       data
     end
@@ -145,7 +145,7 @@ module Petstore
     # Multiple status values can be provided with comma separated strings
     # @param status [Array(String)] Status values that need to be considered for filter
     # @return [Array<(Array(Pet), Integer, Hash)>] Array(Pet) data, response status code and response headers
-    def find_pets_by_status_with_http_info(*, status : Array(String))
+    def find_pets_by_status_with_http_info(status : Array(String))
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.find_pets_by_status ..."}
       end
@@ -196,7 +196,7 @@ module Petstore
     # Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
     # @param tags [Array(String)] Tags to filter by
     # @return [Array(Pet)]
-    def find_pets_by_tags(*, tags : Array(String))
+    def find_pets_by_tags(tags : Array(String))
       data, _status_code, _headers = find_pets_by_tags_with_http_info(tags: tags)
       data
     end
@@ -205,7 +205,7 @@ module Petstore
     # Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
     # @param tags [Array(String)] Tags to filter by
     # @return [Array<(Array(Pet), Integer, Hash)>] Array(Pet) data, response status code and response headers
-    def find_pets_by_tags_with_http_info(*, tags : Array(String))
+    def find_pets_by_tags_with_http_info(tags : Array(String))
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.find_pets_by_tags ..."}
       end
@@ -256,7 +256,7 @@ module Petstore
     # Returns a single pet
     # @param pet_id [Int64] ID of pet to return
     # @return [Pet]
-    def get_pet_by_id(*, pet_id : Int64)
+    def get_pet_by_id(pet_id : Int64)
       data, _status_code, _headers = get_pet_by_id_with_http_info(pet_id: pet_id)
       data
     end
@@ -265,7 +265,7 @@ module Petstore
     # Returns a single pet
     # @param pet_id [Int64] ID of pet to return
     # @return [Array<(Pet, Integer, Hash)>] Pet data, response status code and response headers
-    def get_pet_by_id_with_http_info(*, pet_id : Int64)
+    def get_pet_by_id_with_http_info(pet_id : Int64)
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.get_pet_by_id ..."}
       end
@@ -314,7 +314,7 @@ module Petstore
     # Update an existing pet
     # @param pet [Pet] Pet object that needs to be added to the store
     # @return [Pet]
-    def update_pet(*, pet : Pet)
+    def update_pet(pet : Pet)
       data, _status_code, _headers = update_pet_with_http_info(pet: pet)
       data
     end
@@ -322,7 +322,7 @@ module Petstore
     # Update an existing pet
     # @param pet [Pet] Pet object that needs to be added to the store
     # @return [Array<(Pet, Integer, Hash)>] Pet data, response status code and response headers
-    def update_pet_with_http_info(*, pet : Pet)
+    def update_pet_with_http_info(pet : Pet)
       if @api_client.config.debugging
         Log.debug {"Calling API: PetApi.update_pet ..."}
       end

--- a/samples/client/petstore/crystal/src/petstore/api/pet_api.cr
+++ b/samples/client/petstore/crystal/src/petstore/api/pet_api.cr
@@ -103,7 +103,7 @@ module Petstore
 
       # header parameters
       header_params = Hash(String, String).new
-      header_params["api_key"] = api_key unless api_key.nil?
+      header_params["api_key"] = api_key.to_s unless api_key.nil?
 
       # form parameters
       form_params = Hash(Symbol, (String | ::File)).new
@@ -402,8 +402,8 @@ module Petstore
 
       # form parameters
       form_params = Hash(Symbol, (String | ::File)).new
-      form_params[:"name"] = name unless name.nil?
-      form_params[:"status"] = status unless status.nil?
+      form_params[:"name"] = name.to_s unless name.nil?
+      form_params[:"status"] = status.to_s unless status.nil?
 
       # http body (model)
       post_body = nil
@@ -463,7 +463,7 @@ module Petstore
 
       # form parameters
       form_params = Hash(Symbol, (String | ::File)).new
-      form_params[:"additionalMetadata"] = additional_metadata unless additional_metadata.nil?
+      form_params[:"additionalMetadata"] = additional_metadata.to_s unless additional_metadata.nil?
       form_params[:"file"] = file unless file.nil?
 
       # http body (model)

--- a/samples/client/petstore/crystal/src/petstore/api/pet_api.cr
+++ b/samples/client/petstore/crystal/src/petstore/api/pet_api.cr
@@ -79,7 +79,7 @@ module Petstore
     # Deletes a pet
     # @param pet_id [Int64] Pet id to delete
     # @return [nil]
-    def delete_pet(pet_id : Int64, api_key : String?)
+    def delete_pet(pet_id : Int64, api_key : String? = nil)
       delete_pet_with_http_info(pet_id, api_key)
       nil
     end
@@ -373,7 +373,7 @@ module Petstore
     # Updates a pet in the store with form data
     # @param pet_id [Int64] ID of pet that needs to be updated
     # @return [nil]
-    def update_pet_with_form(pet_id : Int64, name : String?, status : String?)
+    def update_pet_with_form(pet_id : Int64, name : String? = nil, status : String? = nil)
       update_pet_with_form_with_http_info(pet_id, name, status)
       nil
     end
@@ -432,7 +432,7 @@ module Petstore
     # uploads an image
     # @param pet_id [Int64] ID of pet to update
     # @return [ApiResponse]
-    def upload_file(pet_id : Int64, additional_metadata : String?, file : ::File?)
+    def upload_file(pet_id : Int64, additional_metadata : String? = nil, file : ::File? = nil)
       data, _status_code, _headers = upload_file_with_http_info(pet_id, additional_metadata, file)
       data
     end

--- a/samples/client/petstore/crystal/src/petstore/api/store_api.cr
+++ b/samples/client/petstore/crystal/src/petstore/api/store_api.cr
@@ -21,7 +21,7 @@ module Petstore
     # For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
     # @param order_id [String] ID of the order that needs to be deleted
     # @return [nil]
-    def delete_order(*, order_id : String)
+    def delete_order(order_id : String)
       delete_order_with_http_info(order_id: order_id)
       nil
     end
@@ -30,7 +30,7 @@ module Petstore
     # For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
     # @param order_id [String] ID of the order that needs to be deleted
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def delete_order_with_http_info(*, order_id : String)
+    def delete_order_with_http_info(order_id : String)
       if @api_client.config.debugging
         Log.debug {"Calling API: StoreApi.delete_order ..."}
       end
@@ -131,7 +131,7 @@ module Petstore
     # For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
     # @param order_id [Int64] ID of pet that needs to be fetched
     # @return [Order]
-    def get_order_by_id(*, order_id : Int64)
+    def get_order_by_id(order_id : Int64)
       data, _status_code, _headers = get_order_by_id_with_http_info(order_id: order_id)
       data
     end
@@ -140,7 +140,7 @@ module Petstore
     # For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
     # @param order_id [Int64] ID of pet that needs to be fetched
     # @return [Array<(Order, Integer, Hash)>] Order data, response status code and response headers
-    def get_order_by_id_with_http_info(*, order_id : Int64)
+    def get_order_by_id_with_http_info(order_id : Int64)
       if @api_client.config.debugging
         Log.debug {"Calling API: StoreApi.get_order_by_id ..."}
       end
@@ -197,7 +197,7 @@ module Petstore
     # Place an order for a pet
     # @param order [Order] order placed for purchasing the pet
     # @return [Order]
-    def place_order(*, order : Order)
+    def place_order(order : Order)
       data, _status_code, _headers = place_order_with_http_info(order: order)
       data
     end
@@ -205,7 +205,7 @@ module Petstore
     # Place an order for a pet
     # @param order [Order] order placed for purchasing the pet
     # @return [Array<(Order, Integer, Hash)>] Order data, response status code and response headers
-    def place_order_with_http_info(*, order : Order)
+    def place_order_with_http_info(order : Order)
       if @api_client.config.debugging
         Log.debug {"Calling API: StoreApi.place_order ..."}
       end

--- a/samples/client/petstore/crystal/src/petstore/api/store_api.cr
+++ b/samples/client/petstore/crystal/src/petstore/api/store_api.cr
@@ -21,8 +21,8 @@ module Petstore
     # For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
     # @param order_id [String] ID of the order that needs to be deleted
     # @return [nil]
-    def delete_order(order_id : String)
-      delete_order_with_http_info(order_id)
+    def delete_order(*, order_id : String)
+      delete_order_with_http_info(order_id: order_id)
       nil
     end
 
@@ -30,7 +30,7 @@ module Petstore
     # For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
     # @param order_id [String] ID of the order that needs to be deleted
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def delete_order_with_http_info(order_id : String)
+    def delete_order_with_http_info(*, order_id : String)
       if @api_client.config.debugging
         Log.debug {"Calling API: StoreApi.delete_order ..."}
       end
@@ -39,7 +39,7 @@ module Petstore
         raise ArgumentError.new("Missing the required parameter 'order_id' when calling StoreApi.delete_order")
       end
       # resource path
-      local_var_path = "/store/order/{orderId}".sub("{" + "orderId" + "}", URI.encode(order_id.to_s).gsub("%2F", "/"))
+      local_var_path = "/store/order/{orderId}".sub("{" + "orderId" + "}", URI.encode_path(order_id.to_s).gsub("%2F", "/"))
 
       # query parameters
       query_params = Hash(String, String).new
@@ -131,8 +131,8 @@ module Petstore
     # For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
     # @param order_id [Int64] ID of pet that needs to be fetched
     # @return [Order]
-    def get_order_by_id(order_id : Int64)
-      data, _status_code, _headers = get_order_by_id_with_http_info(order_id)
+    def get_order_by_id(*, order_id : Int64)
+      data, _status_code, _headers = get_order_by_id_with_http_info(order_id: order_id)
       data
     end
 
@@ -140,7 +140,7 @@ module Petstore
     # For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
     # @param order_id [Int64] ID of pet that needs to be fetched
     # @return [Array<(Order, Integer, Hash)>] Order data, response status code and response headers
-    def get_order_by_id_with_http_info(order_id : Int64)
+    def get_order_by_id_with_http_info(*, order_id : Int64)
       if @api_client.config.debugging
         Log.debug {"Calling API: StoreApi.get_order_by_id ..."}
       end
@@ -157,7 +157,7 @@ module Petstore
       end
 
       # resource path
-      local_var_path = "/store/order/{orderId}".sub("{" + "orderId" + "}", URI.encode(order_id.to_s).gsub("%2F", "/"))
+      local_var_path = "/store/order/{orderId}".sub("{" + "orderId" + "}", URI.encode_path(order_id.to_s).gsub("%2F", "/"))
 
       # query parameters
       query_params = Hash(String, String).new
@@ -197,15 +197,15 @@ module Petstore
     # Place an order for a pet
     # @param order [Order] order placed for purchasing the pet
     # @return [Order]
-    def place_order(order : Order)
-      data, _status_code, _headers = place_order_with_http_info(order)
+    def place_order(*, order : Order)
+      data, _status_code, _headers = place_order_with_http_info(order: order)
       data
     end
 
     # Place an order for a pet
     # @param order [Order] order placed for purchasing the pet
     # @return [Array<(Order, Integer, Hash)>] Order data, response status code and response headers
-    def place_order_with_http_info(order : Order)
+    def place_order_with_http_info(*, order : Order)
       if @api_client.config.debugging
         Log.debug {"Calling API: StoreApi.place_order ..."}
       end

--- a/samples/client/petstore/crystal/src/petstore/api/user_api.cr
+++ b/samples/client/petstore/crystal/src/petstore/api/user_api.cr
@@ -21,8 +21,8 @@ module Petstore
     # This can only be done by the logged in user.
     # @param user [User] Created user object
     # @return [nil]
-    def create_user(user : User)
-      create_user_with_http_info(user)
+    def create_user(*, user : User)
+      create_user_with_http_info(user: user)
       nil
     end
 
@@ -30,7 +30,7 @@ module Petstore
     # This can only be done by the logged in user.
     # @param user [User] Created user object
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def create_user_with_http_info(user : User)
+    def create_user_with_http_info(*, user : User)
       if @api_client.config.debugging
         Log.debug {"Calling API: UserApi.create_user ..."}
       end
@@ -79,15 +79,15 @@ module Petstore
     # Creates list of users with given input array
     # @param user [Array(User)] List of user object
     # @return [nil]
-    def create_users_with_array_input(user : Array(User))
-      create_users_with_array_input_with_http_info(user)
+    def create_users_with_array_input(*, user : Array(User))
+      create_users_with_array_input_with_http_info(user: user)
       nil
     end
 
     # Creates list of users with given input array
     # @param user [Array(User)] List of user object
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def create_users_with_array_input_with_http_info(user : Array(User))
+    def create_users_with_array_input_with_http_info(*, user : Array(User))
       if @api_client.config.debugging
         Log.debug {"Calling API: UserApi.create_users_with_array_input ..."}
       end
@@ -136,15 +136,15 @@ module Petstore
     # Creates list of users with given input array
     # @param user [Array(User)] List of user object
     # @return [nil]
-    def create_users_with_list_input(user : Array(User))
-      create_users_with_list_input_with_http_info(user)
+    def create_users_with_list_input(*, user : Array(User))
+      create_users_with_list_input_with_http_info(user: user)
       nil
     end
 
     # Creates list of users with given input array
     # @param user [Array(User)] List of user object
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def create_users_with_list_input_with_http_info(user : Array(User))
+    def create_users_with_list_input_with_http_info(*, user : Array(User))
       if @api_client.config.debugging
         Log.debug {"Calling API: UserApi.create_users_with_list_input ..."}
       end
@@ -194,8 +194,8 @@ module Petstore
     # This can only be done by the logged in user.
     # @param username [String] The name that needs to be deleted
     # @return [nil]
-    def delete_user(username : String)
-      delete_user_with_http_info(username)
+    def delete_user(*, username : String)
+      delete_user_with_http_info(username: username)
       nil
     end
 
@@ -203,7 +203,7 @@ module Petstore
     # This can only be done by the logged in user.
     # @param username [String] The name that needs to be deleted
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def delete_user_with_http_info(username : String)
+    def delete_user_with_http_info(*, username : String)
       if @api_client.config.debugging
         Log.debug {"Calling API: UserApi.delete_user ..."}
       end
@@ -212,7 +212,7 @@ module Petstore
         raise ArgumentError.new("Missing the required parameter 'username' when calling UserApi.delete_user")
       end
       # resource path
-      local_var_path = "/user/{username}".sub("{" + "username" + "}", URI.encode(username.to_s).gsub("%2F", "/"))
+      local_var_path = "/user/{username}".sub("{" + "username" + "}", URI.encode_path(username.to_s).gsub("%2F", "/"))
 
       # query parameters
       query_params = Hash(String, String).new
@@ -250,15 +250,15 @@ module Petstore
     # Get user by user name
     # @param username [String] The name that needs to be fetched. Use user1 for testing.
     # @return [User]
-    def get_user_by_name(username : String)
-      data, _status_code, _headers = get_user_by_name_with_http_info(username)
+    def get_user_by_name(*, username : String)
+      data, _status_code, _headers = get_user_by_name_with_http_info(username: username)
       data
     end
 
     # Get user by user name
     # @param username [String] The name that needs to be fetched. Use user1 for testing.
     # @return [Array<(User, Integer, Hash)>] User data, response status code and response headers
-    def get_user_by_name_with_http_info(username : String)
+    def get_user_by_name_with_http_info(*, username : String)
       if @api_client.config.debugging
         Log.debug {"Calling API: UserApi.get_user_by_name ..."}
       end
@@ -267,7 +267,7 @@ module Petstore
         raise ArgumentError.new("Missing the required parameter 'username' when calling UserApi.get_user_by_name")
       end
       # resource path
-      local_var_path = "/user/{username}".sub("{" + "username" + "}", URI.encode(username.to_s).gsub("%2F", "/"))
+      local_var_path = "/user/{username}".sub("{" + "username" + "}", URI.encode_path(username.to_s).gsub("%2F", "/"))
 
       # query parameters
       query_params = Hash(String, String).new
@@ -308,8 +308,8 @@ module Petstore
     # @param username [String] The user name for login
     # @param password [String] The password for login in clear text
     # @return [String]
-    def login_user(username : String, password : String)
-      data, _status_code, _headers = login_user_with_http_info(username, password)
+    def login_user(*, username : String, password : String)
+      data, _status_code, _headers = login_user_with_http_info(username: username, password: password)
       data
     end
 
@@ -317,7 +317,7 @@ module Petstore
     # @param username [String] The user name for login
     # @param password [String] The password for login in clear text
     # @return [Array<(String, Integer, Hash)>] String data, response status code and response headers
-    def login_user_with_http_info(username : String, password : String)
+    def login_user_with_http_info(*, username : String, password : String)
       if @api_client.config.debugging
         Log.debug {"Calling API: UserApi.login_user ..."}
       end
@@ -339,8 +339,8 @@ module Petstore
 
       # query parameters
       query_params = Hash(String, String).new
-      query_params["username"] = username.to_s unless username.nil?
-      query_params["password"] = password.to_s unless password.nil?
+      query_params["username"] = username unless username.nil?
+      query_params["password"] = password unless password.nil?
 
       # header parameters
       header_params = Hash(String, String).new
@@ -428,8 +428,8 @@ module Petstore
     # @param username [String] name that need to be deleted
     # @param user [User] Updated user object
     # @return [nil]
-    def update_user(username : String, user : User)
-      update_user_with_http_info(username, user)
+    def update_user(*, username : String, user : User)
+      update_user_with_http_info(username: username, user: user)
       nil
     end
 
@@ -438,7 +438,7 @@ module Petstore
     # @param username [String] name that need to be deleted
     # @param user [User] Updated user object
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def update_user_with_http_info(username : String, user : User)
+    def update_user_with_http_info(*, username : String, user : User)
       if @api_client.config.debugging
         Log.debug {"Calling API: UserApi.update_user ..."}
       end
@@ -451,7 +451,7 @@ module Petstore
         raise ArgumentError.new("Missing the required parameter 'user' when calling UserApi.update_user")
       end
       # resource path
-      local_var_path = "/user/{username}".sub("{" + "username" + "}", URI.encode(username.to_s).gsub("%2F", "/"))
+      local_var_path = "/user/{username}".sub("{" + "username" + "}", URI.encode_path(username.to_s).gsub("%2F", "/"))
 
       # query parameters
       query_params = Hash(String, String).new

--- a/samples/client/petstore/crystal/src/petstore/api/user_api.cr
+++ b/samples/client/petstore/crystal/src/petstore/api/user_api.cr
@@ -21,7 +21,7 @@ module Petstore
     # This can only be done by the logged in user.
     # @param user [User] Created user object
     # @return [nil]
-    def create_user(*, user : User)
+    def create_user(user : User)
       create_user_with_http_info(user: user)
       nil
     end
@@ -30,7 +30,7 @@ module Petstore
     # This can only be done by the logged in user.
     # @param user [User] Created user object
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def create_user_with_http_info(*, user : User)
+    def create_user_with_http_info(user : User)
       if @api_client.config.debugging
         Log.debug {"Calling API: UserApi.create_user ..."}
       end
@@ -79,7 +79,7 @@ module Petstore
     # Creates list of users with given input array
     # @param user [Array(User)] List of user object
     # @return [nil]
-    def create_users_with_array_input(*, user : Array(User))
+    def create_users_with_array_input(user : Array(User))
       create_users_with_array_input_with_http_info(user: user)
       nil
     end
@@ -87,7 +87,7 @@ module Petstore
     # Creates list of users with given input array
     # @param user [Array(User)] List of user object
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def create_users_with_array_input_with_http_info(*, user : Array(User))
+    def create_users_with_array_input_with_http_info(user : Array(User))
       if @api_client.config.debugging
         Log.debug {"Calling API: UserApi.create_users_with_array_input ..."}
       end
@@ -136,7 +136,7 @@ module Petstore
     # Creates list of users with given input array
     # @param user [Array(User)] List of user object
     # @return [nil]
-    def create_users_with_list_input(*, user : Array(User))
+    def create_users_with_list_input(user : Array(User))
       create_users_with_list_input_with_http_info(user: user)
       nil
     end
@@ -144,7 +144,7 @@ module Petstore
     # Creates list of users with given input array
     # @param user [Array(User)] List of user object
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def create_users_with_list_input_with_http_info(*, user : Array(User))
+    def create_users_with_list_input_with_http_info(user : Array(User))
       if @api_client.config.debugging
         Log.debug {"Calling API: UserApi.create_users_with_list_input ..."}
       end
@@ -194,7 +194,7 @@ module Petstore
     # This can only be done by the logged in user.
     # @param username [String] The name that needs to be deleted
     # @return [nil]
-    def delete_user(*, username : String)
+    def delete_user(username : String)
       delete_user_with_http_info(username: username)
       nil
     end
@@ -203,7 +203,7 @@ module Petstore
     # This can only be done by the logged in user.
     # @param username [String] The name that needs to be deleted
     # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
-    def delete_user_with_http_info(*, username : String)
+    def delete_user_with_http_info(username : String)
       if @api_client.config.debugging
         Log.debug {"Calling API: UserApi.delete_user ..."}
       end
@@ -250,7 +250,7 @@ module Petstore
     # Get user by user name
     # @param username [String] The name that needs to be fetched. Use user1 for testing.
     # @return [User]
-    def get_user_by_name(*, username : String)
+    def get_user_by_name(username : String)
       data, _status_code, _headers = get_user_by_name_with_http_info(username: username)
       data
     end
@@ -258,7 +258,7 @@ module Petstore
     # Get user by user name
     # @param username [String] The name that needs to be fetched. Use user1 for testing.
     # @return [Array<(User, Integer, Hash)>] User data, response status code and response headers
-    def get_user_by_name_with_http_info(*, username : String)
+    def get_user_by_name_with_http_info(username : String)
       if @api_client.config.debugging
         Log.debug {"Calling API: UserApi.get_user_by_name ..."}
       end

--- a/samples/client/petstore/crystal/src/petstore/api/user_api.cr
+++ b/samples/client/petstore/crystal/src/petstore/api/user_api.cr
@@ -339,8 +339,8 @@ module Petstore
 
       # query parameters
       query_params = Hash(String, String).new
-      query_params["username"] = username unless username.nil?
-      query_params["password"] = password unless password.nil?
+      query_params["username"] = username.to_s unless username.nil?
+      query_params["password"] = password.to_s unless password.nil?
 
       # header parameters
       header_params = Hash(String, String).new

--- a/samples/client/petstore/crystal/src/petstore/models/api_response.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/api_response.cr
@@ -16,18 +16,18 @@ module Petstore
   class ApiResponse
     include JSON::Serializable
 
-    @[JSON::Field(key: "code", type: Int32)]
-    property code : Int32
+    @[JSON::Field(key: "code", type: Int32?)]
+    property code : Int32?
 
-    @[JSON::Field(key: "type", type: String)]
-    property _type : String
+    @[JSON::Field(key: "type", type: String?)]
+    property _type : String?
 
-    @[JSON::Field(key: "message", type: String)]
-    property message : String
+    @[JSON::Field(key: "message", type: String?)]
+    property message : String?
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize(@code : Int32?, @_type : String?, @message : String?)
+    def initialize(@code : Int32? = nil, @_type : String? = nil, @message : String? = nil)
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/samples/client/petstore/crystal/src/petstore/models/api_response.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/api_response.cr
@@ -17,13 +17,13 @@ module Petstore
     include JSON::Serializable
 
     # Optional properties
-    @[JSON::Field(key: "code", type: Int32?)]
+    @[JSON::Field(key: "code", type: Int32?, nillable: true)]
     property code : Int32?
 
-    @[JSON::Field(key: "type", type: String?)]
+    @[JSON::Field(key: "type", type: String?, nillable: true)]
     property _type : String?
 
-    @[JSON::Field(key: "message", type: String?)]
+    @[JSON::Field(key: "message", type: String?, nillable: true)]
     property message : String?
 
     # Initializes the object

--- a/samples/client/petstore/crystal/src/petstore/models/api_response.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/api_response.cr
@@ -16,6 +16,7 @@ module Petstore
   class ApiResponse
     include JSON::Serializable
 
+    # Optional properties
     @[JSON::Field(key: "code", type: Int32?)]
     property code : Int32?
 
@@ -27,7 +28,7 @@ module Petstore
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize(@code : Int32? = nil, @_type : String? = nil, @message : String? = nil)
+    def initialize(*, @code : Int32? = nil, @_type : String? = nil, @message : String? = nil)
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/samples/client/petstore/crystal/src/petstore/models/category.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/category.cr
@@ -16,15 +16,15 @@ module Petstore
   class Category
     include JSON::Serializable
 
-    @[JSON::Field(key: "id", type: Int64)]
-    property id : Int64
+    @[JSON::Field(key: "id", type: Int64?)]
+    property id : Int64?
 
-    @[JSON::Field(key: "name", type: String)]
-    property name : String
+    @[JSON::Field(key: "name", type: String?)]
+    property name : String?
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize(@id : Int64?, @name : String?)
+    def initialize(@id : Int64? = nil, @name : String? = nil)
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/samples/client/petstore/crystal/src/petstore/models/category.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/category.cr
@@ -17,10 +17,10 @@ module Petstore
     include JSON::Serializable
 
     # Optional properties
-    @[JSON::Field(key: "id", type: Int64?)]
+    @[JSON::Field(key: "id", type: Int64?, nillable: true)]
     property id : Int64?
 
-    @[JSON::Field(key: "name", type: String?)]
+    @[JSON::Field(key: "name", type: String?, nillable: true)]
     property name : String?
 
     # Initializes the object

--- a/samples/client/petstore/crystal/src/petstore/models/category.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/category.cr
@@ -16,6 +16,7 @@ module Petstore
   class Category
     include JSON::Serializable
 
+    # Optional properties
     @[JSON::Field(key: "id", type: Int64?)]
     property id : Int64?
 
@@ -24,7 +25,7 @@ module Petstore
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize(@id : Int64? = nil, @name : String? = nil)
+    def initialize(*, @id : Int64? = nil, @name : String? = nil)
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/samples/client/petstore/crystal/src/petstore/models/order.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/order.cr
@@ -16,24 +16,24 @@ module Petstore
   class Order
     include JSON::Serializable
 
-    @[JSON::Field(key: "id", type: Int64)]
-    property id : Int64
+    @[JSON::Field(key: "id", type: Int64?)]
+    property id : Int64?
 
-    @[JSON::Field(key: "petId", type: Int64)]
-    property pet_id : Int64
+    @[JSON::Field(key: "petId", type: Int64?)]
+    property pet_id : Int64?
 
-    @[JSON::Field(key: "quantity", type: Int32)]
-    property quantity : Int32
+    @[JSON::Field(key: "quantity", type: Int32?)]
+    property quantity : Int32?
 
-    @[JSON::Field(key: "shipDate", type: Time)]
-    property ship_date : Time
+    @[JSON::Field(key: "shipDate", type: Time?)]
+    property ship_date : Time?
 
     # Order Status
-    @[JSON::Field(key: "status", type: String)]
-    property status : String
+    @[JSON::Field(key: "status", type: String?)]
+    property status : String?
 
-    @[JSON::Field(key: "complete", type: Bool, default: false)]
-    property complete : Bool
+    @[JSON::Field(key: "complete", type: Bool?, default: false)]
+    property complete : Bool?
 
     class EnumAttributeValidator
       getter datatype : String
@@ -60,7 +60,7 @@ module Petstore
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize(@id : Int64?, @pet_id : Int64?, @quantity : Int32?, @ship_date : Time?, @status : String?, @complete : Bool?)
+    def initialize(@id : Int64? = nil, @pet_id : Int64? = nil, @quantity : Int32? = nil, @ship_date : Time? = nil, @status : String? = nil, @complete : Bool? = false)
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/samples/client/petstore/crystal/src/petstore/models/order.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/order.cr
@@ -16,6 +16,7 @@ module Petstore
   class Order
     include JSON::Serializable
 
+    # Optional properties
     @[JSON::Field(key: "id", type: Int64?)]
     property id : Int64?
 
@@ -60,7 +61,7 @@ module Petstore
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize(@id : Int64? = nil, @pet_id : Int64? = nil, @quantity : Int32? = nil, @ship_date : Time? = nil, @status : String? = nil, @complete : Bool? = false)
+    def initialize(*, @id : Int64? = nil, @pet_id : Int64? = nil, @quantity : Int32? = nil, @ship_date : Time? = nil, @status : String? = nil, @complete : Bool? = false)
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/samples/client/petstore/crystal/src/petstore/models/order.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/order.cr
@@ -17,23 +17,23 @@ module Petstore
     include JSON::Serializable
 
     # Optional properties
-    @[JSON::Field(key: "id", type: Int64?)]
+    @[JSON::Field(key: "id", type: Int64?, nillable: true)]
     property id : Int64?
 
-    @[JSON::Field(key: "petId", type: Int64?)]
+    @[JSON::Field(key: "petId", type: Int64?, nillable: true)]
     property pet_id : Int64?
 
-    @[JSON::Field(key: "quantity", type: Int32?)]
+    @[JSON::Field(key: "quantity", type: Int32?, nillable: true)]
     property quantity : Int32?
 
-    @[JSON::Field(key: "shipDate", type: Time?)]
+    @[JSON::Field(key: "shipDate", type: Time?, nillable: true)]
     property ship_date : Time?
 
     # Order Status
-    @[JSON::Field(key: "status", type: String?)]
+    @[JSON::Field(key: "status", type: String?, nillable: true)]
     property status : String?
 
-    @[JSON::Field(key: "complete", type: Bool?, default: false)]
+    @[JSON::Field(key: "complete", type: Bool?, default: false, nillable: true)]
     property complete : Bool?
 
     class EnumAttributeValidator

--- a/samples/client/petstore/crystal/src/petstore/models/pet.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/pet.cr
@@ -16,12 +16,14 @@ module Petstore
   class Pet
     include JSON::Serializable
 
+    # Required properties
     @[JSON::Field(key: "name", type: String)]
     property name : String
 
     @[JSON::Field(key: "photoUrls", type: Array(String))]
     property photo_urls : Array(String)
 
+    # Optional properties
     @[JSON::Field(key: "id", type: Int64?)]
     property id : Int64?
 
@@ -60,7 +62,7 @@ module Petstore
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize(@name : String, @photo_urls : Array(String), @id : Int64? = nil, @category : Category? = nil, @tags : Array(Tag)? = nil, @status : String? = nil)
+    def initialize(*, @name : String, @photo_urls : Array(String), @id : Int64? = nil, @category : Category? = nil, @tags : Array(Tag)? = nil, @status : String? = nil)
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/samples/client/petstore/crystal/src/petstore/models/pet.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/pet.cr
@@ -16,24 +16,24 @@ module Petstore
   class Pet
     include JSON::Serializable
 
-    @[JSON::Field(key: "id", type: Int64)]
-    property id : Int64
-
-    @[JSON::Field(key: "category", type: Category)]
-    property category : Category
-
     @[JSON::Field(key: "name", type: String)]
     property name : String
 
     @[JSON::Field(key: "photoUrls", type: Array(String))]
     property photo_urls : Array(String)
 
-    @[JSON::Field(key: "tags", type: Array(Tag))]
-    property tags : Array(Tag)
+    @[JSON::Field(key: "id", type: Int64?)]
+    property id : Int64?
+
+    @[JSON::Field(key: "category", type: Category?)]
+    property category : Category?
+
+    @[JSON::Field(key: "tags", type: Array(Tag)?)]
+    property tags : Array(Tag)?
 
     # pet status in the store
-    @[JSON::Field(key: "status", type: String)]
-    property status : String
+    @[JSON::Field(key: "status", type: String?)]
+    property status : String?
 
     class EnumAttributeValidator
       getter datatype : String
@@ -60,7 +60,7 @@ module Petstore
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize(@id : Int64?, @category : Category?, @name : String, @photo_urls : Array(String), @tags : Array(Tag)?, @status : String?)
+    def initialize(@name : String, @photo_urls : Array(String), @id : Int64? = nil, @category : Category? = nil, @tags : Array(Tag)? = nil, @status : String? = nil)
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/samples/client/petstore/crystal/src/petstore/models/pet.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/pet.cr
@@ -24,17 +24,17 @@ module Petstore
     property photo_urls : Array(String)
 
     # Optional properties
-    @[JSON::Field(key: "id", type: Int64?)]
+    @[JSON::Field(key: "id", type: Int64?, nillable: true)]
     property id : Int64?
 
-    @[JSON::Field(key: "category", type: Category?)]
+    @[JSON::Field(key: "category", type: Category?, nillable: true)]
     property category : Category?
 
-    @[JSON::Field(key: "tags", type: Array(Tag)?)]
+    @[JSON::Field(key: "tags", type: Array(Tag)?, nillable: true)]
     property tags : Array(Tag)?
 
     # pet status in the store
-    @[JSON::Field(key: "status", type: String?)]
+    @[JSON::Field(key: "status", type: String?, nillable: true)]
     property status : String?
 
     class EnumAttributeValidator

--- a/samples/client/petstore/crystal/src/petstore/models/tag.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/tag.cr
@@ -17,10 +17,10 @@ module Petstore
     include JSON::Serializable
 
     # Optional properties
-    @[JSON::Field(key: "id", type: Int64?)]
+    @[JSON::Field(key: "id", type: Int64?, nillable: true)]
     property id : Int64?
 
-    @[JSON::Field(key: "name", type: String?)]
+    @[JSON::Field(key: "name", type: String?, nillable: true)]
     property name : String?
 
     # Initializes the object

--- a/samples/client/petstore/crystal/src/petstore/models/tag.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/tag.cr
@@ -16,6 +16,7 @@ module Petstore
   class Tag
     include JSON::Serializable
 
+    # Optional properties
     @[JSON::Field(key: "id", type: Int64?)]
     property id : Int64?
 
@@ -24,7 +25,7 @@ module Petstore
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize(@id : Int64? = nil, @name : String? = nil)
+    def initialize(*, @id : Int64? = nil, @name : String? = nil)
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/samples/client/petstore/crystal/src/petstore/models/tag.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/tag.cr
@@ -16,15 +16,15 @@ module Petstore
   class Tag
     include JSON::Serializable
 
-    @[JSON::Field(key: "id", type: Int64)]
-    property id : Int64
+    @[JSON::Field(key: "id", type: Int64?)]
+    property id : Int64?
 
-    @[JSON::Field(key: "name", type: String)]
-    property name : String
+    @[JSON::Field(key: "name", type: String?)]
+    property name : String?
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize(@id : Int64?, @name : String?)
+    def initialize(@id : Int64? = nil, @name : String? = nil)
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/samples/client/petstore/crystal/src/petstore/models/user.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/user.cr
@@ -16,34 +16,34 @@ module Petstore
   class User
     include JSON::Serializable
 
-    @[JSON::Field(key: "id", type: Int64)]
-    property id : Int64
+    @[JSON::Field(key: "id", type: Int64?)]
+    property id : Int64?
 
-    @[JSON::Field(key: "username", type: String)]
-    property username : String
+    @[JSON::Field(key: "username", type: String?)]
+    property username : String?
 
-    @[JSON::Field(key: "firstName", type: String)]
-    property first_name : String
+    @[JSON::Field(key: "firstName", type: String?)]
+    property first_name : String?
 
-    @[JSON::Field(key: "lastName", type: String)]
-    property last_name : String
+    @[JSON::Field(key: "lastName", type: String?)]
+    property last_name : String?
 
-    @[JSON::Field(key: "email", type: String)]
-    property email : String
+    @[JSON::Field(key: "email", type: String?)]
+    property email : String?
 
-    @[JSON::Field(key: "password", type: String)]
-    property password : String
+    @[JSON::Field(key: "password", type: String?)]
+    property password : String?
 
-    @[JSON::Field(key: "phone", type: String)]
-    property phone : String
+    @[JSON::Field(key: "phone", type: String?)]
+    property phone : String?
 
     # User Status
-    @[JSON::Field(key: "userStatus", type: Int32)]
-    property user_status : Int32
+    @[JSON::Field(key: "userStatus", type: Int32?)]
+    property user_status : Int32?
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize(@id : Int64?, @username : String?, @first_name : String?, @last_name : String?, @email : String?, @password : String?, @phone : String?, @user_status : Int32?)
+    def initialize(@id : Int64? = nil, @username : String? = nil, @first_name : String? = nil, @last_name : String? = nil, @email : String? = nil, @password : String? = nil, @phone : String? = nil, @user_status : Int32? = nil)
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?

--- a/samples/client/petstore/crystal/src/petstore/models/user.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/user.cr
@@ -17,29 +17,29 @@ module Petstore
     include JSON::Serializable
 
     # Optional properties
-    @[JSON::Field(key: "id", type: Int64?)]
+    @[JSON::Field(key: "id", type: Int64?, nillable: true)]
     property id : Int64?
 
-    @[JSON::Field(key: "username", type: String?)]
+    @[JSON::Field(key: "username", type: String?, nillable: true)]
     property username : String?
 
-    @[JSON::Field(key: "firstName", type: String?)]
+    @[JSON::Field(key: "firstName", type: String?, nillable: true)]
     property first_name : String?
 
-    @[JSON::Field(key: "lastName", type: String?)]
+    @[JSON::Field(key: "lastName", type: String?, nillable: true)]
     property last_name : String?
 
-    @[JSON::Field(key: "email", type: String?)]
+    @[JSON::Field(key: "email", type: String?, nillable: true)]
     property email : String?
 
-    @[JSON::Field(key: "password", type: String?)]
+    @[JSON::Field(key: "password", type: String?, nillable: true)]
     property password : String?
 
-    @[JSON::Field(key: "phone", type: String?)]
+    @[JSON::Field(key: "phone", type: String?, nillable: true)]
     property phone : String?
 
     # User Status
-    @[JSON::Field(key: "userStatus", type: Int32?)]
+    @[JSON::Field(key: "userStatus", type: Int32?, nillable: true)]
     property user_status : Int32?
 
     # Initializes the object

--- a/samples/client/petstore/crystal/src/petstore/models/user.cr
+++ b/samples/client/petstore/crystal/src/petstore/models/user.cr
@@ -16,6 +16,7 @@ module Petstore
   class User
     include JSON::Serializable
 
+    # Optional properties
     @[JSON::Field(key: "id", type: Int64?)]
     property id : Int64?
 
@@ -43,7 +44,7 @@ module Petstore
 
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
-    def initialize(@id : Int64? = nil, @username : String? = nil, @first_name : String? = nil, @last_name : String? = nil, @email : String? = nil, @password : String? = nil, @phone : String? = nil, @user_status : Int32? = nil)
+    def initialize(*, @id : Int64? = nil, @username : String? = nil, @first_name : String? = nil, @last_name : String? = nil, @email : String? = nil, @password : String? = nil, @phone : String? = nil, @user_status : Int32? = nil)
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
@wing328 This PR mainly refactored how it handles nillable and nullable types and default values. I got some ideas from the kotlin-client sample code
The breaking change is the requirement of keyword argument invoking style of methods which is needed to support setting default values
last in order is required for setting default values to positional params but it's not required in keyword args

There are other minor fixes. Check the details listed below, and you should also check the commit messages.

- Refactor methods to use keyword args if the method has more than one param
- Add default values to method definitions and model initializers
- Add boolean flag `hasOnlyOneParam` - sets to true when the method has only one param
- Handle empty collection param
- Handle conversion to string from non file and non string types
- Refactor model with nilable types - Inspiration from kotlin-client code samples
- Refactor model initializers to support only keyword args
- Add profile crystal-client to pom.xml
- Clean up gitignore.mustache
- Change deprecated URI.encode to URI.encode_path
- Fix tests in file samples/client/petstore/crystal/spec/api/pet_api_spec.cr
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
