### PR TITLE
[java] use IllegalArgumentException instead of RuntimeException

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/ServerConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/ServerConfiguration.mustache
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/webclient-nulable-arrays/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/webclient-nulable-arrays/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ServerConfiguration.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ServerConfiguration.java
@@ -39,7 +39,7 @@ public class ServerConfiguration {
             if (variables != null && variables.containsKey(name)) {
                 value = variables.get(name);
                 if (serverVariable.enumValues.size() > 0 && !serverVariable.enumValues.contains(value)) {
-                    throw new RuntimeException("The variable " + name + " in the server URL has invalid value " + value + ".");
+                    throw new IllegalArgumentException("The variable " + name + " in the server URL has invalid value " + value + ".");
                 }
             }
             url = url.replaceAll("\\{" + name + "\\}", value);


### PR DESCRIPTION
- use IllegalArgumentException instead of RuntimeException as suggested by code review

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
