### PR TITLE
[PYTHON] Setting default value for Required variables

### DIFF
--- a/docs/generators/fsharp-functions.md
+++ b/docs/generators/fsharp-functions.md
@@ -22,7 +22,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|sourceFolder|source folder for generated code| |OpenAPI/src|
+|sourceFolder|source folder for generated code| |OpenAPI\src|
 
 ## IMPORT MAPPING
 

--- a/docs/generators/fsharp-giraffe-server.md
+++ b/docs/generators/fsharp-giraffe-server.md
@@ -19,7 +19,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |packageVersion|F# package version.| |1.0.0|
 |returnICollection|Return ICollection&lt;T&gt; instead of the concrete type.| |false|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|sourceFolder|source folder for generated code| |OpenAPI/src|
+|sourceFolder|source folder for generated code| |OpenAPI\src|
 |useCollection|Deserialize array types to Collection&lt;T&gt; instead of List&lt;T&gt;.| |false|
 |useDateTimeOffset|Use DateTimeOffset to model date-time properties| |false|
 |useSwashbuckle|Uses the Swashbuckle.AspNetCore NuGet package for documentation.| |false|

--- a/docs/generators/java-inflector.md
+++ b/docs/generators/java-inflector.md
@@ -48,7 +48,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshotVersion|Uses a SNAPSHOT version.|<dl><dt>**true**</dt><dd>Use a SnapShot Version</dd><dt>**false**</dt><dd>Use a Release Version</dd></dl>|null|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|sourceFolder|source folder for generated code| |src/gen/java|
+|sourceFolder|source folder for generated code| |src\gen\java|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/docs/generators/jaxrs-cxf-client.md
+++ b/docs/generators/jaxrs-cxf-client.md
@@ -48,7 +48,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |snapshotVersion|Uses a SNAPSHOT version.|<dl><dt>**true**</dt><dd>Use a SnapShot Version</dd><dt>**false**</dt><dd>Use a Release Version</dd></dl>|null|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|sourceFolder|source folder for generated code| |src/gen/java|
+|sourceFolder|source folder for generated code| |src\gen\java|
 |useBeanValidation|Use BeanValidation API annotations| |false|
 |useGenericResponse|Use generic response| |false|
 |useGzipFeatureForTests|Use Gzip Feature for tests| |false|

--- a/docs/generators/swift5.md
+++ b/docs/generators/swift5.md
@@ -37,11 +37,11 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |responseAs|Optionally use libraries to manage response.  Currently PromiseKit, RxSwift, Result, Combine, AsyncAwait are available.| |null|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
-|swiftPackagePath|Set a custom source path instead of OpenAPIClient/Classes/OpenAPIs.| |null|
+|swiftPackagePath|Set a custom source path instead of OpenAPIClient\Classes\OpenAPIs.| |null|
 |swiftUseApiNamespace|Flag to make all the API classes inner-class of {{projectName}}API| |null|
 |useBacktickEscapes|Escape reserved words using backticks (default: false)| |false|
 |useClasses|Use final classes for models instead of structs (default: false)| |false|
-|useSPMFileStructure|Use SPM file structure and set the source path to Sources/{{projectName}} (default: false).| |null|
+|useSPMFileStructure|Use SPM file structure and set the source path to Sources\{{projectName}} (default: false).| |null|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/resources/python/model_templates/method_from_openapi_data_composed.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/method_from_openapi_data_composed.mustache
@@ -1,6 +1,11 @@
     @classmethod
     @convert_js_args_to_python_args
+    {{#setRequiredVars}}
+    def _from_openapi_data(cls{{#requiredVars}}{{^defaultValue}}, {{name}}{{/defaultValue}}{{/requiredVars}}, *args, **kwargs):  # noqa: E501
+    {{/setRequiredVars}}
+    {{^setRequiredVars}}
     def _from_openapi_data(cls, *args, **kwargs):  # noqa: E501
+    {{/setRequiredVars}}
         """{{classname}} - a model defined in OpenAPI
 
         Keyword Args:
@@ -47,6 +52,14 @@
             '_configuration': _configuration,
             '_visited_composed_classes': self._visited_composed_classes,
         }
+        {{#setRequiredVars}}
+        required_args = {
+{{#requiredVars}}
+            '{{name}}': {{name}},
+{{/requiredVars}}
+        }
+        kwargs.update(required_args)
+        {{/setRequiredVars}}
         composed_info = validate_get_composed_info(
             constant_args, kwargs, self)
         self._composed_instances = composed_info[0]

--- a/modules/openapi-generator/src/main/resources/python/model_templates/method_init_composed.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_templates/method_init_composed.mustache
@@ -11,7 +11,12 @@
     ])
 
     @convert_js_args_to_python_args
+    {{#setRequiredVars}}
+    def __init__(self{{#requiredVars}}{{^defaultValue}}, {{name}}{{/defaultValue}}{{/requiredVars}}, *args, **kwargs):  # noqa: E501
+    {{/setRequiredVars}}
+    {{^setRequiredVars}}
     def __init__(self, *args, **kwargs):  # noqa: E501
+    {{/setRequiredVars}}
         """{{classname}} - a model defined in OpenAPI
 
         Keyword Args:
@@ -60,6 +65,14 @@
             '_configuration': _configuration,
             '_visited_composed_classes': self._visited_composed_classes,
         }
+        {{#setRequiredVars}}
+        required_args = {
+{{#requiredVars}}
+            '{{name}}': {{name}},
+{{/requiredVars}}
+        }
+        kwargs.update(required_args)
+        {{/setRequiredVars}}
         composed_info = validate_get_composed_info(
             constant_args, kwargs, self)
         self._composed_instances = composed_info[0]

--- a/samples/client/petstore/R/.openapi-generator/FILES
+++ b/samples/client/petstore/R/.openapi-generator/FILES
@@ -3,6 +3,7 @@
 .travis.yml
 DESCRIPTION
 NAMESPACE
+README.md
 R/api_client.R
 R/api_response.R
 R/category.R
@@ -14,7 +15,6 @@ R/store_api.R
 R/tag.R
 R/user.R
 R/user_api.R
-README.md
 docs/Category.md
 docs/ModelApiResponse.md
 docs/Order.md

--- a/samples/client/petstore/php/OpenAPIClient-php/.openapi-generator/FILES
+++ b/samples/client/petstore/php/OpenAPIClient-php/.openapi-generator/FILES
@@ -57,6 +57,7 @@ docs/Model/SpecialModelName.md
 docs/Model/Tag.md
 docs/Model/User.md
 git_push.sh
+lib/ApiException.php
 lib/Api/AnotherFakeApi.php
 lib/Api/DefaultApi.php
 lib/Api/FakeApi.php
@@ -64,7 +65,6 @@ lib/Api/FakeClassnameTags123Api.php
 lib/Api/PetApi.php
 lib/Api/StoreApi.php
 lib/Api/UserApi.php
-lib/ApiException.php
 lib/Configuration.php
 lib/HeaderSelector.php
 lib/Model/AdditionalPropertiesClass.php

--- a/samples/client/petstore/php/OpenAPIClient-php/phpunit.xml.dist
+++ b/samples/client/petstore/php/OpenAPIClient-php/phpunit.xml.dist
@@ -2,8 +2,8 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage processUncoveredFiles="true">
     <include>
-      <directory suffix=".php">./lib/Api</directory>
-      <directory suffix=".php">./lib/Model</directory>
+      <directory suffix=".php">./lib\/Api</directory>
+      <directory suffix=".php">./lib\/Model</directory>
     </include>
   </coverage>
   <testsuites>

--- a/samples/client/petstore/powershell/README.md
+++ b/samples/client/petstore/powershell/README.md
@@ -79,12 +79,12 @@ Class | Method | HTTP request | Description
 
 ## Documentation for Models
 
- - [PSPetstore/Model.ApiResponse](docs/ApiResponse.md)
- - [PSPetstore/Model.Category](docs/Category.md)
- - [PSPetstore/Model.Order](docs/Order.md)
- - [PSPetstore/Model.Pet](docs/Pet.md)
- - [PSPetstore/Model.Tag](docs/Tag.md)
- - [PSPetstore/Model.User](docs/User.md)
+ - [PSPetstore\Model.ApiResponse](docs/ApiResponse.md)
+ - [PSPetstore\Model.Category](docs/Category.md)
+ - [PSPetstore\Model.Order](docs/Order.md)
+ - [PSPetstore\Model.Pet](docs/Pet.md)
+ - [PSPetstore\Model.Tag](docs/Tag.md)
+ - [PSPetstore\Model.User](docs/User.md)
 
 
 ## Documentation for Authorization

--- a/samples/client/petstore/powershell/docs/PSPetApi.md
+++ b/samples/client/petstore/powershell/docs/PSPetApi.md
@@ -1,4 +1,4 @@
-# PSPetstore.PSPetstore/Api.PSPetApi
+# PSPetstore.PSPetstore\Api.PSPetApi
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 

--- a/samples/client/petstore/powershell/docs/PSStoreApi.md
+++ b/samples/client/petstore/powershell/docs/PSStoreApi.md
@@ -1,4 +1,4 @@
-# PSPetstore.PSPetstore/Api.PSStoreApi
+# PSPetstore.PSPetstore\Api.PSStoreApi
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 

--- a/samples/client/petstore/powershell/docs/PSUserApi.md
+++ b/samples/client/petstore/powershell/docs/PSUserApi.md
@@ -1,4 +1,4 @@
-# PSPetstore.PSPetstore/Api.PSUserApi
+# PSPetstore.PSPetstore\Api.PSUserApi
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
@@ -51,6 +51,7 @@ export interface Capitalization {
     sCAETHFlowPoints?: string;
     /**
      * Name of the pet
+
      * @type {string}
      * @memberof Capitalization
      */

--- a/samples/openapi3/client/elm/src/Api/Data.elm
+++ b/samples/openapi3/client/elm/src/Api/Data.elm
@@ -80,33 +80,33 @@ import Json.Encode
 -}
 type alias Absent =
     { default : Maybe String
-    , required : String
-    , nullable : Maybe String
-    , requiredNullable : Maybe String
-    }
+, required : String
+, nullable : Maybe String
+, requiredNullable : Maybe String
+}
 
 
 {-| Model with arrays
 -}
 type alias Array =
     { array : List (String)
-    , arrayOfArray : List (List (String))
-    , arrayOfPrimitve : Maybe (List (Primitive))
-    , arrayOfEnum : Maybe (List (Enum))
-    }
+, arrayOfArray : List (List (String))
+, arrayOfPrimitve : Maybe (List (Primitive))
+, arrayOfEnum : Maybe (List (Enum))
+}
 
 
 {-| Composed model
 -}
 type alias Composed =
     { base : Float
-    , value : Maybe String
-    }
+, value : Maybe String
+}
 
 
 type alias ComposedBase =
     { base : Float
-    }
+}
 
 
 {-| Discriminated model
@@ -119,19 +119,19 @@ type Discriminated
 
 type alias BaseDiscriminated =
     { kind : String
-    }
+}
 
 
 type alias DiscriminatedA =
     { baseDiscriminated: BaseDiscriminated
-    , a : Maybe String
-    }
+, a : Maybe String
+}
 
 
 type alias DiscriminatedB =
     { baseDiscriminated: BaseDiscriminated
-    , b : Maybe String
-    }
+, b : Maybe String
+}
 
 
 type Enum
@@ -166,8 +166,8 @@ enumericVariants =
 -}
 type alias Maybe_ =
     { type_ : Maybe String
-    , if_ : Maybe Bool
-    }
+, if_ : Maybe Bool
+}
 
 
 {-| One of two models
@@ -180,33 +180,33 @@ type OneOf
 
 type alias OneOfA =
     { a : Maybe String
-    }
+}
 
 
 type alias OneOfB =
     { b : Maybe String
-    }
+}
 
 
 {-| Model with primitive properties
 -}
 type alias Primitive =
     { string : Maybe String
-    , number : Maybe Float
-    , float : Maybe Float
-    , double : Maybe Float
-    , integer : Maybe Int
-    , short : Maybe Int
-    , long : Maybe Int
-    , boolean : Maybe Bool
-    }
+, number : Maybe Float
+, float : Maybe Float
+, double : Maybe Float
+, integer : Maybe Int
+, short : Maybe Int
+, long : Maybe Int
+, boolean : Maybe Bool
+}
 
 
 type alias Recursion =
     { maybe : RecursionMaybe
-    , list : RecursionList
-    , ref : RecursionRef
-    }
+, list : RecursionList
+, ref : RecursionRef
+}
 
 
 type RecursionMaybe = RecursionMaybe (Maybe Recursion)
