### PR TITLE
[Core] Does not recognize the type "ByteArray" as "String"

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3336,6 +3336,7 @@ public class DefaultCodegen implements CodegenConfig {
 
     protected void updatePropertyForString(CodegenProperty property, Schema p) {
         if (ModelUtils.isByteArraySchema(p)) {
+            property.setIsString(false);
             property.isByteArray = true;
         } else if (ModelUtils.isBinarySchema(p)) {
             property.isBinary = true;
@@ -4277,6 +4278,7 @@ public class DefaultCodegen implements CodegenConfig {
             } else if (ModelUtils.isUUIDSchema(responseSchema)) {
                 r.isUuid = true;
             } else if (ModelUtils.isByteArraySchema(responseSchema)) {
+                r.setIsString(false);
                 r.isByteArray = true;
             } else if (ModelUtils.isBinarySchema(responseSchema)) {
                 r.isFile = true; // file = binary in OAS3
@@ -6529,6 +6531,7 @@ public class DefaultCodegen implements CodegenConfig {
     protected void updateRequestBodyForString(CodegenParameter codegenParameter, Schema schema, Set<String> imports, String bodyParameterName) {
         updateRequestBodyForPrimitiveType(codegenParameter, schema, bodyParameterName, imports);
         if (ModelUtils.isByteArraySchema(schema)) {
+            codegenParameter.setIsString(false);
             codegenParameter.isByteArray = true;
         } else if (ModelUtils.isBinarySchema(schema)) {
             codegenParameter.isBinary = true;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
@@ -170,7 +170,7 @@ public interface IJsonSchemaValidationProperties {
         } else if (ModelUtils.isStringSchema(p)) {
             setIsString(true);
             if (ModelUtils.isByteArraySchema(p)) {
-                ;
+                setIsString(false);
             } else if (ModelUtils.isBinarySchema(p)) {
                 // openapi v3 way of representing binary + file data
                 // for backward compatibility with 2.x file type

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
@@ -170,7 +170,7 @@ public interface IJsonSchemaValidationProperties {
         } else if (ModelUtils.isStringSchema(p)) {
             setIsString(true);
             if (ModelUtils.isByteArraySchema(p)) {
-                setIsString(false);
+                ;
             } else if (ModelUtils.isBinarySchema(p)) {
                 // openapi v3 way of representing binary + file data
                 // for backward compatibility with 2.x file type

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1687,38 +1687,6 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     @Override
-    protected void updateRequestBodyForString(CodegenParameter codegenParameter, Schema schema, Set<String> imports, String bodyParameterName) {
-        /**
-         * we have a custom version of this function to set isString to false for isByteArray
-         */
-        updateRequestBodyForPrimitiveType(codegenParameter, schema, bodyParameterName, imports);
-        if (ModelUtils.isByteArraySchema(schema)) {
-            codegenParameter.isByteArray = true;
-            // custom code
-            codegenParameter.setIsString(false);
-        } else if (ModelUtils.isBinarySchema(schema)) {
-            codegenParameter.isBinary = true;
-            codegenParameter.isFile = true; // file = binary in OAS3
-        } else if (ModelUtils.isUUIDSchema(schema)) {
-            codegenParameter.isUuid = true;
-        } else if (ModelUtils.isURISchema(schema)) {
-            codegenParameter.isUri = true;
-        } else if (ModelUtils.isEmailSchema(schema)) {
-            codegenParameter.isEmail = true;
-        } else if (ModelUtils.isDateSchema(schema)) { // date format
-            codegenParameter.setIsString(false); // for backward compatibility with 2.x
-            codegenParameter.isDate = true;
-        } else if (ModelUtils.isDateTimeSchema(schema)) { // date-time format
-            codegenParameter.setIsString(false); // for backward compatibility with 2.x
-            codegenParameter.isDateTime = true;
-        } else if (ModelUtils.isDecimalSchema(schema)) { // type: string, format: number
-            codegenParameter.isDecimal = true;
-            codegenParameter.setIsString(false);
-        }
-        codegenParameter.pattern = toRegularExpression(schema.getPattern());
-    }
-
-    @Override
     protected void updateParameterForString(CodegenParameter codegenParameter, Schema parameterSchema){
         /**
          * we have a custom version of this function to set isString to false for uuid

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -3846,4 +3846,29 @@ public class DefaultCodegenTest {
         cp = co.queryParams.get(0);
         assertTrue(cp.getIsAnyType());
     }
+
+    @Test
+    public void testByteArrayTypeInSchemas() {
+        DefaultCodegen codegen = new DefaultCodegen();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_10725.yaml");
+        codegen.setOpenAPI(openAPI);
+        String path;
+        CodegenOperation co;
+        CodegenParameter cp;
+
+        path = "/TxRxByteArray";
+        co = codegen.fromOperation(path, "POST", openAPI.getPaths().get(path).getPost(), null);
+        cp = co.bodyParam;
+        assertTrue(cp.isByteArray);
+        assertFalse(cp.getIsString());
+        CodegenResponse cr = co.responses.get(0);
+        assertTrue(cr.isByteArray);
+        assertFalse(cr.getIsString());
+
+        String modelName = "ObjectContainingByteArray";
+        CodegenModel m = codegen.fromModel(modelName, openAPI.getComponents().getSchemas().get(modelName));
+        CodegenProperty pr = m.vars.get(0);
+        assertTrue(pr.isByteArray);
+        assertFalse(pr.getIsString());
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_10725.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_10725.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.1
+info:
+  title: OpenAPI Petstore
+  description: "byteArray schema isX type checks"
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+servers:
+  - url: http://petstore.swagger.io:80/v2
+tags: []
+paths:
+  /TxRxByteArray:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+              format: byte
+      responses:
+        '200':
+          description: ComposedObject
+          content:
+            application/json:
+              schema:
+                type: string
+                format: byte
+  /RxRefObjectContainingByteArray:
+    get:
+      responses:
+        '200':
+          description: ComposedNumber
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectContainingByteArray'
+components:
+  schemas:
+    ObjectContainingByteArray:
+      type: object
+      properties:
+        byteArray:
+          type: string
+          format: byte


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes #10725 

Hi @wing328  @spacether @agilob @therve 

This PR tries to fix #10725.  The detail can be found at the page of the issue. 

In a word, "ByteArray" should not be recognized as "String".

Thanks.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
