### PR TITLE
[C][Client] Define and initialize non-primitive variables at the beginning of function

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -528,6 +528,17 @@ fail:
     {{classname}}_t *{{classname}}_local_var = NULL;
 
     {{#vars}}
+    {{^isPrimitiveType}}
+    {{#isModel}}
+    {{^isEnum}}
+    // define the local variable for {{{classname}}}->{{{name}}}
+    {{^isFreeFormObject}}{{complexType}}{{/isFreeFormObject}}{{#isFreeFormObject}}object{{/isFreeFormObject}}_t *{{name}}_local_nonprim = NULL;
+
+    {{/isEnum}}
+    {{/isModel}}
+    {{/isPrimitiveType}}
+    {{/vars}}
+    {{#vars}}
     // {{{classname}}}->{{{name}}}
     cJSON *{{{name}}} = cJSON_GetObjectItemCaseSensitive({{classname}}JSON, "{{{baseName}}}");
     {{#required}}
@@ -614,7 +625,6 @@ fail:
     {{{name}}}_local_nonprim_enum = {{datatypeWithEnum}}_parseFromJSON({{{name}}}); //enum model
     {{/isEnum}}
     {{^isEnum}}
-    {{^isFreeFormObject}}{{complexType}}{{/isFreeFormObject}}{{#isFreeFormObject}}object{{/isFreeFormObject}}_t *{{name}}_local_nonprim = NULL;
     {{^required}}if ({{{name}}}) { {{/required}}
     {{{name}}}_local_nonprim = {{complexType}}{{#isFreeFormObject}}object{{/isFreeFormObject}}_parseFromJSON({{{name}}}); //nonprimitive
     {{/isEnum}}

--- a/samples/client/petstore/c/model/pet.c
+++ b/samples/client/petstore/c/model/pet.c
@@ -168,6 +168,9 @@ pet_t *pet_parseFromJSON(cJSON *petJSON){
 
     pet_t *pet_local_var = NULL;
 
+    // define the local variable for pet->category
+    category_t *category_local_nonprim = NULL;
+
     // pet->id
     cJSON *id = cJSON_GetObjectItemCaseSensitive(petJSON, "id");
     if (id) { 
@@ -179,7 +182,6 @@ pet_t *pet_parseFromJSON(cJSON *petJSON){
 
     // pet->category
     cJSON *category = cJSON_GetObjectItemCaseSensitive(petJSON, "category");
-    category_t *category_local_nonprim = NULL;
     if (category) { 
     category_local_nonprim = category_parseFromJSON(category); //nonprimitive
     }


### PR DESCRIPTION

In the functions  `*_parseFromJSON` of the generated C-libcurl client code, when an error occurs, all the non-primitive variables will be freed before the function exits.
e.g.

```c
pet_t *pet_parseFromJSON(cJSON *petJSON){
...
    // pet->id
    cJSON *id = cJSON_GetObjectItemCaseSensitive(petJSON, "id");
    if (id) { 
        if(!cJSON_IsNumber(id))
        {
            goto end; //Numeric
        }
    }

    // pet->category
    cJSON *category = cJSON_GetObjectItemCaseSensitive(petJSON, "category");
    category_t *category_local_nonprim = NULL;
...

end:
    if (category_local_nonprim) {
        category_free(category_local_nonprim);
        category_local_nonprim = NULL;
    }
    return NULL;
}
```

But sometimes, the variables are not defined and initialized at this time. e.g. `category_local_nonprim` is not defined if `id` is invalid. Freeing `category_local_nonprim` will cause core-dump.

The fix solution is to define and initialize non-primitive variables at the beginning of function.

e.g.
```c
pet_t *pet_parseFromJSON(cJSON *petJSON){

    // define the local varable for pet->category
    category_t *category_local_nonprim = NULL;

    // pet->id
    cJSON *id = cJSON_GetObjectItemCaseSensitive(petJSON, "id");
    if (id) { 
        if(!cJSON_IsNumber(id))
        {
            goto end; //Numeric
        }
    }

    // pet->category
    cJSON *category = cJSON_GetObjectItemCaseSensitive(petJSON, "category");
...
}
```
Hi @wing328 @zhemant @michelealbano

Could you please review this PR ? Thanks !

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
