### PR TITLE
[Java][jersey2] set content-type as "application/octet-stream" in the request if not set

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -908,32 +908,32 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     return StringUtil.join(accepts, ",");
   }
 
-    /**
-     * Select the Content-Type header's value from the given array:
-     *   if JSON exists in the given array, use it;
-     *   otherwise use the first one of the array.
-     *
-     * @param contentTypes The Content-Type array to select from
-     * @return The Content-Type header to use. If the given array is empty,
-     *   returns null. If it matches "any", JSON will be used.
-     */
-    public String selectHeaderContentType(String[] contentTypes) {
-        if (contentTypes.length == 0) {
-            return null;
-        }
+  /**
+    * Select the Content-Type header's value from the given array:
+    *   if JSON exists in the given array, use it;
+    *   otherwise use the first one of the array.
+    *
+    * @param contentTypes The Content-Type array to select from
+    * @return The Content-Type header to use. If the given array is empty,
+    *   returns null. If it matches "any", JSON will be used.
+    */
+  public String selectHeaderContentType(String[] contentTypes) {
+      if (contentTypes.length == 0) {
+          return null;
+      }
 
-        if (contentTypes[0].equals("*/*")) {
-            return "application/json";
-        }
+      if (contentTypes[0].equals("*/*")) {
+          return "application/json";
+      }
 
-        for (String contentType : contentTypes) {
-            if (isJsonMime(contentType)) {
-                return contentType;
-            }
-        }
+      for (String contentType : contentTypes) {
+          if (isJsonMime(contentType)) {
+              return contentType;
+          }
+      }
 
-        return contentTypes[0];
-    }
+      return contentTypes[0];
+  }
 
   /**
    * Escape the given string to be used as URL query value.

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -922,7 +922,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
           return "application/octet-stream";
       }
 
-      if (contentTypes[0].equals("*/*")) {
+      if ("*/*".equals(contentTypes[0])) {
           return "application/json";
       }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -915,11 +915,11 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     *
     * @param contentTypes The Content-Type array to select from
     * @return The Content-Type header to use. If the given array is empty,
-    *   returns null. If it matches "any", JSON will be used.
+    *   returns "application/octet-stream". If it matches "any", JSON will be used.
     */
   public String selectHeaderContentType(String[] contentTypes) {
       if (contentTypes.length == 0) {
-          return null;
+          return "application/octet-stream";
       }
 
       if (contentTypes[0].equals("*/*")) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -908,26 +908,32 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     return StringUtil.join(accepts, ",");
   }
 
-  /**
-   * Select the Content-Type header's value from the given array:
-   *   if JSON exists in the given array, use it;
-   *   otherwise use the first one of the array.
-   *
-   * @param contentTypes The Content-Type array to select from
-   * @return The Content-Type header to use. If the given array is empty,
-   *   JSON will be used.
-   */
-  public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
-      return "application/json";
+    /**
+     * Select the Content-Type header's value from the given array:
+     *   if JSON exists in the given array, use it;
+     *   otherwise use the first one of the array.
+     *
+     * @param contentTypes The Content-Type array to select from
+     * @return The Content-Type header to use. If the given array is empty,
+     *   returns null. If it matches "any", JSON will be used.
+     */
+    public String selectHeaderContentType(String[] contentTypes) {
+        if (contentTypes.length == 0) {
+            return null;
+        }
+
+        if (contentTypes[0].equals("*/*")) {
+            return "application/json";
+        }
+
+        for (String contentType : contentTypes) {
+            if (isJsonMime(contentType)) {
+                return contentType;
+            }
+        }
+
+        return contentTypes[0];
     }
-    for (String contentType : contentTypes) {
-      if (isJsonMime(contentType)) {
-        return contentType;
-      }
-    }
-    return contentTypes[0];
-  }
 
   /**
    * Escape the given string to be used as URL query value.

--- a/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/ApiClient.mustache
@@ -833,26 +833,32 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     return StringUtil.join(accepts, ",");
   }
 
-  /**
-   * Select the Content-Type header's value from the given array:
-   *   if JSON exists in the given array, use it;
-   *   otherwise use the first one of the array.
-   *
-   * @param contentTypes The Content-Type array to select from
-   * @return The Content-Type header to use. If the given array is empty,
-   *   JSON will be used.
-   */
-  public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
-      return "application/json";
+    /**
+     * Select the Content-Type header's value from the given array:
+     *   if JSON exists in the given array, use it;
+     *   otherwise use the first one of the array.
+     *
+     * @param contentTypes The Content-Type array to select from
+     * @return The Content-Type header to use. If the given array is empty,
+     *   returns null. If it matches "any", JSON will be used.
+     */
+    public String selectHeaderContentType(String[] contentTypes) {
+        if (contentTypes.length == 0) {
+            return null;
+        }
+
+        if (contentTypes[0].equals("*/*")) {
+            return "application/json";
+        }
+
+        for (String contentType : contentTypes) {
+            if (isJsonMime(contentType)) {
+                return contentType;
+            }
+        }
+
+        return contentTypes[0];
     }
