### PR TITLE
[Kotlin][Multiplatform] Fix Kotlin Multiplatform Test

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/build.gradle.kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/build.gradle.kts.mustache
@@ -10,7 +10,7 @@ version = "{{artifactVersion}}"
 
 val kotlin_version = "1.5.31"
 val coroutines_version = "1.5.2"
-val serialization_version = "1.3.0-RC"
+val serialization_version = "1.3.0"
 val ktor_version = "1.6.3"
 
 repositories {

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/build.gradle.kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/build.gradle.kts.mustache
@@ -1,17 +1,17 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
-    kotlin("multiplatform") version "1.5.10" // kotlin_version
-    kotlin("plugin.serialization") version "1.5.10" // kotlin_version
+    kotlin("multiplatform") version "1.5.31" // kotlin_version
+    kotlin("plugin.serialization") version "1.5.31" // kotlin_version
 }
 
 group = "{{groupId}}"
 version = "{{artifactVersion}}"
 
-val kotlin_version = "1.5.10"
-val coroutines_version = "1.5.0"
-val serialization_version = "1.2.1"
-val ktor_version = "1.6.0"
+val kotlin_version = "1.5.31"
+val coroutines_version = "1.5.2"
+val serialization_version = "1.3.0-RC"
+val ktor_version = "1.6.3"
 
 repositories {
     mavenCentral()

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/pom.mustache
@@ -27,6 +27,20 @@
                 <version>1.2.1</version>
                 <executions>
                     <execution>
+                        <id>bundle-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>/bin/bash</executable>
+                            <arguments>
+                                <argument>gradlew</argument>
+                                <argument>clean</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>bundle-test</id>
                         <phase>integration-test</phase>
                         <goals>

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/settings.gradle.kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/settings.gradle.kts.mustache
@@ -1,2 +1,1 @@
-enableFeaturePreview("GRADLE_METADATA")
 rootProject.name = "{{artifactId}}"

--- a/samples/client/petstore/kotlin-multiplatform/build.gradle.kts
+++ b/samples/client/petstore/kotlin-multiplatform/build.gradle.kts
@@ -1,17 +1,17 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
-    kotlin("multiplatform") version "1.5.10" // kotlin_version
-    kotlin("plugin.serialization") version "1.5.10" // kotlin_version
+    kotlin("multiplatform") version "1.5.31" // kotlin_version
+    kotlin("plugin.serialization") version "1.5.31" // kotlin_version
 }
 
 group = "org.openapitools"
 version = "1.0.0"
 
-val kotlin_version = "1.5.10"
-val coroutines_version = "1.5.0"
-val serialization_version = "1.2.1"
-val ktor_version = "1.6.0"
+val kotlin_version = "1.5.31"
+val coroutines_version = "1.5.2"
+val serialization_version = "1.3.0-RC"
+val ktor_version = "1.6.3"
 
 repositories {
     mavenCentral()

--- a/samples/client/petstore/kotlin-multiplatform/build.gradle.kts
+++ b/samples/client/petstore/kotlin-multiplatform/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0.0"
 
 val kotlin_version = "1.5.31"
 val coroutines_version = "1.5.2"
-val serialization_version = "1.3.0-RC"
+val serialization_version = "1.3.0"
 val ktor_version = "1.6.3"
 
 repositories {

--- a/samples/client/petstore/kotlin-multiplatform/pom.xml
+++ b/samples/client/petstore/kotlin-multiplatform/pom.xml
@@ -26,6 +26,20 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.2.1</version>
                 <executions>
+                  <execution>
+                      <id>bundle-clean</id>
+                      <phase>clean</phase>
+                      <goals>
+                          <goal>exec</goal>
+                      </goals>
+                      <configuration>
+                          <executable>/bin/bash</executable>
+                          <arguments>
+                              <argument>gradlew</argument>
+                              <argument>clean</argument>
+                          </arguments>
+                      </configuration>
+                  </execution>
                     <execution>
                         <id>bundle-test</id>
                         <phase>integration-test</phase>

--- a/samples/client/petstore/kotlin-multiplatform/pom.xml
+++ b/samples/client/petstore/kotlin-multiplatform/pom.xml
@@ -26,20 +26,20 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>1.2.1</version>
                 <executions>
-                  <execution>
-                      <id>bundle-clean</id>
-                      <phase>clean</phase>
-                      <goals>
-                          <goal>exec</goal>
-                      </goals>
-                      <configuration>
-                          <executable>/bin/bash</executable>
-                          <arguments>
-                              <argument>gradlew</argument>
-                              <argument>clean</argument>
-                          </arguments>
-                      </configuration>
-                  </execution>
+                    <execution>
+                        <id>bundle-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>/bin/bash</executable>
+                            <arguments>
+                                <argument>gradlew</argument>
+                                <argument>clean</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>bundle-test</id>
                         <phase>integration-test</phase>

--- a/samples/client/petstore/kotlin-multiplatform/settings.gradle.kts
+++ b/samples/client/petstore/kotlin-multiplatform/settings.gradle.kts
@@ -1,2 +1,1 @@
-enableFeaturePreview("GRADLE_METADATA")
 rootProject.name = "kotlin-client-petstore-multiplatform"


### PR DESCRIPTION
### PR Description

Fixes #10898 

- Remove [obsolete](https://github.com/gradle/gradle/issues/15993) `GRADLE_METADATA` Gradle preview flag from Kotlin Multiplatform `settings.gradle.kts.mustache` template file.
- Update Kotlin Version to 1.5.31.
- Update `coroutines`, `serialization` and `ktor` versions to the versions recommended for usage with Kotlin 1.5.31 (see https://kotlinlang.org/docs/releases.html#release-details).
- Add a `clean` task to the Kotlin Multiplatform template `pom.xml` file to allow to easily clean the samples folder from previous build outputs.
- Update the Kotlin Multiplatform sample to reflect the changes to the template.

### Testing

To validate that this PR fixes the issue, run the Kotlin Multiplatform test from the project's root folder and see that the test completes successfully.
```
./mvnw clean integration-test -f samples/client/petstore/kotlin-multiplatform/pom.xml
```

#### CCs
Kotlin technical committee:
@jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m

People working on previous change #10468 : @shadowsheep1 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (5.3.0), `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.