### PR TITLE
[php-symfony] Update to newer jsm serializer version

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/api_input_validation.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/api_input_validation.mustache
@@ -27,10 +27,10 @@
 {{/isContainer}}
 {{^isContainer}}
     {{#isDate}}
-        $asserts[] = new Assert\Date();
+        $asserts[] = new Assert\Type("\DateTimeInterface");
     {{/isDate}}
     {{#isDateTime}}
-        $asserts[] = new Assert\DateTime();
+        $asserts[] = new Assert\Type("\DateTimeInterface");
     {{/isDateTime}}
     {{^isDate}}
     {{^isDateTime}}

--- a/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
@@ -24,12 +24,12 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "symfony/validator": "*",
-        "jms/serializer-bundle": "^2.0",
+        "jms/serializer-bundle": "^3.5",
         "symfony/framework-bundle": "^4.4.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
-        "friendsofphp/php-cs-fixer": "^2.16.3",
+        "friendsofphp/php-cs-fixer": "^2.16",
         "symfony/browser-kit": "*",
         "symfony/yaml": "^4.4.8",
         "hoa/regex": "~1.0"

--- a/modules/openapi-generator/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
@@ -5,7 +5,11 @@ namespace {{servicePackage}};
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
+use JMS\Serializer\Visitor\Factory\XmlDeserializationVisitorFactory;
 use JMS\Serializer\XmlDeserializationVisitor;
+use DateTime;
+use RuntimeException;
+
 
 class JmsSerializer implements SerializerInterface
 {
@@ -13,10 +17,12 @@ class JmsSerializer implements SerializerInterface
 
     public function __construct()
     {
-        $naming_strategy = new SerializedNameAnnotationStrategy(new CamelCaseNamingStrategy());
+        $namingStrategy = new SerializedNameAnnotationStrategy(new CamelCaseNamingStrategy());
+
         $this->serializer = SerializerBuilder::create()
-            ->setDeserializationVisitor('json', new StrictJsonDeserializationVisitor($naming_strategy))
-            ->setDeserializationVisitor('xml', new XmlDeserializationVisitor($naming_strategy))
+            ->setDeserializationVisitor('json', new StrictJsonDeserializationVisitor())
+            ->setDeserializationVisitor('xml', new XmlDeserializationVisitorFactory())
+            ->setPropertyNamingStrategy($namingStrategy)
             ->build();
     }
 
@@ -79,6 +85,11 @@ class JmsSerializer implements SerializerInterface
                 }
 
                 break;
+            case 'DateTime':
+            case '\DateTime':
+                return new DateTime($data);
+            default:
+                throw new RuntimeException(sprintf("Type %s is unsupported", $type));
         }
 
         // If we end up here, just return data

--- a/modules/openapi-generator/src/main/resources/php-symfony/serialization/StrictJsonDeserializationVisitor.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/serialization/StrictJsonDeserializationVisitor.mustache
@@ -17,10 +17,13 @@
 
 namespace {{servicePackage}};
 
+use JMS\Serializer\AbstractVisitor;
 use JMS\Serializer\Context;
 use JMS\Serializer\JsonDeserializationVisitor;
+use JMS\Serializer\Visitor\DeserializationVisitorInterface;
+use JMS\Serializer\Visitor\Factory\DeserializationVisitorFactory;
 
-class StrictJsonDeserializationVisitor extends JsonDeserializationVisitor
+class StrictJsonDeserializationVisitor extends AbstractVisitor implements DeserializationVisitorFactory
 {
     /**
      * {@inheritdoc}
@@ -69,4 +72,17 @@ class StrictJsonDeserializationVisitor extends JsonDeserializationVisitor
 
         return parent::visitDouble($data, $type, $context);
     }
+
+    /**
+      * {@inheritdoc}
+      */
+     public function getResult($data)
+     {
+         return $data;
+     }
+
+      public function getVisitor(): DeserializationVisitorInterface
+     {
+         return $this;
+     }
 }

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
@@ -5,7 +5,11 @@ namespace OpenAPI\Server\Service;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
+use JMS\Serializer\Visitor\Factory\XmlDeserializationVisitorFactory;
 use JMS\Serializer\XmlDeserializationVisitor;
+use DateTime;
+use RuntimeException;
+
 
 class JmsSerializer implements SerializerInterface
 {
@@ -13,10 +17,12 @@ class JmsSerializer implements SerializerInterface
 
     public function __construct()
     {
-        $naming_strategy = new SerializedNameAnnotationStrategy(new CamelCaseNamingStrategy());
+        $namingStrategy = new SerializedNameAnnotationStrategy(new CamelCaseNamingStrategy());
+
         $this->serializer = SerializerBuilder::create()
-            ->setDeserializationVisitor('json', new StrictJsonDeserializationVisitor($naming_strategy))
-            ->setDeserializationVisitor('xml', new XmlDeserializationVisitor($naming_strategy))
+            ->setDeserializationVisitor('json', new StrictJsonDeserializationVisitor())
+            ->setDeserializationVisitor('xml', new XmlDeserializationVisitorFactory())
+            ->setPropertyNamingStrategy($namingStrategy)
             ->build();
     }
 
@@ -79,6 +85,11 @@ class JmsSerializer implements SerializerInterface
                 }
 
                 break;
+            case 'DateTime':
+            case '\DateTime':
+                return new DateTime($data);
+            default:
+                throw new RuntimeException(sprintf("Type %s is unsupported", $type));
         }
 
         // If we end up here, just return data

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/StrictJsonDeserializationVisitor.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/StrictJsonDeserializationVisitor.php
@@ -17,10 +17,13 @@
 
 namespace OpenAPI\Server\Service;
 
+use JMS\Serializer\AbstractVisitor;
 use JMS\Serializer\Context;
 use JMS\Serializer\JsonDeserializationVisitor;
+use JMS\Serializer\Visitor\DeserializationVisitorInterface;
+use JMS\Serializer\Visitor\Factory\DeserializationVisitorFactory;
 
-class StrictJsonDeserializationVisitor extends JsonDeserializationVisitor
+class StrictJsonDeserializationVisitor extends AbstractVisitor implements DeserializationVisitorFactory
 {
     /**
      * {@inheritdoc}
@@ -69,4 +72,17 @@ class StrictJsonDeserializationVisitor extends JsonDeserializationVisitor
 
         return parent::visitDouble($data, $type, $context);
     }
+
+    /**
+      * {@inheritdoc}
+      */
+     public function getResult($data)
+     {
+         return $data;
+     }
+
+      public function getVisitor(): DeserializationVisitorInterface
+     {
+         return $this;
+     }
 }

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
@@ -21,12 +21,12 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "symfony/validator": "*",
-        "jms/serializer-bundle": "^2.0",
+        "jms/serializer-bundle": "^3.5",
         "symfony/framework-bundle": "^4.4.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
-        "friendsofphp/php-cs-fixer": "^2.16.3",
+        "friendsofphp/php-cs-fixer": "^2.16",
         "symfony/browser-kit": "*",
         "symfony/yaml": "^4.4.8",
         "hoa/regex": "~1.0"


### PR DESCRIPTION
We've been using the library already on PHP for some time with backward compatibility to 7.4 (config platform override in composer.json). 

However, we want to fully move to PHP 8.0 and we need an updated version of JMS serializer bundle.

THIS MR IS A DRAFT AND STILL NEEDS TO BE TESTED. FEEL FREE TO GENERATE A CLIENT AND TEST IT FOR ME. 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
