### PR TITLE
[java] No @NotNull annotation for readOnly (required) attributes

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/beanValidation.mustache
@@ -1,5 +1,7 @@
 {{#required}}
+{{^isReadOnly}}
   @NotNull
+{{/isReadOnly}}
 {{/required}}
 {{#isContainer}}
 {{^isPrimitiveType}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/beanValidation.mustache
@@ -1,4 +1,6 @@
 {{#required}}
+{{^isReadOnly}}
   @NotNull
+{{/isReadOnly}}
 {{/required}}
 {{>beanValidationCore}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/beanValidation.mustache
@@ -1,1 +1,1 @@
-{{#required}}@NotNull {{/required}}{{#isContainer}}{{^isPrimitiveType}}{{^isEnum}}@Valid {{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{^isContainer}}{{^isPrimitiveType}}@Valid {{/isPrimitiveType}}{{/isContainer}}{{>beanValidationCore}}
+{{#required}}{{^isReadOnly}}@NotNull {{/isReadOnly}}{{/required}}{{#isContainer}}{{^isPrimitiveType}}{{^isEnum}}@Valid {{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{^isContainer}}{{^isPrimitiveType}}@Valid {{/isPrimitiveType}}{{/isContainer}}{{>beanValidationCore}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -793,9 +793,71 @@ public class SpringCodegenTest {
                 assertEquals(desFile, DESTINATIONFILE);
             }
         }
-        if(!flag){
+        if (!flag) {
             fail("OpenAPIDocumentationConfig.java not generated");
         }
+    }
+
+    @Test
+    public void shouldAddNotNullOnRequiredAttributes() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/spring/issue_5026-b.yaml");
+        final SpringCodegen codegen = new SpringCodegen();
+        codegen.setOpenAPI(openAPI);
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+
+        generator.opts(input).generate();
+
+        assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/model/Dummy.java"), "status");
+        assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/model/Dummy.java"), "@NotNull");
+        Files.readAllLines(Paths.get(outputPath + "/src/main/java/org/openapitools/model/Dummy.java")).forEach(System.out::println);
+
+    }
+
+    @Test
+    public void shouldNotAddNotNullOnReadOnlyAttributes() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/spring/issue_5026.yaml");
+        final SpringCodegen codegen = new SpringCodegen();
+        codegen.setOpenAPI(openAPI);
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+
+        generator.opts(input).generate();
+
+        assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/model/Dummy.java"), "status");
+        assertFileNotContains(Paths.get(outputPath + "/src/main/java/org/openapitools/model/Dummy.java"), "@NotNull");
+        Files.readAllLines(Paths.get(outputPath + "/src/main/java/org/openapitools/model/Dummy.java")).forEach(System.out::println);
+
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/spring/issue_5026-b.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/issue_5026-b.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  version: "1.0.0"
+  title: reactive-spring-boot-request-body-issue
+tags:
+  - name: ReactiveSpringBootRequestBodyIssue
+paths:
+  /some/dummy/endpoint:
+    post:
+      tags:
+        - ReactiveSpringBootRequestBodyIssue
+      requestBody:
+        description: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Dummy'
+        required: true
+      responses:
+        200:
+          description: Successfully created reverse listings for retail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dummy'
+components:
+  schemas:
+    Dummy:
+      required:
+        - status
+      type: object
+      properties:
+        status:
+          type: string

--- a/modules/openapi-generator/src/test/resources/3_0/spring/issue_5026.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/issue_5026.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  version: "1.0.0"
+  title: reactive-spring-boot-request-body-issue
+tags:
+  - name: ReactiveSpringBootRequestBodyIssue
+paths:
+  /some/dummy/endpoint:
+    post:
+      tags:
+        - ReactiveSpringBootRequestBodyIssue
+      requestBody:
+        description: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Dummy'
+        required: true
+      responses:
+        200:
+          description: Successfully created reverse listings for retail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dummy'
+components:
+  schemas:
+    Dummy:
+      required:
+        - status
+      type: object
+      properties:
+        status:
+          type: string
+          readOnly: true


### PR DESCRIPTION
fixes #5026

This duplicates #5960 (which was stale because of missing feedback/updates from creator).

@bbdouglas  @sreeshas @jfiala  @lukoyanov @cbornet @jeff9finger @karismann  @Zomzog  @lwlee2608 @nmuesch 


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
