### PR TITLE
Use parallel classes test over reusing forks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,13 +176,12 @@
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <printSummary>true</printSummary>
-                    <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
+                    <parallel>classes</parallel>
+                    <threadCountClasses>3</threadCountClasses>
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <junitArtifactName>none:none</junitArtifactName>
                     <testNGArtifactName>org.testng:testng</testNGArtifactName>
                     <argLine>@{argLine} -XX:+StartAttachListener</argLine>
-                    <forkCount>3</forkCount>
-                    <reuseForks>true</reuseForks>
                     <systemPropertyVariables>
                         <org.openapitools.codegen.utils.oncelogger.expiry>1000</org.openapitools.codegen.utils.oncelogger.expiry>
                         <org.openapitools.codegen.utils.oncelogger.cachesize>5000</org.openapitools.codegen.utils.oncelogger.cachesize>
@@ -1573,7 +1572,7 @@
         <swagger-core.version>2.1.2</swagger-core.version>
         <swagger-parser-groupid.version>io.swagger.parser.v3</swagger-parser-groupid.version>
         <swagger-parser.version>2.0.26</swagger-parser.version>
-        <testng.version>7.4.0</testng.version>
+        <testng.version>7.3.0</testng.version>
         <violations-maven-plugin.version>1.34</violations-maven-plugin.version>
         <wagon-ssh-external.version>3.4.3</wagon-ssh-external.version>
         <wagon-svn.version>1.12</wagon-svn.version>


### PR DESCRIPTION
I played a bit with surefire config locally. `mvn test` with config from master branch runs in 418 seconds on my laptop so this was my baseline. I tried a few different things, experimented with configuration on parallel classes, methods etc. and got to this point where `mvn test ` now completes in 280 seconds

From surefire doesn't really encourage to use fork parallelism:

>forkCount=1/reuseForks=false executes each test class in its own JVM process, one after another. It creates the highest level of separation for the test execution, but it would probably also give you the longest execution time of all the available options. Consider it as a last resort.

testng had to be downgraded to support `parallel` flag in surefire, but that will be fixed in the next version of surefire:
https://stackoverflow.com/questions/68143219/maven-surefire-failsafe-testng-7-4-0-parallel-error-void-org-testng-xml-xmlsuit