### PR TITLE
updates to swagger-parser 2.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1572,7 +1572,7 @@
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <swagger-core.version>2.1.2</swagger-core.version>
         <swagger-parser-groupid.version>io.swagger.parser.v3</swagger-parser-groupid.version>
-        <swagger-parser.version>2.0.26</swagger-parser.version>
+        <swagger-parser.version>2.0.28</swagger-parser.version>
         <testng.version>7.4.0</testng.version>
         <violations-maven-plugin.version>1.34</violations-maven-plugin.version>
         <wagon-ssh-external.version>3.4.3</wagon-ssh-external.version>

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -640,7 +640,6 @@ components:
           nullable: true
           type: string
         nullableWithNullDefault:
-          default: "null"
           nullable: true
           type: string
         nullableWithPresentDefault:

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/NullableTest.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/NullableTest.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **nullable** | **String** |  | 
-**nullable_with_null_default** | **String** |  | [optional] [default to Some(swagger::Nullable::Null)]
+**nullable_with_null_default** | **String** |  | [optional] [default to None]
 **nullable_with_present_default** | **String** |  | [optional] [default to Some(swagger::Nullable::Present("default".to_string()))]
 **nullable_with_no_default** | **String** |  | [optional] [default to None]
 **nullable_array** | **Vec<String>** |  | [optional] [default to None]

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -1478,7 +1478,7 @@ impl NullableTest {
     pub fn new(nullable: swagger::Nullable<String>, ) -> NullableTest {
         NullableTest {
             nullable: nullable,
-            nullable_with_null_default: Some(swagger::Nullable::Null),
+            nullable_with_null_default: None,
             nullable_with_present_default: Some(swagger::Nullable::Present("default".to_string())),
             nullable_with_no_default: None,
             nullable_array: None,


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Updates swagger parser to mitigate vulnerability in dependent httpclient library.
https://github.com/OpenAPITools/openapi-generator/issues/10818

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