@@ -232,7 +232,7 @@ unwrapRecursionRef (RecursionRef ref) = ref
 
 type alias RecursionLoop =
     { ref : RecursionLoopRef
-    }
+}
 
 
 type RecursionLoopRef = RecursionLoopRef (Maybe Recursion)
@@ -246,13 +246,13 @@ unwrapRecursionLoopRef (RecursionLoopRef ref) = ref
 -}
 type alias UnsafeCharacters =
     { prefix : Maybe String
-    , suffix : Maybe String
-    , rnd0mTff : Maybe String
-    , before : Maybe String
-    , after : Maybe String
-    , both : Maybe String
-    , inTheMiddle : Maybe String
-    }
+, suffix : Maybe String
+, rnd0mTff : Maybe String
+, before : Maybe String
+, after : Maybe String
+, both : Maybe String
+, inTheMiddle : Maybe String
+}
 
 
 -- ENCODER

--- a/samples/openapi3/client/petstore/dart-dio-next/dio_http_petstore_client_lib_fake/README.md
+++ b/samples/openapi3/client/petstore/dart-dio-next/dio_http_petstore_client_lib_fake/README.md
@@ -64,97 +64,97 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-[*AnotherFakeApi*](doc/AnotherFakeApi.md) | [**call123testSpecialTags**](doc/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
-[*DefaultApi*](doc/DefaultApi.md) | [**fooGet**](doc/DefaultApi.md#fooget) | **GET** /foo | 
-[*FakeApi*](doc/FakeApi.md) | [**fakeHealthGet**](doc/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
-[*FakeApi*](doc/FakeApi.md) | [**fakeHttpSignatureTest**](doc/FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
-[*FakeApi*](doc/FakeApi.md) | [**fakeOuterBooleanSerialize**](doc/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
-[*FakeApi*](doc/FakeApi.md) | [**fakeOuterCompositeSerialize**](doc/FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
-[*FakeApi*](doc/FakeApi.md) | [**fakeOuterNumberSerialize**](doc/FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
-[*FakeApi*](doc/FakeApi.md) | [**fakeOuterStringSerialize**](doc/FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
-[*FakeApi*](doc/FakeApi.md) | [**fakePropertyEnumIntegerSerialize**](doc/FakeApi.md#fakepropertyenumintegerserialize) | **POST** /fake/property/enum-int | 
-[*FakeApi*](doc/FakeApi.md) | [**testBodyWithBinary**](doc/FakeApi.md#testbodywithbinary) | **PUT** /fake/body-with-binary | 
-[*FakeApi*](doc/FakeApi.md) | [**testBodyWithFileSchema**](doc/FakeApi.md#testbodywithfileschema) | **PUT** /fake/body-with-file-schema | 
-[*FakeApi*](doc/FakeApi.md) | [**testBodyWithQueryParams**](doc/FakeApi.md#testbodywithqueryparams) | **PUT** /fake/body-with-query-params | 
-[*FakeApi*](doc/FakeApi.md) | [**testClientModel**](doc/FakeApi.md#testclientmodel) | **PATCH** /fake | To test \&quot;client\&quot; model
-[*FakeApi*](doc/FakeApi.md) | [**testEndpointParameters**](doc/FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-[*FakeApi*](doc/FakeApi.md) | [**testEnumParameters**](doc/FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
-[*FakeApi*](doc/FakeApi.md) | [**testGroupParameters**](doc/FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
-[*FakeApi*](doc/FakeApi.md) | [**testInlineAdditionalProperties**](doc/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
-[*FakeApi*](doc/FakeApi.md) | [**testJsonFormData**](doc/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
-[*FakeApi*](doc/FakeApi.md) | [**testQueryParameterCollectionFormat**](doc/FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-parameters | 
-[*FakeClassnameTags123Api*](doc/FakeClassnameTags123Api.md) | [**testClassname**](doc/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
-[*PetApi*](doc/PetApi.md) | [**addPet**](doc/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
-[*PetApi*](doc/PetApi.md) | [**deletePet**](doc/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
-[*PetApi*](doc/PetApi.md) | [**findPetsByStatus**](doc/PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
-[*PetApi*](doc/PetApi.md) | [**findPetsByTags**](doc/PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
-[*PetApi*](doc/PetApi.md) | [**getPetById**](doc/PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
-[*PetApi*](doc/PetApi.md) | [**updatePet**](doc/PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
-[*PetApi*](doc/PetApi.md) | [**updatePetWithForm**](doc/PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
-[*PetApi*](doc/PetApi.md) | [**uploadFile**](doc/PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
-[*PetApi*](doc/PetApi.md) | [**uploadFileWithRequiredFile**](doc/PetApi.md#uploadfilewithrequiredfile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
-[*StoreApi*](doc/StoreApi.md) | [**deleteOrder**](doc/StoreApi.md#deleteorder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
-[*StoreApi*](doc/StoreApi.md) | [**getInventory**](doc/StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
-[*StoreApi*](doc/StoreApi.md) | [**getOrderById**](doc/StoreApi.md#getorderbyid) | **GET** /store/order/{order_id} | Find purchase order by ID
-[*StoreApi*](doc/StoreApi.md) | [**placeOrder**](doc/StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
-[*UserApi*](doc/UserApi.md) | [**createUser**](doc/UserApi.md#createuser) | **POST** /user | Create user
-[*UserApi*](doc/UserApi.md) | [**createUsersWithArrayInput**](doc/UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
-[*UserApi*](doc/UserApi.md) | [**createUsersWithListInput**](doc/UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
-[*UserApi*](doc/UserApi.md) | [**deleteUser**](doc/UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
-[*UserApi*](doc/UserApi.md) | [**getUserByName**](doc/UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
-[*UserApi*](doc/UserApi.md) | [**loginUser**](doc/UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
-[*UserApi*](doc/UserApi.md) | [**logoutUser**](doc/UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
-[*UserApi*](doc/UserApi.md) | [**updateUser**](doc/UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
+[*AnotherFakeApi*](doc\AnotherFakeApi.md) | [**call123testSpecialTags**](doc\AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
+[*DefaultApi*](doc\DefaultApi.md) | [**fooGet**](doc\DefaultApi.md#fooget) | **GET** /foo | 
+[*FakeApi*](doc\FakeApi.md) | [**fakeHealthGet**](doc\FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
+[*FakeApi*](doc\FakeApi.md) | [**fakeHttpSignatureTest**](doc\FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
+[*FakeApi*](doc\FakeApi.md) | [**fakeOuterBooleanSerialize**](doc\FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
+[*FakeApi*](doc\FakeApi.md) | [**fakeOuterCompositeSerialize**](doc\FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
+[*FakeApi*](doc\FakeApi.md) | [**fakeOuterNumberSerialize**](doc\FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
+[*FakeApi*](doc\FakeApi.md) | [**fakeOuterStringSerialize**](doc\FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
+[*FakeApi*](doc\FakeApi.md) | [**fakePropertyEnumIntegerSerialize**](doc\FakeApi.md#fakepropertyenumintegerserialize) | **POST** /fake/property/enum-int | 
+[*FakeApi*](doc\FakeApi.md) | [**testBodyWithBinary**](doc\FakeApi.md#testbodywithbinary) | **PUT** /fake/body-with-binary | 
+[*FakeApi*](doc\FakeApi.md) | [**testBodyWithFileSchema**](doc\FakeApi.md#testbodywithfileschema) | **PUT** /fake/body-with-file-schema | 
+[*FakeApi*](doc\FakeApi.md) | [**testBodyWithQueryParams**](doc\FakeApi.md#testbodywithqueryparams) | **PUT** /fake/body-with-query-params | 
+[*FakeApi*](doc\FakeApi.md) | [**testClientModel**](doc\FakeApi.md#testclientmodel) | **PATCH** /fake | To test \&quot;client\&quot; model
+[*FakeApi*](doc\FakeApi.md) | [**testEndpointParameters**](doc\FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+[*FakeApi*](doc\FakeApi.md) | [**testEnumParameters**](doc\FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
+[*FakeApi*](doc\FakeApi.md) | [**testGroupParameters**](doc\FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
+[*FakeApi*](doc\FakeApi.md) | [**testInlineAdditionalProperties**](doc\FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
+[*FakeApi*](doc\FakeApi.md) | [**testJsonFormData**](doc\FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+[*FakeApi*](doc\FakeApi.md) | [**testQueryParameterCollectionFormat**](doc\FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-parameters | 
+[*FakeClassnameTags123Api*](doc\FakeClassnameTags123Api.md) | [**testClassname**](doc\FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
+[*PetApi*](doc\PetApi.md) | [**addPet**](doc\PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
+[*PetApi*](doc\PetApi.md) | [**deletePet**](doc\PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
+[*PetApi*](doc\PetApi.md) | [**findPetsByStatus**](doc\PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
+[*PetApi*](doc\PetApi.md) | [**findPetsByTags**](doc\PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
+[*PetApi*](doc\PetApi.md) | [**getPetById**](doc\PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
+[*PetApi*](doc\PetApi.md) | [**updatePet**](doc\PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
+[*PetApi*](doc\PetApi.md) | [**updatePetWithForm**](doc\PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
+[*PetApi*](doc\PetApi.md) | [**uploadFile**](doc\PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
+[*PetApi*](doc\PetApi.md) | [**uploadFileWithRequiredFile**](doc\PetApi.md#uploadfilewithrequiredfile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
+[*StoreApi*](doc\StoreApi.md) | [**deleteOrder**](doc\StoreApi.md#deleteorder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
+[*StoreApi*](doc\StoreApi.md) | [**getInventory**](doc\StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
+[*StoreApi*](doc\StoreApi.md) | [**getOrderById**](doc\StoreApi.md#getorderbyid) | **GET** /store/order/{order_id} | Find purchase order by ID
+[*StoreApi*](doc\StoreApi.md) | [**placeOrder**](doc\StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
+[*UserApi*](doc\UserApi.md) | [**createUser**](doc\UserApi.md#createuser) | **POST** /user | Create user
+[*UserApi*](doc\UserApi.md) | [**createUsersWithArrayInput**](doc\UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
+[*UserApi*](doc\UserApi.md) | [**createUsersWithListInput**](doc\UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
+[*UserApi*](doc\UserApi.md) | [**deleteUser**](doc\UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
+[*UserApi*](doc\UserApi.md) | [**getUserByName**](doc\UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
+[*UserApi*](doc\UserApi.md) | [**loginUser**](doc\UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
+[*UserApi*](doc\UserApi.md) | [**logoutUser**](doc\UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
+[*UserApi*](doc\UserApi.md) | [**updateUser**](doc\UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [AdditionalPropertiesClass](doc/AdditionalPropertiesClass.md)
- - [Animal](doc/Animal.md)
- - [ApiResponse](doc/ApiResponse.md)
- - [ArrayOfArrayOfNumberOnly](doc/ArrayOfArrayOfNumberOnly.md)
- - [ArrayOfNumberOnly](doc/ArrayOfNumberOnly.md)
- - [ArrayTest](doc/ArrayTest.md)
- - [Capitalization](doc/Capitalization.md)
- - [Cat](doc/Cat.md)
- - [CatAllOf](doc/CatAllOf.md)
- - [Category](doc/Category.md)
- - [ClassModel](doc/ClassModel.md)
- - [DeprecatedObject](doc/DeprecatedObject.md)
- - [Dog](doc/Dog.md)
- - [DogAllOf](doc/DogAllOf.md)
- - [EnumArrays](doc/EnumArrays.md)
- - [EnumTest](doc/EnumTest.md)
- - [FileSchemaTestClass](doc/FileSchemaTestClass.md)
- - [Foo](doc/Foo.md)
- - [FormatTest](doc/FormatTest.md)
- - [HasOnlyReadOnly](doc/HasOnlyReadOnly.md)
- - [HealthCheckResult](doc/HealthCheckResult.md)
- - [InlineResponseDefault](doc/InlineResponseDefault.md)
- - [MapTest](doc/MapTest.md)
- - [MixedPropertiesAndAdditionalPropertiesClass](doc/MixedPropertiesAndAdditionalPropertiesClass.md)
- - [Model200Response](doc/Model200Response.md)
- - [ModelClient](doc/ModelClient.md)
- - [ModelEnumClass](doc/ModelEnumClass.md)
- - [ModelFile](doc/ModelFile.md)
- - [ModelList](doc/ModelList.md)
- - [ModelReturn](doc/ModelReturn.md)
- - [Name](doc/Name.md)
- - [NullableClass](doc/NullableClass.md)
- - [NumberOnly](doc/NumberOnly.md)
- - [ObjectWithDeprecatedFields](doc/ObjectWithDeprecatedFields.md)
- - [Order](doc/Order.md)
- - [OuterComposite](doc/OuterComposite.md)
- - [OuterEnum](doc/OuterEnum.md)
- - [OuterEnumDefaultValue](doc/OuterEnumDefaultValue.md)
- - [OuterEnumInteger](doc/OuterEnumInteger.md)
- - [OuterEnumIntegerDefaultValue](doc/OuterEnumIntegerDefaultValue.md)
- - [OuterObjectWithEnumProperty](doc/OuterObjectWithEnumProperty.md)
- - [Pet](doc/Pet.md)
- - [ReadOnlyFirst](doc/ReadOnlyFirst.md)
- - [SpecialModelName](doc/SpecialModelName.md)
- - [Tag](doc/Tag.md)
- - [User](doc/User.md)
+ - [AdditionalPropertiesClass](doc\AdditionalPropertiesClass.md)
+ - [Animal](doc\Animal.md)
+ - [ApiResponse](doc\ApiResponse.md)
+ - [ArrayOfArrayOfNumberOnly](doc\ArrayOfArrayOfNumberOnly.md)
+ - [ArrayOfNumberOnly](doc\ArrayOfNumberOnly.md)
+ - [ArrayTest](doc\ArrayTest.md)
+ - [Capitalization](doc\Capitalization.md)
+ - [Cat](doc\Cat.md)
+ - [CatAllOf](doc\CatAllOf.md)
+ - [Category](doc\Category.md)
+ - [ClassModel](doc\ClassModel.md)
+ - [DeprecatedObject](doc\DeprecatedObject.md)
+ - [Dog](doc\Dog.md)
+ - [DogAllOf](doc\DogAllOf.md)
+ - [EnumArrays](doc\EnumArrays.md)
+ - [EnumTest](doc\EnumTest.md)
+ - [FileSchemaTestClass](doc\FileSchemaTestClass.md)
+ - [Foo](doc\Foo.md)
+ - [FormatTest](doc\FormatTest.md)
+ - [HasOnlyReadOnly](doc\HasOnlyReadOnly.md)
+ - [HealthCheckResult](doc\HealthCheckResult.md)
+ - [InlineResponseDefault](doc\InlineResponseDefault.md)
+ - [MapTest](doc\MapTest.md)
+ - [MixedPropertiesAndAdditionalPropertiesClass](doc\MixedPropertiesAndAdditionalPropertiesClass.md)
+ - [Model200Response](doc\Model200Response.md)
+ - [ModelClient](doc\ModelClient.md)
+ - [ModelEnumClass](doc\ModelEnumClass.md)
+ - [ModelFile](doc\ModelFile.md)
+ - [ModelList](doc\ModelList.md)
+ - [ModelReturn](doc\ModelReturn.md)
+ - [Name](doc\Name.md)
+ - [NullableClass](doc\NullableClass.md)
+ - [NumberOnly](doc\NumberOnly.md)
+ - [ObjectWithDeprecatedFields](doc\ObjectWithDeprecatedFields.md)
+ - [Order](doc\Order.md)
+ - [OuterComposite](doc\OuterComposite.md)
+ - [OuterEnum](doc\OuterEnum.md)
+ - [OuterEnumDefaultValue](doc\OuterEnumDefaultValue.md)
+ - [OuterEnumInteger](doc\OuterEnumInteger.md)
+ - [OuterEnumIntegerDefaultValue](doc\OuterEnumIntegerDefaultValue.md)
+ - [OuterObjectWithEnumProperty](doc\OuterObjectWithEnumProperty.md)
+ - [Pet](doc\Pet.md)
+ - [ReadOnlyFirst](doc\ReadOnlyFirst.md)
+ - [SpecialModelName](doc\SpecialModelName.md)
+ - [Tag](doc\Tag.md)
+ - [User](doc\User.md)
 
 
 ## Documentation For Authorization

--- a/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/README.md
+++ b/samples/openapi3/client/petstore/dart-dio-next/petstore_client_lib_fake/README.md
@@ -64,97 +64,97 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-[*AnotherFakeApi*](doc/AnotherFakeApi.md) | [**call123testSpecialTags**](doc/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
-[*DefaultApi*](doc/DefaultApi.md) | [**fooGet**](doc/DefaultApi.md#fooget) | **GET** /foo | 
-[*FakeApi*](doc/FakeApi.md) | [**fakeHealthGet**](doc/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
-[*FakeApi*](doc/FakeApi.md) | [**fakeHttpSignatureTest**](doc/FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
-[*FakeApi*](doc/FakeApi.md) | [**fakeOuterBooleanSerialize**](doc/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
-[*FakeApi*](doc/FakeApi.md) | [**fakeOuterCompositeSerialize**](doc/FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
-[*FakeApi*](doc/FakeApi.md) | [**fakeOuterNumberSerialize**](doc/FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
-[*FakeApi*](doc/FakeApi.md) | [**fakeOuterStringSerialize**](doc/FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
-[*FakeApi*](doc/FakeApi.md) | [**fakePropertyEnumIntegerSerialize**](doc/FakeApi.md#fakepropertyenumintegerserialize) | **POST** /fake/property/enum-int | 
-[*FakeApi*](doc/FakeApi.md) | [**testBodyWithBinary**](doc/FakeApi.md#testbodywithbinary) | **PUT** /fake/body-with-binary | 
-[*FakeApi*](doc/FakeApi.md) | [**testBodyWithFileSchema**](doc/FakeApi.md#testbodywithfileschema) | **PUT** /fake/body-with-file-schema | 
-[*FakeApi*](doc/FakeApi.md) | [**testBodyWithQueryParams**](doc/FakeApi.md#testbodywithqueryparams) | **PUT** /fake/body-with-query-params | 
-[*FakeApi*](doc/FakeApi.md) | [**testClientModel**](doc/FakeApi.md#testclientmodel) | **PATCH** /fake | To test \&quot;client\&quot; model
-[*FakeApi*](doc/FakeApi.md) | [**testEndpointParameters**](doc/FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-[*FakeApi*](doc/FakeApi.md) | [**testEnumParameters**](doc/FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
-[*FakeApi*](doc/FakeApi.md) | [**testGroupParameters**](doc/FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
-[*FakeApi*](doc/FakeApi.md) | [**testInlineAdditionalProperties**](doc/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
-[*FakeApi*](doc/FakeApi.md) | [**testJsonFormData**](doc/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
-[*FakeApi*](doc/FakeApi.md) | [**testQueryParameterCollectionFormat**](doc/FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-parameters | 
-[*FakeClassnameTags123Api*](doc/FakeClassnameTags123Api.md) | [**testClassname**](doc/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
-[*PetApi*](doc/PetApi.md) | [**addPet**](doc/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
-[*PetApi*](doc/PetApi.md) | [**deletePet**](doc/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
-[*PetApi*](doc/PetApi.md) | [**findPetsByStatus**](doc/PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
-[*PetApi*](doc/PetApi.md) | [**findPetsByTags**](doc/PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
-[*PetApi*](doc/PetApi.md) | [**getPetById**](doc/PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
-[*PetApi*](doc/PetApi.md) | [**updatePet**](doc/PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
-[*PetApi*](doc/PetApi.md) | [**updatePetWithForm**](doc/PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
-[*PetApi*](doc/PetApi.md) | [**uploadFile**](doc/PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
-[*PetApi*](doc/PetApi.md) | [**uploadFileWithRequiredFile**](doc/PetApi.md#uploadfilewithrequiredfile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
-[*StoreApi*](doc/StoreApi.md) | [**deleteOrder**](doc/StoreApi.md#deleteorder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
-[*StoreApi*](doc/StoreApi.md) | [**getInventory**](doc/StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
-[*StoreApi*](doc/StoreApi.md) | [**getOrderById**](doc/StoreApi.md#getorderbyid) | **GET** /store/order/{order_id} | Find purchase order by ID
-[*StoreApi*](doc/StoreApi.md) | [**placeOrder**](doc/StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
-[*UserApi*](doc/UserApi.md) | [**createUser**](doc/UserApi.md#createuser) | **POST** /user | Create user
-[*UserApi*](doc/UserApi.md) | [**createUsersWithArrayInput**](doc/UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
-[*UserApi*](doc/UserApi.md) | [**createUsersWithListInput**](doc/UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
-[*UserApi*](doc/UserApi.md) | [**deleteUser**](doc/UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
-[*UserApi*](doc/UserApi.md) | [**getUserByName**](doc/UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
-[*UserApi*](doc/UserApi.md) | [**loginUser**](doc/UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
-[*UserApi*](doc/UserApi.md) | [**logoutUser**](doc/UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
-[*UserApi*](doc/UserApi.md) | [**updateUser**](doc/UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
+[*AnotherFakeApi*](doc\AnotherFakeApi.md) | [**call123testSpecialTags**](doc\AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
+[*DefaultApi*](doc\DefaultApi.md) | [**fooGet**](doc\DefaultApi.md#fooget) | **GET** /foo | 
+[*FakeApi*](doc\FakeApi.md) | [**fakeHealthGet**](doc\FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
+[*FakeApi*](doc\FakeApi.md) | [**fakeHttpSignatureTest**](doc\FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
+[*FakeApi*](doc\FakeApi.md) | [**fakeOuterBooleanSerialize**](doc\FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
+[*FakeApi*](doc\FakeApi.md) | [**fakeOuterCompositeSerialize**](doc\FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
+[*FakeApi*](doc\FakeApi.md) | [**fakeOuterNumberSerialize**](doc\FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
+[*FakeApi*](doc\FakeApi.md) | [**fakeOuterStringSerialize**](doc\FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
+[*FakeApi*](doc\FakeApi.md) | [**fakePropertyEnumIntegerSerialize**](doc\FakeApi.md#fakepropertyenumintegerserialize) | **POST** /fake/property/enum-int | 
+[*FakeApi*](doc\FakeApi.md) | [**testBodyWithBinary**](doc\FakeApi.md#testbodywithbinary) | **PUT** /fake/body-with-binary | 
+[*FakeApi*](doc\FakeApi.md) | [**testBodyWithFileSchema**](doc\FakeApi.md#testbodywithfileschema) | **PUT** /fake/body-with-file-schema | 
+[*FakeApi*](doc\FakeApi.md) | [**testBodyWithQueryParams**](doc\FakeApi.md#testbodywithqueryparams) | **PUT** /fake/body-with-query-params | 
+[*FakeApi*](doc\FakeApi.md) | [**testClientModel**](doc\FakeApi.md#testclientmodel) | **PATCH** /fake | To test \&quot;client\&quot; model
+[*FakeApi*](doc\FakeApi.md) | [**testEndpointParameters**](doc\FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+[*FakeApi*](doc\FakeApi.md) | [**testEnumParameters**](doc\FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
+[*FakeApi*](doc\FakeApi.md) | [**testGroupParameters**](doc\FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
+[*FakeApi*](doc\FakeApi.md) | [**testInlineAdditionalProperties**](doc\FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
+[*FakeApi*](doc\FakeApi.md) | [**testJsonFormData**](doc\FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+[*FakeApi*](doc\FakeApi.md) | [**testQueryParameterCollectionFormat**](doc\FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-parameters | 
+[*FakeClassnameTags123Api*](doc\FakeClassnameTags123Api.md) | [**testClassname**](doc\FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
+[*PetApi*](doc\PetApi.md) | [**addPet**](doc\PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
+[*PetApi*](doc\PetApi.md) | [**deletePet**](doc\PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
+[*PetApi*](doc\PetApi.md) | [**findPetsByStatus**](doc\PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
+[*PetApi*](doc\PetApi.md) | [**findPetsByTags**](doc\PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
+[*PetApi*](doc\PetApi.md) | [**getPetById**](doc\PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
+[*PetApi*](doc\PetApi.md) | [**updatePet**](doc\PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
+[*PetApi*](doc\PetApi.md) | [**updatePetWithForm**](doc\PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
+[*PetApi*](doc\PetApi.md) | [**uploadFile**](doc\PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
+[*PetApi*](doc\PetApi.md) | [**uploadFileWithRequiredFile**](doc\PetApi.md#uploadfilewithrequiredfile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
+[*StoreApi*](doc\StoreApi.md) | [**deleteOrder**](doc\StoreApi.md#deleteorder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
+[*StoreApi*](doc\StoreApi.md) | [**getInventory**](doc\StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
+[*StoreApi*](doc\StoreApi.md) | [**getOrderById**](doc\StoreApi.md#getorderbyid) | **GET** /store/order/{order_id} | Find purchase order by ID
+[*StoreApi*](doc\StoreApi.md) | [**placeOrder**](doc\StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
+[*UserApi*](doc\UserApi.md) | [**createUser**](doc\UserApi.md#createuser) | **POST** /user | Create user
+[*UserApi*](doc\UserApi.md) | [**createUsersWithArrayInput**](doc\UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
+[*UserApi*](doc\UserApi.md) | [**createUsersWithListInput**](doc\UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
+[*UserApi*](doc\UserApi.md) | [**deleteUser**](doc\UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
+[*UserApi*](doc\UserApi.md) | [**getUserByName**](doc\UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
+[*UserApi*](doc\UserApi.md) | [**loginUser**](doc\UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
+[*UserApi*](doc\UserApi.md) | [**logoutUser**](doc\UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
+[*UserApi*](doc\UserApi.md) | [**updateUser**](doc\UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [AdditionalPropertiesClass](doc/AdditionalPropertiesClass.md)
- - [Animal](doc/Animal.md)
- - [ApiResponse](doc/ApiResponse.md)
- - [ArrayOfArrayOfNumberOnly](doc/ArrayOfArrayOfNumberOnly.md)
- - [ArrayOfNumberOnly](doc/ArrayOfNumberOnly.md)
- - [ArrayTest](doc/ArrayTest.md)
- - [Capitalization](doc/Capitalization.md)
- - [Cat](doc/Cat.md)
- - [CatAllOf](doc/CatAllOf.md)
- - [Category](doc/Category.md)
- - [ClassModel](doc/ClassModel.md)
- - [DeprecatedObject](doc/DeprecatedObject.md)
- - [Dog](doc/Dog.md)
- - [DogAllOf](doc/DogAllOf.md)
- - [EnumArrays](doc/EnumArrays.md)
- - [EnumTest](doc/EnumTest.md)
- - [FileSchemaTestClass](doc/FileSchemaTestClass.md)
- - [Foo](doc/Foo.md)
- - [FormatTest](doc/FormatTest.md)
- - [HasOnlyReadOnly](doc/HasOnlyReadOnly.md)
- - [HealthCheckResult](doc/HealthCheckResult.md)
- - [InlineResponseDefault](doc/InlineResponseDefault.md)
- - [MapTest](doc/MapTest.md)
- - [MixedPropertiesAndAdditionalPropertiesClass](doc/MixedPropertiesAndAdditionalPropertiesClass.md)
- - [Model200Response](doc/Model200Response.md)
- - [ModelClient](doc/ModelClient.md)
- - [ModelEnumClass](doc/ModelEnumClass.md)
- - [ModelFile](doc/ModelFile.md)
- - [ModelList](doc/ModelList.md)
- - [ModelReturn](doc/ModelReturn.md)
- - [Name](doc/Name.md)
- - [NullableClass](doc/NullableClass.md)
- - [NumberOnly](doc/NumberOnly.md)
- - [ObjectWithDeprecatedFields](doc/ObjectWithDeprecatedFields.md)
- - [Order](doc/Order.md)
- - [OuterComposite](doc/OuterComposite.md)
- - [OuterEnum](doc/OuterEnum.md)
- - [OuterEnumDefaultValue](doc/OuterEnumDefaultValue.md)
- - [OuterEnumInteger](doc/OuterEnumInteger.md)
- - [OuterEnumIntegerDefaultValue](doc/OuterEnumIntegerDefaultValue.md)
- - [OuterObjectWithEnumProperty](doc/OuterObjectWithEnumProperty.md)
- - [Pet](doc/Pet.md)
- - [ReadOnlyFirst](doc/ReadOnlyFirst.md)
- - [SpecialModelName](doc/SpecialModelName.md)
- - [Tag](doc/Tag.md)
- - [User](doc/User.md)
+ - [AdditionalPropertiesClass](doc\AdditionalPropertiesClass.md)
+ - [Animal](doc\Animal.md)
+ - [ApiResponse](doc\ApiResponse.md)
+ - [ArrayOfArrayOfNumberOnly](doc\ArrayOfArrayOfNumberOnly.md)
+ - [ArrayOfNumberOnly](doc\ArrayOfNumberOnly.md)
+ - [ArrayTest](doc\ArrayTest.md)
+ - [Capitalization](doc\Capitalization.md)
+ - [Cat](doc\Cat.md)
+ - [CatAllOf](doc\CatAllOf.md)
+ - [Category](doc\Category.md)
+ - [ClassModel](doc\ClassModel.md)
+ - [DeprecatedObject](doc\DeprecatedObject.md)
+ - [Dog](doc\Dog.md)
+ - [DogAllOf](doc\DogAllOf.md)
+ - [EnumArrays](doc\EnumArrays.md)
+ - [EnumTest](doc\EnumTest.md)
+ - [FileSchemaTestClass](doc\FileSchemaTestClass.md)
+ - [Foo](doc\Foo.md)
+ - [FormatTest](doc\FormatTest.md)
+ - [HasOnlyReadOnly](doc\HasOnlyReadOnly.md)
+ - [HealthCheckResult](doc\HealthCheckResult.md)
+ - [InlineResponseDefault](doc\InlineResponseDefault.md)
+ - [MapTest](doc\MapTest.md)
+ - [MixedPropertiesAndAdditionalPropertiesClass](doc\MixedPropertiesAndAdditionalPropertiesClass.md)
+ - [Model200Response](doc\Model200Response.md)
+ - [ModelClient](doc\ModelClient.md)
+ - [ModelEnumClass](doc\ModelEnumClass.md)
+ - [ModelFile](doc\ModelFile.md)
+ - [ModelList](doc\ModelList.md)
+ - [ModelReturn](doc\ModelReturn.md)
+ - [Name](doc\Name.md)
+ - [NullableClass](doc\NullableClass.md)
+ - [NumberOnly](doc\NumberOnly.md)
+ - [ObjectWithDeprecatedFields](doc\ObjectWithDeprecatedFields.md)
+ - [Order](doc\Order.md)
+ - [OuterComposite](doc\OuterComposite.md)
+ - [OuterEnum](doc\OuterEnum.md)
+ - [OuterEnumDefaultValue](doc\OuterEnumDefaultValue.md)
+ - [OuterEnumInteger](doc\OuterEnumInteger.md)
+ - [OuterEnumIntegerDefaultValue](doc\OuterEnumIntegerDefaultValue.md)
+ - [OuterObjectWithEnumProperty](doc\OuterObjectWithEnumProperty.md)
+ - [Pet](doc\Pet.md)
+ - [ReadOnlyFirst](doc\ReadOnlyFirst.md)
+ - [SpecialModelName](doc\SpecialModelName.md)
+ - [Tag](doc\Tag.md)
+ - [User](doc\User.md)
 
 
 ## Documentation For Authorization

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/README.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib/README.md
@@ -58,36 +58,36 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*PetApi* | [**addPet**](doc/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
-*PetApi* | [**deletePet**](doc/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
-*PetApi* | [**findPetsByStatus**](doc/PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
-*PetApi* | [**findPetsByTags**](doc/PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
-*PetApi* | [**getPetById**](doc/PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
-*PetApi* | [**updatePet**](doc/PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
-*PetApi* | [**updatePetWithForm**](doc/PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
-*PetApi* | [**uploadFile**](doc/PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
-*StoreApi* | [**deleteOrder**](doc/StoreApi.md#deleteorder) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
-*StoreApi* | [**getInventory**](doc/StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
-*StoreApi* | [**getOrderById**](doc/StoreApi.md#getorderbyid) | **GET** /store/order/{orderId} | Find purchase order by ID
-*StoreApi* | [**placeOrder**](doc/StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
-*UserApi* | [**createUser**](doc/UserApi.md#createuser) | **POST** /user | Create user
-*UserApi* | [**createUsersWithArrayInput**](doc/UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
-*UserApi* | [**createUsersWithListInput**](doc/UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
-*UserApi* | [**deleteUser**](doc/UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
-*UserApi* | [**getUserByName**](doc/UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
-*UserApi* | [**loginUser**](doc/UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
-*UserApi* | [**logoutUser**](doc/UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
-*UserApi* | [**updateUser**](doc/UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
+*PetApi* | [**addPet**](doc\PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
+*PetApi* | [**deletePet**](doc\PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
+*PetApi* | [**findPetsByStatus**](doc\PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
+*PetApi* | [**findPetsByTags**](doc\PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
+*PetApi* | [**getPetById**](doc\PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
+*PetApi* | [**updatePet**](doc\PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
+*PetApi* | [**updatePetWithForm**](doc\PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
+*PetApi* | [**uploadFile**](doc\PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
+*StoreApi* | [**deleteOrder**](doc\StoreApi.md#deleteorder) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
+*StoreApi* | [**getInventory**](doc\StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
+*StoreApi* | [**getOrderById**](doc\StoreApi.md#getorderbyid) | **GET** /store/order/{orderId} | Find purchase order by ID
+*StoreApi* | [**placeOrder**](doc\StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
+*UserApi* | [**createUser**](doc\UserApi.md#createuser) | **POST** /user | Create user
+*UserApi* | [**createUsersWithArrayInput**](doc\UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
+*UserApi* | [**createUsersWithListInput**](doc\UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
+*UserApi* | [**deleteUser**](doc\UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
+*UserApi* | [**getUserByName**](doc\UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
+*UserApi* | [**loginUser**](doc\UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
+*UserApi* | [**logoutUser**](doc\UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
+*UserApi* | [**updateUser**](doc\UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [ApiResponse](doc/ApiResponse.md)
- - [Category](doc/Category.md)
- - [Order](doc/Order.md)
- - [Pet](doc/Pet.md)
- - [Tag](doc/Tag.md)
- - [User](doc/User.md)
+ - [ApiResponse](doc\ApiResponse.md)
+ - [Category](doc\Category.md)
+ - [Order](doc\Order.md)
+ - [Pet](doc\Pet.md)
+ - [Tag](doc\Tag.md)
+ - [User](doc\User.md)
 
 
 ## Documentation For Authorization

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/README.md
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/README.md
@@ -58,97 +58,97 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*AnotherFakeApi* | [**call123testSpecialTags**](doc/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
-*DefaultApi* | [**fooGet**](doc/DefaultApi.md#fooget) | **GET** /foo | 
-*FakeApi* | [**fakeHealthGet**](doc/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
-*FakeApi* | [**fakeHttpSignatureTest**](doc/FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
-*FakeApi* | [**fakeOuterBooleanSerialize**](doc/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
-*FakeApi* | [**fakeOuterCompositeSerialize**](doc/FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
-*FakeApi* | [**fakeOuterNumberSerialize**](doc/FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
-*FakeApi* | [**fakeOuterStringSerialize**](doc/FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
-*FakeApi* | [**fakePropertyEnumIntegerSerialize**](doc/FakeApi.md#fakepropertyenumintegerserialize) | **POST** /fake/property/enum-int | 
-*FakeApi* | [**testBodyWithBinary**](doc/FakeApi.md#testbodywithbinary) | **PUT** /fake/body-with-binary | 
-*FakeApi* | [**testBodyWithFileSchema**](doc/FakeApi.md#testbodywithfileschema) | **PUT** /fake/body-with-file-schema | 
-*FakeApi* | [**testBodyWithQueryParams**](doc/FakeApi.md#testbodywithqueryparams) | **PUT** /fake/body-with-query-params | 
-*FakeApi* | [**testClientModel**](doc/FakeApi.md#testclientmodel) | **PATCH** /fake | To test \&quot;client\&quot; model
-*FakeApi* | [**testEndpointParameters**](doc/FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-*FakeApi* | [**testEnumParameters**](doc/FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
-*FakeApi* | [**testGroupParameters**](doc/FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
-*FakeApi* | [**testInlineAdditionalProperties**](doc/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
-*FakeApi* | [**testJsonFormData**](doc/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
-*FakeApi* | [**testQueryParameterCollectionFormat**](doc/FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-parameters | 
-*FakeClassnameTags123Api* | [**testClassname**](doc/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
-*PetApi* | [**addPet**](doc/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
-*PetApi* | [**deletePet**](doc/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
-*PetApi* | [**findPetsByStatus**](doc/PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
-*PetApi* | [**findPetsByTags**](doc/PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
-*PetApi* | [**getPetById**](doc/PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
-*PetApi* | [**updatePet**](doc/PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
-*PetApi* | [**updatePetWithForm**](doc/PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
-*PetApi* | [**uploadFile**](doc/PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
-*PetApi* | [**uploadFileWithRequiredFile**](doc/PetApi.md#uploadfilewithrequiredfile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
-*StoreApi* | [**deleteOrder**](doc/StoreApi.md#deleteorder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
-*StoreApi* | [**getInventory**](doc/StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
-*StoreApi* | [**getOrderById**](doc/StoreApi.md#getorderbyid) | **GET** /store/order/{order_id} | Find purchase order by ID
-*StoreApi* | [**placeOrder**](doc/StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
-*UserApi* | [**createUser**](doc/UserApi.md#createuser) | **POST** /user | Create user
-*UserApi* | [**createUsersWithArrayInput**](doc/UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
-*UserApi* | [**createUsersWithListInput**](doc/UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
-*UserApi* | [**deleteUser**](doc/UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
-*UserApi* | [**getUserByName**](doc/UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
-*UserApi* | [**loginUser**](doc/UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
-*UserApi* | [**logoutUser**](doc/UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
-*UserApi* | [**updateUser**](doc/UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
+*AnotherFakeApi* | [**call123testSpecialTags**](doc\AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
+*DefaultApi* | [**fooGet**](doc\DefaultApi.md#fooget) | **GET** /foo | 
+*FakeApi* | [**fakeHealthGet**](doc\FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
+*FakeApi* | [**fakeHttpSignatureTest**](doc\FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
+*FakeApi* | [**fakeOuterBooleanSerialize**](doc\FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
+*FakeApi* | [**fakeOuterCompositeSerialize**](doc\FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
+*FakeApi* | [**fakeOuterNumberSerialize**](doc\FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
+*FakeApi* | [**fakeOuterStringSerialize**](doc\FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
+*FakeApi* | [**fakePropertyEnumIntegerSerialize**](doc\FakeApi.md#fakepropertyenumintegerserialize) | **POST** /fake/property/enum-int | 
+*FakeApi* | [**testBodyWithBinary**](doc\FakeApi.md#testbodywithbinary) | **PUT** /fake/body-with-binary | 
+*FakeApi* | [**testBodyWithFileSchema**](doc\FakeApi.md#testbodywithfileschema) | **PUT** /fake/body-with-file-schema | 
+*FakeApi* | [**testBodyWithQueryParams**](doc\FakeApi.md#testbodywithqueryparams) | **PUT** /fake/body-with-query-params | 
+*FakeApi* | [**testClientModel**](doc\FakeApi.md#testclientmodel) | **PATCH** /fake | To test \&quot;client\&quot; model
+*FakeApi* | [**testEndpointParameters**](doc\FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+*FakeApi* | [**testEnumParameters**](doc\FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
+*FakeApi* | [**testGroupParameters**](doc\FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
+*FakeApi* | [**testInlineAdditionalProperties**](doc\FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
+*FakeApi* | [**testJsonFormData**](doc\FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**testQueryParameterCollectionFormat**](doc\FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-parameters | 
+*FakeClassnameTags123Api* | [**testClassname**](doc\FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
+*PetApi* | [**addPet**](doc\PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
+*PetApi* | [**deletePet**](doc\PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
+*PetApi* | [**findPetsByStatus**](doc\PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
+*PetApi* | [**findPetsByTags**](doc\PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
+*PetApi* | [**getPetById**](doc\PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
+*PetApi* | [**updatePet**](doc\PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
+*PetApi* | [**updatePetWithForm**](doc\PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
+*PetApi* | [**uploadFile**](doc\PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
+*PetApi* | [**uploadFileWithRequiredFile**](doc\PetApi.md#uploadfilewithrequiredfile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
+*StoreApi* | [**deleteOrder**](doc\StoreApi.md#deleteorder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
+*StoreApi* | [**getInventory**](doc\StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
+*StoreApi* | [**getOrderById**](doc\StoreApi.md#getorderbyid) | **GET** /store/order/{order_id} | Find purchase order by ID
+*StoreApi* | [**placeOrder**](doc\StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
+*UserApi* | [**createUser**](doc\UserApi.md#createuser) | **POST** /user | Create user
+*UserApi* | [**createUsersWithArrayInput**](doc\UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
+*UserApi* | [**createUsersWithListInput**](doc\UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
+*UserApi* | [**deleteUser**](doc\UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
+*UserApi* | [**getUserByName**](doc\UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
+*UserApi* | [**loginUser**](doc\UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
+*UserApi* | [**logoutUser**](doc\UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
+*UserApi* | [**updateUser**](doc\UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [AdditionalPropertiesClass](doc/AdditionalPropertiesClass.md)
- - [Animal](doc/Animal.md)
- - [ApiResponse](doc/ApiResponse.md)
- - [ArrayOfArrayOfNumberOnly](doc/ArrayOfArrayOfNumberOnly.md)
- - [ArrayOfNumberOnly](doc/ArrayOfNumberOnly.md)
- - [ArrayTest](doc/ArrayTest.md)
- - [Capitalization](doc/Capitalization.md)
- - [Cat](doc/Cat.md)
- - [CatAllOf](doc/CatAllOf.md)
- - [Category](doc/Category.md)
- - [ClassModel](doc/ClassModel.md)
- - [DeprecatedObject](doc/DeprecatedObject.md)
- - [Dog](doc/Dog.md)
- - [DogAllOf](doc/DogAllOf.md)
- - [EnumArrays](doc/EnumArrays.md)
- - [EnumTest](doc/EnumTest.md)
- - [FileSchemaTestClass](doc/FileSchemaTestClass.md)
- - [Foo](doc/Foo.md)
- - [FormatTest](doc/FormatTest.md)
- - [HasOnlyReadOnly](doc/HasOnlyReadOnly.md)
- - [HealthCheckResult](doc/HealthCheckResult.md)
- - [InlineResponseDefault](doc/InlineResponseDefault.md)
- - [MapTest](doc/MapTest.md)
- - [MixedPropertiesAndAdditionalPropertiesClass](doc/MixedPropertiesAndAdditionalPropertiesClass.md)
- - [Model200Response](doc/Model200Response.md)
- - [ModelClient](doc/ModelClient.md)
- - [ModelEnumClass](doc/ModelEnumClass.md)
- - [ModelFile](doc/ModelFile.md)
- - [ModelList](doc/ModelList.md)
- - [ModelReturn](doc/ModelReturn.md)
- - [Name](doc/Name.md)
- - [NullableClass](doc/NullableClass.md)
- - [NumberOnly](doc/NumberOnly.md)
- - [ObjectWithDeprecatedFields](doc/ObjectWithDeprecatedFields.md)
- - [Order](doc/Order.md)
- - [OuterComposite](doc/OuterComposite.md)
- - [OuterEnum](doc/OuterEnum.md)
- - [OuterEnumDefaultValue](doc/OuterEnumDefaultValue.md)
- - [OuterEnumInteger](doc/OuterEnumInteger.md)
- - [OuterEnumIntegerDefaultValue](doc/OuterEnumIntegerDefaultValue.md)
- - [OuterObjectWithEnumProperty](doc/OuterObjectWithEnumProperty.md)
- - [Pet](doc/Pet.md)
- - [ReadOnlyFirst](doc/ReadOnlyFirst.md)
- - [SpecialModelName](doc/SpecialModelName.md)
- - [Tag](doc/Tag.md)
- - [User](doc/User.md)
+ - [AdditionalPropertiesClass](doc\AdditionalPropertiesClass.md)
+ - [Animal](doc\Animal.md)
+ - [ApiResponse](doc\ApiResponse.md)
+ - [ArrayOfArrayOfNumberOnly](doc\ArrayOfArrayOfNumberOnly.md)
+ - [ArrayOfNumberOnly](doc\ArrayOfNumberOnly.md)
+ - [ArrayTest](doc\ArrayTest.md)
+ - [Capitalization](doc\Capitalization.md)
+ - [Cat](doc\Cat.md)
+ - [CatAllOf](doc\CatAllOf.md)
+ - [Category](doc\Category.md)
+ - [ClassModel](doc\ClassModel.md)
+ - [DeprecatedObject](doc\DeprecatedObject.md)
+ - [Dog](doc\Dog.md)
+ - [DogAllOf](doc\DogAllOf.md)
+ - [EnumArrays](doc\EnumArrays.md)
+ - [EnumTest](doc\EnumTest.md)
+ - [FileSchemaTestClass](doc\FileSchemaTestClass.md)
+ - [Foo](doc\Foo.md)
+ - [FormatTest](doc\FormatTest.md)
+ - [HasOnlyReadOnly](doc\HasOnlyReadOnly.md)
+ - [HealthCheckResult](doc\HealthCheckResult.md)
+ - [InlineResponseDefault](doc\InlineResponseDefault.md)
+ - [MapTest](doc\MapTest.md)
+ - [MixedPropertiesAndAdditionalPropertiesClass](doc\MixedPropertiesAndAdditionalPropertiesClass.md)
+ - [Model200Response](doc\Model200Response.md)
+ - [ModelClient](doc\ModelClient.md)
+ - [ModelEnumClass](doc\ModelEnumClass.md)
+ - [ModelFile](doc\ModelFile.md)
+ - [ModelList](doc\ModelList.md)
+ - [ModelReturn](doc\ModelReturn.md)
+ - [Name](doc\Name.md)
+ - [NullableClass](doc\NullableClass.md)
+ - [NumberOnly](doc\NumberOnly.md)
+ - [ObjectWithDeprecatedFields](doc\ObjectWithDeprecatedFields.md)
+ - [Order](doc\Order.md)
+ - [OuterComposite](doc\OuterComposite.md)
+ - [OuterEnum](doc\OuterEnum.md)
+ - [OuterEnumDefaultValue](doc\OuterEnumDefaultValue.md)
+ - [OuterEnumInteger](doc\OuterEnumInteger.md)
+ - [OuterEnumIntegerDefaultValue](doc\OuterEnumIntegerDefaultValue.md)
+ - [OuterObjectWithEnumProperty](doc\OuterObjectWithEnumProperty.md)
+ - [Pet](doc\Pet.md)
+ - [ReadOnlyFirst](doc\ReadOnlyFirst.md)
+ - [SpecialModelName](doc\SpecialModelName.md)
+ - [Tag](doc\Tag.md)
+ - [User](doc\User.md)
 
 
 ## Documentation For Authorization

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/README.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/README.md
@@ -60,36 +60,36 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*PetApi* | [**addPet**](doc//PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
-*PetApi* | [**deletePet**](doc//PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
-*PetApi* | [**findPetsByStatus**](doc//PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
-*PetApi* | [**findPetsByTags**](doc//PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
-*PetApi* | [**getPetById**](doc//PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
-*PetApi* | [**updatePet**](doc//PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
-*PetApi* | [**updatePetWithForm**](doc//PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
-*PetApi* | [**uploadFile**](doc//PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
-*StoreApi* | [**deleteOrder**](doc//StoreApi.md#deleteorder) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
-*StoreApi* | [**getInventory**](doc//StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
-*StoreApi* | [**getOrderById**](doc//StoreApi.md#getorderbyid) | **GET** /store/order/{orderId} | Find purchase order by ID
-*StoreApi* | [**placeOrder**](doc//StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
-*UserApi* | [**createUser**](doc//UserApi.md#createuser) | **POST** /user | Create user
-*UserApi* | [**createUsersWithArrayInput**](doc//UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
-*UserApi* | [**createUsersWithListInput**](doc//UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
-*UserApi* | [**deleteUser**](doc//UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
-*UserApi* | [**getUserByName**](doc//UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
-*UserApi* | [**loginUser**](doc//UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
-*UserApi* | [**logoutUser**](doc//UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
-*UserApi* | [**updateUser**](doc//UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
+*PetApi* | [**addPet**](doc\/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
+*PetApi* | [**deletePet**](doc\/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
+*PetApi* | [**findPetsByStatus**](doc\/PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
+*PetApi* | [**findPetsByTags**](doc\/PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
+*PetApi* | [**getPetById**](doc\/PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
+*PetApi* | [**updatePet**](doc\/PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
+*PetApi* | [**updatePetWithForm**](doc\/PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
+*PetApi* | [**uploadFile**](doc\/PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
+*StoreApi* | [**deleteOrder**](doc\/StoreApi.md#deleteorder) | **DELETE** /store/order/{orderId} | Delete purchase order by ID
+*StoreApi* | [**getInventory**](doc\/StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
+*StoreApi* | [**getOrderById**](doc\/StoreApi.md#getorderbyid) | **GET** /store/order/{orderId} | Find purchase order by ID
+*StoreApi* | [**placeOrder**](doc\/StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
+*UserApi* | [**createUser**](doc\/UserApi.md#createuser) | **POST** /user | Create user
+*UserApi* | [**createUsersWithArrayInput**](doc\/UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
+*UserApi* | [**createUsersWithListInput**](doc\/UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
+*UserApi* | [**deleteUser**](doc\/UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
+*UserApi* | [**getUserByName**](doc\/UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
+*UserApi* | [**loginUser**](doc\/UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
+*UserApi* | [**logoutUser**](doc\/UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
+*UserApi* | [**updateUser**](doc\/UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [ApiResponse](doc//ApiResponse.md)
- - [Category](doc//Category.md)
- - [Order](doc//Order.md)
- - [Pet](doc//Pet.md)
- - [Tag](doc//Tag.md)
- - [User](doc//User.md)
+ - [ApiResponse](doc\/ApiResponse.md)
+ - [Category](doc\/Category.md)
+ - [Order](doc\/Order.md)
+ - [Pet](doc\/Pet.md)
+ - [Tag](doc\/Tag.md)
+ - [User](doc\/User.md)
 
 
 ## Documentation For Authorization

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/README.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/README.md
@@ -58,97 +58,97 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*AnotherFakeApi* | [**call123testSpecialTags**](doc//AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
-*DefaultApi* | [**fooGet**](doc//DefaultApi.md#fooget) | **GET** /foo | 
-*FakeApi* | [**fakeHealthGet**](doc//FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
-*FakeApi* | [**fakeHttpSignatureTest**](doc//FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
-*FakeApi* | [**fakeOuterBooleanSerialize**](doc//FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
-*FakeApi* | [**fakeOuterCompositeSerialize**](doc//FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
-*FakeApi* | [**fakeOuterNumberSerialize**](doc//FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
-*FakeApi* | [**fakeOuterStringSerialize**](doc//FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
-*FakeApi* | [**fakePropertyEnumIntegerSerialize**](doc//FakeApi.md#fakepropertyenumintegerserialize) | **POST** /fake/property/enum-int | 
-*FakeApi* | [**testBodyWithBinary**](doc//FakeApi.md#testbodywithbinary) | **PUT** /fake/body-with-binary | 
-*FakeApi* | [**testBodyWithFileSchema**](doc//FakeApi.md#testbodywithfileschema) | **PUT** /fake/body-with-file-schema | 
-*FakeApi* | [**testBodyWithQueryParams**](doc//FakeApi.md#testbodywithqueryparams) | **PUT** /fake/body-with-query-params | 
-*FakeApi* | [**testClientModel**](doc//FakeApi.md#testclientmodel) | **PATCH** /fake | To test \"client\" model
-*FakeApi* | [**testEndpointParameters**](doc//FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-*FakeApi* | [**testEnumParameters**](doc//FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
-*FakeApi* | [**testGroupParameters**](doc//FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
-*FakeApi* | [**testInlineAdditionalProperties**](doc//FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
-*FakeApi* | [**testJsonFormData**](doc//FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
-*FakeApi* | [**testQueryParameterCollectionFormat**](doc//FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-parameters | 
-*FakeClassnameTags123Api* | [**testClassname**](doc//FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
-*PetApi* | [**addPet**](doc//PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
-*PetApi* | [**deletePet**](doc//PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
-*PetApi* | [**findPetsByStatus**](doc//PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
-*PetApi* | [**findPetsByTags**](doc//PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
-*PetApi* | [**getPetById**](doc//PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
-*PetApi* | [**updatePet**](doc//PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
-*PetApi* | [**updatePetWithForm**](doc//PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
-*PetApi* | [**uploadFile**](doc//PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
-*PetApi* | [**uploadFileWithRequiredFile**](doc//PetApi.md#uploadfilewithrequiredfile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
-*StoreApi* | [**deleteOrder**](doc//StoreApi.md#deleteorder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
-*StoreApi* | [**getInventory**](doc//StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
-*StoreApi* | [**getOrderById**](doc//StoreApi.md#getorderbyid) | **GET** /store/order/{order_id} | Find purchase order by ID
-*StoreApi* | [**placeOrder**](doc//StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
-*UserApi* | [**createUser**](doc//UserApi.md#createuser) | **POST** /user | Create user
-*UserApi* | [**createUsersWithArrayInput**](doc//UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
-*UserApi* | [**createUsersWithListInput**](doc//UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
-*UserApi* | [**deleteUser**](doc//UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
-*UserApi* | [**getUserByName**](doc//UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
-*UserApi* | [**loginUser**](doc//UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
-*UserApi* | [**logoutUser**](doc//UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
-*UserApi* | [**updateUser**](doc//UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
+*AnotherFakeApi* | [**call123testSpecialTags**](doc\/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
+*DefaultApi* | [**fooGet**](doc\/DefaultApi.md#fooget) | **GET** /foo | 
+*FakeApi* | [**fakeHealthGet**](doc\/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
+*FakeApi* | [**fakeHttpSignatureTest**](doc\/FakeApi.md#fakehttpsignaturetest) | **GET** /fake/http-signature-test | test http signature authentication
+*FakeApi* | [**fakeOuterBooleanSerialize**](doc\/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
+*FakeApi* | [**fakeOuterCompositeSerialize**](doc\/FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
+*FakeApi* | [**fakeOuterNumberSerialize**](doc\/FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 
+*FakeApi* | [**fakeOuterStringSerialize**](doc\/FakeApi.md#fakeouterstringserialize) | **POST** /fake/outer/string | 
+*FakeApi* | [**fakePropertyEnumIntegerSerialize**](doc\/FakeApi.md#fakepropertyenumintegerserialize) | **POST** /fake/property/enum-int | 
+*FakeApi* | [**testBodyWithBinary**](doc\/FakeApi.md#testbodywithbinary) | **PUT** /fake/body-with-binary | 
+*FakeApi* | [**testBodyWithFileSchema**](doc\/FakeApi.md#testbodywithfileschema) | **PUT** /fake/body-with-file-schema | 
+*FakeApi* | [**testBodyWithQueryParams**](doc\/FakeApi.md#testbodywithqueryparams) | **PUT** /fake/body-with-query-params | 
+*FakeApi* | [**testClientModel**](doc\/FakeApi.md#testclientmodel) | **PATCH** /fake | To test \"client\" model
+*FakeApi* | [**testEndpointParameters**](doc\/FakeApi.md#testendpointparameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+*FakeApi* | [**testEnumParameters**](doc\/FakeApi.md#testenumparameters) | **GET** /fake | To test enum parameters
+*FakeApi* | [**testGroupParameters**](doc\/FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
+*FakeApi* | [**testInlineAdditionalProperties**](doc\/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
+*FakeApi* | [**testJsonFormData**](doc\/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**testQueryParameterCollectionFormat**](doc\/FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-parameters | 
+*FakeClassnameTags123Api* | [**testClassname**](doc\/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
+*PetApi* | [**addPet**](doc\/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
+*PetApi* | [**deletePet**](doc\/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
+*PetApi* | [**findPetsByStatus**](doc\/PetApi.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
+*PetApi* | [**findPetsByTags**](doc\/PetApi.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
+*PetApi* | [**getPetById**](doc\/PetApi.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
+*PetApi* | [**updatePet**](doc\/PetApi.md#updatepet) | **PUT** /pet | Update an existing pet
+*PetApi* | [**updatePetWithForm**](doc\/PetApi.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
+*PetApi* | [**uploadFile**](doc\/PetApi.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image
+*PetApi* | [**uploadFileWithRequiredFile**](doc\/PetApi.md#uploadfilewithrequiredfile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
+*StoreApi* | [**deleteOrder**](doc\/StoreApi.md#deleteorder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
+*StoreApi* | [**getInventory**](doc\/StoreApi.md#getinventory) | **GET** /store/inventory | Returns pet inventories by status
+*StoreApi* | [**getOrderById**](doc\/StoreApi.md#getorderbyid) | **GET** /store/order/{order_id} | Find purchase order by ID
+*StoreApi* | [**placeOrder**](doc\/StoreApi.md#placeorder) | **POST** /store/order | Place an order for a pet
+*UserApi* | [**createUser**](doc\/UserApi.md#createuser) | **POST** /user | Create user
+*UserApi* | [**createUsersWithArrayInput**](doc\/UserApi.md#createuserswitharrayinput) | **POST** /user/createWithArray | Creates list of users with given input array
+*UserApi* | [**createUsersWithListInput**](doc\/UserApi.md#createuserswithlistinput) | **POST** /user/createWithList | Creates list of users with given input array
+*UserApi* | [**deleteUser**](doc\/UserApi.md#deleteuser) | **DELETE** /user/{username} | Delete user
+*UserApi* | [**getUserByName**](doc\/UserApi.md#getuserbyname) | **GET** /user/{username} | Get user by user name
+*UserApi* | [**loginUser**](doc\/UserApi.md#loginuser) | **GET** /user/login | Logs user into the system
+*UserApi* | [**logoutUser**](doc\/UserApi.md#logoutuser) | **GET** /user/logout | Logs out current logged in user session
+*UserApi* | [**updateUser**](doc\/UserApi.md#updateuser) | **PUT** /user/{username} | Updated user
 
 
 ## Documentation For Models
 
- - [AdditionalPropertiesClass](doc//AdditionalPropertiesClass.md)
- - [Animal](doc//Animal.md)
- - [ApiResponse](doc//ApiResponse.md)
- - [ArrayOfArrayOfNumberOnly](doc//ArrayOfArrayOfNumberOnly.md)
- - [ArrayOfNumberOnly](doc//ArrayOfNumberOnly.md)
- - [ArrayTest](doc//ArrayTest.md)
- - [Capitalization](doc//Capitalization.md)
- - [Cat](doc//Cat.md)
- - [CatAllOf](doc//CatAllOf.md)
- - [Category](doc//Category.md)
- - [ClassModel](doc//ClassModel.md)
- - [DeprecatedObject](doc//DeprecatedObject.md)
- - [Dog](doc//Dog.md)
- - [DogAllOf](doc//DogAllOf.md)
- - [EnumArrays](doc//EnumArrays.md)
- - [EnumClass](doc//EnumClass.md)
- - [EnumTest](doc//EnumTest.md)
- - [FileSchemaTestClass](doc//FileSchemaTestClass.md)
- - [Foo](doc//Foo.md)
- - [FormatTest](doc//FormatTest.md)
- - [HasOnlyReadOnly](doc//HasOnlyReadOnly.md)
- - [HealthCheckResult](doc//HealthCheckResult.md)
- - [InlineResponseDefault](doc//InlineResponseDefault.md)
- - [MapTest](doc//MapTest.md)
- - [MixedPropertiesAndAdditionalPropertiesClass](doc//MixedPropertiesAndAdditionalPropertiesClass.md)
- - [Model200Response](doc//Model200Response.md)
- - [ModelClient](doc//ModelClient.md)
- - [ModelFile](doc//ModelFile.md)
- - [ModelList](doc//ModelList.md)
- - [ModelReturn](doc//ModelReturn.md)
- - [Name](doc//Name.md)
- - [NullableClass](doc//NullableClass.md)
- - [NumberOnly](doc//NumberOnly.md)
- - [ObjectWithDeprecatedFields](doc//ObjectWithDeprecatedFields.md)
- - [Order](doc//Order.md)
- - [OuterComposite](doc//OuterComposite.md)
- - [OuterEnum](doc//OuterEnum.md)
- - [OuterEnumDefaultValue](doc//OuterEnumDefaultValue.md)
- - [OuterEnumInteger](doc//OuterEnumInteger.md)
- - [OuterEnumIntegerDefaultValue](doc//OuterEnumIntegerDefaultValue.md)
- - [OuterObjectWithEnumProperty](doc//OuterObjectWithEnumProperty.md)
- - [Pet](doc//Pet.md)
- - [ReadOnlyFirst](doc//ReadOnlyFirst.md)
- - [SpecialModelName](doc//SpecialModelName.md)
- - [Tag](doc//Tag.md)
- - [User](doc//User.md)
+ - [AdditionalPropertiesClass](doc\/AdditionalPropertiesClass.md)
+ - [Animal](doc\/Animal.md)
+ - [ApiResponse](doc\/ApiResponse.md)
+ - [ArrayOfArrayOfNumberOnly](doc\/ArrayOfArrayOfNumberOnly.md)
+ - [ArrayOfNumberOnly](doc\/ArrayOfNumberOnly.md)
+ - [ArrayTest](doc\/ArrayTest.md)
+ - [Capitalization](doc\/Capitalization.md)
+ - [Cat](doc\/Cat.md)
+ - [CatAllOf](doc\/CatAllOf.md)
+ - [Category](doc\/Category.md)
+ - [ClassModel](doc\/ClassModel.md)
+ - [DeprecatedObject](doc\/DeprecatedObject.md)
+ - [Dog](doc\/Dog.md)
+ - [DogAllOf](doc\/DogAllOf.md)
+ - [EnumArrays](doc\/EnumArrays.md)
+ - [EnumClass](doc\/EnumClass.md)
+ - [EnumTest](doc\/EnumTest.md)
+ - [FileSchemaTestClass](doc\/FileSchemaTestClass.md)
+ - [Foo](doc\/Foo.md)
+ - [FormatTest](doc\/FormatTest.md)
+ - [HasOnlyReadOnly](doc\/HasOnlyReadOnly.md)
+ - [HealthCheckResult](doc\/HealthCheckResult.md)
+ - [InlineResponseDefault](doc\/InlineResponseDefault.md)
+ - [MapTest](doc\/MapTest.md)
+ - [MixedPropertiesAndAdditionalPropertiesClass](doc\/MixedPropertiesAndAdditionalPropertiesClass.md)
+ - [Model200Response](doc\/Model200Response.md)
+ - [ModelClient](doc\/ModelClient.md)
+ - [ModelFile](doc\/ModelFile.md)
+ - [ModelList](doc\/ModelList.md)
+ - [ModelReturn](doc\/ModelReturn.md)
+ - [Name](doc\/Name.md)
+ - [NullableClass](doc\/NullableClass.md)
+ - [NumberOnly](doc\/NumberOnly.md)
+ - [ObjectWithDeprecatedFields](doc\/ObjectWithDeprecatedFields.md)
+ - [Order](doc\/Order.md)
+ - [OuterComposite](doc\/OuterComposite.md)
+ - [OuterEnum](doc\/OuterEnum.md)
+ - [OuterEnumDefaultValue](doc\/OuterEnumDefaultValue.md)
+ - [OuterEnumInteger](doc\/OuterEnumInteger.md)
+ - [OuterEnumIntegerDefaultValue](doc\/OuterEnumIntegerDefaultValue.md)
+ - [OuterObjectWithEnumProperty](doc\/OuterObjectWithEnumProperty.md)
+ - [Pet](doc\/Pet.md)
+ - [ReadOnlyFirst](doc\/ReadOnlyFirst.md)
+ - [SpecialModelName](doc\/SpecialModelName.md)
+ - [Tag](doc\/Tag.md)
+ - [User](doc\/User.md)
 
 
 ## Documentation For Authorization

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -117,7 +117,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -226,7 +226,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-3.0/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -117,7 +117,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -226,7 +226,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-3.1/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 405 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(405);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -248,7 +248,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore-5.0/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/PetApi.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/PetApi.cs
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -117,7 +117,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -151,7 +151,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\n  \"name\" : \"doggie\",\n  \"id\" : 0,\n  \"category\" : {\n    \"name\" : \"name\",\n    \"id\" : 6\n  },\n  \"tags\" : [ {\n    \"name\" : \"name\",\n    \"id\" : 1\n  }, {\n    \"name\" : \"name\",\n    \"id\" : 1\n  } ],\n  \"status\" : \"available\"\n}";
+            exampleJson = "{\r\n  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],\r\n  \"name\" : \"doggie\",\r\n  \"id\" : 0,\r\n  \"category\" : {\r\n    \"name\" : \"name\",\r\n    \"id\" : 6\r\n  },\r\n  \"tags\" : [ {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  }, {\r\n    \"name\" : \"name\",\r\n    \"id\" : 1\r\n  } ],\r\n  \"status\" : \"available\"\r\n}";
             exampleJson = "<Pet>\n  <id>123456789</id>\n  <name>doggie</name>\n  <photoUrls>\n    <photoUrls>aeiou</photoUrls>\n  </photoUrls>\n  <tags>\n  </tags>\n  <status>aeiou</status>\n</Pet>";
             
             var example = exampleJson != null
@@ -226,7 +226,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 200 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(200, default(ApiResponse));
             string exampleJson = null;
-            exampleJson = "{\n  \"code\" : 0,\n  \"type\" : \"type\",\n  \"message\" : \"message\"\n}";
+            exampleJson = "{\r\n  \"code\" : 0,\r\n  \"type\" : \"type\",\r\n  \"message\" : \"message\"\r\n}";
             
             var example = exampleJson != null
             ? JsonConvert.DeserializeObject<ApiResponse>(exampleJson)

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/StoreApi.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/StoreApi.cs
@@ -98,7 +98,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 400 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(400);
             string exampleJson = null;
-            exampleJson = "{\n  \"petId\" : 6,\n  \"quantity\" : 1,\n  \"id\" : 0,\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\n  \"complete\" : false,\n  \"status\" : \"placed\"\n}";
+            exampleJson = "{\r\n  \"petId\" : 6,\r\n  \"quantity\" : 1,\r\n  \"id\" : 0,\r\n  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",\r\n  \"complete\" : false,\r\n  \"status\" : \"placed\"\r\n}";
             exampleJson = "<Order>\n  <id>123456789</id>\n  <petId>123456789</petId>\n  <quantity>123</quantity>\n  <shipDate>2000-01-23T04:56:07.000Z</shipDate>\n  <status>aeiou</status>\n  <complete>true</complete>\n</Order>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/UserApi.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Controllers/UserApi.cs
@@ -127,7 +127,7 @@ namespace Org.OpenAPITools.Controllers
             //TODO: Uncomment the next line to return response 404 or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode(404);
             string exampleJson = null;
-            exampleJson = "{\n  \"firstName\" : \"firstName\",\n  \"lastName\" : \"lastName\",\n  \"password\" : \"password\",\n  \"userStatus\" : 6,\n  \"phone\" : \"phone\",\n  \"id\" : 0,\n  \"email\" : \"email\",\n  \"username\" : \"username\"\n}";
+            exampleJson = "{\r\n  \"firstName\" : \"firstName\",\r\n  \"lastName\" : \"lastName\",\r\n  \"password\" : \"password\",\r\n  \"userStatus\" : 6,\r\n  \"phone\" : \"phone\",\r\n  \"id\" : 0,\r\n  \"email\" : \"email\",\r\n  \"username\" : \"username\"\r\n}";
             exampleJson = "<User>\n  <id>123456789</id>\n  <username>aeiou</username>\n  <firstName>aeiou</firstName>\n  <lastName>aeiou</lastName>\n  <email>aeiou</email>\n  <password>aeiou</password>\n  <phone>aeiou</phone>\n  <userStatus>123</userStatus>\n</User>";
             
             var example = exampleJson != null

--- a/samples/server/petstore/kotlin-server/ktor/src/main/kotlin/org/openapitools/server/apis/PetApi.kt
+++ b/samples/server/petstore/kotlin-server/ktor/src/main/kotlin/org/openapitools/server/apis/PetApi.kt
@@ -31,25 +31,27 @@ fun Route.PetApi() {
     authenticate("petstore_auth") {
     post<Paths.addPet> {
         val principal = call.authentication.principal<OAuthAccessTokenResponse>()!!
-        
-        call.respond(HttpStatusCode.NotImplemented)
+
+call.respond(HttpStatusCode.NotImplemented)
+
     }
     }
 
     authenticate("petstore_auth") {
     delete<Paths.deletePet> {
         val principal = call.authentication.principal<OAuthAccessTokenResponse>()!!
-        
-        call.respond(HttpStatusCode.NotImplemented)
+
+call.respond(HttpStatusCode.NotImplemented)
+
     }
     }
 
     authenticate("petstore_auth") {
     get<Paths.findPetsByStatus> {
         val principal = call.authentication.principal<OAuthAccessTokenResponse>()!!
-        
-        val exampleContentType = "application/json"
-            val exampleContentString = """{
+
+val exampleContentType = "application/json"
+val exampleContentString = """{
               "photoUrls" : [ "photoUrls", "photoUrls" ],
               "name" : "doggie",
               "id" : 0,
@@ -66,21 +68,22 @@ fun Route.PetApi() {
               } ],
               "status" : "available"
             }"""
-            
-            when (exampleContentType) {
-                "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
-                "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
-                else -> call.respondText(exampleContentString)
-            }
+
+when (exampleContentType) {
+    "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
+    "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
+    else -> call.respondText(exampleContentString)
+}
+
     }
     }
 
     authenticate("petstore_auth") {
     get<Paths.findPetsByTags> {
         val principal = call.authentication.principal<OAuthAccessTokenResponse>()!!
-        
-        val exampleContentType = "application/json"
-            val exampleContentString = """{
+
+val exampleContentType = "application/json"
+val exampleContentString = """{
               "photoUrls" : [ "photoUrls", "photoUrls" ],
               "name" : "doggie",
               "id" : 0,
@@ -97,21 +100,22 @@ fun Route.PetApi() {
               } ],
               "status" : "available"
             }"""
-            
-            when (exampleContentType) {
-                "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
-                "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
-                else -> call.respondText(exampleContentString)
-            }
+
+when (exampleContentType) {
+    "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
+    "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
+    else -> call.respondText(exampleContentString)
+}
+
     }
     }
 
     authenticate("api_key") {
     get<Paths.getPetById> {
         val principal = call.authentication.principal<ApiPrincipal>()!!
-        
-        val exampleContentType = "application/json"
-            val exampleContentString = """{
+
+val exampleContentType = "application/json"
+val exampleContentString = """{
               "photoUrls" : [ "photoUrls", "photoUrls" ],
               "name" : "doggie",
               "id" : 0,
@@ -128,47 +132,51 @@ fun Route.PetApi() {
               } ],
               "status" : "available"
             }"""
-            
-            when (exampleContentType) {
-                "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
-                "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
-                else -> call.respondText(exampleContentString)
-            }
+
+when (exampleContentType) {
+    "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
+    "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
+    else -> call.respondText(exampleContentString)
+}
+
     }
     }
 
     authenticate("petstore_auth") {
     put<Paths.updatePet> {
         val principal = call.authentication.principal<OAuthAccessTokenResponse>()!!
-        
-        call.respond(HttpStatusCode.NotImplemented)
+
+call.respond(HttpStatusCode.NotImplemented)
+
     }
     }
 
     authenticate("petstore_auth") {
     post<Paths.updatePetWithForm> {
         val principal = call.authentication.principal<OAuthAccessTokenResponse>()!!
-        
-        call.respond(HttpStatusCode.NotImplemented)
+
+call.respond(HttpStatusCode.NotImplemented)
+
     }
     }
 
     authenticate("petstore_auth") {
     post<Paths.uploadFile> {
         val principal = call.authentication.principal<OAuthAccessTokenResponse>()!!
-        
-        val exampleContentType = "application/json"
-            val exampleContentString = """{
+
+val exampleContentType = "application/json"
+val exampleContentString = """{
               "code" : 0,
               "type" : "type",
               "message" : "message"
             }"""
-            
-            when (exampleContentType) {
-                "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
-                "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
-                else -> call.respondText(exampleContentString)
-            }
+
+when (exampleContentType) {
+    "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
+    "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
+    else -> call.respondText(exampleContentString)
+}
+
     }
     }
 

--- a/samples/server/petstore/kotlin-server/ktor/src/main/kotlin/org/openapitools/server/apis/StoreApi.kt
+++ b/samples/server/petstore/kotlin-server/ktor/src/main/kotlin/org/openapitools/server/apis/StoreApi.kt
@@ -29,19 +29,21 @@ fun Route.StoreApi() {
 
     delete<Paths.deleteOrder> {
         call.respond(HttpStatusCode.NotImplemented)
+
     }
 
     authenticate("api_key") {
     get<Paths.getInventory> {
         val principal = call.authentication.principal<ApiPrincipal>()!!
-        
-        call.respond(HttpStatusCode.NotImplemented)
+
+call.respond(HttpStatusCode.NotImplemented)
+
     }
     }
 
     get<Paths.getOrderById> {
         val exampleContentType = "application/json"
-        val exampleContentString = """{
+val exampleContentString = """{
           "petId" : 6,
           "quantity" : 1,
           "id" : 0,
@@ -49,17 +51,18 @@ fun Route.StoreApi() {
           "complete" : false,
           "status" : "placed"
         }"""
-        
-        when (exampleContentType) {
-            "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
-            "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
-            else -> call.respondText(exampleContentString)
-        }
+
+when (exampleContentType) {
+    "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
+    "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
+    else -> call.respondText(exampleContentString)
+}
+
     }
 
     post<Paths.placeOrder> {
         val exampleContentType = "application/json"
-        val exampleContentString = """{
+val exampleContentString = """{
           "petId" : 6,
           "quantity" : 1,
           "id" : 0,
@@ -67,12 +70,13 @@ fun Route.StoreApi() {
           "complete" : false,
           "status" : "placed"
         }"""
-        
-        when (exampleContentType) {
-            "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
-            "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
-            else -> call.respondText(exampleContentString)
-        }
+
+when (exampleContentType) {
+    "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
+    "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
+    else -> call.respondText(exampleContentString)
+}
+
     }
 
 }

--- a/samples/server/petstore/kotlin-server/ktor/src/main/kotlin/org/openapitools/server/apis/UserApi.kt
+++ b/samples/server/petstore/kotlin-server/ktor/src/main/kotlin/org/openapitools/server/apis/UserApi.kt
@@ -29,23 +29,27 @@ fun Route.UserApi() {
 
     post<Paths.createUser> {
         call.respond(HttpStatusCode.NotImplemented)
+
     }
 
     post<Paths.createUsersWithArrayInput> {
         call.respond(HttpStatusCode.NotImplemented)
+
     }
 
     post<Paths.createUsersWithListInput> {
         call.respond(HttpStatusCode.NotImplemented)
+
     }
 
     delete<Paths.deleteUser> {
         call.respond(HttpStatusCode.NotImplemented)
+
     }
 
     get<Paths.getUserByName> {
         val exampleContentType = "application/json"
-        val exampleContentString = """{
+val exampleContentString = """{
           "firstName" : "firstName",
           "lastName" : "lastName",
           "password" : "password",
@@ -55,24 +59,28 @@ fun Route.UserApi() {
           "email" : "email",
           "username" : "username"
         }"""
-        
-        when (exampleContentType) {
-            "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
-            "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
-            else -> call.respondText(exampleContentString)
-        }
+
+when (exampleContentType) {
+    "application/json" -> call.respond(gson.fromJson(exampleContentString, empty::class.java))
+    "application/xml" -> call.respondText(exampleContentString, ContentType.Text.Xml)
+    else -> call.respondText(exampleContentString)
+}
+
     }
 
     get<Paths.loginUser> {
         call.respond(HttpStatusCode.NotImplemented)
+
     }
 
     get<Paths.logoutUser> {
         call.respond(HttpStatusCode.NotImplemented)
+
     }
 
     put<Paths.updateUser> {
         call.respond(HttpStatusCode.NotImplemented)
+
     }
 
 }

--- a/samples/server/petstore/php-slim4/README.md
+++ b/samples/server/petstore/php-slim4/README.md
@@ -168,10 +168,10 @@ Class | Method | HTTP request | Description
 ## Authentication
 
 ### Security schema `api_key`
-> Important! To make ApiKey authentication work you need to extend [\OpenAPIServer\Auth\AbstractAuthenticator](./lib/Auth/AbstractAuthenticator.php) class by [\OpenAPIServer\Auth\ApiKeyAuthenticator](./src/Auth/ApiKeyAuthenticator.php) class.
+> Important! To make ApiKey authentication work you need to extend [\OpenAPIServer\Auth\AbstractAuthenticator](./lib\/Auth/AbstractAuthenticator.php) class by [\OpenAPIServer\Auth\ApiKeyAuthenticator](./src/Auth/ApiKeyAuthenticator.php) class.
 
 ### Security schema `petstore_auth`
-> Important! To make OAuth authentication work you need to extend [\OpenAPIServer\Auth\AbstractAuthenticator](./lib/Auth/AbstractAuthenticator.php) class by [\OpenAPIServer\Auth\OAuthAuthenticator](./src/Auth/OAuthAuthenticator.php) class.
+> Important! To make OAuth authentication work you need to extend [\OpenAPIServer\Auth\AbstractAuthenticator](./lib\/Auth/AbstractAuthenticator.php) class by [\OpenAPIServer\Auth\OAuthAuthenticator](./src/Auth/OAuthAuthenticator.php) class.
 
 Scope list:
 * `write:pets` - modify pets in your account

--- a/samples/server/petstore/php-slim4/phpunit.xml.dist
+++ b/samples/server/petstore/php-slim4/phpunit.xml.dist
@@ -2,9 +2,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="./vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" beStrictAboutTestsThatDoNotTestAnything="false" stopOnFailure="false">
   <coverage processUncoveredFiles="true">
     <include>
-      <directory suffix=".php">./lib/Api</directory>
+      <directory suffix=".php">./lib\/Api</directory>
       <file>./lib/BaseModel.php</file>
-      <directory suffix=".php">./lib/Model</directory>
+      <directory suffix=".php">./lib\/Model</directory>
     </include>
   </coverage>
   <testsuites>

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/phpunit.xml.dist
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/phpunit.xml.dist
@@ -14,9 +14,9 @@
     </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">././Api</directory>
-            <directory suffix=".php">././Model</directory>
-            <directory suffix=".php">././Controller</directory>
+            <directory suffix=".php">./.\/Api</directory>
+            <directory suffix=".php">./.\/Model</directory>
+            <directory suffix=".php">./.\/Controller</directory>
         </whitelist>
     </filter>
     <php>

--- a/samples/server/petstore/python-aiohttp-srclayout/setup.py
+++ b/samples/server/petstore/python-aiohttp-srclayout/setup.py
@@ -27,9 +27,9 @@ setup(
     url="",
     keywords=["OpenAPI", "OpenAPI Petstore"],
     install_requires=REQUIRES,
-    packages=find_packages("src/"),
-    package_dir={"": "src/"},
-    package_data={'': ['src//openapi/openapi.yaml']},
+    packages=find_packages("src\"),
+    package_dir={"": "src\"},
+    package_data={'': ['src\/openapi/openapi.yaml']},
     include_package_data=True,
     entry_points={
         'console_scripts': ['openapi_server=openapi_server.__main__:main']},

--- a/samples/server/petstore/python-aiohttp-srclayout/tests/conftest.py
+++ b/samples/server/petstore/python-aiohttp-srclayout/tests/conftest.py
@@ -12,7 +12,7 @@ def client(loop, aiohttp_client):
         "swagger_ui": True
         }
     specification_dir = os.path.join(os.path.dirname(__file__), '..',
-                                     "src/",
+                                     "src\",
                                      'openapi_server',
                                      'openapi')
     app = connexion.AioHttpApp(__name__, specification_dir=specification_dir,

--- a/samples/server/petstore/python-aiohttp-srclayout/tox.ini
+++ b/samples/server/petstore/python-aiohttp-srclayout/tox.ini
@@ -8,4 +8,4 @@ deps=-r{toxinidir}/requirements.txt
 	 {toxinidir}
 
 commands=
-   pytest --cov=src/openapi_server
+   pytest --cov=src\openapi_server


### PR DESCRIPTION
Problem:
In the following PR:
https://github.com/OpenAPITools/openapi-generator/pull/8802

The requiredVars have been moved out of the composed schema `__init__` and `_from_openapi_data` signature because the required vars were probably defined in the composed oneOf/anyOf/allOf schemas and this schema does not know about them. 
We understand that each schema should be validated separately and required vars of a schema should not be present in composed schema, but while doing the validation of input payload in allOf schema the schema is expecting those requiredVars
to be set and sent in the input payload itself. 

For Example, consider the following snippet from the specification file:

```yaml
schemas:
    Dog:
      allOf:
        - $ref: '#/components/schemas/Mammals'
        - type: object
          properties:
            className:
              enum:
                - 'Dog'
              x-enum-as-string: true
              default: 'Dog'
              type: string
            breed:
              type: string
            legs:
               $ref: '#/components/schemas/Legs'
    Cat:
      allOf:
        - $ref: '#/components/schemas/Mammals'
        - type: object
          properties:
            className:
              enum:
                - 'Cat'
              x-enum-as-string: true
              default: 'Cat'
              type: string
            declawed:
              type: boolean
            legs:
               $ref: '#/components/schemas/Legs'
    Legs:
        type: object
        required:
        - legs
        properties:
            legs:
              enum:
              - '2'
              - '4'
              default: '4'
              x-enum-as-string: true
            name:
               type: string
    Mammals:
      allOf:
        - $ref: '#/components/schemas/Animal'
        - type: object
          required:
            - className
          properties:
            className:
              enum:
                - 'Dog'
                - 'Cat'
              x-enum-as-string: true
              type: string
    Animal:
      type: object
      required:
        - className
      properties:
        className:
          enum:
            - 'Dog'
            - 'Cat'
          x-enum-as-string: true
          type: string
        color:
          type: string
          default: red
        run:
           type: boolean
           default: True
           readOnly: true
```

As we can see in the above case Dog class contain the Mammals class as part of allOf composed schema.
Now if we will not specify the className in Dog class as payload and when the payload will be validated against Mammals class and Animal class, Mammal class will throw an error.

*Code used to test*:

```python
from openapi_client.model.dog import Dog
from openapi_client.model.legs import Legs


def define_legs():
    return Legs(legs="4")


def dog():
    legs = define_legs()

    dog_instance = Dog(color="Black")

    dog_instance.breed = "Bulldog"

    dog_instance.legs = legs

dog()
```

*Error Captured*:
```bash
Traceback (most recent call last):
  File "E:\Dev\Required_Vars\animal\openapi_client\model_utils.py", line 1782, in get_allof_instances
    allof_instance = allof_class(**model_args, **constant_args)
  File "E:\Dev\Required_Vars\animal\openapi_client\model_utils.py", line 45, in wrapped_init
    return fn(_self, *args, **kwargs)
TypeError: __init__() missing 1 required positional argument: 'class_name'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "E:\Dev\Required_Vars\animal\openapi_client\model_utils.py", line 1782, in get_allof_instances
    allof_instance = allof_class(**model_args, **constant_args)
  File "E:\Dev\Required_Vars\animal\openapi_client\model_utils.py", line 45, in wrapped_init
    return fn(_self, *args, **kwargs)
  File "E:\Dev\Required_Vars\animal\openapi_client\model\mammals.py", line 289, in __init__
    composed_info = validate_get_composed_info(
  File "E:\Dev\Required_Vars\animal\openapi_client\model_utils.py", line 1988, in validate_get_composed_info
    allof_instances = get_allof_instances(self, model_args, constant_args)
  File "E:\Dev\Required_Vars\animal\openapi_client\model_utils.py", line 1785, in get_allof_instances
    raise ApiValueError(
openapi_client.exceptions.ApiValueError: Invalid inputs given to generate an instance of 'Animal'. The input data was invalid for the allOf schema 'Animal' in the co
mposed schema 'Mammals'. Error=__init__() missing 1 required positional argument: 'class_name'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "E:\Dev\Required_Vars\animal\examples.py", line 18, in <module>
    dog()
  File "E:\Dev\Required_Vars\animal\examples.py", line 12, in dog
    dog_instance = Dog(color="Black")
  File "E:\Dev\Required_Vars\animal\openapi_client\model_utils.py", line 45, in wrapped_init
    return fn(_self, *args, **kwargs)
  File "E:\Dev\Required_Vars\animal\openapi_client\model\dog.py", line 300, in __init__
    composed_info = validate_get_composed_info(
  File "E:\Dev\Required_Vars\animal\openapi_client\model_utils.py", line 1988, in validate_get_composed_info
    allof_instances = get_allof_instances(self, model_args, constant_args)
  File "E:\Dev\Required_Vars\animal\openapi_client\model_utils.py", line 1785, in get_allof_instances
    raise ApiValueError(
openapi_client.exceptions.ApiValueError: Invalid inputs given to generate an instance of 'Mammals'. The input data was invalid for the allOf schema 'Mammals' in the
composed schema 'Dog'. Error=Invalid inputs given to generate an instance of 'Animal'. The input data was invalid for the allOf schema 'Animal' in the composed schem
a 'Mammals'. Error=__init__() missing 1 required positional argument: 'class_name'
```

And because of this now it will become the user's responsibility to add the requiredVars as a mandatory input in the payload.
That is user need to always specify the className in their payload like the following:

```python
 dog_instance = Dog(class_name="Dog",
                       color="Black")
```

Since in our application end users may not be know these requiredVars always, the SDK failure creates an issue for us.

Solution:
The proposed solution is to add a configuration variable: setRequiredVars.
If it is set to true, then the older logic will be used. The older logic was used to set the default value of requiredVars in `__init__` and `_from_openapi_data` as positional arguments.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed responses from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator bypassing the relevant config(s) as an argument to the script, for example, `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @arun-nalla (2019/11) @spacether (2019/11) @wing328
