### PR TITLE
[JAVA] Fix Hashmap import issue when generateAliasAsModel set to true

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/model.mustache
@@ -8,6 +8,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 {{/useReflectionEqualsHashCode}}
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 {{#imports}}
 import {{import}};
 {{/imports}}

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/model/SomeObj.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/model/SomeObj.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DeprecatedObject.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DeprecatedObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Foo.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Foo.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/HealthCheckResult.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/HealthCheckResult.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/InlineResponseDefault.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/InlineResponseDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterEnumDefaultValue.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterEnumDefaultValue.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterEnumInteger.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterEnumInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterEnumIntegerDefaultValue.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterEnumIntegerDefaultValue.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterObjectWithEnumProperty.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterObjectWithEnumProperty.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 import android.os.Parcelable;
 import android.os.Parcel;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 import android.os.Parcelable;
 import android.os.Parcel;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import javax.validation.constraints.*;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import javax.validation.constraints.*;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 import javax.validation.constraints.*;
 import javax.validation.Valid;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 import javax.validation.constraints.*;
 import javax.validation.Valid;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.dataformat.xml.annotation.*;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.dataformat.xml.annotation.*;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import javax.validation.constraints.*;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import javax.validation.constraints.*;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.IOException;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/BigCat.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/BigCat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/BigCatAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/BigCatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient-nulable-arrays/src/main/java/org/openapitools/client/model/ByteArrayObject.java
+++ b/samples/client/petstore/java/webclient-nulable-arrays/src/main/java/org/openapitools/client/model/ByteArrayObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DeprecatedObject.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DeprecatedObject.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Foo.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Foo.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/HealthCheckResult.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/HealthCheckResult.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/InlineResponseDefault.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/InlineResponseDefault.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NullableClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NullableClass.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ObjectWithDeprecatedFields.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterEnumDefaultValue.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterEnumDefaultValue.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterEnumInteger.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterEnumInteger.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterEnumIntegerDefaultValue.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterEnumIntegerDefaultValue.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterObjectWithEnumProperty.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterObjectWithEnumProperty.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,8 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.HashMap;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

fix #10848

Before the fix Hashmap is not imported causing error when set generateAliasAsModel=true
After the fix, Hashmap will be imported.

not sure if this is the best way to fix it. But jesery client also uses the same method.
https://github.com/openapitools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/model.mustache#L21-L22

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @nmuesch (2021/01)