### PR TITLE
[python] Add enum values as class attributes to enum models

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_templates/classvars.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/classvars.mustache
@@ -1,3 +1,16 @@
+{{#isEnum}}
+
+    """
+    allowed enum values
+    """
+
+{{#allowableValues}}
+{{#enumVars}}
+    {{name}} = {{{value}}},
+{{/enumVars}}
+{{/allowableValues}}
+
+{{/isEnum}}
     allowed_values = {
 {{#isEnum}}
         ('value',): {

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_any_type.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_any_type.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesAnyType(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_array.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_array.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesArray(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_boolean.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_boolean.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesBoolean(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_class.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_class.py
@@ -99,6 +99,7 @@ class AdditionalPropertiesClass(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'map_string': 'map_string',  # noqa: E501
         'map_number': 'map_number',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_integer.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_integer.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesInteger(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_number.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_number.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesNumber(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_object.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_object.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesObject(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/additional_properties_string.py
+++ b/samples/client/petstore/python/petstore_api/model/additional_properties_string.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesString(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/animal.py
+++ b/samples/client/petstore/python/petstore_api/model/animal.py
@@ -104,6 +104,7 @@ class Animal(ModelNormal):
             return None
         return {'class_name': val}
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
         'color': 'color',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/animal_farm.py
+++ b/samples/client/petstore/python/petstore_api/model/animal_farm.py
@@ -84,6 +84,7 @@ class AnimalFarm(ModelSimple):
         return None
 
 
+
     attribute_map = {}
 
     read_only_vars = set()

--- a/samples/client/petstore/python/petstore_api/model/api_response.py
+++ b/samples/client/petstore/python/petstore_api/model/api_response.py
@@ -91,6 +91,7 @@ class ApiResponse(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'code': 'code',  # noqa: E501
         'type': 'type',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/array_of_array_of_number_only.py
+++ b/samples/client/petstore/python/petstore_api/model/array_of_array_of_number_only.py
@@ -89,6 +89,7 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'array_array_number': 'ArrayArrayNumber',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/array_of_number_only.py
+++ b/samples/client/petstore/python/petstore_api/model/array_of_number_only.py
@@ -89,6 +89,7 @@ class ArrayOfNumberOnly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'array_number': 'ArrayNumber',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/array_test.py
+++ b/samples/client/petstore/python/petstore_api/model/array_test.py
@@ -97,6 +97,7 @@ class ArrayTest(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'array_of_string': 'array_of_string',  # noqa: E501
         'array_array_of_integer': 'array_array_of_integer',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/capitalization.py
+++ b/samples/client/petstore/python/petstore_api/model/capitalization.py
@@ -94,6 +94,7 @@ class Capitalization(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'small_camel': 'smallCamel',  # noqa: E501
         'capital_camel': 'CapitalCamel',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/cat.py
+++ b/samples/client/petstore/python/petstore_api/model/cat.py
@@ -102,6 +102,7 @@ class Cat(ModelComposed):
             return None
         return {'class_name': val}
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
         'declawed': 'declawed',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/cat_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/cat_all_of.py
@@ -89,6 +89,7 @@ class CatAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'declawed': 'declawed',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/category.py
+++ b/samples/client/petstore/python/petstore_api/model/category.py
@@ -90,6 +90,7 @@ class Category(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         'id': 'id',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/child.py
+++ b/samples/client/petstore/python/petstore_api/model/child.py
@@ -99,6 +99,7 @@ class Child(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'radio_waves': 'radioWaves',  # noqa: E501
         'tele_vision': 'teleVision',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/child_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/child_all_of.py
@@ -89,6 +89,7 @@ class ChildAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'inter_net': 'interNet',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/child_cat.py
+++ b/samples/client/petstore/python/petstore_api/model/child_cat.py
@@ -101,6 +101,7 @@ class ChildCat(ModelComposed):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
         'name': 'name',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/child_cat_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/child_cat_all_of.py
@@ -89,6 +89,7 @@ class ChildCatAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/child_dog.py
+++ b/samples/client/petstore/python/petstore_api/model/child_dog.py
@@ -101,6 +101,7 @@ class ChildDog(ModelComposed):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
         'bark': 'bark',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/child_dog_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/child_dog_all_of.py
@@ -89,6 +89,7 @@ class ChildDogAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'bark': 'bark',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/child_lizard.py
+++ b/samples/client/petstore/python/petstore_api/model/child_lizard.py
@@ -101,6 +101,7 @@ class ChildLizard(ModelComposed):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
         'loves_rocks': 'lovesRocks',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/child_lizard_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/child_lizard_all_of.py
@@ -89,6 +89,7 @@ class ChildLizardAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'loves_rocks': 'lovesRocks',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/class_model.py
+++ b/samples/client/petstore/python/petstore_api/model/class_model.py
@@ -89,6 +89,7 @@ class ClassModel(ModelNormal):
         return None
 
 
+
     attribute_map = {
         '_class': '_class',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/client.py
+++ b/samples/client/petstore/python/petstore_api/model/client.py
@@ -89,6 +89,7 @@ class Client(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'client': 'client',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/dog.py
+++ b/samples/client/petstore/python/petstore_api/model/dog.py
@@ -102,6 +102,7 @@ class Dog(ModelComposed):
             return None
         return {'class_name': val}
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
         'breed': 'breed',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/dog_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/dog_all_of.py
@@ -89,6 +89,7 @@ class DogAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'breed': 'breed',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/enum_arrays.py
+++ b/samples/client/petstore/python/petstore_api/model/enum_arrays.py
@@ -98,6 +98,7 @@ class EnumArrays(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'just_symbol': 'just_symbol',  # noqa: E501
         'array_enum': 'array_enum',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/enum_class.py
+++ b/samples/client/petstore/python/petstore_api/model/enum_class.py
@@ -50,6 +50,15 @@ class EnumClass(ModelSimple):
           as additional properties values.
     """
 
+
+    """
+    allowed enum values
+    """
+
+    _ABC = "_abc",
+    -EFG = "-efg",
+    (XYZ) = "(xyz)",
+
     allowed_values = {
         ('value',): {
             '_ABC': "_abc",
@@ -82,6 +91,7 @@ class EnumClass(ModelSimple):
     @cached_property
     def discriminator():
         return None
+
 
 
     attribute_map = {}

--- a/samples/client/petstore/python/petstore_api/model/enum_test.py
+++ b/samples/client/petstore/python/petstore_api/model/enum_test.py
@@ -117,6 +117,7 @@ class EnumTest(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'enum_string_required': 'enum_string_required',  # noqa: E501
         'enum_string': 'enum_string',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/file.py
+++ b/samples/client/petstore/python/petstore_api/model/file.py
@@ -89,6 +89,7 @@ class File(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'source_uri': 'sourceURI',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/file_schema_test_class.py
+++ b/samples/client/petstore/python/petstore_api/model/file_schema_test_class.py
@@ -96,6 +96,7 @@ class FileSchemaTestClass(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'file': 'file',  # noqa: E501
         'files': 'files',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/format_test.py
+++ b/samples/client/petstore/python/petstore_api/model/format_test.py
@@ -136,6 +136,7 @@ class FormatTest(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'number': 'number',  # noqa: E501
         'byte': 'byte',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/grandparent.py
+++ b/samples/client/petstore/python/petstore_api/model/grandparent.py
@@ -89,6 +89,7 @@ class Grandparent(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'radio_waves': 'radioWaves',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/grandparent_animal.py
+++ b/samples/client/petstore/python/petstore_api/model/grandparent_animal.py
@@ -109,6 +109,7 @@ class GrandparentAnimal(ModelNormal):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/has_only_read_only.py
+++ b/samples/client/petstore/python/petstore_api/model/has_only_read_only.py
@@ -90,6 +90,7 @@ class HasOnlyReadOnly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'bar': 'bar',  # noqa: E501
         'foo': 'foo',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/list.py
+++ b/samples/client/petstore/python/petstore_api/model/list.py
@@ -89,6 +89,7 @@ class List(ModelNormal):
         return None
 
 
+
     attribute_map = {
         '_123_list': '123-list',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/map_test.py
+++ b/samples/client/petstore/python/petstore_api/model/map_test.py
@@ -102,6 +102,7 @@ class MapTest(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'map_map_of_string': 'map_map_of_string',  # noqa: E501
         'map_of_enum_string': 'map_of_enum_string',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/mixed_properties_and_additional_properties_class.py
+++ b/samples/client/petstore/python/petstore_api/model/mixed_properties_and_additional_properties_class.py
@@ -97,6 +97,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'uuid': 'uuid',  # noqa: E501
         'date_time': 'dateTime',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/model200_response.py
+++ b/samples/client/petstore/python/petstore_api/model/model200_response.py
@@ -90,6 +90,7 @@ class Model200Response(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         '_class': 'class',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/model_return.py
+++ b/samples/client/petstore/python/petstore_api/model/model_return.py
@@ -89,6 +89,7 @@ class ModelReturn(ModelNormal):
         return None
 
 
+
     attribute_map = {
         '_return': 'return',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/name.py
+++ b/samples/client/petstore/python/petstore_api/model/name.py
@@ -92,6 +92,7 @@ class Name(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         'snake_case': 'snake_case',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/number_only.py
+++ b/samples/client/petstore/python/petstore_api/model/number_only.py
@@ -89,6 +89,7 @@ class NumberOnly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'just_number': 'JustNumber',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/number_with_validations.py
+++ b/samples/client/petstore/python/petstore_api/model/number_with_validations.py
@@ -83,6 +83,7 @@ class NumberWithValidations(ModelSimple):
         return None
 
 
+
     attribute_map = {}
 
     read_only_vars = set()

--- a/samples/client/petstore/python/petstore_api/model/object_model_with_ref_props.py
+++ b/samples/client/petstore/python/petstore_api/model/object_model_with_ref_props.py
@@ -97,6 +97,7 @@ class ObjectModelWithRefProps(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'my_number': 'my_number',  # noqa: E501
         'my_string': 'my_string',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/order.py
+++ b/samples/client/petstore/python/petstore_api/model/order.py
@@ -99,6 +99,7 @@ class Order(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'id': 'id',  # noqa: E501
         'pet_id': 'petId',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/parent.py
+++ b/samples/client/petstore/python/petstore_api/model/parent.py
@@ -98,6 +98,7 @@ class Parent(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'radio_waves': 'radioWaves',  # noqa: E501
         'tele_vision': 'teleVision',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/parent_all_of.py
+++ b/samples/client/petstore/python/petstore_api/model/parent_all_of.py
@@ -89,6 +89,7 @@ class ParentAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'tele_vision': 'teleVision',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/parent_pet.py
+++ b/samples/client/petstore/python/petstore_api/model/parent_pet.py
@@ -108,6 +108,7 @@ class ParentPet(ModelComposed):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/pet.py
+++ b/samples/client/petstore/python/petstore_api/model/pet.py
@@ -107,6 +107,7 @@ class Pet(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         'photo_urls': 'photoUrls',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/player.py
+++ b/samples/client/petstore/python/petstore_api/model/player.py
@@ -90,6 +90,7 @@ class Player(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         'enemy_player': 'enemyPlayer',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/read_only_first.py
+++ b/samples/client/petstore/python/petstore_api/model/read_only_first.py
@@ -90,6 +90,7 @@ class ReadOnlyFirst(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'bar': 'bar',  # noqa: E501
         'baz': 'baz',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/special_model_name.py
+++ b/samples/client/petstore/python/petstore_api/model/special_model_name.py
@@ -89,6 +89,7 @@ class SpecialModelName(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'special_property_name': '$special[property.name]',  # noqa: E501
     }

--- a/samples/client/petstore/python/petstore_api/model/string_boolean_map.py
+++ b/samples/client/petstore/python/petstore_api/model/string_boolean_map.py
@@ -88,6 +88,7 @@ class StringBooleanMap(ModelNormal):
         return None
 
 
+
     attribute_map = {
     }
 

--- a/samples/client/petstore/python/petstore_api/model/string_enum.py
+++ b/samples/client/petstore/python/petstore_api/model/string_enum.py
@@ -50,6 +50,15 @@ class StringEnum(ModelSimple):
           as additional properties values.
     """
 
+
+    """
+    allowed enum values
+    """
+
+    PLACED = "placed",
+    APPROVED = "approved",
+    DELIVERED = "delivered",
+
     allowed_values = {
         ('value',): {
             'PLACED': "placed",
@@ -82,6 +91,7 @@ class StringEnum(ModelSimple):
     @cached_property
     def discriminator():
         return None
+
 
 
     attribute_map = {}

--- a/samples/client/petstore/python/petstore_api/model/tag.py
+++ b/samples/client/petstore/python/petstore_api/model/tag.py
@@ -91,6 +91,7 @@ class Tag(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'id': 'id',  # noqa: E501
         'name': 'name',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/type_holder_default.py
+++ b/samples/client/petstore/python/petstore_api/model/type_holder_default.py
@@ -95,6 +95,7 @@ class TypeHolderDefault(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'string_item': 'string_item',  # noqa: E501
         'number_item': 'number_item',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/type_holder_example.py
+++ b/samples/client/petstore/python/petstore_api/model/type_holder_example.py
@@ -102,6 +102,7 @@ class TypeHolderExample(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'string_item': 'string_item',  # noqa: E501
         'number_item': 'number_item',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/user.py
+++ b/samples/client/petstore/python/petstore_api/model/user.py
@@ -96,6 +96,7 @@ class User(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'id': 'id',  # noqa: E501
         'username': 'username',  # noqa: E501

--- a/samples/client/petstore/python/petstore_api/model/xml_item.py
+++ b/samples/client/petstore/python/petstore_api/model/xml_item.py
@@ -117,6 +117,7 @@ class XmlItem(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'attribute_string': 'attribute_string',  # noqa: E501
         'attribute_number': 'attribute_number',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_any_type.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_any_type.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesAnyType(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_array.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_array.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesArray(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_boolean.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_boolean.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesBoolean(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_class.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_class.py
@@ -93,6 +93,7 @@ class AdditionalPropertiesClass(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'map_string': 'map_string',  # noqa: E501
         'map_number': 'map_number',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_integer.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_integer.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesInteger(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_number.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_number.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesNumber(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_object.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_object.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesObject(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_string.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/additional_properties_string.py
@@ -89,6 +89,7 @@ class AdditionalPropertiesString(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/animal.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/animal.py
@@ -97,6 +97,7 @@ class Animal(ModelNormal):
             return None
         return {'class_name': val}
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
         'color': 'color',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/animal_farm.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/animal_farm.py
@@ -84,6 +84,7 @@ class AnimalFarm(ModelSimple):
         return None
 
 
+
     attribute_map = {}
 
     read_only_vars = set()

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/api_response.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/api_response.py
@@ -85,6 +85,7 @@ class ApiResponse(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'code': 'code',  # noqa: E501
         'type': 'type',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/array_of_array_of_number_only.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/array_of_array_of_number_only.py
@@ -83,6 +83,7 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'array_array_number': 'ArrayArrayNumber',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/array_of_number_only.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/array_of_number_only.py
@@ -83,6 +83,7 @@ class ArrayOfNumberOnly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'array_number': 'ArrayNumber',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/array_test.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/array_test.py
@@ -90,6 +90,7 @@ class ArrayTest(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'array_of_string': 'array_of_string',  # noqa: E501
         'array_array_of_integer': 'array_array_of_integer',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/capitalization.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/capitalization.py
@@ -88,6 +88,7 @@ class Capitalization(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'small_camel': 'smallCamel',  # noqa: E501
         'capital_camel': 'CapitalCamel',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/cat.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/cat.py
@@ -95,6 +95,7 @@ class Cat(ModelComposed):
             return None
         return {'class_name': val}
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
         'declawed': 'declawed',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/cat_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/cat_all_of.py
@@ -83,6 +83,7 @@ class CatAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'declawed': 'declawed',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/category.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/category.py
@@ -84,6 +84,7 @@ class Category(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         'id': 'id',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child.py
@@ -92,6 +92,7 @@ class Child(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'radio_waves': 'radioWaves',  # noqa: E501
         'tele_vision': 'teleVision',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_all_of.py
@@ -83,6 +83,7 @@ class ChildAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'inter_net': 'interNet',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_cat.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_cat.py
@@ -94,6 +94,7 @@ class ChildCat(ModelComposed):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
         'name': 'name',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_cat_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_cat_all_of.py
@@ -83,6 +83,7 @@ class ChildCatAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_dog.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_dog.py
@@ -94,6 +94,7 @@ class ChildDog(ModelComposed):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
         'bark': 'bark',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_dog_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_dog_all_of.py
@@ -83,6 +83,7 @@ class ChildDogAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'bark': 'bark',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_lizard.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_lizard.py
@@ -94,6 +94,7 @@ class ChildLizard(ModelComposed):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
         'loves_rocks': 'lovesRocks',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_lizard_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/child_lizard_all_of.py
@@ -83,6 +83,7 @@ class ChildLizardAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'loves_rocks': 'lovesRocks',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/class_model.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/class_model.py
@@ -83,6 +83,7 @@ class ClassModel(ModelNormal):
         return None
 
 
+
     attribute_map = {
         '_class': '_class',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/client.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/client.py
@@ -83,6 +83,7 @@ class Client(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'client': 'client',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/dog.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/dog.py
@@ -95,6 +95,7 @@ class Dog(ModelComposed):
             return None
         return {'class_name': val}
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
         'breed': 'breed',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/dog_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/dog_all_of.py
@@ -83,6 +83,7 @@ class DogAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'breed': 'breed',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/enum_arrays.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/enum_arrays.py
@@ -92,6 +92,7 @@ class EnumArrays(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'just_symbol': 'just_symbol',  # noqa: E501
         'array_enum': 'array_enum',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/enum_class.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/enum_class.py
@@ -50,6 +50,15 @@ class EnumClass(ModelSimple):
           as additional properties values.
     """
 
+
+    """
+    allowed enum values
+    """
+
+    _ABC = "_abc",
+    -EFG = "-efg",
+    (XYZ) = "(xyz)",
+
     allowed_values = {
         ('value',): {
             '_ABC': "_abc",
@@ -82,6 +91,7 @@ class EnumClass(ModelSimple):
     @cached_property
     def discriminator():
         return None
+
 
 
     attribute_map = {}

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/enum_test.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/enum_test.py
@@ -110,6 +110,7 @@ class EnumTest(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'enum_string_required': 'enum_string_required',  # noqa: E501
         'enum_string': 'enum_string',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/file.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/file.py
@@ -83,6 +83,7 @@ class File(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'source_uri': 'sourceURI',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/file_schema_test_class.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/file_schema_test_class.py
@@ -89,6 +89,7 @@ class FileSchemaTestClass(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'file': 'file',  # noqa: E501
         'files': 'files',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/format_test.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/format_test.py
@@ -130,6 +130,7 @@ class FormatTest(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'number': 'number',  # noqa: E501
         'byte': 'byte',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/grandparent.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/grandparent.py
@@ -83,6 +83,7 @@ class Grandparent(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'radio_waves': 'radioWaves',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/grandparent_animal.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/grandparent_animal.py
@@ -102,6 +102,7 @@ class GrandparentAnimal(ModelNormal):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/has_only_read_only.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/has_only_read_only.py
@@ -84,6 +84,7 @@ class HasOnlyReadOnly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'bar': 'bar',  # noqa: E501
         'foo': 'foo',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/list.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/list.py
@@ -83,6 +83,7 @@ class List(ModelNormal):
         return None
 
 
+
     attribute_map = {
         '_123_list': '123-list',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/map_test.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/map_test.py
@@ -95,6 +95,7 @@ class MapTest(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'map_map_of_string': 'map_map_of_string',  # noqa: E501
         'map_of_enum_string': 'map_of_enum_string',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/mixed_properties_and_additional_properties_class.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/mixed_properties_and_additional_properties_class.py
@@ -90,6 +90,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'uuid': 'uuid',  # noqa: E501
         'date_time': 'dateTime',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/model200_response.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/model200_response.py
@@ -84,6 +84,7 @@ class Model200Response(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         '_class': 'class',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/model_return.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/model_return.py
@@ -83,6 +83,7 @@ class ModelReturn(ModelNormal):
         return None
 
 
+
     attribute_map = {
         '_return': 'return',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/name.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/name.py
@@ -86,6 +86,7 @@ class Name(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         'snake_case': 'snake_case',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/number_only.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/number_only.py
@@ -83,6 +83,7 @@ class NumberOnly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'just_number': 'JustNumber',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/number_with_validations.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/number_with_validations.py
@@ -83,6 +83,7 @@ class NumberWithValidations(ModelSimple):
         return None
 
 
+
     attribute_map = {}
 
     read_only_vars = set()

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/object_model_with_ref_props.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/object_model_with_ref_props.py
@@ -90,6 +90,7 @@ class ObjectModelWithRefProps(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'my_number': 'my_number',  # noqa: E501
         'my_string': 'my_string',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/order.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/order.py
@@ -93,6 +93,7 @@ class Order(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'id': 'id',  # noqa: E501
         'pet_id': 'petId',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/parent.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/parent.py
@@ -91,6 +91,7 @@ class Parent(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'radio_waves': 'radioWaves',  # noqa: E501
         'tele_vision': 'teleVision',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/parent_all_of.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/parent_all_of.py
@@ -83,6 +83,7 @@ class ParentAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'tele_vision': 'teleVision',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/parent_pet.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/parent_pet.py
@@ -101,6 +101,7 @@ class ParentPet(ModelComposed):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/pet.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/pet.py
@@ -100,6 +100,7 @@ class Pet(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         'photo_urls': 'photoUrls',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/player.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/player.py
@@ -84,6 +84,7 @@ class Player(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         'enemy_player': 'enemyPlayer',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/read_only_first.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/read_only_first.py
@@ -84,6 +84,7 @@ class ReadOnlyFirst(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'bar': 'bar',  # noqa: E501
         'baz': 'baz',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/special_model_name.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/special_model_name.py
@@ -83,6 +83,7 @@ class SpecialModelName(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'special_property_name': '$special[property.name]',  # noqa: E501
     }

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/string_boolean_map.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/string_boolean_map.py
@@ -88,6 +88,7 @@ class StringBooleanMap(ModelNormal):
         return None
 
 
+
     attribute_map = {
     }
 

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/string_enum.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/string_enum.py
@@ -50,6 +50,15 @@ class StringEnum(ModelSimple):
           as additional properties values.
     """
 
+
+    """
+    allowed enum values
+    """
+
+    PLACED = "placed",
+    APPROVED = "approved",
+    DELIVERED = "delivered",
+
     allowed_values = {
         ('value',): {
             'PLACED': "placed",
@@ -82,6 +91,7 @@ class StringEnum(ModelSimple):
     @cached_property
     def discriminator():
         return None
+
 
 
     attribute_map = {}

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/tag.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/tag.py
@@ -85,6 +85,7 @@ class Tag(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'id': 'id',  # noqa: E501
         'name': 'name',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/type_holder_default.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/type_holder_default.py
@@ -89,6 +89,7 @@ class TypeHolderDefault(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'string_item': 'string_item',  # noqa: E501
         'number_item': 'number_item',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/type_holder_example.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/type_holder_example.py
@@ -96,6 +96,7 @@ class TypeHolderExample(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'string_item': 'string_item',  # noqa: E501
         'number_item': 'number_item',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/user.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/user.py
@@ -90,6 +90,7 @@ class User(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'id': 'id',  # noqa: E501
         'username': 'username',  # noqa: E501

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/xml_item.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/model/xml_item.py
@@ -111,6 +111,7 @@ class XmlItem(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'attribute_string': 'attribute_string',  # noqa: E501
         'attribute_number': 'attribute_number',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/additional_properties_class.py
@@ -96,6 +96,7 @@ class AdditionalPropertiesClass(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'map_property': 'map_property',  # noqa: E501
         'map_of_map_property': 'map_of_map_property',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/additional_properties_with_array_of_enums.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/additional_properties_with_array_of_enums.py
@@ -94,6 +94,7 @@ class AdditionalPropertiesWithArrayOfEnums(ModelNormal):
         return None
 
 
+
     attribute_map = {
     }
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/address.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/address.py
@@ -88,6 +88,7 @@ class Address(ModelNormal):
         return None
 
 
+
     attribute_map = {
     }
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/animal.py
@@ -105,6 +105,7 @@ class Animal(ModelNormal):
             return None
         return {'class_name': val}
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
         'color': 'color',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/animal_farm.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/animal_farm.py
@@ -84,6 +84,7 @@ class AnimalFarm(ModelSimple):
         return None
 
 
+
     attribute_map = {}
 
     read_only_vars = set()

--- a/samples/openapi3/client/petstore/python/petstore_api/model/api_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/api_response.py
@@ -91,6 +91,7 @@ class ApiResponse(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'code': 'code',  # noqa: E501
         'type': 'type',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/apple.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/apple.py
@@ -101,6 +101,7 @@ class Apple(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'cultivar': 'cultivar',  # noqa: E501
         'origin': 'origin',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/apple_req.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/apple_req.py
@@ -84,6 +84,7 @@ class AppleReq(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'cultivar': 'cultivar',  # noqa: E501
         'mealy': 'mealy',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/array_of_array_of_number_only.py
@@ -89,6 +89,7 @@ class ArrayOfArrayOfNumberOnly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'array_array_number': 'ArrayArrayNumber',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/array_of_enums.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/array_of_enums.py
@@ -84,6 +84,7 @@ class ArrayOfEnums(ModelSimple):
         return None
 
 
+
     attribute_map = {}
 
     read_only_vars = set()

--- a/samples/openapi3/client/petstore/python/petstore_api/model/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/array_of_number_only.py
@@ -89,6 +89,7 @@ class ArrayOfNumberOnly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'array_number': 'ArrayNumber',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/array_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/array_test.py
@@ -97,6 +97,7 @@ class ArrayTest(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'array_of_string': 'array_of_string',  # noqa: E501
         'array_array_of_integer': 'array_array_of_integer',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/banana.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/banana.py
@@ -89,6 +89,7 @@ class Banana(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'length_cm': 'lengthCm',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/banana_req.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/banana_req.py
@@ -84,6 +84,7 @@ class BananaReq(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'length_cm': 'lengthCm',  # noqa: E501
         'sweet': 'sweet',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/basque_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/basque_pig.py
@@ -89,6 +89,7 @@ class BasquePig(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/boolean_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/boolean_enum.py
@@ -50,6 +50,13 @@ class BooleanEnum(ModelSimple):
           as additional properties values.
     """
 
+
+    """
+    allowed enum values
+    """
+
+    TRUE = True,
+
     allowed_values = {
         ('value',): {
             'TRUE': True,
@@ -80,6 +87,7 @@ class BooleanEnum(ModelSimple):
     @cached_property
     def discriminator():
         return None
+
 
 
     attribute_map = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/model/capitalization.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/capitalization.py
@@ -94,6 +94,7 @@ class Capitalization(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'small_camel': 'smallCamel',  # noqa: E501
         'capital_camel': 'CapitalCamel',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/cat.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/cat.py
@@ -103,6 +103,7 @@ class Cat(ModelComposed):
             return None
         return {'class_name': val}
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
         'declawed': 'declawed',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/cat_all_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/cat_all_of.py
@@ -89,6 +89,7 @@ class CatAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'declawed': 'declawed',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/category.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/category.py
@@ -90,6 +90,7 @@ class Category(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         'id': 'id',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/child_cat.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/child_cat.py
@@ -101,6 +101,7 @@ class ChildCat(ModelComposed):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
         'name': 'name',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/child_cat_all_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/child_cat_all_of.py
@@ -89,6 +89,7 @@ class ChildCatAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/class_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/class_model.py
@@ -89,6 +89,7 @@ class ClassModel(ModelNormal):
         return None
 
 
+
     attribute_map = {
         '_class': '_class',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/client.py
@@ -89,6 +89,7 @@ class Client(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'client': 'client',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/complex_quadrilateral.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/complex_quadrilateral.py
@@ -98,6 +98,7 @@ class ComplexQuadrilateral(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'shape_type': 'shapeType',  # noqa: E501
         'quadrilateral_type': 'quadrilateralType',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/composed_one_of_number_with_validations.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/composed_one_of_number_with_validations.py
@@ -99,6 +99,7 @@ class ComposedOneOfNumberWithValidations(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'color': 'color',  # noqa: E501
         'tail': 'tail',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/composed_schema_with_props_and_no_add_props.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/composed_schema_with_props_and_no_add_props.py
@@ -90,6 +90,7 @@ class ComposedSchemaWithPropsAndNoAddProps(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'color': 'color',  # noqa: E501
         'id': 'id',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/danish_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/danish_pig.py
@@ -89,6 +89,7 @@ class DanishPig(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/dog.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/dog.py
@@ -106,6 +106,7 @@ class Dog(ModelComposed):
             return None
         return {'class_name': val}
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
         'breed': 'breed',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/dog_all_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/dog_all_of.py
@@ -96,6 +96,7 @@ class DogAllOf(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'breed': 'breed',  # noqa: E501
         'legs': 'legs',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/drawing.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/drawing.py
@@ -104,6 +104,7 @@ class Drawing(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'main_shape': 'mainShape',  # noqa: E501
         'shape_or_null': 'shapeOrNull',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/enum_arrays.py
@@ -98,6 +98,7 @@ class EnumArrays(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'just_symbol': 'just_symbol',  # noqa: E501
         'array_enum': 'array_enum',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/enum_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/enum_class.py
@@ -50,6 +50,15 @@ class EnumClass(ModelSimple):
           as additional properties values.
     """
 
+
+    """
+    allowed enum values
+    """
+
+    _ABC = "_abc",
+    -EFG = "-efg",
+    (XYZ) = "(xyz)",
+
     allowed_values = {
         ('value',): {
             '_ABC': "_abc",
@@ -82,6 +91,7 @@ class EnumClass(ModelSimple):
     @cached_property
     def discriminator():
         return None
+
 
 
     attribute_map = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/model/enum_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/enum_test.py
@@ -140,6 +140,7 @@ class EnumTest(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'enum_string_required': 'enum_string_required',  # noqa: E501
         'enum_string': 'enum_string',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/equilateral_triangle.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/equilateral_triangle.py
@@ -98,6 +98,7 @@ class EquilateralTriangle(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'shape_type': 'shapeType',  # noqa: E501
         'triangle_type': 'triangleType',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/fake_post_inline_additional_properties_payload_array_data.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/fake_post_inline_additional_properties_payload_array_data.py
@@ -89,6 +89,7 @@ class FakePostInlineAdditionalPropertiesPayloadArrayData(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'labels': 'labels',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/file.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/file.py
@@ -89,6 +89,7 @@ class File(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'source_uri': 'sourceURI',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/file_schema_test_class.py
@@ -96,6 +96,7 @@ class FileSchemaTestClass(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'file': 'file',  # noqa: E501
         'files': 'files',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/foo.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/foo.py
@@ -89,6 +89,7 @@ class Foo(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'bar': 'bar',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/format_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/format_test.py
@@ -147,6 +147,7 @@ class FormatTest(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'number': 'number',  # noqa: E501
         'byte': 'byte',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/fruit.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/fruit.py
@@ -111,6 +111,7 @@ class Fruit(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'cultivar': 'cultivar',  # noqa: E501
         'length_cm': 'lengthCm',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/fruit_req.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/fruit_req.py
@@ -100,6 +100,7 @@ class FruitReq(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'mealy': 'mealy',  # noqa: E501
         'sweet': 'sweet',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/gm_fruit.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/gm_fruit.py
@@ -111,6 +111,7 @@ class GmFruit(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'cultivar': 'cultivar',  # noqa: E501
         'length_cm': 'lengthCm',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/grandparent_animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/grandparent_animal.py
@@ -103,6 +103,7 @@ class GrandparentAnimal(ModelNormal):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/has_only_read_only.py
@@ -90,6 +90,7 @@ class HasOnlyReadOnly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'bar': 'bar',  # noqa: E501
         'foo': 'foo',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/health_check_result.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/health_check_result.py
@@ -89,6 +89,7 @@ class HealthCheckResult(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'nullable_message': 'NullableMessage',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/inline_additional_properties_ref_payload.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/inline_additional_properties_ref_payload.py
@@ -95,6 +95,7 @@ class InlineAdditionalPropertiesRefPayload(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'array_data': 'arrayData',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/inline_object6.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/inline_object6.py
@@ -95,6 +95,7 @@ class InlineObject6(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'array_data': 'arrayData',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/inline_response_default.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/inline_response_default.py
@@ -95,6 +95,7 @@ class InlineResponseDefault(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'string': 'string',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum.py
@@ -50,6 +50,15 @@ class IntegerEnum(ModelSimple):
           as additional properties values.
     """
 
+
+    """
+    allowed enum values
+    """
+
+    0 = 0,
+    1 = 1,
+    2 = 2,
+
     allowed_values = {
         ('value',): {
             '0': 0,
@@ -82,6 +91,7 @@ class IntegerEnum(ModelSimple):
     @cached_property
     def discriminator():
         return None
+
 
 
     attribute_map = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum_one_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum_one_value.py
@@ -50,6 +50,13 @@ class IntegerEnumOneValue(ModelSimple):
           as additional properties values.
     """
 
+
+    """
+    allowed enum values
+    """
+
+    0 = 0,
+
     allowed_values = {
         ('value',): {
             '0': 0,
@@ -80,6 +87,7 @@ class IntegerEnumOneValue(ModelSimple):
     @cached_property
     def discriminator():
         return None
+
 
 
     attribute_map = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum_with_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/integer_enum_with_default_value.py
@@ -50,6 +50,15 @@ class IntegerEnumWithDefaultValue(ModelSimple):
           as additional properties values.
     """
 
+
+    """
+    allowed enum values
+    """
+
+    0 = 0,
+    1 = 1,
+    2 = 2,
+
     allowed_values = {
         ('value',): {
             '0': 0,
@@ -82,6 +91,7 @@ class IntegerEnumWithDefaultValue(ModelSimple):
     @cached_property
     def discriminator():
         return None
+
 
 
     attribute_map = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/model/isosceles_triangle.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/isosceles_triangle.py
@@ -98,6 +98,7 @@ class IsoscelesTriangle(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'shape_type': 'shapeType',  # noqa: E501
         'triangle_type': 'triangleType',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/legs.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/legs.py
@@ -94,6 +94,7 @@ class Legs(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'legs': 'legs',  # noqa: E501
         'name': 'name',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/list.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/list.py
@@ -89,6 +89,7 @@ class List(ModelNormal):
         return None
 
 
+
     attribute_map = {
         '_123_list': '123-list',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/mammal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/mammal.py
@@ -114,6 +114,7 @@ class Mammal(ModelComposed):
             return None
         return {'class_name': val}
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
         'has_baleen': 'hasBaleen',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/map_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/map_test.py
@@ -102,6 +102,7 @@ class MapTest(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'map_map_of_string': 'map_map_of_string',  # noqa: E501
         'map_of_enum_string': 'map_of_enum_string',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/mixed_properties_and_additional_properties_class.py
@@ -97,6 +97,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'uuid': 'uuid',  # noqa: E501
         'date_time': 'dateTime',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/model200_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/model200_response.py
@@ -90,6 +90,7 @@ class Model200Response(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         '_class': 'class',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/model_return.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/model_return.py
@@ -89,6 +89,7 @@ class ModelReturn(ModelNormal):
         return None
 
 
+
     attribute_map = {
         '_return': 'return',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/mole.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/mole.py
@@ -94,6 +94,7 @@ class Mole(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'blind': 'blind',  # noqa: E501
         'smell': 'smell',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/name.py
@@ -92,6 +92,7 @@ class Name(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         'snake_case': 'snake_case',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/nullable_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/nullable_class.py
@@ -101,6 +101,7 @@ class NullableClass(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'integer_prop': 'integer_prop',  # noqa: E501
         'number_prop': 'number_prop',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/nullable_shape.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/nullable_shape.py
@@ -105,6 +105,7 @@ class NullableShape(ModelComposed):
             return None
         return {'shape_type': val}
 
+
     attribute_map = {
         'shape_type': 'shapeType',  # noqa: E501
         'quadrilateral_type': 'quadrilateralType',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/number_only.py
@@ -89,6 +89,7 @@ class NumberOnly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'just_number': 'JustNumber',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/number_with_validations.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/number_with_validations.py
@@ -83,6 +83,7 @@ class NumberWithValidations(ModelSimple):
         return None
 
 
+
     attribute_map = {}
 
     read_only_vars = set()

--- a/samples/openapi3/client/petstore/python/petstore_api/model/object_interface.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/object_interface.py
@@ -88,6 +88,7 @@ class ObjectInterface(ModelNormal):
         return None
 
 
+
     attribute_map = {
     }
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/object_model_with_ref_props.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/object_model_with_ref_props.py
@@ -100,6 +100,7 @@ class ObjectModelWithRefProps(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'my_number': 'my_number',  # noqa: E501
         'my_readonly': 'my_readonly',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/object_with_validations.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/object_with_validations.py
@@ -91,6 +91,7 @@ class ObjectWithValidations(ModelNormal):
         return None
 
 
+
     attribute_map = {
     }
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/order.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/order.py
@@ -99,6 +99,7 @@ class Order(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'id': 'id',  # noqa: E501
         'pet_id': 'petId',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/parent_pet.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/parent_pet.py
@@ -102,6 +102,7 @@ class ParentPet(ModelComposed):
             return None
         return {'pet_type': val}
 
+
     attribute_map = {
         'pet_type': 'pet_type',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/pet.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/pet.py
@@ -107,6 +107,7 @@ class Pet(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
         'photo_urls': 'photoUrls',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/pig.py
@@ -103,6 +103,7 @@ class Pig(ModelComposed):
             return None
         return {'class_name': val}
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/quadrilateral.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/quadrilateral.py
@@ -104,6 +104,7 @@ class Quadrilateral(ModelComposed):
             return None
         return {'quadrilateral_type': val}
 
+
     attribute_map = {
         'quadrilateral_type': 'quadrilateralType',  # noqa: E501
         'shape_type': 'shapeType',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/quadrilateral_interface.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/quadrilateral_interface.py
@@ -89,6 +89,7 @@ class QuadrilateralInterface(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'quadrilateral_type': 'quadrilateralType',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/read_only_first.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/read_only_first.py
@@ -90,6 +90,7 @@ class ReadOnlyFirst(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'bar': 'bar',  # noqa: E501
         'baz': 'baz',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/readonly.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/readonly.py
@@ -89,6 +89,7 @@ class Readonly(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'name': 'name',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/scalene_triangle.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/scalene_triangle.py
@@ -98,6 +98,7 @@ class ScaleneTriangle(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'shape_type': 'shapeType',  # noqa: E501
         'triangle_type': 'triangleType',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/shape.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/shape.py
@@ -105,6 +105,7 @@ class Shape(ModelComposed):
             return None
         return {'shape_type': val}
 
+
     attribute_map = {
         'shape_type': 'shapeType',  # noqa: E501
         'quadrilateral_type': 'quadrilateralType',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/shape_interface.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/shape_interface.py
@@ -89,6 +89,7 @@ class ShapeInterface(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'shape_type': 'shapeType',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/shape_or_null.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/shape_or_null.py
@@ -105,6 +105,7 @@ class ShapeOrNull(ModelComposed):
             return None
         return {'shape_type': val}
 
+
     attribute_map = {
         'shape_type': 'shapeType',  # noqa: E501
         'quadrilateral_type': 'quadrilateralType',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/simple_quadrilateral.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/simple_quadrilateral.py
@@ -98,6 +98,7 @@ class SimpleQuadrilateral(ModelComposed):
         return None
 
 
+
     attribute_map = {
         'shape_type': 'shapeType',  # noqa: E501
         'quadrilateral_type': 'quadrilateralType',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/some_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/some_object.py
@@ -94,6 +94,7 @@ class SomeObject(ModelComposed):
         return None
 
 
+
     attribute_map = {
     }
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/some_object_with_self_attr.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/some_object_with_self_attr.py
@@ -89,6 +89,7 @@ class SomeObjectWithSelfAttr(ModelNormal):
         return None
 
 
+
     attribute_map = {
         '_self': 'self',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/special_model_name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/special_model_name.py
@@ -89,6 +89,7 @@ class SpecialModelName(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'special_property_name': '$special[property.name]',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/string_boolean_map.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/string_boolean_map.py
@@ -88,6 +88,7 @@ class StringBooleanMap(ModelNormal):
         return None
 
 
+
     attribute_map = {
     }
 

--- a/samples/openapi3/client/petstore/python/petstore_api/model/string_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/string_enum.py
@@ -50,6 +50,20 @@ class StringEnum(ModelSimple):
           as additional properties values.
     """
 
+
+    """
+    allowed enum values
+    """
+
+    PLACED = "placed",
+    APPROVED = "approved",
+    DELIVERED = "delivered",
+    SINGLE_QUOTED = "single quoted",
+    MULTIPLE_LINES = '''multiple
+lines''',
+    DOUBLE_QUOTE_WITH_NEWLINE = '''double quote 
+ with newline''',
+
     allowed_values = {
         ('value',): {
             'None': None,
@@ -88,6 +102,7 @@ lines''',
     @cached_property
     def discriminator():
         return None
+
 
 
     attribute_map = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/model/string_enum_with_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/string_enum_with_default_value.py
@@ -50,6 +50,15 @@ class StringEnumWithDefaultValue(ModelSimple):
           as additional properties values.
     """
 
+
+    """
+    allowed enum values
+    """
+
+    PLACED = "placed",
+    APPROVED = "approved",
+    DELIVERED = "delivered",
+
     allowed_values = {
         ('value',): {
             'PLACED': "placed",
@@ -82,6 +91,7 @@ class StringEnumWithDefaultValue(ModelSimple):
     @cached_property
     def discriminator():
         return None
+
 
 
     attribute_map = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/model/tag.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/tag.py
@@ -90,6 +90,7 @@ class Tag(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'id': 'id',  # noqa: E501
         'name': 'name',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/triangle.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/triangle.py
@@ -107,6 +107,7 @@ class Triangle(ModelComposed):
             return None
         return {'triangle_type': val}
 
+
     attribute_map = {
         'triangle_type': 'triangleType',  # noqa: E501
         'shape_type': 'shapeType',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/triangle_interface.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/triangle_interface.py
@@ -89,6 +89,7 @@ class TriangleInterface(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'triangle_type': 'triangleType',  # noqa: E501
     }

--- a/samples/openapi3/client/petstore/python/petstore_api/model/user.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/user.py
@@ -100,6 +100,7 @@ class User(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'id': 'id',  # noqa: E501
         'username': 'username',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/whale.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/whale.py
@@ -91,6 +91,7 @@ class Whale(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
         'has_baleen': 'hasBaleen',  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/model/zebra.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/model/zebra.py
@@ -95,6 +95,7 @@ class Zebra(ModelNormal):
         return None
 
 
+
     attribute_map = {
         'class_name': 'className',  # noqa: E501
         'type': 'type',  # noqa: E501


### PR DESCRIPTION
Fixes #10752

This adds all of the enum values as class attributes onto enum models so that they can be accessed in a typesafe way.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ x Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@taxpon @frol @mbohlool  @cbornet @kenjones-cisco @tomplus @Jyhess @arun-nalla @spacethe
