### PR TITLE
[GO] dont canonize headers 

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -316,7 +316,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/client/petstore/go/auth_test.go
+++ b/samples/client/petstore/go/auth_test.go
@@ -151,7 +151,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 	}
 
 	reqb, _ := httputil.DumpRequest(r.Request, true)
-	if !strings.Contains((string)(reqb), "Api_key: TEST123") {
+	if !strings.Contains((string)(reqb), "api_key: TEST123") {
 		t.Errorf("APIKey Authentication is missing")
 	}
 
@@ -186,7 +186,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 	}
 
 	reqb, _ := httputil.DumpRequest(r.Request, true)
-	if !strings.Contains((string)(reqb), "Api_key: Bearer TEST123") {
+	if !strings.Contains((string)(reqb), "api_key: Bearer TEST123") {
 		t.Errorf("APIKey Authentication is missing")
 	}
 

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -324,7 +324,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/client.go
@@ -309,7 +309,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}

--- a/samples/openapi3/client/petstore/go/auth_test.go
+++ b/samples/openapi3/client/petstore/go/auth_test.go
@@ -151,7 +151,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 	}
 
 	reqb, _ := httputil.DumpRequest(r.Request, true)
-	if !strings.Contains((string)(reqb), "Api_key: TEST123") {
+	if !strings.Contains((string)(reqb), "api_key: TEST123") {
 		t.Errorf("APIKey Authentication is missing")
 	}
 
@@ -186,7 +186,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 	}
 
 	reqb, _ := httputil.DumpRequest(r.Request, true)
-	if !strings.Contains((string)(reqb), "Api_key: Bearer TEST123") {
+	if !strings.Contains((string)(reqb), "api_key: Bearer TEST123") {
 		t.Errorf("APIKey Authentication is missing")
 	}
 

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -327,7 +327,7 @@ func (c *APIClient) prepareRequest(
 	if len(headerParams) > 0 {
 		headers := http.Header{}
 		for h, v := range headerParams {
-			headers.Set(h, v)
+			headers[h] = []string{v}
 		}
 		localVarRequest.Header = headers
 	}


### PR DESCRIPTION

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Golang be default canonizes header names for example `content-type` will be converted to `Content-Type`, this PR allows to opt out this behaviour by setting additional property dontCanonizeHeaders=true.
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
