### PR TITLE
[Java][resttemplate][webclient] ApiClient should not produce warning

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -480,6 +480,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         }
 
         if (value instanceof Map) {
+            @SuppressWarnings("unchecked")
             final Map<String, Object> valuesMap = (Map<String, Object>) value;
             for (final Entry<String, Object> entry : valuesMap.entrySet()) {
                 params.add(entry.getKey(), parameterToString(entry.getValue()));

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -458,6 +458,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         }
 
         if (value instanceof Map) {
+            @SuppressWarnings("unchecked")
             final Map<String, Object> valuesMap = (Map<String, Object>) value;
             for (final Entry<String, Object> entry : valuesMap.entrySet()) {
                 params.add(entry.getKey(), parameterToString(entry.getValue()));

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -436,6 +436,7 @@ public class ApiClient extends JavaTimeFormatter {
         }
 
         if (value instanceof Map) {
+            @SuppressWarnings("unchecked")
             final Map<String, Object> valuesMap = (Map<String, Object>) value;
             for (final Entry<String, Object> entry : valuesMap.entrySet()) {
                 params.add(entry.getKey(), parameterToString(entry.getValue()));

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -431,6 +431,7 @@ public class ApiClient extends JavaTimeFormatter {
         }
 
         if (value instanceof Map) {
+            @SuppressWarnings("unchecked")
             final Map<String, Object> valuesMap = (Map<String, Object>) value;
             for (final Entry<String, Object> entry : valuesMap.entrySet()) {
                 params.add(entry.getKey(), parameterToString(entry.getValue()));

--- a/samples/client/petstore/java/webclient-nulable-arrays/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-nulable-arrays/src/main/java/org/openapitools/client/ApiClient.java
@@ -424,6 +424,7 @@ public class ApiClient extends JavaTimeFormatter {
         }
 
         if (value instanceof Map) {
+            @SuppressWarnings("unchecked")
             final Map<String, Object> valuesMap = (Map<String, Object>) value;
             for (final Entry<String, Object> entry : valuesMap.entrySet()) {
                 params.add(entry.getKey(), parameterToString(entry.getValue()));

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -445,6 +445,7 @@ public class ApiClient extends JavaTimeFormatter {
         }
 
         if (value instanceof Map) {
+            @SuppressWarnings("unchecked")
             final Map<String, Object> valuesMap = (Map<String, Object>) value;
             for (final Entry<String, Object> entry : valuesMap.entrySet()) {
                 params.add(entry.getKey(), parameterToString(entry.getValue()));


### PR DESCRIPTION
Motivation:

Remove useless warnings for webclient and resttemplate

See https://github.com/OpenAPITools/openapi-generator/issues/10788
