### PR TITLE
Updates HandlebarsEngineAdapter, allows getX methods to be used in templates + indented partials

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/HandlebarsEngineAdapter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/HandlebarsEngineAdapter.java
@@ -23,6 +23,7 @@ import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.context.FieldValueResolver;
 import com.github.jknack.handlebars.context.JavaBeanValueResolver;
 import com.github.jknack.handlebars.context.MapValueResolver;
+import com.github.jknack.handlebars.context.MethodValueResolver;
 import com.github.jknack.handlebars.helper.ConditionalHelpers;
 import com.github.jknack.handlebars.helper.StringHelpers;
 import com.github.jknack.handlebars.io.AbstractTemplateLoader;
@@ -46,6 +47,7 @@ public class HandlebarsEngineAdapter extends AbstractTemplatingEngineAdapter {
     // We use this as a simple lookup for valid file name extensions. This adapter will inspect .mustache (built-in) and infer the relevant handlebars filename
     private final String[] canCompileFromExtensions = new String[]{".handlebars",".hbs",".mustache"};
     private boolean infiniteLoops = false;
+    private boolean prettyPrint = false;
 
     /**
      * Provides an identifier used to load the adapter. This could be a name, uuid, or any other string.
@@ -71,7 +73,8 @@ public class HandlebarsEngineAdapter extends AbstractTemplatingEngineAdapter {
                 .resolver(
                         MapValueResolver.INSTANCE,
                         JavaBeanValueResolver.INSTANCE,
-                        FieldValueResolver.INSTANCE)
+                        FieldValueResolver.INSTANCE,
+                        MethodValueResolver.INSTANCE)
                 .build();
 
         Handlebars handlebars = new Handlebars(loader);
@@ -84,6 +87,7 @@ public class HandlebarsEngineAdapter extends AbstractTemplatingEngineAdapter {
         handlebars.registerHelpers(ConditionalHelpers.class);
         handlebars.registerHelpers(org.openapitools.codegen.templating.handlebars.StringHelpers.class);
         handlebars.setInfiniteLoops(infiniteLoops);
+        handlebars.setPrettyPrint(prettyPrint);
         Template tmpl = handlebars.compile(templateFile);
         return tmpl.apply(context);
     }
@@ -133,6 +137,10 @@ public class HandlebarsEngineAdapter extends AbstractTemplatingEngineAdapter {
     public HandlebarsEngineAdapter infiniteLoops(boolean infiniteLoops) {
         this.infiniteLoops = infiniteLoops;
         return this;
+    }
+
+    public void setPrettyPrint(boolean prettyPrint) {
+        this.prettyPrint = prettyPrint;
     }
 }
 


### PR DESCRIPTION
Updates HandlebarsEngineAdapter, needed changes for production usage
- adds the resolver MethodValueResolver.INSTANCE, because templates need it to be able to access method names like getHasRequired
- adds the method setPrettyPrint to allow generators to turn on prettyPrint which is needed if generators want to have partials be indented in their templates

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