-    for (String contentType : contentTypes) {
-      if (isJsonMime(contentType)) {
-        return contentType;
-      }
-    }
-    return contentTypes[0];
-  }
 
   /**
    * Escape the given string to be used as URL query value.

--- a/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/ApiClient.mustache
@@ -840,11 +840,11 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     *
     * @param contentTypes The Content-Type array to select from
     * @return The Content-Type header to use. If the given array is empty,
-    *   returns null. If it matches "any", JSON will be used.
+    *   returns "application/octet-stream". If it matches "any", JSON will be used.
     */
   public String selectHeaderContentType(String[] contentTypes) {
       if (contentTypes.length == 0) {
-          return null;
+          return "application/octet-stream";
       }
 
       if (contentTypes[0].equals("*/*")) {

--- a/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/ApiClient.mustache
@@ -833,32 +833,32 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     return StringUtil.join(accepts, ",");
   }
 
-    /**
-     * Select the Content-Type header's value from the given array:
-     *   if JSON exists in the given array, use it;
-     *   otherwise use the first one of the array.
-     *
-     * @param contentTypes The Content-Type array to select from
-     * @return The Content-Type header to use. If the given array is empty,
-     *   returns null. If it matches "any", JSON will be used.
-     */
-    public String selectHeaderContentType(String[] contentTypes) {
-        if (contentTypes.length == 0) {
-            return null;
-        }
+  /**
+    * Select the Content-Type header's value from the given array:
+    *   if JSON exists in the given array, use it;
+    *   otherwise use the first one of the array.
+    *
+    * @param contentTypes The Content-Type array to select from
+    * @return The Content-Type header to use. If the given array is empty,
+    *   returns null. If it matches "any", JSON will be used.
+    */
+  public String selectHeaderContentType(String[] contentTypes) {
+      if (contentTypes.length == 0) {
+          return null;
+      }
 
-        if (contentTypes[0].equals("*/*")) {
-            return "application/json";
-        }
+      if (contentTypes[0].equals("*/*")) {
+          return "application/json";
+      }
 
-        for (String contentType : contentTypes) {
-            if (isJsonMime(contentType)) {
-                return contentType;
-            }
-        }
+      for (String contentType : contentTypes) {
+          if (isJsonMime(contentType)) {
+              return contentType;
+          }
+      }
 
-        return contentTypes[0];
-    }
+      return contentTypes[0];
+  }
 
   /**
    * Escape the given string to be used as URL query value.

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -838,7 +838,7 @@ public class ApiClient extends JavaTimeFormatter {
           return "application/octet-stream";
       }
 
-      if (contentTypes[0].equals("*/*")) {
+      if ("*/*".equals(contentTypes[0])) {
           return "application/json";
       }
 

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -825,24 +825,30 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
-   * Select the Content-Type header's value from the given array:
-   *   if JSON exists in the given array, use it;
-   *   otherwise use the first one of the array.
-   *
-   * @param contentTypes The Content-Type array to select from
-   * @return The Content-Type header to use. If the given array is empty,
-   *   JSON will be used.
-   */
+    * Select the Content-Type header's value from the given array:
+    *   if JSON exists in the given array, use it;
+    *   otherwise use the first one of the array.
+    *
+    * @param contentTypes The Content-Type array to select from
+    * @return The Content-Type header to use. If the given array is empty,
+    *   returns null. If it matches "any", JSON will be used.
+    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
-      return "application/json";
-    }
-    for (String contentType : contentTypes) {
-      if (isJsonMime(contentType)) {
-        return contentType;
+      if (contentTypes.length == 0) {
+          return null;
       }
-    }
-    return contentTypes[0];
+
+      if (contentTypes[0].equals("*/*")) {
+          return "application/json";
+      }
+
+      for (String contentType : contentTypes) {
+          if (isJsonMime(contentType)) {
+              return contentType;
+          }
+      }
+
+      return contentTypes[0];
   }
 
   /**

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -831,11 +831,11 @@ public class ApiClient extends JavaTimeFormatter {
     *
     * @param contentTypes The Content-Type array to select from
     * @return The Content-Type header to use. If the given array is empty,
-    *   returns null. If it matches "any", JSON will be used.
+    *   returns "application/octet-stream". If it matches "any", JSON will be used.
     */
   public String selectHeaderContentType(String[] contentTypes) {
       if (contentTypes.length == 0) {
-          return null;
+          return "application/octet-stream";
       }
 
       if (contentTypes[0].equals("*/*")) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -838,7 +838,7 @@ public class ApiClient extends JavaTimeFormatter {
           return "application/octet-stream";
       }
 
-      if (contentTypes[0].equals("*/*")) {
+      if ("*/*".equals(contentTypes[0])) {
           return "application/json";
       }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -825,24 +825,30 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
-   * Select the Content-Type header's value from the given array:
-   *   if JSON exists in the given array, use it;
-   *   otherwise use the first one of the array.
-   *
-   * @param contentTypes The Content-Type array to select from
-   * @return The Content-Type header to use. If the given array is empty,
-   *   JSON will be used.
-   */
+    * Select the Content-Type header's value from the given array:
+    *   if JSON exists in the given array, use it;
+    *   otherwise use the first one of the array.
+    *
+    * @param contentTypes The Content-Type array to select from
+    * @return The Content-Type header to use. If the given array is empty,
+    *   returns null. If it matches "any", JSON will be used.
+    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
-      return "application/json";
-    }
-    for (String contentType : contentTypes) {
-      if (isJsonMime(contentType)) {
-        return contentType;
+      if (contentTypes.length == 0) {
+          return null;
       }
-    }
-    return contentTypes[0];
+
+      if (contentTypes[0].equals("*/*")) {
+          return "application/json";
+      }
+
+      for (String contentType : contentTypes) {
+          if (isJsonMime(contentType)) {
+              return contentType;
+          }
+      }
+
+      return contentTypes[0];
   }
 
   /**

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -831,11 +831,11 @@ public class ApiClient extends JavaTimeFormatter {
     *
     * @param contentTypes The Content-Type array to select from
     * @return The Content-Type header to use. If the given array is empty,
-    *   returns null. If it matches "any", JSON will be used.
+    *   returns "application/octet-stream". If it matches "any", JSON will be used.
     */
   public String selectHeaderContentType(String[] contentTypes) {
       if (contentTypes.length == 0) {
-          return null;
+          return "application/octet-stream";
       }
 
       if (contentTypes[0].equals("*/*")) {

--- a/samples/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/ApiClientTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/ApiClientTest.java
@@ -95,7 +95,7 @@ public class ApiClientTest {
         assertEquals("text/plain", apiClient.selectHeaderContentType(contentTypes));
 
         contentTypes = new String[]{};
-        assertNull(apiClient.selectHeaderContentType(contentTypes));
+        assertEquals("application/octet-stream", apiClient.selectHeaderContentType(contentTypes));
     }
 
     @Test

--- a/samples/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/ApiClientTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/test/java/org/openapitools/client/ApiClientTest.java
@@ -95,7 +95,7 @@ public class ApiClientTest {
         assertEquals("text/plain", apiClient.selectHeaderContentType(contentTypes));
 
         contentTypes = new String[]{};
-        assertEquals("application/json", apiClient.selectHeaderContentType(contentTypes));
+        assertNull(apiClient.selectHeaderContentType(contentTypes));
     }
 
     @Test

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -768,7 +768,7 @@ public class ApiClient extends JavaTimeFormatter {
           return "application/octet-stream";
       }
 
-      if (contentTypes[0].equals("*/*")) {
+      if ("*/*".equals(contentTypes[0])) {
           return "application/json";
       }
 

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -761,11 +761,11 @@ public class ApiClient extends JavaTimeFormatter {
     *
     * @param contentTypes The Content-Type array to select from
     * @return The Content-Type header to use. If the given array is empty,
-    *   returns null. If it matches "any", JSON will be used.
+    *   returns "application/octet-stream". If it matches "any", JSON will be used.
     */
   public String selectHeaderContentType(String[] contentTypes) {
       if (contentTypes.length == 0) {
-          return null;
+          return "application/octet-stream";
       }
 
       if (contentTypes[0].equals("*/*")) {

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -755,24 +755,30 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
-   * Select the Content-Type header's value from the given array:
-   *   if JSON exists in the given array, use it;
-   *   otherwise use the first one of the array.
-   *
-   * @param contentTypes The Content-Type array to select from
-   * @return The Content-Type header to use. If the given array is empty,
-   *   JSON will be used.
-   */
+    * Select the Content-Type header's value from the given array:
+    *   if JSON exists in the given array, use it;
+    *   otherwise use the first one of the array.
+    *
+    * @param contentTypes The Content-Type array to select from
+    * @return The Content-Type header to use. If the given array is empty,
+    *   returns null. If it matches "any", JSON will be used.
+    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
-      return "application/json";
-    }
-    for (String contentType : contentTypes) {
-      if (isJsonMime(contentType)) {
-        return contentType;
+      if (contentTypes.length == 0) {
+          return null;
       }
-    }
-    return contentTypes[0];
+
+      if (contentTypes[0].equals("*/*")) {
+          return "application/json";
+      }
+
+      for (String contentType : contentTypes) {
+          if (isJsonMime(contentType)) {
+              return contentType;
+          }
+      }
+
+      return contentTypes[0];
   }
 
   /**

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -706,11 +706,11 @@ public class ApiClient extends JavaTimeFormatter {
     *
     * @param contentTypes The Content-Type array to select from
     * @return The Content-Type header to use. If the given array is empty,
-    *   returns null. If it matches "any", JSON will be used.
+    *   returns "application/octet-stream". If it matches "any", JSON will be used.
     */
   public String selectHeaderContentType(String[] contentTypes) {
       if (contentTypes.length == 0) {
-          return null;
+          return "application/octet-stream";
       }
 
       if (contentTypes[0].equals("*/*")) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -713,7 +713,7 @@ public class ApiClient extends JavaTimeFormatter {
           return "application/octet-stream";
       }
 
-      if (contentTypes[0].equals("*/*")) {
+      if ("*/*".equals(contentTypes[0])) {
           return "application/json";
       }
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -700,24 +700,30 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
-   * Select the Content-Type header's value from the given array:
-   *   if JSON exists in the given array, use it;
-   *   otherwise use the first one of the array.
-   *
-   * @param contentTypes The Content-Type array to select from
-   * @return The Content-Type header to use. If the given array is empty,
-   *   JSON will be used.
-   */
+    * Select the Content-Type header's value from the given array:
+    *   if JSON exists in the given array, use it;
+    *   otherwise use the first one of the array.
+    *
+    * @param contentTypes The Content-Type array to select from
+    * @return The Content-Type header to use. If the given array is empty,
+    *   returns null. If it matches "any", JSON will be used.
+    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
-      return "application/json";
-    }
-    for (String contentType : contentTypes) {
-      if (isJsonMime(contentType)) {
-        return contentType;
+      if (contentTypes.length == 0) {
+          return null;
       }
-    }
-    return contentTypes[0];
+
+      if (contentTypes[0].equals("*/*")) {
+          return "application/json";
+      }
+
+      for (String contentType : contentTypes) {
+          if (isJsonMime(contentType)) {
+              return contentType;
+          }
+      }
+
+      return contentTypes[0];
   }
 
   /**

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -915,11 +915,11 @@ public class ApiClient extends JavaTimeFormatter {
     *
     * @param contentTypes The Content-Type array to select from
     * @return The Content-Type header to use. If the given array is empty,
-    *   returns null. If it matches "any", JSON will be used.
+    *   returns "application/octet-stream". If it matches "any", JSON will be used.
     */
   public String selectHeaderContentType(String[] contentTypes) {
       if (contentTypes.length == 0) {
-          return null;
+          return "application/octet-stream";
       }
 
       if (contentTypes[0].equals("*/*")) {

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -909,24 +909,30 @@ public class ApiClient extends JavaTimeFormatter {
   }
 
   /**
-   * Select the Content-Type header's value from the given array:
-   *   if JSON exists in the given array, use it;
-   *   otherwise use the first one of the array.
-   *
-   * @param contentTypes The Content-Type array to select from
-   * @return The Content-Type header to use. If the given array is empty,
-   *   JSON will be used.
-   */
+    * Select the Content-Type header's value from the given array:
+    *   if JSON exists in the given array, use it;
+    *   otherwise use the first one of the array.
+    *
+    * @param contentTypes The Content-Type array to select from
+    * @return The Content-Type header to use. If the given array is empty,
+    *   returns null. If it matches "any", JSON will be used.
+    */
   public String selectHeaderContentType(String[] contentTypes) {
-    if (contentTypes.length == 0) {
-      return "application/json";
-    }
-    for (String contentType : contentTypes) {
-      if (isJsonMime(contentType)) {
-        return contentType;
+      if (contentTypes.length == 0) {
+          return null;
       }
-    }
-    return contentTypes[0];
+
+      if (contentTypes[0].equals("*/*")) {
+          return "application/json";
+      }
+
+      for (String contentType : contentTypes) {
+          if (isJsonMime(contentType)) {
+              return contentType;
+          }
+      }
+
+      return contentTypes[0];
   }
 
   /**

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -922,7 +922,7 @@ public class ApiClient extends JavaTimeFormatter {
           return "application/octet-stream";
       }
 
-      if (contentTypes[0].equals("*/*")) {
+      if ("*/*".equals(contentTypes[0])) {
           return "application/json";
       }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Before this fix, the content-type of the request defaults to "application/json".

With this fix, set it to "application/octet-stream"

It is not possible to not set any content-type to header, because jersey2 will raise the exception "java.lang.IllegalArgumentException: MediaType header is null"

relate to #8116, #10769, #10782

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @nmuesch (2021/01)