### PR TITLE
Add option to skip case conversion for api operation names

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -227,6 +227,11 @@ public class Generate extends OpenApiGeneratorCommand {
             description = "Skips the default behavior of validating an input specification.")
     private Boolean skipValidateSpec;
 
+    @Option(name = {"--skip-case-conversion"},
+            title = "skip conversion between cases",
+            description = "Skips the conversion between cases ie. camel to snake and vice versa.")
+    private Boolean skipCaseConversion;
+
     @Option(name = {"--strict-spec"},
             title = "true/false strict behavior",
             description = "'MUST' and 'SHALL' wording in OpenAPI spec is strictly adhered to. e.g. when false, no fixes will be applied to documents which pass validation but don't follow the spec.",
@@ -286,6 +291,10 @@ public class Generate extends OpenApiGeneratorCommand {
         // now override with any specified parameters
         if (skipValidateSpec != null) {
             configurator.setValidateSpec(false);
+        }
+        
+        if (skipCaseConversion != null) {
+            configurator.setCaseConversion(false);
         }
 
         if (verbose != null) {

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
@@ -42,6 +42,7 @@ public class WorkflowSettings {
     public static final boolean DEFAULT_SKIP_OPERATION_EXAMPLE = false;
     public static final boolean DEFAULT_LOG_TO_STDERR = false;
     public static final boolean DEFAULT_VALIDATE_SPEC = true;
+    public static final boolean DEFAULT_CASE_CONVERSION = true;
     public static final boolean DEFAULT_ENABLE_POST_PROCESS_FILE = false;
     public static final boolean DEFAULT_ENABLE_MINIMAL_UPDATE = false;
     public static final boolean DEFAULT_STRICT_SPEC_BEHAVIOR = true;
@@ -57,6 +58,7 @@ public class WorkflowSettings {
     private boolean skipOperationExample = DEFAULT_SKIP_OPERATION_EXAMPLE;
     private boolean logToStderr = DEFAULT_LOG_TO_STDERR;
     private boolean validateSpec = DEFAULT_VALIDATE_SPEC;
+    private boolean caseConversion = DEFAULT_CASE_CONVERSION;
     private boolean enablePostProcessFile = DEFAULT_ENABLE_POST_PROCESS_FILE;
     private boolean enableMinimalUpdate = DEFAULT_ENABLE_MINIMAL_UPDATE;
     private boolean strictSpecBehavior = DEFAULT_STRICT_SPEC_BEHAVIOR;
@@ -74,6 +76,7 @@ public class WorkflowSettings {
         this.removeOperationIdPrefix = builder.removeOperationIdPrefix;
         this.logToStderr = builder.logToStderr;
         this.validateSpec = builder.validateSpec;
+        this.caseConversion = builder.caseConversion;
         this.enablePostProcessFile = builder.enablePostProcessFile;
         this.enableMinimalUpdate = builder.enableMinimalUpdate;
         this.strictSpecBehavior = builder.strictSpecBehavior;
@@ -106,6 +109,7 @@ public class WorkflowSettings {
         builder.skipOperationExample = copy.isSkipOperationExample();
         builder.logToStderr = copy.isLogToStderr();
         builder.validateSpec = copy.isValidateSpec();
+        builder.caseConversion = copy.isCaseConversion();
         builder.enablePostProcessFile = copy.isEnablePostProcessFile();
         builder.enableMinimalUpdate = copy.isEnableMinimalUpdate();
         builder.generateAliasAsModel = copy.isGenerateAliasAsModel();
@@ -198,6 +202,16 @@ public class WorkflowSettings {
      */
     public boolean isValidateSpec() {
         return validateSpec;
+    }
+
+    /**
+     * Indicates whether or not generation should convert cases.
+     * <p>
+     *
+     * @return <code>true</code> if case conversion is enabled, otherwise <code>false</code>. Default: <code>true</code>.
+     */
+    public boolean isCaseConversion() {
+        return caseConversion;
     }
 
     /**
@@ -304,6 +318,7 @@ public class WorkflowSettings {
         private Boolean skipOperationExample = DEFAULT_SKIP_OPERATION_EXAMPLE;
         private Boolean logToStderr = DEFAULT_LOG_TO_STDERR;
         private Boolean validateSpec = DEFAULT_VALIDATE_SPEC;
+        private Boolean caseConversion = DEFAULT_CASE_CONVERSION;
         private Boolean enablePostProcessFile = DEFAULT_ENABLE_POST_PROCESS_FILE;
         private Boolean enableMinimalUpdate = DEFAULT_ENABLE_MINIMAL_UPDATE;
         private Boolean strictSpecBehavior = DEFAULT_STRICT_SPEC_BEHAVIOR;
@@ -410,6 +425,17 @@ public class WorkflowSettings {
          */
         public Builder withValidateSpec(Boolean validateSpec) {
             this.validateSpec = validateSpec != null ? validateSpec : Boolean.valueOf(DEFAULT_VALIDATE_SPEC);
+            return this;
+        }
+
+        /**
+         * Sets the {@code caseConversion} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param caseConversion the {@code caseConversion} to set
+         * @return a reference to this Builder
+         */
+        public Builder withCaseConversion(Boolean caseConversion) {
+            this.caseConversion = caseConversion != null ? caseConversion : Boolean.valueOf(DEFAULT_CASE_CONVERSION);
             return this;
         }
 
@@ -578,6 +604,7 @@ public class WorkflowSettings {
                 ", removeOperationIdPrefix=" + removeOperationIdPrefix +
                 ", logToStderr=" + logToStderr +
                 ", validateSpec=" + validateSpec +
+                ", caseConversion=" + caseConversion + 
                 ", enablePostProcessFile=" + enablePostProcessFile +
                 ", enableMinimalUpdate=" + enableMinimalUpdate +
                 ", strictSpecBehavior=" + strictSpecBehavior +
@@ -600,6 +627,7 @@ public class WorkflowSettings {
                 isSkipOperationExample() == that.isSkipOperationExample() &&
                 isLogToStderr() == that.isLogToStderr() &&
                 isValidateSpec() == that.isValidateSpec() &&
+                isCaseConversion() == that.isCaseConversion() &&
                 isEnablePostProcessFile() == that.isEnablePostProcessFile() &&
                 isEnableMinimalUpdate() == that.isEnableMinimalUpdate() &&
                 isStrictSpecBehavior() == that.isStrictSpecBehavior() &&
@@ -623,6 +651,7 @@ public class WorkflowSettings {
                 isSkipOperationExample(),
                 isLogToStderr(),
                 isValidateSpec(),
+                isCaseConversion(),
                 isGenerateAliasAsModel(),
                 isEnablePostProcessFile(),
                 isEnableMinimalUpdate(),

--- a/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/config/WorkflowSettingsTest.java
+++ b/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/config/WorkflowSettingsTest.java
@@ -76,6 +76,7 @@ public class WorkflowSettingsTest {
                 .withRemoveOperationIdPrefix(true)
                 .withLogToStderr(true)
                 .withValidateSpec(false)
+                .withCaseConversion(false)
                 .withEnablePostProcessFile(true)
                 .withEnableMinimalUpdate(true)
                 .withStrictSpecBehavior(false)
@@ -98,6 +99,9 @@ public class WorkflowSettingsTest {
 
         assertNotEquals(defaults.isValidateSpec(), settings.isValidateSpec());
         assertFalse(settings.isValidateSpec());
+
+        assertNotEquals(defaults.isCaseConversion(), settings.isCaseConversion());
+        assertFalse(settings.isCaseConversion());
 
         assertNotEquals(defaults.isEnablePostProcessFile(), settings.isEnablePostProcessFile());
         assertTrue(settings.isEnablePostProcessFile());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -304,4 +304,6 @@ public interface CodegenConfig {
     void setRemoveEnumValuePrefix(boolean removeEnumValuePrefix);
 
     Schema unaliasSchema(Schema schema, Map<String, String> usedImportMappings);
+
+    void setCaseConversion(boolean caseConversion);
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -183,6 +183,7 @@ public class DefaultCodegen implements CodegenConfig {
     protected String removeOperationIdPrefixDelimiter = "_";
     protected int removeOperationIdPrefixCount = 1;
     protected boolean skipOperationExample;
+    protected boolean caseConversion = true;
 
     protected final static Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)application\\/json(;.*)?");
     protected final static Pattern JSON_VENDOR_MIME_PATTERN = Pattern.compile("(?i)application\\/vnd.(.*)+json(;.*)?");
@@ -1355,7 +1356,7 @@ public class DefaultCodegen implements CodegenConfig {
      * Return the variable name in the Api
      *
      * @param name the variable name of the Api
-     * @return the snake-cased variable name
+     * @return the camel-cased variable name
      */
     @Override
     public String toApiVarName(String name) {
@@ -2109,6 +2110,11 @@ public class DefaultCodegen implements CodegenConfig {
     @Override
     public Schema unaliasSchema(Schema schema, Map<String, String> usedImportMappings) {
         return ModelUtils.unaliasSchema(this.openAPI, schema, usedImportMappings);
+    }
+
+    @Override
+    public void setCaseConversion(boolean caseConversion) {
+        this.caseConversion = caseConversion;
     }
 
     /**
@@ -3930,7 +3936,7 @@ public class DefaultCodegen implements CodegenConfig {
             op.path = path;
         }
 
-        op.operationId = toOperationId(operationId);
+        op.operationId = caseConversion ? toOperationId(operationId) : operationId;
         op.summary = escapeText(operation.getSummary());
         op.unescapedNotes = operation.getDescription();
         op.notes = escapeText(operation.getDescription());
@@ -3939,7 +3945,6 @@ public class DefaultCodegen implements CodegenConfig {
         if (operation.getDeprecated() != null) {
             op.isDeprecated = operation.getDeprecated();
         }
-
         addConsumesInfo(operation, op);
 
         if (operation.getResponses() != null && !operation.getResponses().isEmpty()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -472,6 +472,11 @@ public class CodegenConfigurator {
         return this;
     }
 
+    public CodegenConfigurator setCaseConversion(final boolean caseConversion) {
+        workflowSettingsBuilder.withCaseConversion(caseConversion);
+        return this;
+    }
+
     public CodegenConfigurator setVerbose(boolean verbose) {
         workflowSettingsBuilder.withVerbose(verbose);
         return this;
@@ -590,6 +595,7 @@ public class CodegenConfigurator {
         config.setEnablePostProcessFile(workflowSettings.isEnablePostProcessFile());
         config.setEnableMinimalUpdate(workflowSettings.isEnableMinimalUpdate());
         config.setStrictSpecBehavior(workflowSettings.isStrictSpecBehavior());
+        config.setCaseConversion(workflowSettings.isCaseConversion());
 
         TemplatingEngineAdapter templatingEngine = TemplatingEngineLoader.byIdentifier(workflowSettings.getTemplatingEngineName());
         config.setTemplatingEngine(templatingEngine);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -226,6 +226,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
     @Override
     public String toOperationId(String operationId) {
+        System.out.println("HOW ABOUT THIS?");
         // throw exception if method name is empty (should not occur as an auto-generated method name will be used)
         if (StringUtils.isEmpty(operationId)) {
             throw new RuntimeException("Empty method name (operationId) not allowed");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -226,7 +226,6 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
     @Override
     public String toOperationId(String operationId) {
-        System.out.println("HOW ABOUT THIS?");
         // throw exception if method name is empty (should not occur as an auto-generated method name will be used)
         if (StringUtils.isEmpty(operationId)) {
             throw new RuntimeException("Empty method name (operationId) not allowed");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientTest.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -506,7 +507,7 @@ public class PythonClientTest {
 
         String f = "openapi_client/api/user_api.py";
         Path p = output.toPath().resolve(f);
-        String content = new String(Files.readAllBytes(p));
+        String content = new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
 
         // should be def createUser and not def create_user
         Pattern pattern = Pattern.compile("def createUser");


### PR DESCRIPTION
Added a flag to skip any case conversion for operationId
ie. operationId: 'addPet' does not change to 'add_pet' when using a python generator

Added test cases for checking that the flag sets the correct variables in WorkFlowSettings/CodegenConfig
Added test case for checking that the operationId is not modified when the flag is set in the PythonClientTest test file