### PR TITLE
[Python] remove default content-type in the request

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-legacy/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/api.mustache
@@ -250,10 +250,11 @@ class {{classname}}(object):
         {{/hasProduces}}
         {{#hasConsumes}}
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                [{{#consumes}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/consumes}}],
-                '{{httpMethod}}', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            [{{#consumes}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/consumes}}])  # noqa: E501
+            [{{#consumes}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/consumes}}])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         {{/hasConsumes}}
         # Authentication setting

--- a/modules/openapi-generator/src/main/resources/python-legacy/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/api.mustache
@@ -252,7 +252,6 @@ class {{classname}}(object):
         # HTTP header `Content-Type`
         content_types_list = self.api_client.select_header_content_type(  # noqa: E501
             [{{#consumes}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/consumes}}])  # noqa: E501
-            [{{#consumes}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/consumes}}])  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 

--- a/modules/openapi-generator/src/main/resources/python-legacy/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/api.mustache
@@ -250,8 +250,10 @@ class {{classname}}(object):
         {{/hasProduces}}
         {{#hasConsumes}}
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            [{{#consumes}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/consumes}}])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                [{{#consumes}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/consumes}}],
+                '{{httpMethod}}', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 

--- a/modules/openapi-generator/src/main/resources/python-legacy/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python-legacy/api_client.mustache
@@ -554,7 +554,7 @@ class ApiClient(object):
         :return: Content-Type (e.g. application/json).
         """
         if not content_types:
-            return 'application/json'
+            return None
 
         content_types = [x.lower() for x in content_types]
 

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -594,7 +594,7 @@ class ApiClient(object):
         :return: Content-Type (e.g. application/json).
         """
         if not content_types:
-            return 'application/json'
+            return None
 
         content_types = [x.lower() for x in content_types]
 
@@ -863,10 +863,10 @@ class Endpoint(object):
             content_type_headers_list = self.headers_map['content_type']
             if content_type_headers_list:
                 if params['body'] != "":
-                    header_list = self.api_client.select_header_content_type(
-                        content_type_headers_list, self.settings['http_method'],
-                        params['body'])
-                    params['header']['Content-Type'] = header_list
+                    content_types_list = self.api_client.select_header_content_type(
+                        content_type_headers_list)
+                    if content_types_list:
+                        params['header']['Content-Type'] = content_types_list
 
         return self.api_client.call_api(
             self.settings['endpoint_path'], self.settings['http_method'],

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -864,7 +864,9 @@ class Endpoint(object):
             if content_type_headers_list:
                 if params['body'] != "":
                     content_types_list = self.api_client.select_header_content_type(
-                        content_type_headers_list)
+                        content_type_headers_list,
+                        self.settings['http_method'],
+                        params['body'])
                     if content_types_list:
                         params['header']['Content-Type'] = content_types_list
 

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -864,8 +864,7 @@ class Endpoint(object):
             if content_type_headers_list:
                 if params['body'] != "":
                     content_types_list = self.api_client.select_header_content_type(
-                        content_type_headers_list,
-                        self.settings['http_method'],
+                        content_type_headers_list, self.settings['http_method'],
                         params['body'])
                     if content_types_list:
                         params['header']['Content-Type'] = content_types_list

--- a/samples/client/petstore/python-asyncio/petstore_api/api/another_fake_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/another_fake_api.py
@@ -151,10 +151,12 @@ class AnotherFakeApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PATCH', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501

--- a/samples/client/petstore/python-asyncio/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/fake_api.py
@@ -147,10 +147,12 @@ class FakeApi(object):
         if 'xml_item' in local_var_params:
             body_params = local_var_params['xml_item']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/xml', 'application/xml; charset=utf-8', 'application/xml; charset=utf-16', 'text/xml', 'text/xml; charset=utf-8', 'text/xml; charset=utf-16'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -821,10 +823,12 @@ class FakeApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PUT', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -968,10 +972,12 @@ class FakeApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PUT', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1110,10 +1116,12 @@ class FakeApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PATCH', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1381,10 +1389,12 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/x-www-form-urlencoded'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['http_basic_test']  # noqa: E501
@@ -1567,10 +1577,12 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/x-www-form-urlencoded'],
                 'GET', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1878,10 +1890,12 @@ class FakeApi(object):
         if 'param' in local_var_params:
             body_params = local_var_params['param']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -2025,10 +2039,12 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/x-www-form-urlencoded'],
                 'GET', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501

--- a/samples/client/petstore/python-asyncio/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/fake_classname_tags123_api.py
@@ -151,10 +151,12 @@ class FakeClassnameTags123Api(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PATCH', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['api_key_query']  # noqa: E501

--- a/samples/client/petstore/python-asyncio/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/pet_api.py
@@ -145,10 +145,12 @@ class PetApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json', 'application/xml'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -838,10 +840,12 @@ class PetApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json', 'application/xml'],
                 'PUT', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -988,10 +992,12 @@ class PetApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/x-www-form-urlencoded'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -1142,10 +1148,12 @@ class PetApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['multipart/form-data'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -1302,10 +1310,12 @@ class PetApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['multipart/form-data'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -531,7 +531,7 @@ class ApiClient(object):
         :return: Content-Type (e.g. application/json).
         """
         if not content_types:
-            return 'application/json'
+            return None
 
         content_types = [x.lower() for x in content_types]
 

--- a/samples/client/petstore/python-legacy/petstore_api/api/another_fake_api.py
+++ b/samples/client/petstore/python-legacy/petstore_api/api/another_fake_api.py
@@ -151,10 +151,12 @@ class AnotherFakeApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PATCH', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501

--- a/samples/client/petstore/python-legacy/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python-legacy/petstore_api/api/fake_api.py
@@ -147,10 +147,12 @@ class FakeApi(object):
         if 'xml_item' in local_var_params:
             body_params = local_var_params['xml_item']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/xml', 'application/xml; charset=utf-8', 'application/xml; charset=utf-16', 'text/xml', 'text/xml; charset=utf-8', 'text/xml; charset=utf-16'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -821,10 +823,12 @@ class FakeApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PUT', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -968,10 +972,12 @@ class FakeApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PUT', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1110,10 +1116,12 @@ class FakeApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PATCH', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1381,10 +1389,12 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/x-www-form-urlencoded'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['http_basic_test']  # noqa: E501
@@ -1567,10 +1577,12 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/x-www-form-urlencoded'],
                 'GET', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1878,10 +1890,12 @@ class FakeApi(object):
         if 'param' in local_var_params:
             body_params = local_var_params['param']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -2025,10 +2039,12 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/x-www-form-urlencoded'],
                 'GET', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501

--- a/samples/client/petstore/python-legacy/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/client/petstore/python-legacy/petstore_api/api/fake_classname_tags123_api.py
@@ -151,10 +151,12 @@ class FakeClassnameTags123Api(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PATCH', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['api_key_query']  # noqa: E501

--- a/samples/client/petstore/python-legacy/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python-legacy/petstore_api/api/pet_api.py
@@ -145,10 +145,12 @@ class PetApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json', 'application/xml'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -838,10 +840,12 @@ class PetApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json', 'application/xml'],
                 'PUT', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -988,10 +992,12 @@ class PetApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/x-www-form-urlencoded'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -1142,10 +1148,12 @@ class PetApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['multipart/form-data'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -1302,10 +1310,12 @@ class PetApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['multipart/form-data'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501

--- a/samples/client/petstore/python-legacy/petstore_api/api_client.py
+++ b/samples/client/petstore/python-legacy/petstore_api/api_client.py
@@ -530,7 +530,7 @@ class ApiClient(object):
         :return: Content-Type (e.g. application/json).
         """
         if not content_types:
-            return 'application/json'
+            return None
 
         content_types = [x.lower() for x in content_types]
 

--- a/samples/client/petstore/python-legacy/tests/test_api_client.py
+++ b/samples/client/petstore/python-legacy/tests/test_api_client.py
@@ -96,7 +96,7 @@ class ApiClientTests(unittest.TestCase):
 
         content_types = []
         content_type = self.api_client.select_header_content_type(content_types)
-        self.assertEqual(content_type, 'application/json')
+        self.assertEqual(content_type, None)
 
         content_types = ['application/json-patch+json', 'application/json']
         content_type = self.api_client.select_header_content_type(content_types,

--- a/samples/client/petstore/python-tornado/petstore_api/api/another_fake_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/another_fake_api.py
@@ -151,10 +151,12 @@ class AnotherFakeApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PATCH', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501

--- a/samples/client/petstore/python-tornado/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/fake_api.py
@@ -147,10 +147,12 @@ class FakeApi(object):
         if 'xml_item' in local_var_params:
             body_params = local_var_params['xml_item']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/xml', 'application/xml; charset=utf-8', 'application/xml; charset=utf-16', 'text/xml', 'text/xml; charset=utf-8', 'text/xml; charset=utf-16'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -821,10 +823,12 @@ class FakeApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PUT', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -968,10 +972,12 @@ class FakeApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PUT', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1110,10 +1116,12 @@ class FakeApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PATCH', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1381,10 +1389,12 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/x-www-form-urlencoded'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['http_basic_test']  # noqa: E501
@@ -1567,10 +1577,12 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/x-www-form-urlencoded'],
                 'GET', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1878,10 +1890,12 @@ class FakeApi(object):
         if 'param' in local_var_params:
             body_params = local_var_params['param']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -2025,10 +2039,12 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/x-www-form-urlencoded'],
                 'GET', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501

--- a/samples/client/petstore/python-tornado/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/fake_classname_tags123_api.py
@@ -151,10 +151,12 @@ class FakeClassnameTags123Api(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json'],
                 'PATCH', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['api_key_query']  # noqa: E501

--- a/samples/client/petstore/python-tornado/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/pet_api.py
@@ -145,10 +145,12 @@ class PetApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json', 'application/xml'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -838,10 +840,12 @@ class PetApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/json', 'application/xml'],
                 'PUT', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -988,10 +992,12 @@ class PetApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['application/x-www-form-urlencoded'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -1142,10 +1148,12 @@ class PetApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['multipart/form-data'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -1302,10 +1310,12 @@ class PetApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
+        content_types_list = local_var_params.get('_content_type',
             self.api_client.select_header_content_type(
                 ['multipart/form-data'],
                 'POST', body_params))  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -532,7 +532,7 @@ class ApiClient(object):
         :return: Content-Type (e.g. application/json).
         """
         if not content_types:
-            return 'application/json'
+            return None
 
         content_types = [x.lower() for x in content_types]
 

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -843,8 +843,7 @@ class Endpoint(object):
             if content_type_headers_list:
                 if params['body'] != "":
                     content_types_list = self.api_client.select_header_content_type(
-                        content_type_headers_list,
-                        self.settings['http_method'],
+                        content_type_headers_list, self.settings['http_method'],
                         params['body'])
                     if content_types_list:
                         params['header']['Content-Type'] = content_types_list

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -582,7 +582,7 @@ class ApiClient(object):
         :return: Content-Type (e.g. application/json).
         """
         if not content_types:
-            return 'application/json'
+            return None
 
         content_types = [x.lower() for x in content_types]
 
@@ -842,10 +842,12 @@ class Endpoint(object):
             content_type_headers_list = self.headers_map['content_type']
             if content_type_headers_list:
                 if params['body'] != "":
-                    header_list = self.api_client.select_header_content_type(
-                        content_type_headers_list, self.settings['http_method'],
+                    content_types_list = self.api_client.select_header_content_type(
+                        content_type_headers_list,
+                        self.settings['http_method'],
                         params['body'])
-                    params['header']['Content-Type'] = header_list
+                    if content_types_list:
+                        params['header']['Content-Type'] = content_types_list
 
         return self.api_client.call_api(
             self.settings['endpoint_path'], self.settings['http_method'],

--- a/samples/client/petstore/python/tests/test_api_client.py
+++ b/samples/client/petstore/python/tests/test_api_client.py
@@ -120,7 +120,7 @@ class ApiClientTests(unittest.TestCase):
 
         content_types = []
         content_type = self.api_client.select_header_content_type(content_types)
-        self.assertEqual(content_type, 'application/json')
+        self.assertEqual(content_type, None)
 
         content_types = ['application/json-patch+json', 'application/json']
         content_type = self.api_client.select_header_content_type(content_types,

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/api_client.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/api_client.py
@@ -843,8 +843,7 @@ class Endpoint(object):
             if content_type_headers_list:
                 if params['body'] != "":
                     content_types_list = self.api_client.select_header_content_type(
-                        content_type_headers_list,
-                        self.settings['http_method'],
+                        content_type_headers_list, self.settings['http_method'],
                         params['body'])
                     if content_types_list:
                         params['header']['Content-Type'] = content_types_list

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/api_client.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/petstore_api/api_client.py
@@ -582,7 +582,7 @@ class ApiClient(object):
         :return: Content-Type (e.g. application/json).
         """
         if not content_types:
-            return 'application/json'
+            return None
 
         content_types = [x.lower() for x in content_types]
 
@@ -842,10 +842,12 @@ class Endpoint(object):
             content_type_headers_list = self.headers_map['content_type']
             if content_type_headers_list:
                 if params['body'] != "":
-                    header_list = self.api_client.select_header_content_type(
-                        content_type_headers_list, self.settings['http_method'],
+                    content_types_list = self.api_client.select_header_content_type(
+                        content_type_headers_list,
+                        self.settings['http_method'],
                         params['body'])
-                    params['header']['Content-Type'] = header_list
+                    if content_types_list:
+                        params['header']['Content-Type'] = content_types_list
 
         return self.api_client.call_api(
             self.settings['endpoint_path'], self.settings['http_method'],

--- a/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/tests/test_api_client.py
+++ b/samples/client/petstore/python_disallowAdditionalPropertiesIfNotPresent/tests/test_api_client.py
@@ -120,7 +120,7 @@ class ApiClientTests(unittest.TestCase):
 
         content_types = []
         content_type = self.api_client.select_header_content_type(content_types)
-        self.assertEqual(content_type, 'application/json')
+        self.assertEqual(content_type, None)
 
     def test_sanitize_for_serialization(self):
         # None

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/api_client.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/api_client.py
@@ -843,8 +843,7 @@ class Endpoint(object):
             if content_type_headers_list:
                 if params['body'] != "":
                     content_types_list = self.api_client.select_header_content_type(
-                        content_type_headers_list,
-                        self.settings['http_method'],
+                        content_type_headers_list, self.settings['http_method'],
                         params['body'])
                     if content_types_list:
                         params['header']['Content-Type'] = content_types_list

--- a/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/api_client.py
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/python/x_auth_id_alias/api_client.py
@@ -582,7 +582,7 @@ class ApiClient(object):
         :return: Content-Type (e.g. application/json).
         """
         if not content_types:
-            return 'application/json'
+            return None
 
         content_types = [x.lower() for x in content_types]
 
@@ -842,10 +842,12 @@ class Endpoint(object):
             content_type_headers_list = self.headers_map['content_type']
             if content_type_headers_list:
                 if params['body'] != "":
-                    header_list = self.api_client.select_header_content_type(
-                        content_type_headers_list, self.settings['http_method'],
+                    content_types_list = self.api_client.select_header_content_type(
+                        content_type_headers_list,
+                        self.settings['http_method'],
                         params['body'])
-                    params['header']['Content-Type'] = header_list
+                    if content_types_list:
+                        params['header']['Content-Type'] = content_types_list
 
         return self.api_client.call_api(
             self.settings['endpoint_path'], self.settings['http_method'],

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api_client.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api_client.py
@@ -843,8 +843,7 @@ class Endpoint(object):
             if content_type_headers_list:
                 if params['body'] != "":
                     content_types_list = self.api_client.select_header_content_type(
-                        content_type_headers_list,
-                        self.settings['http_method'],
+                        content_type_headers_list, self.settings['http_method'],
                         params['body'])
                     if content_types_list:
                         params['header']['Content-Type'] = content_types_list

--- a/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api_client.py
+++ b/samples/openapi3/client/features/dynamic-servers/python/dynamic_servers/api_client.py
@@ -582,7 +582,7 @@ class ApiClient(object):
         :return: Content-Type (e.g. application/json).
         """
         if not content_types:
-            return 'application/json'
+            return None
 
         content_types = [x.lower() for x in content_types]
 
@@ -842,10 +842,12 @@ class Endpoint(object):
             content_type_headers_list = self.headers_map['content_type']
             if content_type_headers_list:
                 if params['body'] != "":
-                    header_list = self.api_client.select_header_content_type(
-                        content_type_headers_list, self.settings['http_method'],
+                    content_types_list = self.api_client.select_header_content_type(
+                        content_type_headers_list,
+                        self.settings['http_method'],
                         params['body'])
-                    params['header']['Content-Type'] = header_list
+                    if content_types_list:
+                        params['header']['Content-Type'] = content_types_list
 
         return self.api_client.call_api(
             self.settings['endpoint_path'], self.settings['http_method'],

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/another_fake_api.py
@@ -151,8 +151,10 @@ class AnotherFakeApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'PATCH', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/another_fake_api.py
@@ -151,10 +151,10 @@ class AnotherFakeApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'PATCH', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/fake_api.py
@@ -284,10 +284,10 @@ class FakeApi(object):
         if 'pet' in local_var_params:
             body_params = local_var_params['pet']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json', 'application/xml'],
-                'GET', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json', 'application/xml'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['http_signature_test']  # noqa: E501
@@ -422,10 +422,10 @@ class FakeApi(object):
             ['*/*'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -562,10 +562,10 @@ class FakeApi(object):
             ['*/*'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -702,10 +702,10 @@ class FakeApi(object):
             ['*/*'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -842,10 +842,10 @@ class FakeApi(object):
             ['*/*'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -986,10 +986,10 @@ class FakeApi(object):
             ['*/*'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1122,10 +1122,10 @@ class FakeApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['image/png'],
-                'PUT', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['image/png'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1260,10 +1260,10 @@ class FakeApi(object):
         if 'file_schema_test_class' in local_var_params:
             body_params = local_var_params['file_schema_test_class']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'PUT', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1407,10 +1407,10 @@ class FakeApi(object):
         if 'user' in local_var_params:
             body_params = local_var_params['user']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'PUT', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1549,10 +1549,10 @@ class FakeApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'PATCH', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1820,10 +1820,10 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/x-www-form-urlencoded'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/x-www-form-urlencoded'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['http_basic_test']  # noqa: E501
@@ -2006,10 +2006,10 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/x-www-form-urlencoded'],
-                'GET', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/x-www-form-urlencoded'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -2319,10 +2319,10 @@ class FakeApi(object):
         if 'request_body' in local_var_params:
             body_params = local_var_params['request_body']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -2468,10 +2468,10 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/x-www-form-urlencoded'],
-                'GET', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/x-www-form-urlencoded'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/fake_api.py
@@ -284,8 +284,10 @@ class FakeApi(object):
         if 'pet' in local_var_params:
             body_params = local_var_params['pet']
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json', 'application/xml'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json', 'application/xml'],
+                'GET', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -422,8 +424,10 @@ class FakeApi(object):
             ['*/*'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -562,8 +566,10 @@ class FakeApi(object):
             ['*/*'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -702,8 +708,10 @@ class FakeApi(object):
             ['*/*'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -842,8 +850,10 @@ class FakeApi(object):
             ['*/*'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -986,8 +996,10 @@ class FakeApi(object):
             ['*/*'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -1122,8 +1134,10 @@ class FakeApi(object):
         if 'body' in local_var_params:
             body_params = local_var_params['body']
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['image/png'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['image/png'],
+                'PUT', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -1260,8 +1274,10 @@ class FakeApi(object):
         if 'file_schema_test_class' in local_var_params:
             body_params = local_var_params['file_schema_test_class']
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'PUT', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -1407,8 +1423,10 @@ class FakeApi(object):
         if 'user' in local_var_params:
             body_params = local_var_params['user']
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'PUT', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -1549,8 +1567,10 @@ class FakeApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'PATCH', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -1820,8 +1840,10 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/x-www-form-urlencoded'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/x-www-form-urlencoded'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -2006,8 +2028,10 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/x-www-form-urlencoded'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/x-www-form-urlencoded'],
+                'GET', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -2319,8 +2343,10 @@ class FakeApi(object):
         if 'request_body' in local_var_params:
             body_params = local_var_params['request_body']
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -2468,8 +2494,10 @@ class FakeApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/x-www-form-urlencoded'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/x-www-form-urlencoded'],
+                'GET', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/fake_classname_tags123_api.py
@@ -151,10 +151,10 @@ class FakeClassnameTags123Api(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'PATCH', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['api_key_query']  # noqa: E501

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/fake_classname_tags123_api.py
@@ -151,8 +151,10 @@ class FakeClassnameTags123Api(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'PATCH', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/pet_api.py
@@ -160,10 +160,10 @@ class PetApi(object):
         if 'pet' in local_var_params:
             body_params = local_var_params['pet']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json', 'application/xml'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json', 'application/xml'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -871,10 +871,10 @@ class PetApi(object):
         if 'pet' in local_var_params:
             body_params = local_var_params['pet']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json', 'application/xml'],
-                'PUT', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json', 'application/xml'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -1024,10 +1024,10 @@ class PetApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/x-www-form-urlencoded'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/x-www-form-urlencoded'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -1180,10 +1180,10 @@ class PetApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['multipart/form-data'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['multipart/form-data'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501
@@ -1342,10 +1342,10 @@ class PetApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['multipart/form-data'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['multipart/form-data'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = ['petstore_auth']  # noqa: E501

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/pet_api.py
@@ -160,8 +160,10 @@ class PetApi(object):
         if 'pet' in local_var_params:
             body_params = local_var_params['pet']
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json', 'application/xml'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json', 'application/xml'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -871,8 +873,10 @@ class PetApi(object):
         if 'pet' in local_var_params:
             body_params = local_var_params['pet']
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json', 'application/xml'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json', 'application/xml'],
+                'PUT', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -1024,8 +1028,10 @@ class PetApi(object):
 
         body_params = None
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/x-www-form-urlencoded'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/x-www-form-urlencoded'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -1180,8 +1186,10 @@ class PetApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['multipart/form-data'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['multipart/form-data'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -1342,8 +1350,10 @@ class PetApi(object):
             ['application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['multipart/form-data'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['multipart/form-data'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/store_api.py
@@ -554,8 +554,10 @@ class StoreApi(object):
             ['application/xml', 'application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/store_api.py
@@ -554,10 +554,10 @@ class StoreApi(object):
             ['application/xml', 'application/json'])  # noqa: E501
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/user_api.py
@@ -147,8 +147,10 @@ class UserApi(object):
         if 'user' in local_var_params:
             body_params = local_var_params['user']
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -285,8 +287,10 @@ class UserApi(object):
         if 'user' in local_var_params:
             body_params = local_var_params['user']
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -423,8 +427,10 @@ class UserApi(object):
         if 'user' in local_var_params:
             body_params = local_var_params['user']
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'POST', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 
@@ -1115,8 +1121,10 @@ class UserApi(object):
         if 'user' in local_var_params:
             body_params = local_var_params['user']
         # HTTP header `Content-Type`
-        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
-            ['application/json'])  # noqa: E501
+        content_types_list = local_var_params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json'],
+                'PUT', body_params))  # noqa: E501
         if content_types_list:
                 header_params['Content-Type'] = content_types_list
 

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api/user_api.py
@@ -147,10 +147,10 @@ class UserApi(object):
         if 'user' in local_var_params:
             body_params = local_var_params['user']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -285,10 +285,10 @@ class UserApi(object):
         if 'user' in local_var_params:
             body_params = local_var_params['user']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -423,10 +423,10 @@ class UserApi(object):
         if 'user' in local_var_params:
             body_params = local_var_params['user']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'POST', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501
@@ -1115,10 +1115,10 @@ class UserApi(object):
         if 'user' in local_var_params:
             body_params = local_var_params['user']
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = local_var_params.get('_content_type',
-            self.api_client.select_header_content_type(
-                ['application/json'],
-                'PUT', body_params))  # noqa: E501
+        content_types_list = self.api_client.select_header_content_type(  # noqa: E501
+            ['application/json'])  # noqa: E501
+        if content_types_list:
+                header_params['Content-Type'] = content_types_list
 
         # Authentication setting
         auth_settings = []  # noqa: E501

--- a/samples/openapi3/client/petstore/python-legacy/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-legacy/petstore_api/api_client.py
@@ -530,7 +530,7 @@ class ApiClient(object):
         :return: Content-Type (e.g. application/json).
         """
         if not content_types:
-            return 'application/json'
+            return None
 
         content_types = [x.lower() for x in content_types]
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -850,8 +850,7 @@ class Endpoint(object):
             if content_type_headers_list:
                 if params['body'] != "":
                     content_types_list = self.api_client.select_header_content_type(
-                        content_type_headers_list,
-                        self.settings['http_method'],
+                        content_type_headers_list, self.settings['http_method'],
                         params['body'])
                     if content_types_list:
                         params['header']['Content-Type'] = content_types_list

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -582,7 +582,7 @@ class ApiClient(object):
         :return: Content-Type (e.g. application/json).
         """
         if not content_types:
-            return 'application/json'
+            return None
 
         content_types = [x.lower() for x in content_types]
 
@@ -849,10 +849,10 @@ class Endpoint(object):
             content_type_headers_list = self.headers_map['content_type']
             if content_type_headers_list:
                 if params['body'] != "":
-                    header_list = self.api_client.select_header_content_type(
-                        content_type_headers_list, self.settings['http_method'],
-                        params['body'])
-                    params['header']['Content-Type'] = header_list
+                    content_types_list = self.api_client.select_header_content_type(
+                        content_type_headers_list)
+                    if content_types_list:
+                        params['header']['Content-Type'] = content_types_list
 
         return self.api_client.call_api(
             self.settings['endpoint_path'], self.settings['http_method'],

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -850,7 +850,9 @@ class Endpoint(object):
             if content_type_headers_list:
                 if params['body'] != "":
                     content_types_list = self.api_client.select_header_content_type(
-                        content_type_headers_list)
+                        content_type_headers_list,
+                        self.settings['http_method'],
+                        params['body'])
                     if content_types_list:
                         params['header']['Content-Type'] = content_types_list
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Before this fix, the content-type of the request defaults to "application/json".

With this fix, we no longer set such default.

fix #8116, relate to https://github.com/OpenAPITools/openapi-generator/pull/10769/

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @arun-nalla (2019/11) @spacether (2019/11)